### PR TITLE
manifest: use socat instead of nmap-ncat

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -795,9 +795,6 @@
     "nftables": {
       "evra": "1:0.9.1-3.fc31.x86_64"
     },
-    "nmap-ncat": {
-      "evra": "2:7.80-2.fc31.x86_64"
-    },
     "npth": {
       "evra": "1.6-3.fc31.x86_64"
     },
@@ -974,6 +971,9 @@
     },
     "slirp4netns": {
       "evra": "0.4.0-20.1.dev.gitbbd6f25.fc31.x86_64"
+    },
+    "socat": {
+      "evra": "1.7.3.3-2.fc31.x86_64"
     },
     "sqlite-libs": {
       "evra": "3.30.0-1.fc31.x86_64"

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -132,7 +132,7 @@ packages:
   - logrotate
   # Used by admins interactively
   - sudo coreutils less tar xz gzip bzip2
-  - nmap-ncat net-tools bind-utils
+  - socat net-tools bind-utils
   - bash-completion
   - openssl
   - vim-minimal


### PR DESCRIPTION
This binary is required for e2e tests for OKD-on-FCOS project. It 
probably barely useful for enduser, so it might be worth keeping this 
package in `testing-devel` and not backport to release branches