### PR TITLE
turn arbitrary SELinux booleans on or off at boot

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/setsebool-off@.service
+++ b/overlay.d/05core/usr/lib/systemd/setsebool-off@.service
@@ -1,0 +1,22 @@
+# This service is currently specific to CoreOS distros,
+# but we may want to add it to the base OS in the future.
+# The idea here is to allow users to set SELinux booleans
+# without having to modify the on-disk policy, by enabling
+# the appropriate systemd service via Ignition
+[Unit]
+Description=Turn OFF SELinux boolean %I
+# We want to run quite early, in particular before anything
+# that may require any access permitted by the boolean;
+# it may make sense to do this in the initramfs too.
+DefaultDependencies=no
+After=local-fs.target
+Conflicts=setsebool-on@%i.service
+
+[Service]
+ExecStart=/usr/sbin/setsebool %i off
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/sbin/setsebool %i on
+
+[Install]
+WantedBy=sysinit.target

--- a/overlay.d/05core/usr/lib/systemd/setsebool-on@.service
+++ b/overlay.d/05core/usr/lib/systemd/setsebool-on@.service
@@ -1,0 +1,22 @@
+# This service is currently specific to CoreOS distros,
+# but we may want to add it to the base OS in the future.
+# The idea here is to allow users to set SELinux booleans
+# without having to modify the on-disk policy, by enabling
+# the appropriate systemd service via Ignition
+[Unit]
+Description=Turn ON SELinux boolean %I
+# We want to run quite early, in particular before anything
+# that may require any access permitted by the boolean;
+# it may make sense to do this in the initramfs too.
+DefaultDependencies=no
+After=local-fs.target
+Conflicts=setsebool-off@%i.service
+
+[Service]
+ExecStart=/usr/sbin/setsebool %i on
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/sbin/setsebool %i off
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
to use it after first boot, do something like
`systemctl enable --now setsebool-on@container_manage_cgroup.service`

To use it, you'd normally use an `fcc` like this one:

```yaml
---
variant: fcos
version: 1.0.0
ignition: {}
systemd:
  units:
  - name: setsebool-on@container_manage_cgroup.service
    enabled: true
```

That doesn't actually work because of https://github.com/coreos/ignition/issues/586 or a related bug.

to make it work for now, use something like this:
```yaml
variant: fcos
version: 1.0.0
ignition: {}
systemd:
  units:
  - name: ignition-firstboot-selinux-booleans.service
    enabled: true
    contents: |
      [Unit]
      Description=Tweak SELinux booleans at first boot
      ConditionFirstBoot=true
      After=local-fs.target
      
      [Service]
      ExecStart=/usr/bin/systemctl enable --now setsebool-on@container_manage_cgroup.service
      Type=oneshot
      RemainAfterExit=yes
      
      [Install]
      WantedBy=sysinit.target
```