### PR TITLE
manifest: Move moby-engine and zincati to fedora-coreos.yaml

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -30,11 +30,7 @@ etc-group-members:
   - sudo
   - systemd-journal
   - adm
-  # Add the docker group to /etc/group
-  # https://github.com/coreos/fedora-coreos-tracker/issues/2
-  # This will be no longer needed when systemd-sysusers has been implemented:
-  # https://github.com/projectatomic/rpm-ostree/issues/49
-  - docker
+
 check-passwd:
   type: "file"
   filename: "passwd"
@@ -107,7 +103,7 @@ packages:
   # SSH
   - openssh-server openssh-clients
   # Containers
-  - podman skopeo runc moby-engine systemd-container
+  - podman skopeo runc systemd-container
   - fuse-overlayfs slirp4netns
   # Remote IPC for podman
   - libvarlink-util
@@ -148,8 +144,6 @@ packages:
   # i18n
   - kbd
   - whois-nls
-  # Updates
-  - zincati
   # Parsing/Interacting with JSON data
   - jq
 

--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -11,8 +11,19 @@ mutate-os-release: "${releasever}"
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree
+  # CL ships this.
+  - moby-engine
   # User metrics
   - fedora-coreos-pinger
+  # Updates
+  - zincati
+
+etc-group-members:
+  # Add the docker group to /etc/group
+  # https://github.com/coreos/fedora-coreos-tracker/issues/2
+  # This will be no longer needed when systemd-sysusers has been implemented:
+  # https://github.com/projectatomic/rpm-ostree/issues/49
+  - docker
 
 # XXX: this is used by coreos-assembler for artifact naming...
 rojig:


### PR DESCRIPTION
These two aren't used by RHCOS; move them to the toplevel.
Currently RHCOS inherits from `ignition-and-ostree.yaml`; this
is part of an effort to have RHCOS use something closer to
`fedora-coreos-base.yaml`.