### PR TITLE
overlay.d/05core: Fix boot-efi.mount unit dependency

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/boot-efi.mount
+++ b/overlay.d/05core/usr/lib/systemd/system/boot-efi.mount
@@ -1,11 +1,11 @@
 [Unit]
 Description=EFI System Partition
 Documentation=https://github.com/coreos/fedora-coreos-config
-ConditionPathExists=/boot/efi
+ConditionPathExists=/sys/firmware/efi/
 
 [Mount]
 What=/dev/disk/by-label/EFI-SYSTEM
 Where=/boot/efi
 
 [Install]
-RequiredBy=local-fs.target
+WantedBy=local-fs.target


### PR DESCRIPTION
Fix #115