### PR TITLE
manifest: Add excludes for python,perl,nodejs,dnf,grubby

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -169,3 +169,16 @@ packages-ppc64le:
   - irqbalance
 packages-aarch64:
   - irqbalance
+
+# Things we don't expect to ship on the host.  We currently
+# have recommends: false so these could only come in via
+# hard requirement, in which case the build will fail.
+exclude-packages:
+  - python
+  - python2
+  - python3
+  - perl
+  - nodejs
+  - dnf
+  - grubby
+  - cowsay  # Just in case


### PR DESCRIPTION
This makes use of the new
https://github.com/coreos/rpm-ostree/pull/1980

And we can then drop the test in kola that boots a whole VM
for this.