### PR TITLE
fcos-base: add utils for static firewalling

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -159,8 +159,10 @@ packages:
   # Containers
   - podman skopeo runc moby-engine
   # Networking
-  - bridge-utils nfs-utils iptables-services
+  - bridge-utils nfs-utils
   - NetworkManager dnsmasq hostname
+  # Static firewalling
+  - iptables nftables iptables-nft iptables-services
   # Storage
   - cloud-utils-growpart
   - lvm2 iscsi-initiator-utils sg3_utils


### PR DESCRIPTION
This adds utils and service units for loading static firewalling rules,
supporting both iptables and nftables flavors.
Ref: https://github.com/coreos/fedora-coreos-tracker/pull/103