### PR TITLE
overlay/growpart: Fix growpart on NVMe devices

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-growpart
+++ b/overlay.d/05core/usr/libexec/coreos-growpart
@@ -31,7 +31,7 @@ parent_device=/dev/$(basename "${parent_path}")
 # we can't resize.
 growpart "${parent_device}" "${partition}" || true
 
-eval $(blkid -o export "${parent_device}${partition}")
+eval $(blkid -o export "${src}")
 if [ "${TYPE}" == "crypto_LUKS" ]; then
     luks_name=$(dmsetup info ${src} -C -o name --noheadings)
     cryptsetup resize ${luks_name}


### PR DESCRIPTION
The previous commit here for LUKS broke growpart on NVMe even
without LUKS set up, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1769157

This isn't the first time, and it won't be the last time that
someone is tempted to form a device name from a parent and
partition by simply concatenating them (`growpart` also broke this way).
But NVMe devices have an extra `p` in their name.

In this case, we already found the device here above as `${src}`, so just
use that.  Tested to work in a RHCOS build with LUKS as well
as FCOS (without), both with and without `cosa run --disk-channel nvme`.