### PR TITLE
s390x: add zipl parameter

### DIFF
--- a/installer/zipl.prm
+++ b/installer/zipl.prm
@@ -1,0 +1,1 @@
+rd.neednet=1 coreos.inst=yes


### PR DESCRIPTION
This will be read by s390x zipl bootloader during
cosa buildextend-installer