### PR TITLE
base: add moby-engine

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -133,7 +133,7 @@ packages:
   # SSH
   - openssh-server openssh-clients
   # Containers
-  - podman skopeo runc
+  - podman skopeo runc moby-engine
   # Networking
   - bridge-utils nfs-utils biosdevname iptables-services
   - NetworkManager dnsmasq hostname


### PR DESCRIPTION
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/64