### PR TITLE
overlay/ignition-ostree: Use ignition-diskful.target

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -6,6 +6,7 @@ DefaultDependencies=false
 # If root is specified, then systemd's generator will win
 ConditionKernelCommandLine=!root
 ConditionKernelCommandLine=ostree
+# This is redundant since we're queued on -diskful.target, but eh.
 ConditionPathExists=!/run/ostree-live
 # There can be only one, Highlander style
 Conflicts=ignition-ostree-mount-subsequent-sysroot.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -59,7 +59,7 @@ install() {
         inst_script "$moddir/ignition-ostree-${x}-var.sh" "/usr/sbin/ignition-ostree-${x}-var"
     done
 
-    install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service
+    install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service diskful
     inst_simple "$moddir/ignition-ostree-mount-subsequent-sysroot.service" "$systemdsystemunitdir/ignition-ostree-mount-subsequent-sysroot.service"
     # The -subsequent service activation is handled via generator below
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \


### PR DESCRIPTION
For the firstboot mount; this way if we ever decided to add
non-default dependencies to this unit they wouldn't be pulled
into the transaction.

Reference: https://github.com/coreos/fedora-coreos-config/pull/271
Suggested-by: @jlebon