### PR TITLE
base: add afterburn-dracut

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -130,6 +130,7 @@ packages:
   # System setup
   - ignition
   - afterburn
+  - afterburn-dracut
   - dracut-network
   - passwd
   # SSH


### PR DESCRIPTION
afterburn-dracut is now built with the afterburn-4.1.1-3 module.

---

Requires [this PR](https://pagure.io/dusty/coreos-koji-data/pull-request/5), and the tag into `coreos-pool` to be completed.