### PR TITLE
overlay/growpart: update reference to service file

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# See also coreos-growpart.service.
+# See also ignition-ostree-growfs.service.
 
 # https://github.com/coreos/fedora-coreos-tracker/issues/18
 # See also image.ks.


### PR DESCRIPTION
coreos-growpart.service was removed and ignition-ostree-growfs.service
was added in a8b363b.