### PR TITLE
Update console-login-helper-messages manifest and enabled presets

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -128,9 +128,8 @@ packages:
   - rsync fuse-sshfs
   - gnupg2
   # User experience
-  - console-login-helper-messages
-  - console-login-helper-messages-motdgen
   - console-login-helper-messages-issuegen
+  - console-login-helper-messages-motdgen
   - console-login-helper-messages-profile
   # CoreOS Installer
   - coreos-installer coreos-installer-dracut

--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -1,6 +1,6 @@
 # Presets here that eventually should live in the generic fedora presets
 enable coreos-growpart.service
-enable console-login-helper-messages-*.service
-enable console-login-helper-messages-*.path
+enable console-login-helper-messages-issuegen.service
+enable console-login-helper-messages-motdgen.service
 # This one is from https://github.com/coreos/ignition-dracut
 enable ignition-firstboot-complete.service


### PR DESCRIPTION
These changes should be added once the update to the latest source lands in stable https://bodhi.fedoraproject.org/updates/console-login-helper-messages-0.16-2.fc29. This update will remove the `.path` units from the source.

This PR can be merged anytime before the update lands as well, as the `.path` units are not involved in the MOTD or issue generation today, and they do not need enabling.

Also lists only the following in the manifest:

```
console-login-helper-messages-issuegen
console-login-helper-messages-motdgen
console-login-helper-messages-profile
```

as the `console-login-helper-messages` package on its own provides common dependencies for the 3 subpackages, and need not be requested explicitly.