### PR TITLE
manifest: Add NetworkManager-team and teamd

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -116,6 +116,8 @@ packages:
   - NetworkManager hostname
   - iproute-tc
   - adcli
+  ## Teaming https://github.com/coreos/fedora-coreos-config/pull/289 and http://bugzilla.redhat.com/1758162
+  - NetworkManager-team teamd
   # Static firewalling
   - iptables nftables iptables-nft iptables-services
   # Storage


### PR DESCRIPTION
http://bugzilla.redhat.com/1758162

`teamd` is needed for teaming at all and `NetworkManager-team`
is needed if we want to drop down files on the
host for teaming and have NetworkManager bring them up.

The argument for adding this to the host by default is
that particularly on some bare metal installs, one wants to use
teaming for the "primary" network interface, which one would
then use to e.g. pull containers.  There's already code in
dracut which handles setting up teaming on the kernel cmdline too.