### PR TITLE
Drop ostree-grub2

### DIFF
--- a/bootable-rpm-ostree.yaml
+++ b/bootable-rpm-ostree.yaml
@@ -13,15 +13,15 @@ packages:
 
 # bootloader
 packages-aarch64:
-  - grub2-efi-aa64 ostree-grub2 efibootmgr shim
+  - grub2-efi-aa64 efibootmgr shim
 packages-armhfp:
   - extlinux-bootloader
 packages-ppc64le:
-  - grub2 ostree-grub2
+  - grub2
 packages-s390x:
   - s390utils-base
 packages-x86_64:
-  - grub2 grub2-efi-x64 ostree-grub2 efibootmgr shim
+  - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
 # And remove some cruft from grub2
 arch-include:


### PR DESCRIPTION
Since we switched to having the BLS be canonical and use the
`ostree.bootloader=none` config, we don't need the `15_ostree`
stuff.

Drop the `ostree-grub2` package and that cruft, finally achieving
what the intention was from the start in having that be a separate
subpackage that was intended as a short term hack.