### PR TITLE
manifest: drop "unified-core compatible" magic string

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,4 +1,3 @@
-# unified-core compatible
 ref: fedora/30/${basearch}/coreos
 include: fedora-coreos-base.yaml
 


### PR DESCRIPTION
I think this used to be picked up by cosa or someplace else to know that
it was OK to use `--unified-core`. Nowadays, we only work in unified
core mode, so let's just drop the comment.