### PR TITLE
manifest: Remove biosdevname from package list

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -135,7 +135,7 @@ packages:
   # Containers
   - podman skopeo runc moby-engine
   # Networking
-  - bridge-utils nfs-utils biosdevname iptables-services
+  - bridge-utils nfs-utils iptables-services
   - NetworkManager dnsmasq hostname
   # Storage
   - cloud-utils-growpart


### PR DESCRIPTION
This package is only for x86_64 (also i686 if this architecture is
ever suported in the future) which causes non-x86_64 architectures
to fail the rpm-ostree compose.