### PR TITLE
fedora-coreos-base: rm things with python deps

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -105,7 +105,7 @@ packages:
   # Containers
   - podman skopeo runc moby-engine
   # Networking
-  - bridge-utils nfs-utils
+  - bridge-utils nfs-utils-coreos
   - NetworkManager dnsmasq hostname
   # Static firewalling
   - iptables nftables iptables-nft iptables-services
@@ -118,7 +118,7 @@ packages:
   # Time sync
   - chrony
   # Extra runtime
-  - authconfig sssd shadow-utils
+  - sssd shadow-utils
   - logrotate
   # Used by admins interactively
   - sudo coreutils less tar xz gzip bzip2


### PR DESCRIPTION
This doesn't remove all things with python dependencies, just authconfig
and nfs-utils (replaced by nfs-utils-coreos).

Tested, works.

Addresses https://github.com/coreos/fedora-coreos-tracker/issues/123 and https://github.com/coreos/fedora-coreos-tracker/issues/121