### PR TITLE
Also systemctl --user preset-all

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -127,6 +127,8 @@ postprocess:
     set -xeuo pipefail
     rm -rf /etc/systemd/system/*
     systemctl preset-all
+    rm -rf /etc/systemd/user/*
+    systemctl --user --global preset-all
   # Disable Zincati and fedora-coreos-pinger on non-release builds
   # https://github.com/coreos/fedora-coreos-tracker/issues/212
   - |


### PR DESCRIPTION
Not doing so means that we miss enabling `dbus.service` for the user
session, which breaks GDM for Silverblue, among other things.  And
`systemctl --user` is also generally useful even on CoreOS systems.