### PR TITLE
[bodhi-updates] manifest-lock: temporarily pin ostree to 2019.5

### DIFF
--- a/manifest-lock.x86_64.yaml
+++ b/manifest-lock.x86_64.yaml
@@ -1,0 +1,7 @@
+packages:
+  # freezing at 2019.5 until we resolve issues with sysroot.readonly
+  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  ostree:
+    evra: 2019.5-2.fc31.x86_64
+  ostree-libs:
+    evra: 2019.5-2.fc31.x86_64


### PR DESCRIPTION
We need some more fixes to the readonly path before we can bump to
2020.2:

https://github.com/coreos/fedora-coreos-tracker/issues/343