### PR TITLE
manifest: inject stream name into commit metadata

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,3 +5,6 @@ repos:
   - fedora
   - fedora-updates
   - fedora-coreos-pool
+
+add-commit-metadata:
+  fedora-coreos.stream: testing


### PR DESCRIPTION
This is required for node introspection by client apps like Zincati.