### PR TITLE
overlay: Add an ignition-ostree-generator to fix install path

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-generator
@@ -1,0 +1,16 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+# This generator handles the non-live case; see also live-generator
+
+set -euo pipefail
+
+UNIT_DIR="${1:-/tmp}"
+
+if is-live-image; then
+    exit 0
+fi
+
+requiresdir="${UNIT_DIR}/ignition-subsequent.target.requires"
+mkdir -p "${requiresdir}"
+ln -sr /usr/lib/systemd/system/ignition-ostree-mount-subsequent-sysroot.service ${requiresdir}/

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
@@ -1,3 +1,4 @@
+# Note this unit is conditionally enabled by ignition-ostree-generator
 [Unit]
 Description=CoreOS: Mount (subsequent) /sysroot
 # These dependencies should match the "other" in

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -60,9 +60,13 @@ install() {
     done
 
     install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service
-    install_ignition_unit ignition-ostree-mount-subsequent-sysroot.service subsequent
+    inst_simple "$moddir/ignition-ostree-mount-subsequent-sysroot.service" "$systemdsystemunitdir/ignition-ostree-mount-subsequent-sysroot.service"
+    # The -subsequent service activation is handled via generator below
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \
         "/usr/sbin/ignition-ostree-mount-sysroot"
+
+    inst_simple "$moddir/ignition-ostree-generator" \
+        "$systemdutildir/system-generators/ignition-ostree-generator"
 
     install_ignition_unit ignition-ostree-growfs.service
     inst_script "$moddir/coreos-growpart" /usr/libexec/coreos-growpart


### PR DESCRIPTION
The current documentation for the FCOS PXE install path:
https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/#_live_pxe
Uses the `coreos.inst` kernel arguments instead of providing
an Ignition config.  In this case, we fail because
the `mount-subsequent.service` kicks in, and will fail to find
a root device.  (Or worse, may mistakenly find an existing disk
and mount it)

The bug here is a now familiar one - the
`ignition-ostree-mount-subsequent-sysroot.service` already has
`ConditionFileExists=!/run/ostree-live` which is correct for the
Live PXE case, but it also has a hard `Requires`, and as we know
systemd still pulls in requirements for units that aren't enabled.

Fix this by using a generator to enable the unit rather than doing
so as part of ignition-subsequent.

Note if Ignition is provided, then `ignition.firstboot` should be
present which would mean this bug isn't triggered.