### PR TITLE
dracut: omit modules we don't use

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -12,8 +12,11 @@ initramfs-args:
   # in /var/ and then ignition can't cleanly unmount it. For example:
   # https://github.com/dracutdevs/dracut/blob/1856ae95c873a6fe855b3dccd0144f1a96b9e71c/modules.d/95nfs/nfs-start-rpc.sh#L7
   # See also discussion in https://github.com/coreos/fedora-coreos-config/pull/60
-  - --omit
-  - nfs
+  - --omit=nfs
+  # Omit these since we don't use them
+  - --omit=lvm
+  - --omit=multipath
+  - --omit=iscsi
 
 # Required by Ignition, and makes the system not compatible with Anaconda
 machineid-compat: false


### PR DESCRIPTION
This should help build a smaller initramfs and clean up the logs a bit

Still testing, will make non-draft once tested