### PR TITLE
coreos-growpart: drop LUKS resize support

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-growpart
+++ b/overlay.d/05core/usr/libexec/coreos-growpart
@@ -12,16 +12,6 @@ path=$1
 shift
 
 majmin=$(findmnt -nvr -o MAJ:MIN "$path")
-
-# Detect if the rootfs is on a luks container and map
-# it to the underlying partition. This assumes that the
-# LUKS volumes is housed in a partition.
-src=$(findmnt -nvr -o SOURCE "$path")
-is_luks=0
-if [[ "${src}" =~ /dev/mapper ]]; then
-    majmin=$(dmsetup table ${src} | cut -d " " -f7)
-fi
-
 devpath=$(realpath "/sys/dev/block/$majmin")
 partition=$(cat "$devpath/partition")
 parent_path=$(dirname "$devpath")
@@ -30,12 +20,6 @@ parent_device=/dev/$(basename "${parent_path}")
 # TODO: make this idempotent, and don't error out if
 # we can't resize.
 growpart "${parent_device}" "${partition}" || true
-
-eval $(blkid -o export "${src}")
-if [ "${TYPE}" == "crypto_LUKS" ]; then
-    luks_name=$(dmsetup info ${src} -C -o name --noheadings)
-    cryptsetup resize ${luks_name}
-fi
 
 # this part is already idempotent
 xfs_growfs /sysroot


### PR DESCRIPTION
The support for growing LUKS containers was short-sighted and it was
mistake to add it Fedora CoreOS Config for a couple of reasons:
- the code only works with 'null-cipher' (e.g. no encryption) LUKS
  containers. When you attempt to use this code against a properly
  encrypted container, 'cryptsetup' wants a passphrase from stdin.
- FCOS has no current plans to use LUKS by default, therefore the
  code is RHCOS specific.
- Worse, the RHCOS specific implementation uses Clevis pins for the
  passphrase retrieval. Clevis/Tang support is not FCOS and adding
  the dependencies is undesirable at this time. As a result, RHCOS
  now has its own 'growpart' service.

Frankly, the code is useless cruft for FCOS.

This reverts commits:
  c053f99a2829192e537a106ce84766eeaa1e4230
  38f5342e1d819714505dd19c16cfa0cce0b519f4