### PR TITLE
Add 40coreos dracut module

### DIFF
--- a/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-mount-var.service
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-mount-var.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Mount OSTree /var
+DefaultDependencies=false
+
+# Make sure ExecStop= runs before we switch root
+Before=initrd-switch-root.target
+
+# Make sure if ExecStop= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+# Make sure /sysroot is mounted first, since we're mounting under there
+Requires=initrd-root-fs.target
+After=initrd-root-fs.target
+
+# Need to do this before Ignition mounts any other filesystems (potentially
+# shadowing our own bind mount).
+Before=ignition-mount.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/coreos-mount-var mount
+ExecStop=/usr/sbin/coreos-mount-var umount

--- a/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-mount-var.sh
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-mount-var.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ $# -ne 1 ] || { [[ $1 != mount ]] && [[ $1 != umount ]]; }; then
+    fatal "Usage: $0 <mount|umount>"
+fi
+
+get_ostree_arg() {
+    # yes, this doesn't account for spaces within args, e.g. myarg="my val", but
+    # it still works for our purposes
+    (
+    IFS=$' '
+    # shellcheck disable=SC2013
+    for arg in $(cat /proc/cmdline); do
+        if [[ $arg == ostree=* ]]; then
+            echo "${arg#ostree=}"
+        fi
+    done
+    )
+}
+
+do_mount() {
+    ostree=$(get_ostree_arg)
+    if [ -z "${ostree}" ]; then
+        fatal "No ostree= kernel argument in /proc/cmdline"
+    fi
+
+    deployment_path=/sysroot/${ostree}
+    if [ ! -L "${deployment_path}" ]; then
+        fatal "${deployment_path} is not a symlink"
+    fi
+
+    stateroot_var_path=$(realpath "${deployment_path}/../../var")
+    if [ ! -d "${stateroot_var_path}" ]; then
+        fatal "${stateroot_var_path} is not a directory"
+    fi
+
+    echo "Mounting $stateroot_var_path"
+    mount --bind "$stateroot_var_path" /sysroot/var
+}
+
+do_umount() {
+    echo "Unmounting /sysroot/var"
+    umount /sysroot/var
+}
+
+"do_$1"

--- a/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-populate-var.service
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-populate-var.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Populate OSTree /var
+DefaultDependencies=false
+
+# Need to do this with all mount points active
+After=ignition-mount.service
+
+# But *before* we start dumping files in there
+Before=ignition-files.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/coreos-populate-var

--- a/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-populate-var.sh
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-var/coreos-populate-var.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ $# -ne 0 ]; then
+    fatal "Usage: $0"
+fi
+
+# See the similar code block in Anaconda, which handles this today for Atomic
+# Host and Silverblue:
+# https://github.com/rhinstaller/anaconda/blob/b9ea8ce4e68196b30a524c1cc5680dcdc4b89371/pyanaconda/payload/rpmostreepayload.py#L332
+
+# Simply manually mkdir /var/lib; the tmpfiles.d entries otherwise reference
+# users/groups which we don't have access to from here (though... we *could*
+# import them from the sysroot, and have nss-altfiles in the initrd, but meh...
+# let's just wait for systemd-sysusers which will make this way easier:
+# https://github.com/coreos/fedora-coreos-config/pull/56/files#r262592361).
+mkdir -p /sysroot/var/lib
+
+systemd-tmpfiles --create --boot --root=/sysroot \
+    --prefix=/var/home \
+    --prefix=/var/roothome \
+    --prefix=/var/opt \
+    --prefix=/var/srv \
+    --prefix=/var/usrlocal \
+    --prefix=/var/mnt \
+    --prefix=/var/media
+
+# Ask for /var to be relabeled.
+# See also: https://github.com/coreos/ignition/issues/635.
+mkdir -p /run/tmpfiles.d
+echo "Z /var - - -" > /run/tmpfiles.d/var-relabel.conf
+
+# XXX: https://github.com/systemd/systemd/pull/11903
+for unit in systemd-{journal-catalog-update,random-seed}.service; do
+    mkdir -p /run/systemd/system/${unit}.d
+    cat > /run/systemd/system/${unit}.d/after-tmpfiles.conf <<EOF
+[Unit]
+After=systemd-tmpfiles-setup.service
+EOF
+done

--- a/overlay/usr/lib/dracut/modules.d/40coreos-var/module-setup.sh
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-var/module-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo ignition
+}
+
+install_ignition_unit() {
+    unit=$1; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    ln_r "../$unit" "$systemdsystemunitdir/ignition-complete.target.requires/$unit"
+}
+
+install() {
+    inst_multiple \
+        systemd-sysusers \
+        systemd-tmpfiles
+
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
+
+    install_ignition_unit coreos-mount-var.service
+    inst_script "$moddir/coreos-mount-var.sh" \
+        "/usr/sbin/coreos-mount-var"
+
+    install_ignition_unit coreos-populate-var.service
+    inst_script "$moddir/coreos-populate-var.sh" \
+        "/usr/sbin/coreos-populate-var"
+}


### PR DESCRIPTION
This module is the integration point between Ignition and Fedora CoreOS.
Notably, we add two new systemd services in the initrd which mesh with
Ignition's own systemd services:

1. `coreos-mount-var.service`, which finds the `/var` stateroot bind
   mount and mounts it under `/sysroot/var` before `ignition-mount`
   potentially adds more mounts underneath (or even shadowing `/var`
   itself).
2. `coreos-populate-var.service`, which sets up `/var` on first boot
   using `systemd-tmpfiles` before `ignition-files` runs.