### PR TITLE
 overlay/05core: Remove /etc/profile.d/path.sh

### DIFF
--- a/overlay.d/05core/etc/profile.d/path.sh
+++ b/overlay.d/05core/etc/profile.d/path.sh
@@ -1,8 +1,0 @@
-# install default PATH file to expand non-login shells PATH for kola
-# https://github.com/openshift/os/issues/191
-pathmunge /bin
-pathmunge /sbin
-pathmunge /usr/bin
-pathmunge /usr/sbin
-pathmunge /usr/local/bin
-pathmunge /usr/local/sbin


### PR DESCRIPTION

Trying to rebase RHCOS on this config, I hit upon a conflict
because long ago (before `overlay/` existed) we stuck this
in the `redhat-release-coreos` package.

One thing I wanted to verify is; is this really necessary for
FCOS today?  And the answer is: no.  The original rationale
from openshift/os#191 mentioned the
kola SELinux tests, but `cosa kola` passes just fine with this
as is.