### PR TITLE
aarch64: Remove unnecessary packages for aarch64

### DIFF
--- a/minimal.yaml
+++ b/minimal.yaml
@@ -9,7 +9,6 @@ packages:
 # bootloader
 packages-aarch64:
   - grub2-efi ostree-grub2 efibootmgr shim
-  - uboot-tools uboot-images-armv8 bcm283x-firmware
 packages-armhfp:
   - extlinux-bootloader
 packages-ppc64le:


### PR DESCRIPTION
aarch64 is currently using UEFI and not u-boot, additionally the
bcm283x-firmware package is only needed for Raspberry Pi devices which
have the Broadcom BCM283x devices, and can also be safely removed.