### PR TITLE
fedora-coreos-base:  add cifs-utils

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -112,6 +112,7 @@ packages:
   - device-mapper-multipath
   - xfsprogs e2fsprogs mdadm
   - cryptsetup
+  - cifs-utils
   # Time sync
   - chrony timedatex
   # Extra runtime

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -112,6 +112,10 @@
       "evra": "3.5-1.fc30.x86_64",
       "digest": "sha256:dc96069efc1430d879776bfa8f8fa1cbfc61d604d8b86fad9f0be66d4e30044e"
     },
+    "cifs-utils": {
+      "evra": "6.9-1.fc30.x86_64",
+      "digest": "sha256:0f01346700be362afe051b2c0dbd74d707f692b1a17286d1c0e948e10c0a6cea"
+    },
     "cloud-utils-growpart": {
       "evra": "0.31-2.fc30.noarch",
       "digest": "sha256:bf653bf6dfc1e9055086f9e43f32cc607724c75a40cd516bff86c27cb7261047"
@@ -575,6 +579,10 @@
     "kernel-modules": {
       "evra": "5.2.14-200.fc30.x86_64",
       "digest": "sha256:a2be00013555b6d43a8db685af343286055d80edfa67d4eba4cd390040fab330"
+    },
+    "keyutils": {
+      "evra": "1.6-2.fc30.x86_64",
+      "digest": "sha256:cd65636e28d5280f005d2d226af35d8e459823c1cd19968d24facc8104b75d55"
     },
     "keyutils-libs": {
       "evra": "1.6-2.fc30.x86_64",


### PR DESCRIPTION
In the downstream BZ#1752395[0], it is reported that users are unable
to mount Azure files in OCP 4.2.  This was a feature of OCP 3.11[1] and
we wish to maintain feature parity in OCP 4.2 on Azure as much as
possible.

This commit adds the `cifs-utils` package, in order to pull in the
`mount.cifs` binary to allow for the mounting of Azure files.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1752395
[1] https://docs.openshift.com/container-platform/3.11/architecture/additional_concepts/storage.html