### PR TITLE
overlay: Seed /root with default bash profile

### DIFF
--- a/overlay/usr/lib/dracut/modules.d/15coreos-root/coreos-root-bash.service
+++ b/overlay/usr/lib/dracut/modules.d/15coreos-root/coreos-root-bash.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CoreOS Root Bash
+DefaultDependencies=false
+Before=ignition-complete.target
+
+# We need all the filesystems already mounted.
+Requires=ignition-mount.service
+After=ignition-mount.service
+
+# Run before ignition-files.service so configs can further modify.
+Before=ignition-files.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sh -c "cp /sysroot/etc/skel/.bash* /sysroot/root"

--- a/overlay/usr/lib/dracut/modules.d/15coreos-root/module-setup.sh
+++ b/overlay/usr/lib/dracut/modules.d/15coreos-root/module-setup.sh
@@ -1,0 +1,17 @@
+# Populate /root with default bash configs. See:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1193590
+
+depends() {
+    echo ignition
+}
+
+check() {
+    return 0
+}
+
+install() {
+    local unit=coreos-root-bash.service
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    ln_r "../$unit" "$systemdsystemunitdir/ignition-complete.target.requires/$unit"
+}


### PR DESCRIPTION
This has a long history in Atomic Host:
https://bugzilla.redhat.com/show_bug.cgi?id=1193590

The TL;DR is that since OSTree commits ship with empty `/var`, and
`/root` is really `/var/roothome`, then the default `.bash*` files for
the root don't actually exist. The RHBZ above was to try to teach bash
to fallback to the default files automatically, but it was deemed too
intrusive in the end and backed out.

In Atomic Host, we've worked around this by simply seeding the files
from the kickstart:
https://pagure.io/fedora-kickstarts/c/740a9b4969ca30da36458faf6809908f4da904c4?branch=master

This patch does something similar but at Ignition time. We do this
before the files stage so that for all purposes, this is part of the
distro (e.g. an Ignition config can append to `/root/.bashrc` for
example, or can add a file to `/etc/profile.d/` and expect it to be
sourced).

Concretely, this fixes non-login shells not sourcing `/etc/bashrc` and
`/etc/profile.d/` and thus having a prompt like `bash-5.0# `, no `ls`
colouring, non-default umask, etc...