### PR TITLE
installer: make grub.cfg usable on aarch64

### DIFF
--- a/installer/EFI/fedora/grub.cfg
+++ b/installer/EFI/fedora/grub.cfg
@@ -2,6 +2,10 @@
 # efiboot.img on the Fedora Server DVD iso. Diff this file with that
 # file in the future to pick up changes.
 #
+# One diff to note is we use linux and initrd instead of linuxefi and
+# initrdefi. We do this because it works and allows us to use this same
+# file on other architecutres. https://github.com/coreos/fedora-coreos-config/issues/63
+#
 # This file gets embedded into the efiboot.img on our Fedora CoreOS ISO.
 set default="1"
 
@@ -24,6 +28,6 @@ set timeout=60
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Install Fedora CoreOS' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi /images/vmlinuz nomodeset rd.neednet=1 coreos.inst=yes
-	initrdefi /images/initramfs.img
+	linux /images/vmlinuz nomodeset rd.neednet=1 coreos.inst=yes
+	initrd /images/initramfs.img
 }


### PR DESCRIPTION
From some brief testing it looks like `linux` and `initrd` work
on x86_64 EFI boot so we'll just use that so we can use the same
grub.cfg for aarch64 or for x86_64.

Fixes #63