### PR TITLE
overlay: add Azure udev rules

### DIFF
--- a/overlay.d/05core/usr/lib/udev/rules.d/66-azure-storage.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/66-azure-storage.rules
@@ -1,0 +1,28 @@
+ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk"
+GOTO="azure_end"
+
+LABEL="azure_disk"
+# Root has a GUID of 0000 as the second value
+# The resource/resource has GUID of 0001 as the second value
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
+ATTRS{device_id}=="?00000001-0001-*", ENV{fabric_name}="BEK", GOTO="azure_names"
+# Wellknown SCSI controllers
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi3", GOTO="azure_datadisk"
+GOTO="azure_end"
+
+# Retrieve LUN number for datadisks
+LABEL="azure_datadisk"
+ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+GOTO="azure_end"
+
+# Create the symlinks
+LABEL="azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+
+LABEL="azure_end"

--- a/overlay.d/05core/usr/lib/udev/rules.d/99-azure-product-uuid.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/99-azure-product-uuid.rules
@@ -1,0 +1,9 @@
+SUBSYSTEM!="dmi", GOTO="product_uuid-exit"
+ATTR{sys_vendor}!="Microsoft Corporation", GOTO="product_uuid-exit"
+ATTR{product_name}!="Virtual Machine", GOTO="product_uuid-exit"
+TEST!="/sys/devices/virtual/dmi/id/product_uuid", GOTO="product_uuid-exit"
+
+RUN+="/bin/chmod 0444 /sys/devices/virtual/dmi/id/product_uuid"
+
+LABEL="product_uuid-exit"
+


### PR DESCRIPTION
The downstream RHBZ#1747575[0] requests the addition of these udev
rules to allow nodes in Azure to handle the dynamic provisioning of
storage devices.  The WALinuxAgent repo[1] provides the two udev rules
required for this functionality, which haven't changed in a year or more.
This commit is just a copy of the rules from the repo.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1747575
[1] https://github.com/Azure/WALinuxAgent/tree/master/config/