### PR TITLE
overrides add zincati-0.0.5-1.module_f30+6699+1eaa40c6.x86_64

### DIFF
--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -18,6 +18,9 @@
     "rpm-ostree-libs": {
       "evra": "2019.6-1.fc30.x86_64",
       "digest": "sha256:9466a002f00b553ce039f2bd1efcc3ca5eb8db41f16f29a8bcb292c2824ef745"
+    },
+    "zincati": {
+      "evra": "0.0.5-1.module_f30+6699+1eaa40c6.x86_64"
     }
   }
 }


### PR DESCRIPTION
Fast track the new zincati version for our next release of FCOS.