### PR TITLE
move fuse-sshfs from file-transfer.yaml

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -136,6 +136,9 @@ packages:
   - bash-completion
   - openssl
   - vim-minimal
+  # file-transfer: note fuse-sshfs is not in RHEL
+  # so we can't put it in file-transfer.yaml
+  - fuse-sshfs
   # User experience
   - console-login-helper-messages-issuegen
   - console-login-helper-messages-motdgen

--- a/manifests/file-transfer.yaml
+++ b/manifests/file-transfer.yaml
@@ -1,6 +1,5 @@
 # Moving files around and verifying them
 packages:
-  - fuse-sshfs
   - git-core
   - gnupg2
   - rsync


### PR DESCRIPTION
The goal was to share with rhcos and fuse-sshfs isn't in any RHEL
repos so we get an error when pulling them in. Just leave fuse-sshfs
in a fedora coreos specific manifest for now.