### PR TITLE
15coreos-root: run after coreos-populate-var.service

### DIFF
--- a/overlay/usr/lib/dracut/modules.d/15coreos-root/coreos-root-bash.service
+++ b/overlay/usr/lib/dracut/modules.d/15coreos-root/coreos-root-bash.service
@@ -3,9 +3,9 @@ Description=CoreOS Root Bash
 DefaultDependencies=false
 Before=ignition-complete.target
 
-# We need all the filesystems already mounted.
-Requires=ignition-mount.service
-After=ignition-mount.service
+# We need all the filesystems already mounted and /var/roothome created.
+Requires=coreos-populate-var.service
+After=coreos-populate-var.service
 
 # Run before ignition-files.service so configs can further modify.
 Before=ignition-files.service


### PR DESCRIPTION
Otherwise `/var/roothome` might not have been created yet.

I didn't notice this before because we weren't fully cleaning out `/var`
in the image: coreos/coreos-assembler#494.