### PR TITLE
manifest: add fedora-updates-testing

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -13,6 +13,7 @@ automatic_version_prefix: "29"
 repos:
   - fedora
   - fedora-updates
+  - fedora-updates-testing
   - dustymabe-ignition
 
 ignore-removed-users:

--- a/fedora.repo
+++ b/fedora.repo
@@ -1,7 +1,8 @@
 [fedora]
 name=Fedora $releasever - $basearch
 failovermethod=priority
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1
 #metadata_expire=7d
 repo_gpgcheck=0
@@ -13,7 +14,8 @@ skip_if_unavailable=False
 [fedora-updates]
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -25,7 +27,8 @@ skip_if_unavailable=False
 [fedora-updates-testing]
 name=Fedora $releasever - $basearch - Test Updates
 failovermethod=priority
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
 enabled=1
 gpgcheck=1
 metadata_expire=6h


### PR DESCRIPTION
So that we get the latest OSTree version which is needed to match the
recent Ignition/OSTree initrd services re-ordering.