### PR TITLE
overlay: Tweak coreos-boot-mount-generator to deal with older RHCOS

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -11,6 +11,14 @@ add_wants() {
     ln -sf "../${name}" "${wants_dir}/${name}"
 }
 
+# If there's no aleph version from https://github.com/coreos/coreos-assembler/pull/768
+# then this is a non-FCOS system, likely RHCOS pre-4.3.  In
+# that case, we don't want to overwrite what the systemd-fstab-generator
+# will do.
+if ! [ -f /sysroot/.coreos-aleph-version.json ]; then
+    exit 0
+fi
+
 # Don't create mount units for /boot or /boot/efi on live systems.
 # ConditionPathExists won't work here because conditions don't affect
 # the dependency on the underlying device unit.


### PR DESCRIPTION
I was debugging a customer's test system that was installed as
OpenShift 4.2 and then upgraded, and noticed rpm-ostreed wasn't
starting on reboot, which was because `/boot` wasn't mounted,
which was because the `systemd-fstab-generator` and this code
had actually raced and generated a corrupted `/run/systemd/boot.mount`.

Tweak this code so it cleanly exits and defers to systemd-fstab-generator
for RHCOS-4.2 or older systems.