### PR TITLE
motd: link to FCOS Discourse forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Base manifest configuration for
 Use https://github.com/coreos/coreos-assembler to build it.
 
 Discussions in
-https://discussion.fedoraproject.org/c/server/coreos and
+https://discussion.fedoraproject.org/c/server/coreos. Bug
+tracking and feature requests at
 https://github.com/coreos/fedora-coreos-tracker.
 
 ## About this repo

--- a/overlay.d/15fcos/usr/lib/motd.d/tracker.motd
+++ b/overlay.d/15fcos/usr/lib/motd.d/tracker.motd
@@ -1,2 +1,3 @@
 Tracker: https://github.com/coreos/fedora-coreos-tracker
+Discuss: https://discussion.fedoraproject.org/c/server/coreos/
 


### PR DESCRIPTION
Add a link to the Discourse forum directly in the MOTD to make it easier
for new users to figure out where to discuss and ask for help.