### PR TITLE
overlay: Add a README to /etc/sysconfig

### DIFF
--- a/overlay.d/09misc/etc/sysconfig/README
+++ b/overlay.d/09misc/etc/sysconfig/README
@@ -1,0 +1,9 @@
+This directory is a legacy of Red Hat Linux days.
+Do not write new software that uses configuration
+files here.  Instead your software should use a regular
+config file in `/etc/foo.conf`, a configuration directory
+such as `/etc/foo/`.
+
+Where appropriate, it's also best practice to use "systemd style config"
+where default config files live in `/usr/lib/foo` that can be
+overridden in `/etc` and `/run`.


### PR DESCRIPTION
This directory is a legacy of the Red Hat Linux days; it
was an attempt to basically declare `/etc` as broken and
start a new "/etc in your /etc".  It didn't succeed.

The only reason we carry it forward to this day is inertia
and legacy.  Other distributions (all of the Debian derivatives
for example) don't ship it.

Let's add this file here starting with FCOS; we can bring
it to the other Fedora distributions later.