### PR TITLE
Add udev rule to ignore Azure SR-IOV interface

### DIFF
--- a/overlay/usr/lib/udev/rules.d/68-azure-sriov-nm-unmanaged.rules
+++ b/overlay/usr/lib/udev/rules.d/68-azure-sriov-nm-unmanaged.rules
@@ -1,0 +1,4 @@
+# Accelerated Networking on Azure exposes a new SRIOV interface to the VM.
+# This interface is transparently bonded to the synthetic interface,
+# so NetworkManager should just ignore any SRIOV interfaces.
+SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", ENV{NM_UNMANAGED}="1"


### PR DESCRIPTION
Pulled from a downstream RHCOS change originally authored
by Jerry Zhang.  I would like RHCOS to directly inherit
from FCOS's config, and having this upstream helps that.

Slightly tweaked original commit message follows:

Add udev rule to mark the SR-IOV interface on Azure to be unmanaged;
otherwise it will bond to the synthetic interface by default which
causes networking issues.