### PR TITLE
[bodhi-updates] manifest.yaml: use regular Fedora 31 repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,10 +9,10 @@ rojig:
   summary: Fedora CoreOS bodhi-updates
 
 repos:
-  - fedora-next
-  - fedora-next-updates
-  - fedora-next-modular
-  - fedora-next-updates-modular
+  - fedora
+  - fedora-updates
+  - fedora-modular
+  - fedora-updates-modular
   # We don't actually want this here... it's only until we update the lockfile a
   # better way, see: https://github.com/coreos/fedora-coreos-tracker/issues/293
   - fedora-coreos-pool


### PR DESCRIPTION
(Same as https://github.com/coreos/fedora-coreos-config/pull/248)

Looks like the repo structure for f31 have finally stabilized. The
`-next` ones don't work anymore.