### PR TITLE
manifest: Use boot-location: modules

### DIFF
--- a/ignition-and-ostree.yaml
+++ b/ignition-and-ostree.yaml
@@ -9,7 +9,7 @@
 include: bootable-rpm-ostree.yaml
 
 # Modern defaults we want
-boot-location: new
+boot-location: modules
 tmp-is-dir: true
 
 # Required by Ignition, and makes the system not compatible with Anaconda


### PR DESCRIPTION
This is the new default; we end up with the kernel data in
only once place.  See the treefile docs as well as
https://github.com/ostreedev/ostree/pull/1079
and discussion in
https://github.com/ostreedev/ostree/pull/1873