### PR TITLE
base: Use /var/home for home directories by default

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -48,6 +48,9 @@ postprocess:
     # Persistent journal by default
     echo 'Storage=persistent' >> /etc/systemd/journald.conf
 
+    # Fix /home to be /var/home - software wants to canonicalize this.
+    sed -i -e 's,^HOME=.*,HOME=/var/home,' /etc/default/useradd
+
     # https://github.com/openshift/os/issues/96
     # sudo group https://github.com/openshift/os/issues/96
     echo '%sudo        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/coreos-sudo-group


### PR DESCRIPTION
This came up in `#silverblue` discussion; let's do it here
first under the general concept that most changes to the "core"
underlying both Silverblue and FCOS should be made in FCOS first.

Tested locally with a build+run.  It doesn't affect the `core`
user today, because anaconda+libuser aren't reading the defaults
from the target OS.