### PR TITLE
manifest: Move grub2-removals.yaml include into minimal.yaml

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -4,10 +4,6 @@
 # https://github.com/coreos/coreos-assembler/pull/639
 
 include: minimal.yaml
-arch-include:
-  x86_64: grub2-removals.yaml
-  aarch64: grub2-removals.yaml
-  ppc64le: grub2-removals.yaml
 
 # Modern defaults we want
 boot-location: new

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -22,3 +22,8 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 ostree-grub2 efibootmgr shim
   - microcode_ctl
+# And remove some cruft from grub2
+arch-include:
+  x86_64: grub2-removals.yaml
+  aarch64: grub2-removals.yaml
+  ppc64le: grub2-removals.yaml


### PR DESCRIPTION
Came up in code review; it's cleaner to have the bootloader-related
stuff together.