### PR TITLE
Drop preview/experimental notices

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -52,13 +52,6 @@ postprocess:
     set -xeuo pipefail
     sed -Ei 's/^(PasswordAuthentication|PermitRootLogin)[[:blank:]]/#&/' /etc/ssh/sshd_config
     echo -e '\n# Disable password logins by default\nPasswordAuthentication no\nPermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
-  # This will be dropped once FCOS is out of preview.
-  # See also experimental.motd in overlay/.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/164
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    sed -i -e 's/CoreOS/CoreOS preview/' $(realpath /etc/os-release)
   # Users shouldn't be configuring `rpm-ostreed.conf`
   # https://github.com/coreos/fedora-coreos-tracker/issues/271
   - |

--- a/overlay.d/15fcos/usr/lib/motd.d/tracker.motd
+++ b/overlay.d/15fcos/usr/lib/motd.d/tracker.motd
@@ -1,0 +1,2 @@
+Tracker: https://github.com/coreos/fedora-coreos-tracker
+

--- a/overlay.d/80experimental/usr/lib/motd.d/experimental.motd
+++ b/overlay.d/80experimental/usr/lib/motd.d/experimental.motd
@@ -1,3 +1,0 @@
-Tracker: https://github.com/coreos/fedora-coreos-tracker
-Preview release: breaking changes may occur
-


### PR DESCRIPTION
Prep for releasing FCOS stable.

Closes: coreos/fedora-coreos-tracker#164