### PR TITLE
overlay: Bind ostree-prepare-root.service to ignition-complete.target

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -30,4 +30,9 @@ install() {
     install_ignition_unit ignition-ostree-mount-sysroot.service
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \
         "/usr/sbin/ignition-ostree-mount-sysroot"
+
+    # This unit comes from ostree upstream, but forms part of our
+    # Ignition sequence.  Make it required by ignition-complete.target
+    # so that if it fails we get the same OnFailure= behavior.
+    ln_r "../ostree-prepare-root.service" "$systemdsystemunitdir/ignition-complete.target.requires/ostree-prepare-root.service"
 }


### PR DESCRIPTION
This unit comes from ostree upstream, but forms part of our
Ignition sequence.  Make it required by ignition-complete.target
so that if it fails we get the same OnFailure= behavior.

Making this change as during development `ignition-ostree-mount-sysroot.service`
wasn't running which caused this unit to fail; the root cause would have been
a bit more obvious with this change.