### PR TITLE
manifest: Omit nfs dracut module

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -5,6 +5,13 @@ include: minimal.yaml
 boot_location: new
 tmp-is-dir: true
 
+initramfs-args:
+  - --no-hostonly
+  # We don't support root on NFS, so we don't need it in the initramfs. It also
+  # conflicts with /var mount support.
+  - --omit
+  - nfs
+
 # Required by Ignition, and makes the system not compatible with Anaconda
 machineid-compat: false
 


### PR DESCRIPTION
The nfs dracut module is needed to support root-on-NFS. But this is
something we don't support for FCOS, so let's just disable it. This also
works around issues with supporting separate `/var` filesystems and the
`rpc_pipefs` mount that the module creates.