### PR TITLE
Add general ignition-ostree module with rootfs replacement

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+rootdisk=/dev/disk/by-label/root
+rootmnt=/sysroot
+tmproot=/run/ignition-ostree-rootfs
+saved_rootmnt=${tmproot}/orig-sysroot
+memdev=/dev/ram0
+
+case "${1:-}" in
+    detect)
+        # This is obviously crude; perhaps in the future we could change ignition's `fetch`
+        # stage to write out a file if the rootfs is being replaced or so.  But eh, it
+        # works for now.
+        has_rootfs=$(jq '.storage?.filesystems? // [] | map(select(.label == "root")) | length' < /run/ignition.json)
+        if [ "${has_rootfs}" = "0" ]; then
+            exit 0
+        fi
+        echo "Detected rootfs replacement in fetched Ignition config: /run/ignition.json"
+        mkdir "${tmproot}"
+        ;;
+    save)
+        size=$(lsblk -bn -o SIZE "${rootdisk}")
+        sizekbs="$(($size / 1024 + 1))"
+        if lsmod | grep -q brd; then
+            echo 'error: brd module is already loaded' 1>&2; exit 1
+        fi
+        modprobe brd rd_nr=1 rd_size="$sizekbs" max_part=1
+        echo "Moving rootfs to RAM..."
+        dd "if=${rootdisk}" "of=${memdev}" bs=8M
+        echo "Moved rootfs to RAM, pending redeployment: ${memdev}"
+        ;;
+    restore)
+        # This one is in a private mount namespace since we're not "offically" mounting
+        mount "$rootdisk" $rootmnt
+        # This can occur when specifying `wipeFilesystem: false`; TODO detect that above
+        if [ -d "${rootmnt}/boot" ]; then
+            echo "NOTE: Detected Ignition rootfs replacement, but filesystem is not empty"
+            exit 0
+        fi
+        echo "Restoring rootfs from RAM..."
+        mkdir "${saved_rootmnt}"
+        mount "${memdev}" "${saved_rootmnt}"
+        # Remove the immutable bits so we can use `mv`
+        chattr -i ${saved_rootmnt} ${saved_rootmnt}/ostree/deploy/*/deploy/*.0
+        for x in .coreos-aleph-version.json boot ostree; do
+            mv -Tn ${saved_rootmnt}/${x} ${rootmnt}/${x}
+        done
+        # And restore the immutable bits
+        chattr +i ${rootmnt}/ostree/deploy/*/deploy/*.0 ${rootmnt}
+        echo "...done"
+        umount $rootmnt
+        umount $saved_rootmnt
+        rmmod brd
+        rm -rf "${tmproot}"
+        ;;
+    *)
+        echo "Unsupported operation: ${1:-}" 1>&2; exit 1
+        ;;
+esac

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
@@ -7,13 +7,16 @@ tmproot=/run/ignition-ostree-rootfs
 saved_rootmnt=${tmproot}/orig-sysroot
 memdev=/dev/ram0
 
+# Note that save & restore run in private mount namespaces, hence why we don't
+# bother unmounting things here.
+
 case "${1:-}" in
     detect)
         # This is obviously crude; perhaps in the future we could change ignition's `fetch`
         # stage to write out a file if the rootfs is being replaced or so.  But eh, it
         # works for now.
-        has_rootfs=$(jq '.storage?.filesystems? // [] | map(select(.label == "root")) | length' < /run/ignition.json)
-        if [ "${has_rootfs}" = "0" ]; then
+        wipes_rootfs=$(jq '.storage?.filesystems? // [] | map(select(.label == "root" and .wipeFilesystem == true)) | length' < /run/ignition.json)
+        if [ "${wipes_rootfs}" = "0" ]; then
             exit 0
         fi
         echo "Detected rootfs replacement in fetched Ignition config: /run/ignition.json"
@@ -22,34 +25,17 @@ case "${1:-}" in
     save)
         size=$(lsblk -bn -o SIZE "${rootdisk}")
         sizekbs="$(($size / 1024 + 1))"
-        if lsmod | grep -q brd; then
-            echo 'error: brd module is already loaded' 1>&2; exit 1
-        fi
-        modprobe brd rd_nr=1 rd_size="$sizekbs" max_part=1
+        modprobe --first-time brd rd_nr=1 rd_size="$sizekbs" max_part=1
         echo "Moving rootfs to RAM..."
         dd "if=${rootdisk}" "of=${memdev}" bs=8M
         echo "Moved rootfs to RAM, pending redeployment: ${memdev}"
         ;;
     restore)
-        # This one is in a private mount namespace since we're not "offically" mounting
         mount "$rootdisk" $rootmnt
-        # This can occur when specifying `wipeFilesystem: false`; TODO detect that above
-        if [ -d "${rootmnt}/boot" ]; then
-            echo "NOTE: Detected Ignition rootfs replacement, but filesystem is not empty"
-            exit 0
-        fi
         echo "Restoring rootfs from RAM..."
         mkdir "${saved_rootmnt}"
         mount "${memdev}" "${saved_rootmnt}"
-        # Remove the immutable bits so we can use `mv`
-        chattr -i ${saved_rootmnt} ${saved_rootmnt}/ostree/deploy/*/deploy/*.0
-        for x in .coreos-aleph-version.json boot ostree; do
-            mv -Tn ${saved_rootmnt}/${x} ${rootmnt}/${x}
-        done
-        # And restore the immutable bits
-        chattr +i ${rootmnt}/ostree/deploy/*/deploy/*.0 ${rootmnt}
-        echo "...done"
-        umount $rootmnt
+        rsync -aXHA "${saved_rootmnt}/" "${rootmnt}"
         umount $saved_rootmnt
         rmmod brd
         rm -rf "${tmproot}"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ignition OSTree: detect rootfs replacement
+DefaultDependencies=false
+After=ignition-fetch.service
+Before=ignition-disks.service
+Before=initrd-root-fs.target
+Before=sysroot.mount
+ConditionKernelCommandLine=ostree
+
+# This stage requires udevd to detect disks
+Requires=systemd-udevd.service
+After=systemd-udevd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs detect

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-restore.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Ignition OSTree: restore rootfs
+DefaultDependencies=false
+After=ignition-disks.service
+Before=ignition-ostree-growfs.service
+Before=ignition-ostree-mount-firstboot-sysroot.service
+
+ConditionKernelCommandLine=ostree
+ConditionPathIsDirectory=/run/ignition-ostree-rootfs
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+# So we can transiently mount sysroot
+MountFlags=slave
+ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs restore

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-save.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ignition OSTree: save rootfs
+DefaultDependencies=false
+After=ignition-ostree-rootfs-detect.service
+Before=ignition-disks.service
+ConditionKernelCommandLine=ostree
+ConditionPathIsDirectory=/run/ignition-ostree-rootfs
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+# So we can transiently mount sysroot
+MountFlags=slave
+ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs save

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -52,7 +52,8 @@ install() {
 	rm        \
 	sed       \
 	sfdisk    \
-	sgdisk
+	sgdisk    \
+	rsync
 
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -65,6 +65,12 @@ install() {
     inst_simple "$moddir/multipath-generator" \
         "$systemdutildir/system-generators/multipath-generator"
 
+    inst_multiple jq chattr getfattr lsmod dd modprobe
+    inst_script "$moddir/ignition-ostree-dracut-rootfs.sh" "/usr/libexec/ignition-ostree-dracut-rootfs"
+    for x in detect save restore; do
+        install_ignition_unit ignition-ostree-rootfs-${x}.service
+    done
+
     # Disk support
     install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service diskful
     install_ignition_unit ignition-ostree-mount-subsequent-sysroot.service diskful-subsequent


### PR DESCRIPTION
Previously the `40coreos-var` module was "special /var
handling for Ignition + OSTree".

This new module takes over that, renaming it to `ignition-ostree`,
and extends it with support for replacing the root filesystem.