### PR TITLE
lockfiles: drop overrides

### DIFF
--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -3,22 +3,6 @@
     "ignition": {
       "evra": "2.0.1-4.git641ec6a.fc30.x86_64"
     },
-    "ostree": {
-      "evra": "2019.4-1.fc30.x86_64",
-      "digest": "sha256:96cdbdd3417be58c2c8399adf30c7efd1b74c4571460fcac34d2ea2dd5442b51"
-    },
-    "ostree-libs": {
-      "evra": "2019.4-1.fc30.x86_64",
-      "digest": "sha256:809815cf9a9dd80d0e710afbd3804d06ceea56fba43d73dffb43bbd539591f38"
-    },
-    "rpm-ostree": {
-      "evra": "2019.6-1.fc30.x86_64",
-      "digest": "sha256:300a06a8bcff60c7f40266fcb654a5904e41bfcd20f4b619e40adc56c9864c90"
-    },
-    "rpm-ostree-libs": {
-      "evra": "2019.6-1.fc30.x86_64",
-      "digest": "sha256:9466a002f00b553ce039f2bd1efcc3ca5eb8db41f16f29a8bcb292c2824ef745"
-    },
     "zincati": {
       "evra": "0.0.5-1.module_f30+6699+1eaa40c6.x86_64"
     }


### PR DESCRIPTION
The versions in Fedora stable have matched or moved past the
ostree/rpm-ostree versions in the overrides file.