### PR TITLE
manifest: add releasever to manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,8 @@
 ref: fedora/${basearch}/coreos/bodhi-updates
 include: fedora-coreos.yaml
 
+releasever: "30"
+
 rojig:
   license: MIT
   name: fedora-coreos


### PR DESCRIPTION
Changes to manifest.yaml don't propagate automatically
using our tools (config-bot). So I'll add the releasever
(part of 13583c2) here in a separate commit.