### PR TITLE
overrides: bump to latest ignition build

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -15,10 +15,15 @@ coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true
         }
     }
     stage("Kola") {
-        dir("cosa") {
-            coreos.shwrap("""
-                cosa kola run -- --parallel 8
-            """)
+        try {
+            dir("cosa") {
+                coreos.shwrap("""
+                    cosa kola run -- --parallel 8
+                """)
+            }
+        } finally {
+            coreos.shwrap("tar -cf - cosa/tmp/kola/ | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
         }
     }
 }

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -8,6 +8,8 @@ coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true
         dir("cosa") {
             coreos.shwrap("""
                 cosa init ${env.WORKSPACE}/fedora-coreos-config
+                curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/master/scripts/download-overrides.py
+                python3 download-overrides.py
                 cosa build
             """)
         }

--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     "ignition": {
-      "evra": "2.0.1-5.git641ec6a.fc31.x86_64"
+      "evra": "2.0.1-9.gita8f91fa.fc31.x86_64"
     }
   }
 }

--- a/manifest-lock.overrides.x86_64.json
+++ b/manifest-lock.overrides.x86_64.json
@@ -2,9 +2,6 @@
   "packages": {
     "ignition": {
       "evra": "2.0.1-5.git641ec6a.fc31.x86_64"
-    },
-    "nfs-utils-coreos": {
-      "evra": "1:2.4.1-2.rc1.fc31.x86_64"
     }
   }
 }


### PR DESCRIPTION
For the SELinux labeling work. Also submitted to Bodhi:
https://bodhi.fedoraproject.org/updates/FEDORA-2019-8f331fb834

We also change CI here to download new overrides that may not be built yet.
Requires: https://github.com/coreos/fedora-coreos-releng-automation/pull/63