### PR TITLE
base: disable updates-testing repo

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -13,7 +13,6 @@ automatic_version_prefix: "29"
 repos:
   - fedora
   - fedora-updates
-  - fedora-updates-testing
   - dustymabe-ignition
   - rfairley-console-login-helper-messages
 


### PR DESCRIPTION
Once we get our stream work in place this will change again, but
for now let's stick with the stable repo by default.