### PR TITLE
overlay/systemd: add boot.mount unit

### DIFF
--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -9,3 +9,5 @@ enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
 # Service to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys@.service
+# mount /boot/efi
+enable boot-efi.mount

--- a/overlay/usr/lib/systemd/system/boot-efi.mount
+++ b/overlay/usr/lib/systemd/system/boot-efi.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=EFI System Partition
+Documentation=https://github.com/coreos/fedora-coreos-config
+ConditionPathExists=/boot/efi
+
+[Mount]
+What=/dev/disk/by-label/EFI-SYSTEM
+Where=/boot/efi
+
+[Install]
+RequiredBy=local-fs.target

--- a/overlay/usr/lib/systemd/system/boot.mount
+++ b/overlay/usr/lib/systemd/system/boot.mount
@@ -1,0 +1,9 @@
+[Unit]
+Description=Boot partition
+Documentation=https://github.com/coreos/fedora-coreos-config
+# This prevents the systemd-gpt-auto-generator from generating a mount unit for
+# /boot using the ESP.
+
+[Mount]
+What=/dev/disk/by-label/boot
+Where=/boot


### PR DESCRIPTION
Add boot.mount unit so the systemd gpt mount generator doesn't think the
efi system partition should be /boot.