### PR TITLE
Live ISO: extend boot prompt timeout to 5 seconds

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -23,7 +23,7 @@ insmod gzio
 insmod part_gpt
 insmod ext2
 
-set timeout=1
+set timeout=5
 ### END /etc/grub.d/00_header ###
 
 ### BEGIN /etc/grub.d/10_linux ###

--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -3,7 +3,8 @@
 # changes.
 serial 0
 default vesamenu.c32
-timeout 10
+# timeout in units of 1/10s. 50 == 5 seconds
+timeout 50
 
 display boot.msg
 


### PR DESCRIPTION
At 1 second it's almost impossible to catch the boot prompt if you need
to change the kernel command line parameters. Let's extend it to 5 seconds
so users have a fighting chance to catch the prompt.