### PR TITLE
Use metalink instead of baseurl in fedora repo

### DIFF
--- a/fedora.repo
+++ b/fedora.repo
@@ -1,8 +1,8 @@
 [fedora]
 name=Fedora $releasever - $basearch
 failovermethod=priority
-baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1
 #metadata_expire=7d
 repo_gpgcheck=0
@@ -14,8 +14,8 @@ skip_if_unavailable=False
 [fedora-updates]
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
-baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -27,8 +27,8 @@ skip_if_unavailable=False
 [fedora-updates-testing]
 name=Fedora $releasever - $basearch - Test Updates
 failovermethod=priority
-baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
 enabled=1
 gpgcheck=1
 metadata_expire=6h


### PR DESCRIPTION
baseurl differs for primary and secondary arches
in Fedora
