### PR TITLE
minimal.yaml: tweak GRUB2 EFI package name for aarch64

### DIFF
--- a/minimal.yaml
+++ b/minimal.yaml
@@ -12,7 +12,7 @@ packages:
 
 # bootloader
 packages-aarch64:
-  - grub2-efi ostree-grub2 efibootmgr shim
+  - grub2-efi-aa64 ostree-grub2 efibootmgr shim
 packages-armhfp:
   - extlinux-bootloader
 packages-ppc64le:


### PR DESCRIPTION
So that we match https://github.com/coreos/coreos-assembler/pull/710.

See also:
https://github.com/coreos/coreos-assembler/issues/660#issuecomment-520768829