### PR TITLE
[testing] Add coreos-keep-cgroup-v1.service

### DIFF
--- a/fedora-coreos-base.yaml
+++ b/fedora-coreos-base.yaml
@@ -146,6 +146,13 @@ packages:
   - whois-nls
   # Parsing/Interacting with JSON data
   - jq
+  # HACK for https://github.com/coreos/fedora-coreos-config/pull/238#issuecomment-558707064
+  - brotli-1.0.7-3.fc30.x86_64
+  - curl-7.65.3-4.fc30.x86_64
+  - libcurl-7.65.3-4.fc30.x86_64
+  - libmetalink-0.1.3-8.fc30.x86_64
+  - libssh-0.9.0-5.fc30.x86_64
+  - libssh-config-0.9.0-5.fc30.noarch
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -13,3 +13,4 @@ enable afterburn-firstboot-checkin.service
 enable afterburn-sshkeys@.service
 # Update agent
 enable zincati.service
+enable coreos-keep-cgroup-v1.service

--- a/overlay.d/90cgroups/usr/lib/systemd/system/coreos-keep-cgroup-v1.service
+++ b/overlay.d/90cgroups/usr/lib/systemd/system/coreos-keep-cgroup-v1.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CoreOS Keep CGroups v1
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/292
+RequiresMountsFor=/boot
+# Note we don't conditionalize on ConditionKernelCommandLine= here because the
+# kernel arg might've been added manually just for this boot; we still want to
+# change the BLS entries in that case.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/coreos-keep-cgroup-v1
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/90cgroups/usr/libexec/coreos-keep-cgroup-v1
+++ b/overlay.d/90cgroups/usr/libexec/coreos-keep-cgroup-v1
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+for f in /boot/loader/entries/*.conf; do
+    options=$(grep '^options ' "$f" | cut -f2- -d' ')
+
+    # If it's already specified, don't touch whatever value is there. That way,
+    # users that purposely opted into v2 early keep it. It also makes this
+    # script idempotent.
+    if grep -q "systemd.unified_cgroup_hierarchy" <<< "$options"; then
+        continue
+    fi
+
+    # otherwise, make sure we stay on v1
+    sed -e "/^options / s/$/ systemd.unified_cgroup_hierarchy=0/" -i "$f"
+    echo "$(basename "$f"): injected systemd.unified_cgroup_hierarchy=0"
+done


### PR DESCRIPTION
In f31, the default cgroup changed to v2. However, we've decided to stay
on v1 for the time being. Thus, we don't want older nodes upgrading to
f31 to be forced into v2.

Add a tiny service which just scans the BLS configs and injects the
`systemd.unified_cgroup_hierarchy` karg as needed.

For more information, see:
coreos/fedora-coreos-tracker#292
https://github.com/coreos/fedora-coreos-streams/issues/26#issuecomment-558361931
