### PR TITLE
fedora.repo: go back again to using dl.fp.o directly

### DIFF
--- a/fedora.repo
+++ b/fedora.repo
@@ -1,11 +1,12 @@
-# Note we use metalink= here to abstract over the base URLs being different
-# between primary and secondary architectures.
+# Note we use baseurl= here because using auto-selected mirrors conflicts with
+# change detection: https://github.com/coreos/fedora-coreos-pipeline/issues/85.
 
 [fedora]
 name=Fedora $releasever - $basearch
 failovermethod=priority
-#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/releases/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1
 #metadata_expire=7d
 repo_gpgcheck=0
@@ -17,8 +18,9 @@ skip_if_unavailable=False
 [fedora-updates]
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
-#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -30,8 +32,9 @@ skip_if_unavailable=False
 [fedora-updates-testing]
 name=Fedora $releasever - $basearch - Test Updates
 failovermethod=priority
-#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
 enabled=1
 gpgcheck=1
 metadata_expire=6h
@@ -40,8 +43,9 @@ skip_if_unavailable=False
 
 [fedora-modular]
 name=Fedora Modular $releasever - $basearch
-#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Modular/$basearch/os/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Modular/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/releases/$releasever/Modular/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch
 enabled=1
 #metadata_expire=7d
 repo_gpgcheck=0
@@ -53,8 +57,9 @@ skip_if_unavailable=False
 [fedora-updates-modular]
 name=Fedora Modular $releasever - $basearch - Updates
 failovermethod=priority
-#baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Modular/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm


### PR DESCRIPTION
This is take two on #109. What's different this time is that we just
include *both* the primary and secondary `dl.fp.o` baseurls. The stack
knows how to handle this and just tries one before going to the next.