### PR TITLE
Prep patches for setting up branched/next-devel/next

### DIFF
--- a/fedora-coreos.yaml
+++ b/fedora-coreos.yaml
@@ -4,7 +4,6 @@
 
 include: fedora-coreos-base.yaml
 
-releasever: "30"
 automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
 mutate-os-release: "${releasever}"
 

--- a/fedora-next.repo
+++ b/fedora-next.repo
@@ -1,0 +1,81 @@
+# Note we use baseurl= here because using auto-selected mirrors conflicts with
+# change detection: https://github.com/coreos/fedora-coreos-pipeline/issues/85.
+
+[fedora-next]
+name=Fedora $releasever - $basearch
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/development/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+
+[fedora-next-updates]
+name=Fedora $releasever - $basearch - Updates
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+
+[fedora-next-updates-testing]
+name=Fedora $releasever - $basearch - Test Updates
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+enabled=1
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+
+[fedora-next-modular]
+name=Fedora Modular $releasever - $basearch
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/Modular/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/development/$releasever/Modular/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-next-updates-modular]
+name=Fedora Modular $releasever - $basearch - Updates
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Modular/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-next-updates-testing-modular]
+name=Fedora Modular $releasever - $basearch - Test Updates
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Modular/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Modular/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+enabled=1
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False

--- a/fedora.repo
+++ b/fedora.repo
@@ -67,3 +67,15 @@ gpgcheck=1
 metadata_expire=6h
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 skip_if_unavailable=False
+
+[fedora-updates-testing-modular]
+name=Fedora Modular $releasever - $basearch - Test Updates
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Modular/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Modular/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+enabled=1
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,8 @@
 ref: fedora/${basearch}/coreos/testing-devel
 include: fedora-coreos.yaml
 
+releasever: "30"
+
 rojig:
   license: MIT
   name: fedora-coreos


### PR DESCRIPTION
Move the `releasever` key to `manifest.yaml`, and add branched development yum repo definitions.