### PR TITLE
Use unversioned ref and mark as testing stream

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,4 +1,4 @@
-ref: fedora/30/${basearch}/coreos
+ref: fedora/${basearch}/coreos/testing
 include: fedora-coreos-base.yaml
 
 packages:


### PR DESCRIPTION
First, drop the `30` in the branch name. A key change from FAH to FCOS
is that the latter provides a unified continuous stream of updates, even
across major releases.

Second, add `/testing` to the ref, as in: let's pretend for now that
`master` represents the testing stream, and that's what CentOS CI is
currently building (see also [this commit] related to this).

This is somewhat prep for actually having multiple branches and multiple
streams from those.

[this commit]: https://github.com/coreos/fedora-coreos-pipeline/commit/d5026b689ca186c494c2bdd30e35e15a7ab73fa6