### PR TITLE
overlay/mount-generator: Test directly for /root/.squashfs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -13,7 +13,7 @@ add_requires() {
     ln -sf "../${name}" "${requires_dir}/${name}"
 }
 
-if [ -e /root.squashfs ]; then
+if is-live-image; then
     # Create stamp file that everything else should use to detect a live boot
     > /run/ostree-live
 

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -21,8 +21,9 @@ fi
 
 # Don't create mount units for /boot or /boot/efi on live systems.
 # ConditionPathExists won't work here because conditions don't affect
-# the dependency on the underlying device unit.
-if [ ! -f /run/ostree-live ]; then
+# the dependency on the underlying device unit.  Note this can't
+# test for /run/ostree-live as that races with the live-generator.
+if ! is_live_image; then
     add_wants boot.mount
     cat > "${UNIT_DIR}/boot.mount" <<EOF
 # Automatically created by coreos-boot-mount-generator


### PR DESCRIPTION
This should close a race I hit while trying out a live system
(Silverblue-based-on-FCOS).

The generators here run in parallel; so we can't test for
`/run/ostree-live` in `coreos-boot-mount-generator` while
writing it in `live-generator.`

(Probably we should fold these generators together, but
 this is a small simple patch)