### PR TITLE
manifest: Remove redundant module includes

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -5,12 +5,6 @@ include: minimal.yaml
 boot_location: new
 tmp-is-dir: true
 
-# Add a richer set of early boot drivers, including vmware storage
-initramfs-args:
-  - "--no-hostonly"
-  - "--add-drivers"
-  - "mptspi vmw_pvscsi"
-
 # Required by Ignition, and makes the system not compatible with Anaconda
 machineid-compat: false
 


### PR DESCRIPTION
Further testing reveals that, for F28/F29 at least, the mptspi
and VMWare PV SCSI driver are already included by dracut when
you specify --no-hostonly.  Removing them here as they are not
actually needed.