### PR TITLE
add fedora-coreos-pinger package

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -192,3 +192,5 @@ packages:
   - whois-nls
   # Updates
   - zincati
+  # User metrics
+  - fedora-coreos-pinger

--- a/overlay/usr/lib/systemd/system-preset/42-coreos.preset
+++ b/overlay/usr/lib/systemd/system-preset/42-coreos.preset
@@ -13,3 +13,5 @@ enable afterburn-sshkeys@.service
 enable boot-efi.mount
 # Update agent
 enable zincati.service
+# User metrics client
+enable fedora-coreos-pinger.service


### PR DESCRIPTION
Add the fedora-coreos-pinger package to the base manifest, and
enable fedora-coreos-pinger.service in the overlay presets.

---

Tested this when composing a FCOS image with `cosa build`. Running in the dev image with `cosa run`, reporting is logged as disabled as expected. Dropping in a file to enable the reporting reports that the metrics are enabled at minimal level as desired.

This changed can be merged into `testing-devel` once either:

- the build is tagged manually by doing: `koji tag-build f30-coreos-signing-pending rust-fedora-coreos-pinger-0.0.4-1.module_f30+5099+4493ad29`

**or**:
- the following PRs are merged and the `coreos-koji-tagger` tags in `fedora-coreos-pinger` to `coreos-pool`
  - https://github.com/coreos/fedora-coreos-releng-automation/pull/14
  - https://pagure.io/dusty/coreos-koji-data/pull-request/8

This change can be synced to `bodhi-updates`, once the update has been pushed to stable:
- https://bodhi.fedoraproject.org/updates/FEDORA-MODULAR-2019-c06d324b82

Closes: https://github.com/coreos/fedora-coreos-pinger/issues/3