### PR TITLE
tests/kola: New `basic` test using kola external tests

### DIFF
--- a/tests/kola/basic
+++ b/tests/kola/basic
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec systemctl is-enabled logrotate.service


### PR DESCRIPTION
Pairs with https://github.com/coreos/coreos-assembler/pull/1252

The motivation here is to get the ball rolling for (where it
makes sense) to have a place to add tests corresponding to changes
in this repository.