### PR TITLE
overlay: Run coreos-growpart.service in basic.target

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/coreos-growpart.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-growpart.service
@@ -4,7 +4,8 @@
 Description=Resize root partition
 ConditionPathExists=!/run/ostree-live
 ConditionPathExists=!/var/lib/coreos-growpart.stamp
-Before=sshd.service
+DefaultDependencies=no
+Before=basic.target
 
 [Service]
 Type=oneshot
@@ -12,4 +13,4 @@ ExecStart=/usr/libexec/coreos-growpart /
 RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=basic.target


### PR DESCRIPTION
Otherwise, services running on boot may see a much smaller disk
than expected.

We hit this in RHCOS where we needed to order `kubelet.service`
`After=coreos-growpart.service` because we were pulling a lot
of container images.