### PR TITLE
overlay.d: Add 08nouveau to blacklist the nouveau driver

### DIFF
--- a/overlay.d/08nouveau/etc/modprobe.d/blacklist-nouveau.conf
+++ b/overlay.d/08nouveau/etc/modprobe.d/blacklist-nouveau.conf
@@ -1,0 +1,2 @@
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1700056
+blacklist nouveau

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -3,6 +3,15 @@
 
 This overlay matches `fedora-coreos-base.yaml`; core Ignition+ostree bits.
 
+08nouveau
+---------
+
+Blacklist the nouveau driver because it causes issues with some NVidia GPUs in EC2,
+and we don't have a use case for FCOS with nouveau.
+
+"Cannot boot an p3.2xlarge instance with RHCOS (g3.4xlarge is working)"
+https://bugzilla.redhat.com/show_bug.cgi?id=1700056
+
 10coreuser
 ---------
 


### PR DESCRIPTION
Pulled from RHCOS, following the upstreaming principle.  The
nouveau driver apparently has bugs with some NVidia hardware in EC2.
Since (unlike a Fedora desktop system) having a GPU enabled isn't
critical path, blacklist the driver.  Anyone who wants to enable
nouveau can do so of course, or they can install the proprietary
driver.