### PR TITLE
coreos-boot-mount-generator: key off of /etc/fstab

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -11,11 +11,10 @@ add_wants() {
     ln -sf "../${name}" "${wants_dir}/${name}"
 }
 
-# If there's no aleph version from https://github.com/coreos/coreos-assembler/pull/768
-# then this is a non-FCOS system, likely RHCOS pre-4.3.  In
-# that case, we don't want to overwrite what the systemd-fstab-generator
-# will do.
-if ! [ -f /sysroot/.coreos-aleph-version.json ]; then
+# If there's already an /etc/fstab entries for /boot, then this is is a non-FCOS
+# system, likely RHCOS pre-4.3 (which still used Anaconda).  In that case, we
+# don't want to overwrite what the systemd-fstab-generator will do.
+if findmnt --fstab /boot &>/dev/null; then
     exit 0
 fi
 


### PR DESCRIPTION
Just look at `/etc/fstab` for `/boot` mounts to determine whether to
generate them ourselves or let the `systemd-fstab-generator` do it.

See also: https://github.com/coreos/fedora-coreos-tracker/issues/322