### PR TITLE
manifest: override rojig.summary for bodhi-updates

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,11 @@
 ref: fedora/${basearch}/coreos/bodhi-updates
 include: fedora-coreos.yaml
 
+rojig:
+  license: MIT
+  name: fedora-coreos
+  summary: Fedora CoreOS bodhi-updates
+
 repos:
   - fedora
   - fedora-updates


### PR DESCRIPTION
We're currently releasing AMIs with a description field of the form `Fedora CoreOS base image <version>`.  Let's include the stream name in the rojig summary for each stream.

Copy over the license and name fields because that appears to be required.