### PR TITLE
[bodhi-updates] manifest: temporarily add fedora-coreos-pool repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,9 @@ repos:
   - fedora-next-updates
   - fedora-next-modular
   - fedora-next-updates-modular
+  # We don't actually want this here... it's only until we update the lockfile a
+  # better way, see: https://github.com/coreos/fedora-coreos-tracker/issues/293
+  - fedora-coreos-pool
 
 add-commit-metadata:
   fedora-coreos.stream: bodhi-updates


### PR DESCRIPTION
As discussed in https://github.com/coreos/fedora-coreos-config/pull/104,
we don't actually want the bodhi-updates stream to pull in newer
packages from the pool.

That said, bodhi-updates also current acts as our lockfile updater in
testing-devel, so it's crucial that it keeps working. We're working to
decouple that, see:

https://github.com/coreos/fedora-coreos-tracker/issues/293
https://github.com/coreos/fedora-coreos-releng-automation/pull/48

But for now, the updates must flow...