### PR TITLE
ks: Rename $coreos_firstboot grub var to $ignition_firstboot

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -115,8 +115,8 @@ postprocess:
 
     cat >/usr/lib/systemd/system-preset/42-coreos.preset << EOF
     # Presets here that eventually should live in the generic fedora presets
-    # This one is from https://github.com/dustymabe/ignition-dracut
-    enable coreos-firstboot-complete.service
+    # This one is from https://github.com/coreos/ignition-dracut
+    enable ignition-firstboot-complete.service
     enable coreos-growpart.service
     enable coreos-useradd-core.service
     EOF

--- a/image.ks
+++ b/image.ks
@@ -32,8 +32,8 @@ clearpart --initlabel --all
 # Add the following to kernel boot args:
 #  - ip=dhcp           # how to get network
 #  - rd.neednet=1      # tell dracut we need network
-#  - $coreos_firstboot # This is actually a GRUB variable
-bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 rw $coreos_firstboot"
+#  - $ignition_firstboot # This is actually a GRUB variable
+bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 rw $ignition_firstboot"
 
 # https://github.com/coreos/fedora-coreos-tracker/issues/18
 # See also coreos-growpart.service defined in fedora-coreos-base.yaml


### PR DESCRIPTION
to make things more distribution neutral

Depends on: https://github.com/coreos/ignition-dracut/pull/30