### PR TITLE
overlay: add 40coreos-network dracut module

### DIFF
--- a/overlay/usr/lib/dracut/modules.d/40coreos-network/coreos-teardown-initramfs-network.service
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-network/coreos-teardown-initramfs-network.service
@@ -1,0 +1,20 @@
+# Clean up the initramfs networking on first boot
+# so the real network is being brought up
+
+[Unit]
+Description=Tear down initramfs networking
+DefaultDependencies=false
+After=ignition-files.service
+
+# Make sure ExecStop= runs before we switch root
+Conflicts=initrd-switch-root.target umount.target
+Before=initrd-switch-root.target
+
+# Make sure if ExecStop= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/sbin/coreos-teardown-initramfs-network

--- a/overlay/usr/lib/dracut/modules.d/40coreos-network/coreos-teardown-initramfs-network.sh
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-network/coreos-teardown-initramfs-network.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clean up the interfaces set up in the initramfs
+# This mimics the behaviour of dracut's ifdown() in net-lib.sh
+# This script should be considered temporary. We eventually
+# want to move to NetworkManager based dracut modules. See:
+# https://github.com/dracutdevs/dracut/tree/master/modules.d/35network-manager
+if ! [ -z "$(ls /sys/class/net)" ]; then
+    for f in /sys/class/net/*; do
+        interface=$(basename "$f")
+        ip link set $interface down
+        ip addr flush dev $interface
+        rm -f -- /tmp/net.$interface.did-setup
+    done
+fi

--- a/overlay/usr/lib/dracut/modules.d/40coreos-network/module-setup.sh
+++ b/overlay/usr/lib/dracut/modules.d/40coreos-network/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo ignition
+}
+
+install() {
+    local unit=coreos-teardown-initramfs-network.service
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
+        "/usr/sbin/coreos-teardown-initramfs-network"
+}


### PR DESCRIPTION
Add coreos-teardown-initramfs-network.service to run after ignition
has finished using initramfs networking, so NetworkManager properly
brings up ignition-configured networking in the real root. Otherwise
the initramfs network persists into the real root.

Note: I'm not sure what the correct priority is, so I made it 40 to match other services.
It shouldn't really matter since this service actually runs during `ExecStop` and
before `Before=initrd-switch-root.target`.