### PR TITLE
overrides: bump to latest igntion rpm

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,5 +1,7 @@
 packages:
-  # https://github.com/coreos/ignition/pull/846
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2019-8f331fb834
+  # New 2.1.1 release of ignition + a backport for:
+  # https://github.com/coreos/ignition/pull/907
+  #
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2019-4bdb83f0af
   ignition:
-    evra: 2.0.1-9.gita8f91fa.fc31.x86_64
+    evra: 2.1.1-3.git40c0b57.fc31.x86_64


### PR DESCRIPTION
New 2.1.1 release of ignition + a backport for:
https://github.com/coreos/ignition/pull/907