### PR TITLE
fedora-coreos-base: Add console-login-helper-messages package

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -15,6 +15,7 @@ repos:
   - fedora-updates
   - fedora-updates-testing
   - dustymabe-ignition
+  - rfairley-console-login-helper-messages
 
 ignore-removed-users:
   - root
@@ -119,6 +120,8 @@ postprocess:
     enable ignition-firstboot-complete.service
     enable coreos-growpart.service
     enable coreos-useradd-core.service
+    enable console-login-helper-messages-*.service
+    enable console-login-helper-messages-*.path
     EOF
 
     # Let's have a non-boring motd, just like CL (although theirs is more subdued
@@ -168,3 +171,8 @@ packages:
   - bash-completion
   # Moving files around
   - rsync fuse-sshfs
+  # User experience
+  - console-login-helper-messages
+  - console-login-helper-messages-motdgen
+  - console-login-helper-messages-issuegen
+  - console-login-helper-messages-profile

--- a/rfairley-console-login-helper-messages.repo
+++ b/rfairley-console-login-helper-messages.repo
@@ -1,0 +1,10 @@
+[rfairley-console-login-helper-messages]
+name=Copr repo for console-login-helper-messages owned by rfairley
+baseurl=https://copr-be.cloud.fedoraproject.org/results/rfairley/console-login-helper-messages/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/rfairley/console-login-helper-messages/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Adds the rfairley-console-login-helper-messages COPR repo to download
the console-login-helper-messages package from.

---

Right now, this gets the console-login-helper-messages package and the required PAM version (`pam-1.3.1-12.fc29`) into the build when using coreos-assembler with the config on this branch. These two packages are sourced from COPR https://copr.fedorainfracloud.org/coprs/rfairley/console-login-helper-messages/monitor/.

There are 3 issues left to get motdgen fully working:

1) The main issue left to sort out is making sure the `motdgen` and `issuegen` units are enabled and started without needing to enter the commands manually. As of now, to use them requires the following when first booting in after `coreos-assembler run`:

```
# systemctl enable motdgen.service motdgen.path issuegen.service issuegen.path
# systemctl start motdgen.service issuegen.service
```
- [x] solved

2) The other blocker is getting `selinux-policy >= 3.14.3-11` in so that the generated `/run/motd.d/console-login-helper-messages.motd` can be displayed by `sshd`. For now the following is required to do the labeling:

```
echo "placeholder" > /run/motd
mkdir -p /run/motd.d
chcon -t etc_t /run/motd
chcon -t etc_t /run/motd.d
```

Looking into building `selinux-policy` in my COPR repo to use here, or using the rawhide version. Is it possible to specify the rawhide  `selinux-policy` in the `fedora-coreos-base.yml`? The rawhide version has the needed changes.

- [x] solved

3) One last issue is when using `coreos-assembler run`, `sshd` is not used so the generated motd under `/run` will not be displayed. To have `login` display it,  a config in `/etc/login.defs`  `MOTD_FILE=/etc/motd:/run/motd.d/console-login-helper-messages.motd` could be added so that the generated message gets displayed (http://man7.org/linux/man-pages/man1/login.1.html under `CONFIG FILE ITEMS`).

- [ ] solved (handling this in https://github.com/coreos/coreos-assembler/issues/244)

Other than that, `issuegen` works well to display the SSH keys and IP address from `eth0`, with `agetty` following a symlink in `/etc/issue.d` to read the generated file. The profile script showing the systemd failed units is also working. Just minor formatting edits are needed to the issue and profile scripts.

One possibility to immediately get the profile and issue messages in is to install the `console-login-helper-messages`, `console-login-helper-messages-issuegen`, `console-login-helper-messages-profile` packages (not `motdgen`) while the remaining issues are sorted out. Possibly do that, and follow up to add the `console-login-helper-messages-motdgen` subpackage in.