### PR TITLE
overrides: add ignition-2.0.1-4.git641ec6a.fc30

### DIFF
--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -1,5 +1,8 @@
 {
   "packages": {
+    "ignition": {
+      "evra": "2.0.1-4.git641ec6a.fc30.x86_64"
+    },
     "ostree": {
       "evra": "2019.4-1.fc30.x86_64",
       "digest": "sha256:96cdbdd3417be58c2c8399adf30c7efd1b74c4571460fcac34d2ea2dd5442b51"


### PR DESCRIPTION
For the new `fetch` stage for the rootfs redeploy work.