### PR TITLE
[testing] manifest.yaml: adapt for new path to fedora-coreos.yaml 

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 ref: fedora/${basearch}/coreos/testing
 include: manifests/fedora-coreos.yaml
 
-releasever: "30"
+releasever: "31"
 
 rojig:
   license: MIT

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,5 @@
 ref: fedora/${basearch}/coreos/testing
-include: fedora-coreos.yaml
+include: manifests/fedora-coreos.yaml
 
 releasever: "30"
 


### PR DESCRIPTION
This was changed on `testing-devel`.

While we're here, I also bumped the releasever to 31 in prep for the next release.