### PR TITLE
fedora-coreos-base: add btrfs-progs

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -122,7 +122,7 @@ packages:
   - cloud-utils-growpart
   - lvm2 iscsi-initiator-utils sg3_utils
   - device-mapper-multipath
-  - xfsprogs e2fsprogs mdadm
+  - xfsprogs e2fsprogs btrfs-progs mdadm
   - cryptsetup
   - cifs-utils
   # Time sync


### PR DESCRIPTION
Ignition used to pull it in, but now it's going to become a weak dep.
But we still want it in FCOS so users can have btrfs partitions if
they'd like.

More info in: https://github.com/coreos/fedora-coreos-tracker/issues/323