### PR TITLE
overlay: Enable logrotate.timer

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -129,6 +129,11 @@ packages:
   - chrony
   # Extra runtime
   - sssd shadow-utils
+  # There are things that write outside of the journal still (such as the classic wtmp, etc.)
+  # (auditd also writes outside the journal but it has its own log rotation.)
+  # Anything package layered will also tend to expect files dropped in
+  # /etc/logrotate.d to work.  Really, this is a legacy thing, but if we don't
+  # have it then people's disks will slowly fill up with logs.
   - logrotate
   # Used by admins interactively
   - sudo coreutils attr less tar xz gzip bzip2

--- a/overlay.d/05core/usr/lib/systemd/system-preset/41-fcos-workarounds.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/41-fcos-workarounds.preset
@@ -1,0 +1,2 @@
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1655153#c4
+enable logrotate.timer


### PR DESCRIPTION
Add some comments to the manifest for why we include `logrotate`
(as I understand it).

Then, enable the timer so it actually works; see
https://bugzilla.redhat.com/show_bug.cgi?id=1655153#c4

This is part of ensuring it's on for RHCOS:
https://bugzilla.redhat.com/show_bug.cgi?id=1780079