### PR TITLE
overrides: add nfs-utils-coreos-2.4.1-2.rc1.fc31

### DIFF
--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -2,6 +2,9 @@
   "packages": {
     "ignition": {
       "evra": "2.0.1-5.git641ec6a.fc31.x86_64"
+    },
+    "nfs-utils-coreos": {
+      "evra": "2.4.1-2.rc1.fc31.x86_64"
     }
   }
 }


### PR DESCRIPTION
There are some bugs in nfs-utils-coreos:
https://bugzilla.redhat.com/show_bug.cgi?id=1768897

Let's pull in the fixes ahead of Bodhi to unblock FCOS-on-OKD work.