### PR TITLE
ci: use Jenkins checkout instead of recloning

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/jlebon/coreos-ci-lib@master') _
+@Library('github.com/coreos/coreos-ci-lib@master') _
 
 coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true]) {
     stage("Build") {

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,21 +2,21 @@
 
 coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true]) {
     stage("Build") {
-        def commitHash = checkout(scm).GIT_COMMIT
-        coreos.shwrap("""
-            mkdir -p cosa && cd cosa
-            # XXX: need to fix cosa handling of relative dirs in unprivileged path
-            cosa init https://github.com/coreos/fedora-coreos-config
-            git -C src/config fetch origin ${commitHash}
-            git -C src/config checkout FETCH_HEAD
-            cosa build
-        """)
+        dir("fedora-coreos-config") {
+            checkout scm
+        }
+        dir("cosa") {
+            coreos.shwrap("""
+                cosa init ${env.WORKSPACE}/fedora-coreos-config
+                cosa build
+            """)
+        }
     }
     stage("Kola") {
-        checkout scm
-        coreos.shwrap("""
-            cd cosa
-            cosa kola run
-        """)
+        dir("cosa") {
+            coreos.shwrap("""
+                cosa kola run
+            """)
+        }
     }
 }


### PR DESCRIPTION
Just do the checkout in a subdirectory in the the workspace, then point
`cosa` at it. That way we don't clone the repo twice.

This should fix CI errors when PRs are not fully rebased.