### PR TITLE
overlay: Enable afterburn-sshkeys@.service

### DIFF
--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -7,3 +7,5 @@ enable ignition-firstboot-complete.service
 # Boot checkin services for cloud providers.
 enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
+# Service to write SSH key snippets from cloud providers.
+enable afterburn-sshkeys@.service


### PR DESCRIPTION
With https://github.com/coreos/afterburn/pull/217 in Fedora, enable
this unit in FCOS.

---

Hold until the updated module (https://release-engineering.github.io/mbs-ui/module/4325) is finished building and tagged in `coreos-pool`.