### PR TITLE
Add afterburn package

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -97,6 +97,7 @@ packages:
   - selinux-policy-targeted
   # System setup
   - ignition
+  - afterburn
   - dracut-network
   - passwd
   # SSH

--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -4,3 +4,6 @@ enable console-login-helper-messages-issuegen.service
 enable console-login-helper-messages-motdgen.service
 # This one is from https://github.com/coreos/ignition-dracut
 enable ignition-firstboot-complete.service
+# Boot checkin services for cloud providers.
+enable afterburn-checkin.service
+enable afterburn-firstboot-checkin.service


### PR DESCRIPTION
Add Afterburn to the package manifest, and enable the provider checkin
services through the coreos preset file.

Part of coreos/fedora-coreos-tracker#4.

---

Now gets sourced from `fedora-coreos-pool`:

```
afterburn-4.1.0-1.module_f30+4209+68fe9bdd.x86_64 (fedora-coreos-pool)
```
