### PR TITLE
manifest: drop more networkd units

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -52,19 +52,19 @@ default-target: multi-user.target
 
 remove-from-packages:
   # We're not using resolved yet.
+  - [systemd, /usr/lib/systemd/systemd-resolved,
+              /usr/lib/systemd/system/systemd-resolved.service]
   # We're not using networkd.
-  # We don't want systemd-firstboot.service. It conceptually conflicts with
-  # Ignition.
   - [systemd, /etc/systemd/networkd.conf,
-              /usr/bin/systemd-firstboot,
               /usr/lib/systemd/systemd-networkd,
               /usr/lib/systemd/systemd-networkd-wait-online,
-              /usr/lib/systemd/systemd-resolved,
-              /usr/lib/systemd/system/systemd-firstboot.service,
               /usr/lib/systemd/system/systemd-networkd.service,
               /usr/lib/systemd/system/systemd-networkd.socket,
-              /usr/lib/systemd/system/systemd-networkd-wait-online.service,
-              /usr/lib/systemd/system/systemd-resolved.service,
+              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
+  # We don't want systemd-firstboot.service. It conceptually conflicts with
+  # Ignition.
+  - [systemd, /usr/bin/systemd-firstboot,
+              /usr/lib/systemd/system/systemd-firstboot.service,
               /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
 
   # We don't want auto-generated mount units. See also

--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -58,9 +58,12 @@ remove-from-packages:
   - [systemd, /etc/systemd/networkd.conf,
               /usr/lib/systemd/systemd-networkd,
               /usr/lib/systemd/systemd-networkd-wait-online,
+              /usr/lib/systemd/network/.*,
               /usr/lib/systemd/system/systemd-networkd.service,
               /usr/lib/systemd/system/systemd-networkd.socket,
               /usr/lib/systemd/system/systemd-networkd-wait-online.service]
+  - [systemd-container, /usr/lib/systemd/network/.*]
+  - [systemd-udev, /usr/lib/systemd/network/.*]
   # We don't want systemd-firstboot.service. It conceptually conflicts with
   # Ignition.
   - [systemd, /usr/bin/systemd-firstboot,


### PR DESCRIPTION
Remove all networkd unit files that come from systemd. It'd be easier to
just use a postprocess script here to `rm -rf` everything, though being
able to keep track of which packages bring them in like this is nice.