### PR TITLE
ignition-ostree: Split unit for sysroot mounting

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -1,11 +1,14 @@
 [Unit]
-Description=Mount OSTree /sysroot
+Description=Ignition OSTree: Mount (firstboot) /sysroot
+# These dependencies should match the "other" in
+# ignition-ostree-mount-subsequent-sysroot.service
 DefaultDependencies=false
 # If root is specified, then systemd's generator will win
 ConditionKernelCommandLine=!root
 ConditionKernelCommandLine=ostree
 ConditionPathExists=!/run/ostree-live
-
+# There can be only one, Highlander style
+Conflicts=ignition-ostree-mount-subsequent-sysroot.service
 Before=initrd-root-fs.target
 After=ignition-disks.service
 # These have an explicit dependency on After=sysroot.mount today

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=CoreOS: Mount (subsequent) /sysroot
+# These dependencies should match the "other" in
+# ignition-ostree-mount-firsboot-sysroot.service
+DefaultDependencies=false
+# If root is specified, then systemd's generator will win
+ConditionKernelCommandLine=!root
+ConditionKernelCommandLine=ostree
+ConditionPathExists=!/run/ostree-live
+# There can be only one, Highlander style
+Conflicts=ignition-ostree-mount-firstboot-sysroot.service
+# And in contrast to the firstboot, we expect
+# the root device to be ready.
+Requires=dev-disk-by\x2dlabel-root.device
+After=dev-disk-by\x2dlabel-root.device
+Before=initrd-root-fs.target
+# This has an explicit dependency on After=sysroot.mount today
+Before=ostree-prepare-root.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/ignition-ostree-mount-sysroot


### PR DESCRIPTION
The unit to mount sysroot only worked the *first* boot
because it was integrated with Ignition.  We need to have
separate units with different dependencies (but that execute
the same code) for the "Ignition boot" compared with "subsequent"
boots.

Depends https://github.com/coreos/ignition-dracut/pull/131