### PR TITLE
Partially revert "Drop ostree-grub2" for ppc64le

### DIFF
--- a/bootable-rpm-ostree.yaml
+++ b/bootable-rpm-ostree.yaml
@@ -17,7 +17,7 @@ packages-aarch64:
 packages-armhfp:
   - extlinux-bootloader
 packages-ppc64le:
-  - grub2
+  - grub2 ostree-grub2
 packages-s390x:
   - s390utils-base
 packages-x86_64:


### PR DESCRIPTION
This partially reverts commit fb1e4b07ee7178cd6f4f4eb84b0bf6795c5493b2
for ppc64le only since we still use Anaconda + `grub2-mkconfig` there.

See: https://github.com/coreos/fedora-coreos-config/pull/173