### PR TITLE
overlay.d: teach coreos-growpart about growing LUKS rootfs

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-growpart
+++ b/overlay.d/05core/usr/libexec/coreos-growpart
@@ -12,6 +12,16 @@ path=$1
 shift
 
 majmin=$(findmnt -nvr -o MAJ:MIN "$path")
+
+# Detect if the rootfs is on a luks container and map
+# it to the underlying partition. This assumes that the
+# LUKS volumes is housed in a partition.
+src=$(findmnt -nvr -o SOURCE "$path")
+is_luks=0
+if [[ "${src}" =~ /dev/mapper ]]; then
+    majmin=$(dmsetup table ${src} | cut -d " " -f7)
+fi
+
 devpath=$(realpath "/sys/dev/block/$majmin")
 partition=$(cat "$devpath/partition")
 parent_path=$(dirname "$devpath")
@@ -20,6 +30,12 @@ parent_device=/dev/$(basename "${parent_path}")
 # TODO: make this idempotent, and don't error out if
 # we can't resize.
 growpart "${parent_device}" "${partition}" || true
+
+eval $(blkid -o export "${parent_device}${partition}")
+if [ "${TYPE}" == "crypto_LUKS" ]; then
+    luks_name=$(dmsetup info ${src} -C -o name --noheadings)
+    cryptsetup resize ${luks_name}
+fi
 
 # this part is already idempotent
 xfs_growfs /sysroot


### PR DESCRIPTION
In order to support the rootfs in LUKS containers, `coreos-growpart`
needs awareness of mapping the device mapper target to the underlying
device. This change only support LUKS for now.

