### PR TITLE
manifest: Drop bridge-utils

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -157,7 +157,7 @@ packages:
   - podman skopeo runc moby-engine
   - fuse-overlayfs slirp4netns
   # Networking
-  - bridge-utils nfs-utils-coreos
+  - nfs-utils-coreos
   - NetworkManager hostname
   - iproute-tc
   - adcli


### PR DESCRIPTION
We cargo culted this from Atomic Host:
https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2017-January/msg00023.html

See also https://lwn.net/Articles/703776/

Closes: https://github.com/coreos/fedora-coreos-config/issues/86