### PR TITLE
overlay/populate-var: Add missing realpath dependency

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -17,6 +17,7 @@ install_ignition_unit() {
 
 install() {
     inst_multiple \
+        realpath \
         systemd-sysusers \
         systemd-tmpfiles
 


### PR DESCRIPTION
This was hitting RHCOS, something else must be pulling it in on FCOS.