### PR TITLE
overlay.d: Split up preset file

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -15,5 +15,3 @@ enable afterburn-sshkeys@.service
 enable boot-efi.mount
 # Update agent
 enable zincati.service
-# User metrics client
-enable fedora-coreos-pinger.service

--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -1,0 +1,2 @@
+# User metrics client
+enable fedora-coreos-pinger.service

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -1,0 +1,14 @@
+05core
+-----
+
+This overlay matches `fedora-coreos-base.yaml`; core Ignition+ostree bits.
+
+15fcos
+------
+
+Things that are more closely "Fedora CoreOS"; branding, services.
+
+80experimental
+--------------
+
+Very FCOS specific, adds an experimental notice to the MOTD.


### PR DESCRIPTION
RHCOS also has the name `42-coreos.preset` in a different place.
Trying to avoid having them conflict, let's both work around
the conflict and make things clearer by renaming/splitting the
preset files.

The FCOS-specific bit goes into `15fcos`.