### PR TITLE
manifest: drop ignition-dracut

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -190,7 +190,7 @@ packages:
   - selinux-policy-targeted policycoreutils-python
   - setools-console
   # System setup
-  - ignition ignition-dracut
+  - ignition
   - dracut-network
   - passwd
   # SSH


### PR DESCRIPTION
In [1] ignition-dracut was folded into the ignition top level package
so we don't need to include it in the manifest any longer.

[1] https://src.fedoraproject.org/rpms/ignition/pull-request/26