### PR TITLE
manifest: set ref to bodhi-updates

### DIFF
--- a/fedora.repo
+++ b/fedora.repo
@@ -34,3 +34,28 @@ gpgcheck=1
 metadata_expire=6h
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
+
+[fedora-modular]
+name=Fedora Modular $releasever - $basearch
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Modular/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-updates-modular]
+name=Fedora Modular $releasever - $basearch - Updates
+failovermethod=priority
+#baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,8 @@
-ref: fedora/${basearch}/coreos/testing
+ref: fedora/${basearch}/coreos/bodhi-updates
 include: fedora-coreos.yaml
 
 repos:
   - fedora
   - fedora-updates
-  - fedora-coreos-pool
+  - fedora-modular
+  - fedora-updates-modular


### PR DESCRIPTION
This is the `bodhi-updates` stream. Right now, this is identical
otherwise to `testing-devel`, though in the future, the latter should
only be sourcing from `coreos-pool`, as opposed to the stable repos as
well.