### PR TITLE
kola-blacklist: drop fcos.python

### DIFF
--- a/kola-blacklist.yaml
+++ b/kola-blacklist.yaml
@@ -1,6 +1,3 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically blacklist some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
-
-- pattern: fcos.python
-  tracker: https://github.com/coreos/mantle/issues/1103


### PR DESCRIPTION
This is fixed now:
https://github.com/coreos/fedora-coreos-tracker/issues/280