### PR TITLE
manifests: add ppc64le packages to detect dynamically attached devices

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -165,6 +165,9 @@ packages-x86_64:
   - irqbalance
 packages-ppc64le:
   - irqbalance
+  - librtas
+  - powerpc-utils-core
+  - ppc64-diag-rtas
 packages-aarch64:
   - irqbalance
 

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -22,3 +22,7 @@ enable zincati.service
 enable coreos-liveiso-success.service
 # See bootupd.yaml
 enable bootupd.socket
+# Enable rtas_errd for ppc64le to discover dynamically attached pci devices - https://bugzilla.redhat.com/show_bug.cgi?id=1811537
+# The event for the attached device comes as a diag event.
+# Ideally it should have been added as part of base Fedora - but since it was arch specific, it was not added: https://bugzilla.redhat.com/show_bug.cgi?id=1433859
+enable rtas_errd.service


### PR DESCRIPTION
While running the Openshift CI encountered: https://bugzilla.redhat.com/show_bug.cgi?id=1811537
which requires some extra ppc64le libraries required to detect dynamically attached pci devices.
These devices show up through the diag events which is why the diag libraries are necessary