### PR TITLE
DNM: overlay/systemd/boot-efi.mount: use efivars

### DIFF
--- a/overlay/usr/lib/systemd/system/boot-efi.mount
+++ b/overlay/usr/lib/systemd/system/boot-efi.mount
@@ -1,7 +1,7 @@
 [Unit]
 Description=EFI System Partition
 Documentation=https://github.com/coreos/fedora-coreos-config
-ConditionPathExists=/boot/efi
+ConditionPathExists=/sys/firmware/efi/efivars
 
 [Mount]
 What=/dev/disk/by-label/EFI-SYSTEM


### PR DESCRIPTION
Only mount /boot/efi if we're running on EFI

see discussion here:
https://github.com/coreos/fedora-coreos-config/pull/105#pullrequestreview-252017906

Marking DNM since we don't have consensus on it yet