### PR TITLE
README.md: add instructions on adding new packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ following exceptions:
   imported from `bodhi-updates` to `testing-devel`.
   Overrides (`manifest-lock.overrides.*`) are manually
   curated.
+
+## Adding packages to the OS
+
+Since `testing-devel` is directly promoted to `testing`, it
+must always be in a known state. The way we enforce this is
+by requiring all packages to have a corresponding entry in
+the lockfile.
+
+Therefore, to add new packages to the OS, one must also add
+the corresponding entries in the lockfiles:
+- for packages which should follow Bodhi updates, place them
+  in `manifest-lock.$basearch.json`
+- for packages which should remain pinned, place them
+  in `manifest-lock.overrides.$basearch.json`
+
+There will be better tooling to come to enable this, though
+one easy way to do this is for now:
+- add packages to the correct YAML manifest
+- run `cosa fetch --update-lockfile`
+- commit only the new package entries

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -532,6 +532,10 @@
       "evra": "2.12-2.fc30.x86_64",
       "digest": "sha256:f4270a5ace04775e27156a29424c98ddbf7d3f76ecef4d865fbc0c8634a67b56"
     },
+    "jq": {
+      "evra": "1.6-2.fc30.x86_64",
+      "digest": "sha256:39e04188f8a6a4957d6501e6d61e21a7262822820c6ef428de371d8dd6741b54"
+    },
     "json-c": {
       "evra": "0.13.1-4.fc30.x86_64",
       "digest": "sha256:3c182282d05793662145ccd8c2178966707b90619f842fcc1b89fb3f32e55ae1"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,6 +3,13 @@ include: fedora-coreos.yaml
 
 repos:
   - fedora-coreos-pool
+  # these repos are there to make it easier to add new packages to the OS and to
+  # use `cosa fetch --update-lockfile`; but note that all package versions are
+  # still pinned
+  - fedora
+  - fedora-updates
+  - fedora-modular
+  - fedora-updates-modular
 
 add-commit-metadata:
   fedora-coreos.stream: testing-devel


### PR DESCRIPTION
Now that we've completely switched over to lockfiles, we need to
describe the procedure for adding new packages to the OS.

Also add back the Bodhi repos to make the task easier. Otherwise, we'd
get a bootstrapping problem: we can't add packages not tagged in
coreos-pool, but the tagger won't tag a package that's not added.

But also, we really want those repos there by default so that the local
dev case of pulling in all new packages can just be
`cosa fetch --update-lockfile`.

---

The fundamental issue here is that right now we're relying on `bodhi-updates` to sync up our lockfile with our manifests. But this means that adding a package without a corresponding lockfile entry will instantly break `testing-devel` until the next `bodhi-updates` sync. This is what happened right now with `jq`: because `bodhi-updates` is currently failing (due to https://github.com/coreos/fedora-coreos-releng-automation/pull/35), the lockfile in `testing-devel` doesn't yet have `jq`. If we want to remain decoupled from `bodhi-updates` builds, we need to enforce lockfiles at the stage where package get added.
