### PR TITLE
image: Use reflinks for / by default

### DIFF
--- a/image.ks
+++ b/image.ks
@@ -27,7 +27,8 @@ bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=t
 # https://github.com/coreos/fedora-coreos-tracker/issues/18
 # See also coreos-growpart.service defined in fedora-coreos-base.yaml
 part /boot --size=300 --fstype="xfs" --label=boot
-part / --size=3000 --fstype="xfs" --label=root --grow
+# Note no reflinks for /boot since the bootloader may not understand them
+part / --size=3000 --fstype="xfs" --label=root --grow --mkfsoptions="-m reflink=1"
 
 reboot
 


### PR DESCRIPTION
This is transparently used by overlayfs for copyups, rpm-ostree
can use it for the rpmdb, and ostree uses it for `/etc`.

It's The Future.  (Also probably the default for `mkfs.xfs` at
some point I imagine...if that happens we'll need to explicitly
turn it off for `/boot` or perhaps suck it up and use `ext4`
or something)

https://lwn.net/Articles/659677/
https://lwn.net/Articles/747633/