### PR TITLE
manifest: drop all repos except fedora-coreos-pool

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,8 +2,6 @@ ref: fedora/${basearch}/coreos/testing-devel
 include: fedora-coreos.yaml
 
 repos:
-  - fedora
-  - fedora-updates
   - fedora-coreos-pool
 
 add-commit-metadata:


### PR DESCRIPTION
All our packages should now come from the coreos-pool repo.