### PR TITLE
Split out ref into `manifest.yaml`

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -24,10 +24,6 @@ machineid-compat: false
 releasever: "30"
 automatic-version-prefix: "30"
 mutate-os-release: "30"
-repos:
-  - fedora
-  - fedora-updates
-  - fedora-coreos-pool
 # Be minimal
 recommends: false
 

--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,10 +1,10 @@
-ref: fedora/${basearch}/coreos/testing
 include: fedora-coreos-base.yaml
 
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree
 
+# XXX: this is used by coreos-assembler for artifact naming...
 rojig:
   license: MIT
   name: fedora-coreos

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,1 +1,7 @@
-fedora-coreos.yaml
+ref: fedora/${basearch}/coreos/testing
+include: fedora-coreos.yaml
+
+repos:
+  - fedora
+  - fedora-updates
+  - fedora-coreos-pool


### PR DESCRIPTION
Make `manifest.yaml` be the "stream identity". I.e. this is the thing
that will *not* change from merges across branches. Crucially, it
includes the `ref` and the `repos`.