### PR TITLE
RPM Overlay to Reduce Python Dependencies

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -14,6 +14,7 @@ repos:
   - fedora
   - fedora-updates
   - dustymabe-ignition
+  - promaethius-rpm-overlay
 
 ignore-removed-users:
   - root

--- a/promaethius-rpm-overlay.repo
+++ b/promaethius-rpm-overlay.repo
@@ -1,0 +1,10 @@
+[promaethius-rpm-overlay]
+name=Copr repo for rpm-overlay owned by promaethius
+baseurl=https://copr-be.cloud.fedoraproject.org/results/promaethius/rpm-overlay/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/promaethius/rpm-overlay/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Purpose of this repository: provide modified packages which do not require Python.

Currently in Repo:
- [container-selinux](https://copr-be.cloud.fedoraproject.org/results/promaethius/rpm-overlay/fedora-28-x86_64/00801076-container-selinux/container-selinux.spec)