### PR TITLE
manifest: Add systemd-container (nspawn)

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -154,7 +154,7 @@ packages:
   # SSH
   - openssh-server openssh-clients
   # Containers
-  - podman skopeo runc moby-engine
+  - podman skopeo runc moby-engine systemd-container
   - fuse-overlayfs slirp4netns
   # Networking
   - bridge-utils nfs-utils-coreos


### PR DESCRIPTION
Consensus was this should join our suite of container engines.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/230