### PR TITLE
repos: move to coreos-pool repo

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -27,7 +27,7 @@ mutate-os-release: "30"
 repos:
   - fedora
   - fedora-updates
-  - fedora-coreos-continuous
+  - fedora-coreos-pool
 
 ignore-removed-users:
   - root

--- a/fedora-coreos-continuous.repo
+++ b/fedora-coreos-continuous.repo
@@ -1,8 +1,0 @@
-[fedora-coreos-continuous]
-name=Fedora coreos continuous $releasever - $basearch
-baseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$releasever-coreos-continuous/latest/$basearch/
-enabled=1
-repo_gpgcheck=0
-type=rpm-md
-gpgcheck=0
-skip_if_unavailable=True

--- a/fedora-coreos-pool.repo
+++ b/fedora-coreos-pool.repo
@@ -1,0 +1,8 @@
+[fedora-coreos-pool]
+name=Fedora coreos pool repository - $basearch
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/$basearch/
+enabled=1
+repo_gpgcheck=0
+type=rpm-md
+gpgcheck=1
+skip_if_unavailable=True


### PR DESCRIPTION
This is an intermediate step towards our longer term goal of consuming
everything for our production refs from a distRepo generated from the
coreos-pool koji tag. Right now we'll just consume from the coreos-pool
as well as the traditional fedora repos.

This replaces the fedora-coreos-continuous repo as that will be used for
CI streams that rebuild quickly from upstream sources. We were currently
using it to bypass bodhi but we can use coreos-pool for that too.