### PR TITLE
manifest: add jq package

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -175,3 +175,5 @@ packages:
   - zincati
   # User metrics
   - fedora-coreos-pinger
+  # Parsing/Interacting with JSON data
+  - jq


### PR DESCRIPTION
It's useful for parsing/interacting with JSON
data.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/254