### PR TITLE
[bodhi-updates] manifest.yaml: adapt for new path to fedora-coreos.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,5 @@
 ref: fedora/${basearch}/coreos/bodhi-updates
-include: fedora-coreos.yaml
+include: manifests/fedora-coreos.yaml
 
 releasever: "31"
 


### PR DESCRIPTION
This was changed on `testing-devel`.