### PR TITLE
postprocess: run systemctl preset-all

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -89,7 +89,8 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-    rm -vrf /etc/systemd/system/*
+    rm -rf /etc/systemd/system/*
+    systemctl preset-all
 
 packages:
   # SELinux


### PR DESCRIPTION
This is a followup to https://github.com/coreos/fedora-coreos-config/pull/73

The problem we hit with RHCOS is that becomes a dangerous upgrade hazard.
Since we previously shipped with the unit files default enabled in `/etc`
(i.e. in ostree, the defaults are in `/usr/etc`), the problem comes
with the combination of the fact that during `ConditionFirstBoot`
we'll do `systemctl preset-all` which will write those files, but
they already existed.

Then if we try to upgrade to a tree without them, ostree will notice
the files were deleted in the new defaults and apparently not modified...
and then no `NetworkManager.service` anymore.

Really we want to have these defaults in `/usr`.  We want e.g.
`NetworkManager.service` to be defined as defaulted to on by us,
not in `/etc`.

I couldn't see a way to do this directly via the systemd CLI tools but the two-line
shell implementation is pretty trivial, just need to do a `mkdir`
pass, then move the links.

I really wish rpm-ostree had done this from the very start, it seems
obvious in retrospect.