### PR TITLE
base: Ensure version numbers are strings

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -8,8 +8,8 @@ tmp-is-dir: true
 # Required by Ignition, and makes the system not compatible with Anaconda
 machineid-compat: false
 
-releasever: 29
-automatic_version_prefix: 29
+releasever: "29"
+automatic_version_prefix: "29"
 repos:
   - fedora
   - fedora-updates


### PR DESCRIPTION
Newer versions of serde that we may use for rpm-ostree are more
strict about this.