### PR TITLE
manifest:  enable SELinux booleans

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -89,10 +89,12 @@ postprocess:
     echo -e '\n# Read authorized_keys fragments written by Ignition and Afterburn\nAuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn' >> /etc/ssh/sshd_config
 
   # Enable SELinux booleans used by OpenShift
+  # https://github.com/coreos/fedora-coreos-tracker/issues/284
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
     setsebool -P -N container_use_cephfs on  # RHBZ#1692369
+    setsebool -P -N virt_use_samba on  # RHBZ#1754825
 
 packages:
   # Security

--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -88,6 +88,11 @@ postprocess:
     sed -i 's/^AuthorizedKeysFile[[:blank:]]/#&/' /etc/ssh/sshd_config
     echo -e '\n# Read authorized_keys fragments written by Ignition and Afterburn\nAuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn' >> /etc/ssh/sshd_config
 
+  # Enable SELinux booleans used by OpenShift
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    setsebool -P -N container_use_cephfs on  # RHBZ#1692369
 
 packages:
   # Security


### PR DESCRIPTION
These two commits enable the following SELinux booleans that are needed for OpenShift operation:

  - `container_use_cephfs`
  - `virt_use_samba`

The first boolean in the list is a backport of something that is currently enabled in RHCOS.  It allows for Ceph volumes to be mounted into containers.

The second boolean in the list is a new request via [RHBZ#1754825](https://bugzilla.redhat.com/show_bug.cgi?id=1754825) that would enable privileged containers to mount in Azure files.