### PR TITLE
ci: migrate to new coreos-ci project

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,30 +1,16 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-coreos.pod([image: "quay.io/coreos-assembler/coreos-assembler:latest", kvm: true, memory: "9Gi"]) {
-    stage("Build") {
-        dir("fedora-coreos-config") {
-            checkout scm
-            coreos.shwrap("./ci/validate")
-        }
-        dir("cosa") {
-            coreos.shwrap("""
-                cosa init ${env.WORKSPACE}/fedora-coreos-config
-                curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/master/scripts/download-overrides.py
-                python3 download-overrides.py
-                cosa build
-            """)
-        }
-    }
-    stage("Kola") {
-        try {
-            dir("cosa") {
-                coreos.shwrap("""
-                    cosa kola run -- --parallel 8
-                """)
-            }
-        } finally {
-            coreos.shwrap("tar -cf - cosa/tmp/kola/ | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
-        }
-    }
+cosaPod {
+    checkout scm
+
+    shwrap("ci/validate")
+
+    shwrap("""
+        mkdir -p /srv/fcos && cd /srv/fcos
+        cosa init ${env.WORKSPACE}
+        curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/master/scripts/download-overrides.py
+        python3 download-overrides.py
+    """)
+
+    fcosBuild(skipInit: true)
 }


### PR DESCRIPTION
And in the process, use the new custom steps from coreos-ci-lib to
simplify things.

Requires: https://github.com/coreos/coreos-ci/pull/6
Requires: https://github.com/coreos/coreos-ci-lib/pull/11