### PR TITLE
overlay: Add NM config for dhcp-client-id=mac

### DIFF
--- a/overlay/usr/lib/NetworkManager/conf.d/client-id-from-mac.conf
+++ b/overlay/usr/lib/NetworkManager/conf.d/client-id-from-mac.conf
@@ -1,0 +1,2 @@
+[connection]
+ipv4.dhcp-client-id=mac


### PR DESCRIPTION
We regressed on [1] when moving towards persistent NIC naming in [2].
It's cleaner to have the config for this here anyway.

This tells NetworkManager to default to using the MAC address as the
client ID during DHCP requests to ensure we get the same IP address
again during network setup in the real root. See [3] for more background
on this.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/156
[2] https://github.com/coreos/coreos-assembler/pull/442
[3] https://github.com/coreos/coreos-assembler/pull/367