### PR TITLE
base: rm setools-console, policycoreutils-python

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -94,8 +94,7 @@ postprocess:
 
 packages:
   # SELinux
-  - selinux-policy-targeted policycoreutils-python
-  - setools-console
+  - selinux-policy-targeted
   # System setup
   - ignition
   - dracut-network


### PR DESCRIPTION
Remove these as they depend on python

closes https://github.com/coreos/fedora-coreos-tracker/issues/122
closes https://github.com/coreos/fedora-coreos-tracker/issues/126