### PR TITLE
postprocess: Nuke everything in /etc/systemd/system

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -78,7 +78,12 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     sed -i -e 's/CoreOS/CoreOS preview/' $(realpath /etc/os-release)
-
+  # Undo RPM scripts enabling units; we want the presets to be canonical
+  # https://github.com/projectatomic/rpm-ostree/issues/1803
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rm -vrf /etc/systemd/system/*
 
 packages:
   # SELinux

--- a/image.yaml
+++ b/image.yaml
@@ -6,3 +6,5 @@ size: 8
 # After this, we plan to add support for the Ignition
 # storage/filesystems sections.  (Although one can do
 # that on boot as well)
+
+


### PR DESCRIPTION
This should really be done in rpm-ostree if `machineid-compat: false`
but for now let's do the quick hack here.

The core problem is today the RPM scriptlets are enabling units,
but for us Ignition+presets should be the canonical definition of
things.

This avoids having another source of truth.