### PR TITLE
fedora-coreos-base: add attr package

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -21,6 +21,9 @@
     "alternatives": {
       "evra": "1.11-5.fc31.x86_64"
     },
+    "attr": {
+      "evra": "2.4.48-7.fc31.x86_64"
+    },
     "audit-libs": {
       "evra": "3.0-0.15.20191104git1c2f876.fc31.x86_64"
     },

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -131,7 +131,7 @@ packages:
   - sssd shadow-utils
   - logrotate
   # Used by admins interactively
-  - sudo coreutils less tar xz gzip bzip2
+  - sudo coreutils attr less tar xz gzip bzip2
   - socat net-tools bind-utils
   - bash-completion
   - openssl


### PR DESCRIPTION
This is one of those utilities that I consider "core".

Brings no additional deps (we're already shipping libattr as a dep of
coreutils), and has a tiny footprint.

(Also the rpm-ostree testsuite depends on it).