### PR TITLE
Switch to coreos.liveiso= karg

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -28,6 +28,6 @@ set timeout=1
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
-	linux /images/vmlinuz coreos-iso @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+	linux /images/vmlinuz @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
 	initrd /images/initramfs.img
 }

--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -66,7 +66,7 @@ label linux
   menu label ^Fedora CoreOS (Live)
   menu default
   kernel /images/vmlinuz
-  append initrd=/images/initramfs.img coreos-iso @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
 
 menu separator # insert an empty line
 

--- a/live/zipl.prm
+++ b/live/zipl.prm
@@ -1,1 +1,1 @@
-coreos-iso @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+@@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-autologin-generator
@@ -9,7 +9,7 @@ have_karg() {
     local cmdline=( $(</proc/cmdline) )
     local i
     for i in "${cmdline[@]}"; do
-        if [ "$arg" = "$i" ]; then
+        if [[ "$i" =~ "$arg=" ]]; then
             return 0
         fi
     done
@@ -39,7 +39,7 @@ fi
 
 # Autologin on ISO boots but not PXE boots.  The only way to tell the
 # difference is a kernel argument.
-if ! have_karg coreos-iso; then
+if ! have_karg coreos.liveiso; then
     exit 0
 fi
 


### PR DESCRIPTION
Requires https://github.com/coreos/coreos-assembler/pull/927

Prep for supporting a `fulliso` build that requires locating
the ISO.  Also drops some copy-paste between the different bootloaders.