### PR TITLE
Add coreos-useradd-core.service to create `core` user

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -100,11 +100,25 @@ postprocess:
     WantedBy=multi-user.target
     EOF
 
+    # See https://github.com/coreos/ignition/issues/600
+    # which originated from https://github.com/coreos/coreos-metadata/pull/90#discussion_r202438581
+    cat > /usr/lib/systemd/system/coreos-useradd-core.service <<'EOF'
+    [Unit]
+    ConditionFirstBoot=true
+    Before=sshd.service
+    [Service]
+    ExecStart=/usr/bin/sh -c 'if !getent passwd core &>/dev/null; then /usr/sbin/useradd -G wheel,sudo,adm,systemd-journal core; fi'
+    RemainAfterExit=yes
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+
     cat >/usr/lib/systemd/system-preset/42-coreos.preset << EOF
     # Presets here that eventually should live in the generic fedora presets
     # This one is from https://github.com/dustymabe/ignition-dracut
     enable coreos-firstboot-complete.service
     enable coreos-growpart.service
+    enable coreos-useradd-core.service
     EOF
 
     # Let's have a non-boring motd, just like CL (although theirs is more subdued

--- a/image.ks
+++ b/image.ks
@@ -20,9 +20,6 @@ keyboard us
 timezone --utc Etc/UTC
 selinux --enforcing
 rootpw --lock --iscrypted locked
-# create core user for now
-# https://github.com/openshift/os/issues/96
-user --name=core --groups='wheel,sudo,adm,systemd-journal'
 
 # Explicitly disable firewall since cloud providers generally provide
 # higher level firewall constructs (i.e. security groups).


### PR DESCRIPTION
I'd like to change coreos-assembler to have `/var` completely
empty in the disk image, and hence all content is created consistently
via systemd-tmpfiles at boot.

This is an important preparatory step for moving away from Anaconda.

For backwards compatibility (for now) let's auto-create the `core`
user still, but via a systemd unit on boot.  The right thing
I think is to move this logic into Ignition, but this works
for now.

We need to create a `dummy` user in Anaconda since it insists
there's either a root account or a user, but it gets deleted in
`%post`.