### PR TITLE
overrides: add {rpm-,}ostree for read-only /sysroot fixes

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -11,3 +11,14 @@ packages:
     evra: 2:1.8.1-2.fc31.x86_64
   podman-plugins:
     evra: 2:1.8.1-2.fc31.x86_64
+  # Cherry-pick new {rpm-,}ostree to resolve issues with /read-only sysroot
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d920214f63
+  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  ostree:
+    evra: 2020.3-2.fc31.x86_64
+  ostree-libs:
+    evra: 2020.3-2.fc31.x86_64
+  rpm-ostree:
+    evra: 2020.1.21.ge9011530-2.fc31.x86_64
+  rpm-ostree-libs:
+    evra: 2020.1.21.ge9011530-2.fc31.x86_64


### PR DESCRIPTION
Fetch the newer ostree release and rpm-ostree rebuild which complete the
read-only sysroot enablement.