### PR TITLE
manifest: add lsof utility

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -141,6 +141,7 @@ packages:
   - bash-completion
   - openssl
   - vim-minimal
+  - lsof
   # file-transfer: note fuse-sshfs is not in RHEL
   # so we can't put it in file-transfer.yaml
   - fuse-sshfs


### PR DESCRIPTION
This PR adds two utilities that I've needed over the past few weeks: `time` and `lsof`. They each are self contained and don't introduce any new dependencies.

- `time`: I needed this when debugging a problem where [a user was reporting operations taking long periods of time](https://discussion.fedoraproject.org/t/cannot-docker-login-to-dockerhub-although-can-pull-public-images/17015/2). I had to work around this by wrapping the command with two `date` calls.

- `lsof`: I've been having some trouble with podman volumes lately and when trying to debug this I thought maybe some files had been deleted on the host but were still being held open by other programs. I've [used lsof to debug this situation in the past](https://dustymabe.com/2012/01/22/recover-space-by-finding-deleted-files-that-are-still-held-open./)