### PR TITLE
manifest: Use ${basearch}

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 # unified-core compatible
-ref: fedora/29/x86_64/coreos
+ref: fedora/29/${basearch}/coreos
 include: fedora-coreos-base.yaml
 
 packages:


### PR DESCRIPTION
Like we do elsewhere.  It turns out multiple architectures may be
important...

Depends https://github.com/coreos/coreos-assembler/pull/192