### PR TITLE
README.md: rework with more information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
-Base manifest configuration for Fedora CoreOS.
-
-This is the successor to https://pagure.io/fedora-atomic
+Base manifest configuration for
+[Fedora CoreOS](https://coreos.fedoraproject.org/).
 
 Use https://github.com/coreos/coreos-assembler to build it.
+
+Discussions in
+https://discussion.fedoraproject.org/c/server/coreos and
+https://github.com/coreos/fedora-coreos-tracker.
+
+## About this repo
+
+There is one branch for each stream. The default branch is
+[`testing-devel`](https://github.com/coreos/fedora-coreos-config/commits/testing-devel),
+on which all development happens. See
+[the design](https://github.com/coreos/fedora-coreos-tracker/blob/master/Design.md#release-streams)
+and [tooling](https://github.com/coreos/fedora-coreos-tracker/blob/master/stream-tooling.md)
+docs for more information about streams.


### PR DESCRIPTION
1. link to main Fedora CoreOS website
2. no longer reference fedora-atomic repo
3. link to discussions away from repo
4. add note about repo structure