### PR TITLE
fedora-coreos-base.yaml: nuke systemd-gpt-auto-generator

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -63,6 +63,10 @@ remove-from-packages:
               /usr/lib/systemd/system/systemd-resolved.service,
               /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
 
+  # We don't want auto-generated mount units. See also
+  # https://github.com/systemd/systemd/issues/13099
+  - [systemd-udev, /usr/lib/systemd/system-generators/systemd-gpt-auto-generator]
+
   # The grub bits are mainly designed for desktops, and IMO haven't seen
   # enough testing in concert with ostree. At some point we'll flesh out
   # the full plan in https://github.com/coreos/fedora-coreos-tracker/issues/47

--- a/overlay/usr/lib/systemd/system/boot.mount
+++ b/overlay/usr/lib/systemd/system/boot.mount
@@ -1,8 +1,6 @@
 [Unit]
 Description=Boot partition
 Documentation=https://github.com/coreos/fedora-coreos-config
-# This prevents the systemd-gpt-auto-generator from generating a mount unit for
-# /boot using the ESP.
 
 [Mount]
 What=/dev/disk/by-label/boot


### PR DESCRIPTION
Otherwise, `systemd-gpt-auto-generator`'s generated `boot.automount`
will cause a funky mount structure:

```
├─/boot           systemd-1    autofs
│ └─/boot         /dev/vda1    ext4
│   └─/boot/efi   /dev/vda2    vfat
```

The nature of `autofs` then causes issues for us around shutdown
ordering. See also the linked systemd issue.

Really, we don't need the GPT generator at all for now, so just nuke it
from the tree.

Closes: coreos/fedora-coreos-tracker#215