### PR TITLE
manifest: override rojig.summary for testing-devel

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,11 @@
 ref: fedora/${basearch}/coreos/testing-devel
 include: fedora-coreos.yaml
 
+rojig:
+  license: MIT
+  name: fedora-coreos
+  summary: Fedora CoreOS testing-devel
+
 repos:
   - fedora-coreos-pool
   # these repos are there to make it easier to add new packages to the OS and to


### PR DESCRIPTION
We're currently releasing AMIs with a description field of the form `Fedora CoreOS base image <version>`.  Let's include the stream name in the rojig summary for each stream.

Copy over the license and name fields because that appears to be required.

I'll PR the other branches once this lands.