### PR TITLE
manifest: add fedora-repos-ostree

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -4,6 +4,7 @@ include: fedora-coreos-base.yaml
 
 packages:
   - fedora-release-coreos
+  - fedora-repos-ostree
 
 rojig:
   license: MIT


### PR DESCRIPTION
The subpackage has been created now, so we can start shipping it.