### PR TITLE
Add image.yaml

### DIFF
--- a/image.ks
+++ b/image.ks
@@ -1,3 +1,7 @@
+# THIS FILE IS DEPRECATED, use image.yaml
+#
+# original contents below:
+#
 # Currently the coreos-assembler tool is generating
 # disk images via Anaconda (inside virt-install).
 # This is likely to change in the future; see

--- a/image.yaml
+++ b/image.yaml
@@ -1,0 +1,8 @@
+# This replaces image.ks
+# size is the target disk size in GB.
+# Currently, it is the only supported key.
+size: 8
+
+# After this, we plan to add support for the Ignition
+# storage/filesystems sections.  (Although one can do
+# that on boot as well)


### PR DESCRIPTION
Let's just support configuring the base disk size for now so that we
say we *do* have some configuration.  We need to abstract this for
multiple reasons (we want to remove Anaconda, and even without removing
Anaconda we want to do dual bios/UEFI and also potentially arch-specific
code).

Most people will probably be OK for now configuring the base ostree and the
outer image size.

This commit doesn't yet remove image.ks in order to support version skew,
but we intend to shortly drop it.