### PR TITLE
overrides: pull in crypto-policies without python dependencies

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -5,3 +5,10 @@ packages:
     evra: 0.1.2-1.fc31.x86_64
   coreos-installer-systemd:
     evra: 0.1.2-1.fc31.x86_64
+  # crypto-policies without python dependencies
+  # We're pulling from rawhide here as this is a brand new change
+  # and the maintainer is not comfortable sending it to F31 yet.
+  # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
+  crypto-policies:
+    evra: 20191128-3.gitcd267a5.fc32.noarch
+


### PR DESCRIPTION
We're pulling from rawhide here as this is a brand new change
and the maintainer is not comfortable sending it to F31 yet.

See https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/280