### PR TITLE
[bodhi-updates] overrides: stop pinning ostree

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,7 +1,0 @@
-packages:
-  # freezing at 2019.5 until we resolve issues with sysroot.readonly
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
-  ostree:
-    evra: 2019.5-2.fc31.x86_64
-  ostree-libs:
-    evra: 2019.5-2.fc31.x86_64


### PR DESCRIPTION
Issues with read-only sysroot should be fixed now!
https://github.com/coreos/fedora-coreos-tracker/issues/343