### PR TITLE
manifest: Move versioning and fedora-coreos-pinger to toplevel

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -18,10 +18,6 @@ initramfs-args:
   - --omit=multipath
   - --omit=iscsi
 
-releasever: "30"
-automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
-mutate-os-release: "${releasever}"
-
 # Be minimal
 recommends: false
 
@@ -141,8 +137,6 @@ packages:
   - whois-nls
   # Updates
   - zincati
-  # User metrics
-  - fedora-coreos-pinger
   # Parsing/Interacting with JSON data
   - jq
 

--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -1,8 +1,18 @@
+# This manifest file defines things that should really only go
+# into "official" builds of Fedora CoreOS (such as including `fedora-release-coreos`)
+# or are very "opinionated" like disabling SSH passwords by default.
+
 include: fedora-coreos-base.yaml
+
+releasever: "30"
+automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
+mutate-os-release: "${releasever}"
 
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree
+  # User metrics
+  - fedora-coreos-pinger
 
 # XXX: this is used by coreos-assembler for artifact naming...
 rojig:


### PR DESCRIPTION
The version numbering is more clearly `fedora-coreos` level.
Similarly, I think we only want `fedora-coreos-pinger` for
things that are actually FCOS.