### PR TITLE
Use fedora-coreos-continuous repo for custom builds

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -27,8 +27,7 @@ mutate-os-release: "29"
 repos:
   - fedora
   - fedora-updates
-  - dustymabe-ignition
-  - dustymabe-coreos-installer
+  - fedora-coreos-continuous
 
 ignore-removed-users:
   - root

--- a/fedora-coreos-continuous.repo
+++ b/fedora-coreos-continuous.repo
@@ -1,0 +1,8 @@
+[fedora-coreos-continuous]
+name=Fedora coreos continuous $releasever - $basearch
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$releasever-coreos-continuous/latest/$basearch/
+enabled=1
+repo_gpgcheck=0
+type=rpm-md
+gpgcheck=0
+skip_if_unavailable=True


### PR DESCRIPTION
We have f*-coreos-continuous reps in place which we can
use to include packages not yet available in Fedora stable
or updates repos.

Related - https://pagure.io/releng/issue/8165

Signed-off-by: Sinny Kumari <sinny@redhat.com>