### PR TITLE
Add coreos-update-ca-trust.service

### DIFF
--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -2,6 +2,8 @@
 enable coreos-growpart.service
 enable console-login-helper-messages-issuegen.service
 enable console-login-helper-messages-motdgen.service
+# CA certs (probably to add to base fedora eventually)
+enable coreos-update-ca-trust.service
 # This one is from https://github.com/coreos/ignition-dracut
 enable ignition-firstboot-complete.service
 # Boot checkin services for cloud providers.

--- a/overlay/usr/lib/systemd/system/coreos-update-ca-trust.service
+++ b/overlay/usr/lib/systemd/system/coreos-update-ca-trust.service
@@ -1,0 +1,21 @@
+# This service is currently specific to Fedora CoreOS,
+# but we may want to add it to the base OS in the future.
+# The idea here is to allow users to just drop in CA roots
+# via Ignition without having to know to run the special
+# update command.
+[Unit]
+Description=Run update-ca-trust
+ConditionFirstBoot=true
+ConditionDirectoryNotEmpty=/etc/pki/ca-trust/source/anchors/
+# We want to run quite early, in particular before anything
+# that may speak TLS to external services.  In the future,
+# it may make sense to do this in the initramfs too.
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/bin/update-ca-trust extract
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This blends well with Ignition, allowing people to just drop
in certs without having to worry about injecting their own
systemd service to update them.

We also want this for RHCOS.
See: https://github.com/openshift/machine-config-operator/issues/528
For FCOS, in theory this could be a "run at most once" service.
But for RHCOS, since we support dynamic changes, we need it to
run on each boot too.  The cost of doing so is very small.