### PR TITLE
overlay: re-enable 40coreos-network

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40coreos-network/module-setup.sh
@@ -11,4 +11,6 @@ install() {
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
     inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
         "/usr/sbin/coreos-teardown-initramfs-network"
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
+    ln_r "../$unit" "$systemdsystemunitdir/ignition-complete.target.requires/$unit"
 }


### PR DESCRIPTION
Reanble 40coreos-network to run after ignition. When this service
was ported, it was no longer linked to ignition-complete.

(Was there a reason we disabled this? If so maybe we should remove
the service entirely. I will re-test behaviour on some platforms first)