### PR TITLE
add Zincati package

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -174,3 +174,5 @@ packages:
   # i18n
   - kbd
   - whois-nls
+  # Updates
+  - zincati

--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -11,3 +11,5 @@ enable afterburn-firstboot-checkin.service
 enable afterburn-sshkeys@.service
 # mount /boot/efi
 enable boot-efi.mount
+# Update agent
+enable zincati.service


### PR DESCRIPTION
Request `zincati` in the manifest treefile.

Part of: https://github.com/coreos/fedora-coreos-tracker/issues/190

---

Requires tagging the `zincati` module into `coreos-pool` (PR https://pagure.io/dusty/coreos-koji-data/pull-request/6 for the tagger, or can manually tag it).

Not enabling the `zincati.service` unit for now, as currently the journal shows two errors (both errors are expected right now I believe - with `rpm-ostree-2019.4-3.fc30.x86_64` installed in the image):

```
Jul 03 15:11:52 localhost systemd[1]: Started Zincati Update Agent.
Jul 03 15:11:53 localhost zincati[784]: [INFO ] starting update agent (zincati 0.0.2)
Jul 03 15:11:53 localhost zincati[784]: [INFO ] agent running on node 'bbd92f9d8fd54731835e06ffed95bc54' in group 'default'
Jul 03 15:11:53 localhost zincati[784]: [ERROR] failed to check for updates: failed to query Cincinnati: https://updates.coreos.stg.fedoraproject.org/v1/graph?current_os=49891ccc3cn
Jul 03 15:16:54 coreos zincati[784]: [ERROR] failed to stage update: rpm-ostree upgrade failed:
Jul 03 15:16:54 coreos zincati[784]: error: Unknown option --lock-finalization
Jul 03 15:21:54 coreos zincati[784]: [ERROR] failed to stage update: rpm-ostree upgrade failed:
Jul 03 15:21:54 coreos zincati[784]: error: Unknown option --lock-finalization
...
```