### PR TITLE
image: install default PATH file

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -49,6 +49,16 @@ postprocess:
     echo '%sudo        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/coreos-sudo-group
     # We're not using resolved yet
     rm -f /usr/lib/systemd/system/systemd-resolved.service
+    # https://github.com/openshift/os/issues/191
+    # install default PATH file to expand non-login shells PATH for kola
+    cat > /etc/profile.d/path.sh << 'EOF'
+    pathmunge /bin
+    pathmunge /sbin
+    pathmunge /usr/bin
+    pathmunge /usr/sbin
+    pathmunge /usr/local/bin
+    pathmunge /usr/local/sbin
+    EOF
     # https://github.com/coreos/fedora-coreos-tracker/issues/18
     # See also image.ks.
     # Growpart /, until we can fix Ignition for separate /var


### PR DESCRIPTION
This drops a file in `/etc/profile.d` which configures the default
value of `PATH` for FCOS. This is mostly only useful for testing
purposes.