### PR TITLE
manifest: Explicitly pull in kernel-core, not kernel-debug-core

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -565,16 +565,16 @@
       "digest": "sha256:5e08d7f13d4ded6e96e152d2b8b803f24edcc73a480815008b712161d35dfe5a"
     },
     "kernel": {
-      "evra": "5.2.13-200.fc30.x86_64",
-      "digest": "sha256:d365e5667df0328378a7dd96df02d3d477da0b1f1edca713a2ff3df0b0de79c6"
+      "evra": "5.2.14-200.fc30.x86_64",
+      "digest": "sha256:8c5a6f64e04ebd6f81d20384caceb106204cb4bf0612b61e7d3c617a79ec553d"
     },
     "kernel-core": {
-      "evra": "5.2.13-200.fc30.x86_64",
-      "digest": "sha256:7a9eb687dea6786380cdc0000cbe5a8f53bfe5df286123542d577a7364ab47f0"
+      "evra": "5.2.14-200.fc30.x86_64",
+      "digest": "sha256:b2131132581909eb13f3eb645cc0657793758ae64a28ce4d280f7b762c9d7114"
     },
     "kernel-modules": {
-      "evra": "5.2.13-200.fc30.x86_64",
-      "digest": "sha256:b0408e959e055afb896c881239deec443d4b2dc4719fcbe22bbc17e11a08e423"
+      "evra": "5.2.14-200.fc30.x86_64",
+      "digest": "sha256:a2be00013555b6d43a8db685af343286055d80edfa67d4eba4cd390040fab330"
     },
     "keyutils-libs": {
       "evra": "1.6-2.fc30.x86_64",

--- a/minimal.yaml
+++ b/minimal.yaml
@@ -5,8 +5,9 @@
 # We expect most people though using coreos-assembler to inherit from
 # fedora-coreos-base.yaml.
 packages:
- # Kernel + systemd
- - kernel systemd
+ # Kernel + systemd.  Note we explicitly specify kernel-{core,modules}
+ # because otherwise depsolving could bring in kernel-debug.
+ - kernel kernel-core kernel-modules systemd
  # rpm-ostree
  - rpm-ostree nss-altfiles
 


### PR DESCRIPTION
We were just adding `kernel` which is a metapackage.  Recently
it looks like the kernel package grew a separate `kernel-debug-core`
(I'm guessing to make it easy to switch between the two)

We need to explicitly pull in `kernel-core` and `kernel-modules`
to ensure the depsolver doesn't pull in the debug kernel.