### PR TITLE
Bump to Fedora 30

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -21,13 +21,15 @@ initramfs-args:
 # Required by Ignition, and makes the system not compatible with Anaconda
 machineid-compat: false
 
-releasever: "29"
-automatic-version-prefix: "29"
-mutate-os-release: "29"
+releasever: "30"
+automatic-version-prefix: "30"
+mutate-os-release: "30"
 repos:
   - fedora
   - fedora-updates
   - fedora-coreos-continuous
+  # until https://github.com/systemd/systemd/pull/12281 is in f30 proper
+  - jlebon-systemd
 
 ignore-removed-users:
   - root

--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 # unified-core compatible
-ref: fedora/29/${basearch}/coreos
+ref: fedora/30/${basearch}/coreos
 include: fedora-coreos-base.yaml
 
 packages:

--- a/fedora.repo
+++ b/fedora.repo
@@ -8,7 +8,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-29-primary
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates]
@@ -21,7 +21,7 @@ repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-29-primary
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates-testing]
@@ -32,5 +32,5 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$relea
 enabled=1
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-29-primary
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/jlebon-systemd.repo
+++ b/jlebon-systemd.repo
@@ -1,0 +1,7 @@
+[jlebon-systemd]
+baseurl=https://jlebon.fedorapeople.org/systemd-f30/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Fedora 30 is almost at beta freeze now. It should be pretty stable to
hack on by this point. Let's bump to the actual content we'll be
shipping.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/168