### PR TITLE
manifest: Turn on mutate-os-release

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -23,6 +23,7 @@ machineid-compat: false
 
 releasever: "29"
 automatic_version_prefix: "29"
+mutate-os-release: "29"
 repos:
   - fedora
   - fedora-updates


### PR DESCRIPTION
This allows RPM-OSTree to inject some information in the os-release
about the compose. Notably the `VERSION` and `PRETTY_NAME` keys are
updated to reflect the OSTree commit version. A new `OSTREE_VERSION` key
is also added. This also matches what we had in Fedora Atomic Host.