### PR TITLE
Add kola-blacklist.yaml

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -15,10 +15,7 @@ coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true
     stage("Kola") {
         dir("cosa") {
             coreos.shwrap("""
-                # This is known to fail right now. See:
-                # https://github.com/coreos/fedora-coreos-tracker/issues/280
-                # https://github.com/coreos/mantle/issues/1103
-                cosa kola -- run --blacklist-test fcos.python
+                cosa kola run
             """)
         }
     }

--- a/kola-blacklist.yaml
+++ b/kola-blacklist.yaml
@@ -1,0 +1,6 @@
+# This file documents currently known-to-fail kola tests. It is consumed by
+# coreos-assembler to automatically blacklist some tests. For more information,
+# see: https://github.com/coreos/coreos-assembler/pull/866.
+
+- pattern: fcos.python
+  tracker: https://github.com/coreos/mantle/issues/1103


### PR DESCRIPTION
This will contain a documented list of tests known to fail right now.
For details, see the corresponding cosa PR which learns how to read
this, and the mantle RFE:

https://github.com/coreos/coreos-assembler/pull/866
https://github.com/coreos/mantle/issues/1103