### PR TITLE
image.yaml: enable sysroot-ro

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -13,6 +13,10 @@ extra-kargs:
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora
 
+# We want read-only /sysroot to protect from unintentional damage.
+# https://github.com/ostreedev/ostree/issues/1265
+sysroot-readonly: true
+
 # After this, we plan to add support for the Ignition
 # storage/filesystems sections.  (Although one can do
 # that on boot as well)


### PR DESCRIPTION
We want to use the new read-only `/sysroot` feature of libostree. Opt-in
to that to tell cosa we support it and want it.

For more details, see:
https://github.com/ostreedev/ostree/issues/1265
https://github.com/coreos/coreos-assembler/pull/1235