### PR TITLE
Revert "manifest: Use ${basearch}"

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 # unified-core compatible
-ref: fedora/29/${basearch}/coreos
+ref: fedora/29/x86_64/coreos
 include: fedora-coreos-base.yaml
 
 packages:


### PR DESCRIPTION
This reverts commit ee5b62592364fba29926d9fcc70cbda2bc14f823.

Sorry, I'd only done basic testing on this; coreos-assembler doesn't support this yet.