### PR TITLE
manifest.yaml: use regular Fedora 31 repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,11 +13,10 @@ repos:
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
-  # NB: we use -next for now until f31 is GA and the repo structure is finalized
-  - fedora-next
-  - fedora-next-updates
-  - fedora-next-modular
-  - fedora-next-updates-modular
+  - fedora
+  - fedora-updates
+  - fedora-modular
+  - fedora-updates-modular
 
 add-commit-metadata:
   fedora-coreos.stream: testing-devel


### PR DESCRIPTION
Looks like the repo structure for f31 have finally stabilized. The
`-next` ones don't work anymore.