### PR TITLE
[next-devel] manifest: point next-devel at f32

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -14,7 +14,11 @@ cosaPod {
         cosa buildprep https://builds.coreos.fedoraproject.org/prod/streams/${env.CHANGE_TARGET}/builds
     """)
 
-    fcosBuild(skipInit: true)
+    // temporarily skip kola upgrade tests since there aren't any next-devel
+    // builds yet (but see https://github.com/coreos/coreos-ci-lib/pull/19)
+    // this modification will get nuked on the next sync from testing-devel.
+    fcosBuild(skipInit: true, skipKola: true)
+    fcosKola(skipUpgrade: true)
 
     // also print the pkgdiff as a separate stage to make it more visible
     stage("RPM Diff") {

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,24 +1,16 @@
 packages:
-  # crypto-policies without python dependencies
-  # We're pulling from f32 here as this is a brand new change
-  # and the maintainer is not comfortable sending it to F31 yet.
-  # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
-  crypto-policies:
-    evra: 20191128-5.gitcd267a5.fc32.noarch
-  # New release of podman with fix for https://github.com/containers/libpod/issues/5306
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-fc91673e24
-  podman:
-    evra: 2:1.8.1-2.fc31.x86_64
-  podman-plugins:
-    evra: 2:1.8.1-2.fc31.x86_64
-  # Cherry-pick new {rpm-,}ostree to resolve issues with /read-only sysroot
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d920214f63
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
-  ostree:
-    evra: 2020.3-2.fc31.x86_64
-  ostree-libs:
-    evra: 2020.3-2.fc31.x86_64
+  # for https://github.com/coreos/ignition-dracut/pull/163
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-25a1e85abc
+  ignition:
+    evra: 2.2.1-3.git2d3ff58.fc32.x86_64
+  # for read-only sysroot
+  # remove on next release
   rpm-ostree:
-    evra: 2020.1.21.ge9011530-2.fc31.x86_64
+    evra: 2020.1.21.ge9011530-2.fc32.x86_64
   rpm-ostree-libs:
-    evra: 2020.1.21.ge9011530-2.fc31.x86_64
+    evra: 2020.1.21.ge9011530-2.fc32.x86_64
+  # for https://src.fedoraproject.org/rpms/skopeo/pull-request/6
+  skopeo:
+    evra: 1:0.1.41-3.fc32.x86_64
+  containers-common:
+    evra: 1:0.1.41-3.fc32.x86_64

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1103 +1,1097 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.20.10-1.fc31.x86_64"
+      "evra": "1:1.22.10-1.fc32.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.20.10-1.fc31.x86_64"
+      "evra": "1:1.22.10-1.fc32.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.20.10-1.fc31.x86_64"
+      "evra": "1:1.22.10-1.fc32.x86_64"
     },
     "acl": {
-      "evra": "2.2.53-4.fc31.x86_64"
+      "evra": "2.2.53-5.fc32.x86_64"
     },
     "adcli": {
-      "evra": "0.8.2-7.fc31.x86_64"
+      "evra": "0.9.0-1.fc32.x86_64"
     },
     "afterburn": {
-      "evra": "4.3.1-2.fc31.x86_64"
+      "evra": "4.3.2-1.fc32.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "4.3.1-2.fc31.x86_64"
+      "evra": "4.3.2-1.fc32.x86_64"
     },
     "alternatives": {
-      "evra": "1.11-5.fc31.x86_64"
+      "evra": "1.11-6.fc32.x86_64"
     },
     "attr": {
-      "evra": "2.4.48-7.fc31.x86_64"
+      "evra": "2.4.48-8.fc32.x86_64"
     },
     "audit-libs": {
-      "evra": "3.0-0.15.20191104git1c2f876.fc31.x86_64"
+      "evra": "3.0-0.19.20191104git1c2f876.fc32.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.7-20.fc31.x86_64"
+      "evra": "0.7-23.fc32.x86_64"
     },
     "basesystem": {
-      "evra": "11-8.fc31.noarch"
+      "evra": "11-9.fc32.noarch"
     },
     "bash": {
-      "evra": "5.0.11-1.fc31.x86_64"
+      "evra": "5.0.11-2.fc32.x86_64"
     },
     "bash-completion": {
-      "evra": "1:2.8-7.fc31.noarch"
+      "evra": "1:2.8-8.fc32.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.11.14-2.fc31.x86_64"
+      "evra": "32:9.11.14-5.fc32.x86_64"
     },
     "bind-libs-lite": {
-      "evra": "32:9.11.14-2.fc31.x86_64"
+      "evra": "32:9.11.14-5.fc32.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.11.14-2.fc31.noarch"
+      "evra": "32:9.11.14-5.fc32.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.11.14-2.fc31.x86_64"
-    },
-    "brotli": {
-      "evra": "1.0.7-6.fc31.x86_64"
+      "evra": "32:9.11.14-5.fc32.x86_64"
     },
     "btrfs-progs": {
-      "evra": "5.4-1.fc31.x86_64"
+      "evra": "5.6-1.fc32.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.4.0-1.fc31.x86_64"
+      "evra": "0.4.1-1.fc32.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-1.fc31.x86_64"
+      "evra": "1.0.8-2.fc32.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-1.fc31.x86_64"
+      "evra": "1.0.8-2.fc32.x86_64"
     },
     "c-ares": {
-      "evra": "1.15.0-5.module_f31+7521+8d6677fc.x86_64"
+      "evra": "1.16.0-1.module_f32+8330+e40f9292.x86_64"
     },
     "ca-certificates": {
-      "evra": "2020.2.40-1.1.fc31.noarch"
+      "evra": "2020.2.40-3.fc32.noarch"
     },
     "chrony": {
-      "evra": "3.5-4.fc31.x86_64"
+      "evra": "3.5-8.fc32.x86_64"
     },
     "cifs-utils": {
-      "evra": "6.9-2.fc31.x86_64"
+      "evra": "6.9-3.fc32.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-3.fc31.noarch"
+      "evra": "0.31-6.fc32.noarch"
     },
     "compat-readline5": {
-      "evra": "5.2-34.fc31.x86_64"
+      "evra": "5.2-36.fc32.x86_64"
     },
     "conmon": {
-      "evra": "2:2.0.11-1.fc31.x86_64"
+      "evra": "2:2.0.14-1.fc32.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.17-1.fc31.noarch"
+      "evra": "0.17-2.fc32.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.17-1.fc31.noarch"
+      "evra": "0.17-2.fc32.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.17-1.fc31.noarch"
+      "evra": "0.17-2.fc32.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.17-1.fc31.noarch"
+      "evra": "0.17-2.fc32.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.124.0-3.fc31.noarch"
+      "evra": "2:2.124.0-4.dev.git5624558.fc32.noarch"
     },
     "containerd": {
       "evra": "1.2.6-2.20190627gitd68b593.fc31.x86_64"
     },
     "containernetworking-plugins": {
-      "evra": "0.8.5-1.fc31.x86_64"
+      "evra": "0.8.5-1.1.gitf5c3d1b.fc32.x86_64"
     },
     "containers-common": {
-      "evra": "1:0.1.41-1.fc31.x86_64"
+      "evra": "1:0.1.41-1.fc32.x86_64"
     },
     "coreos-installer": {
-      "evra": "0.1.2-1.fc31.x86_64"
+      "evra": "0.1.3-1.fc31.x86_64"
     },
     "coreos-installer-systemd": {
-      "evra": "0.1.2-1.fc31.x86_64"
+      "evra": "0.1.3-1.fc31.x86_64"
     },
     "coreutils": {
-      "evra": "8.31-6.fc31.x86_64"
+      "evra": "8.32-3.fc32.1.x86_64"
     },
     "coreutils-common": {
-      "evra": "8.31-6.fc31.x86_64"
+      "evra": "8.32-3.fc32.1.x86_64"
     },
     "cpio": {
-      "evra": "2.12-12.fc31.x86_64"
+      "evra": "2.13-4.fc32.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.6-21.fc31.x86_64"
+      "evra": "2.9.6-22.fc32.x86_64"
     },
     "crun": {
-      "evra": "0.13-1.fc31.x86_64"
+      "evra": "0.13-1.fc32.x86_64"
     },
     "crypto-policies": {
       "evra": "20191128-5.gitcd267a5.fc32.noarch"
     },
     "cryptsetup": {
-      "evra": "2.3.0-1.fc31.x86_64"
+      "evra": "2.3.0-1.fc32.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.3.0-1.fc31.x86_64"
+      "evra": "2.3.0-1.fc32.x86_64"
     },
     "cups-libs": {
-      "evra": "1:2.2.12-3.fc31.x86_64"
+      "evra": "1:2.3.1-5.fc32.x86_64"
     },
     "curl": {
-      "evra": "7.66.0-1.fc31.x86_64"
+      "evra": "7.69.1-1.fc32.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.27-2.fc31.x86_64"
+      "evra": "2.1.27-4.fc32.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.27-2.fc31.x86_64"
+      "evra": "2.1.27-4.fc32.x86_64"
     },
     "dbus": {
-      "evra": "1:1.12.16-3.fc31.x86_64"
+      "evra": "1:1.12.16-4.fc32.x86_64"
     },
     "dbus-broker": {
-      "evra": "21-6.fc31.x86_64"
+      "evra": "22-1.fc32.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.12.16-3.fc31.noarch"
+      "evra": "1:1.12.16-4.fc32.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.12.16-3.fc31.x86_64"
+      "evra": "1:1.12.16-4.fc32.x86_64"
     },
     "dbxtool": {
-      "evra": "8-10.fc31.x86_64"
+      "evra": "8-11.fc32.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.165-1.fc31.x86_64"
+      "evra": "1.02.171-1.fc32.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.165-1.fc31.x86_64"
+      "evra": "1.02.171-1.fc32.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.165-1.fc31.x86_64"
+      "evra": "1.02.171-1.fc32.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.165-1.fc31.x86_64"
+      "evra": "1.02.171-1.fc32.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.8.0-3.fc31.x86_64"
+      "evra": "0.8.2-3.fc32.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.8.0-3.fc31.x86_64"
+      "evra": "0.8.2-3.fc32.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.8.5-2.fc31.x86_64"
-    },
-    "dhcp-client": {
-      "evra": "12:4.4.1-19.fc31.x86_64"
-    },
-    "dhcp-common": {
-      "evra": "12:4.4.1-19.fc31.noarch"
+      "evra": "0.8.5-3.fc32.x86_64"
     },
     "diffutils": {
-      "evra": "3.7-3.fc31.x86_64"
+      "evra": "3.7-4.fc32.x86_64"
     },
     "dosfstools": {
-      "evra": "4.1-9.fc31.x86_64"
+      "evra": "4.1-10.fc32.x86_64"
     },
     "dracut": {
-      "evra": "049-27.git20181204.fc31.1.x86_64"
+      "evra": "050-26.git20200316.fc32.x86_64"
     },
     "dracut-network": {
-      "evra": "049-27.git20181204.fc31.1.x86_64"
+      "evra": "050-26.git20200316.fc32.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.45.5-1.fc31.x86_64"
+      "evra": "1.45.5-3.fc32.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.45.5-1.fc31.x86_64"
+      "evra": "1.45.5-3.fc32.x86_64"
     },
     "efi-filesystem": {
-      "evra": "4-3.fc31.noarch"
+      "evra": "4-4.fc32.noarch"
     },
     "efibootmgr": {
-      "evra": "16-6.fc31.x86_64"
+      "evra": "16-7.fc32.x86_64"
     },
     "efivar-libs": {
-      "evra": "37-6.fc31.x86_64"
+      "evra": "37-6.fc32.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.178-7.fc31.noarch"
+      "evra": "0.179-1.fc32.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.178-7.fc31.x86_64"
+      "evra": "0.179-1.fc32.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.178-7.fc31.x86_64"
+      "evra": "0.179-1.fc32.x86_64"
     },
     "expat": {
-      "evra": "2.2.8-1.fc31.x86_64"
+      "evra": "2.2.8-2.fc32.x86_64"
     },
     "fedora-coreos-pinger": {
-      "evra": "0.0.4-1.module_f31+5371+3c747891.x86_64"
+      "evra": "0.0.4-1.module_f32+6507+a4e4adf6.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "31-1.noarch"
+      "evra": "32-0.7.noarch"
     },
     "fedora-release-common": {
-      "evra": "31-2.noarch"
+      "evra": "32-0.8.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "31-2.noarch"
+      "evra": "32-0.8.noarch"
     },
     "fedora-repos": {
-      "evra": "31-1.noarch"
+      "evra": "32-0.7.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "31-1.noarch"
+      "evra": "32-0.7.noarch"
     },
     "file": {
-      "evra": "5.37-8.fc31.x86_64"
+      "evra": "5.38-2.fc32.x86_64"
     },
     "file-libs": {
-      "evra": "5.37-8.fc31.x86_64"
+      "evra": "5.38-2.fc32.x86_64"
     },
     "filesystem": {
-      "evra": "3.12-2.fc31.x86_64"
+      "evra": "3.14-2.fc32.x86_64"
     },
     "findutils": {
-      "evra": "1:4.6.0-24.fc31.x86_64"
+      "evra": "1:4.7.0-3.fc32.x86_64"
     },
     "fipscheck": {
-      "evra": "1.5.0-7.fc31.x86_64"
+      "evra": "1.5.0-8.fc32.x86_64"
     },
     "fipscheck-lib": {
-      "evra": "1.5.0-7.fc31.x86_64"
+      "evra": "1.5.0-8.fc32.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.4.4-2.fc31.x86_64"
-    },
-    "freetype": {
-      "evra": "2.10.0-3.fc31.x86_64"
+      "evra": "1.6.3-1.fc32.x86_64"
     },
     "fstrm": {
-      "evra": "0.5.0-1.fc31.x86_64"
+      "evra": "0.5.0-2.fc32.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-8.fc31.x86_64"
+      "evra": "2.9.9-9.fc32.x86_64"
     },
     "fuse-common": {
-      "evra": "3.6.2-1.fc31.x86_64"
+      "evra": "3.9.1-1.fc32.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-8.fc31.x86_64"
+      "evra": "2.9.9-9.fc32.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "0.7.6-2.fc31.x86_64"
+      "evra": "0.7.8-1.fc32.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.0-2.fc31.x86_64"
+      "evra": "3.7.0-3.fc32.x86_64"
     },
     "fuse3": {
-      "evra": "3.6.2-1.fc31.x86_64"
+      "evra": "3.9.1-1.fc32.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.6.2-1.fc31.x86_64"
+      "evra": "3.9.1-1.fc32.x86_64"
     },
     "gawk": {
-      "evra": "5.0.1-5.fc31.x86_64"
+      "evra": "5.0.1-7.fc32.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.4-5.fc31.x86_64"
+      "evra": "1.0.5-1.fc32.x86_64"
     },
     "gettext": {
-      "evra": "0.20.1-3.fc31.x86_64"
+      "evra": "0.20.1-4.fc32.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.20.1-3.fc31.x86_64"
+      "evra": "0.20.1-4.fc32.x86_64"
     },
     "git-core": {
-      "evra": "2.25.1-2.fc31.x86_64"
+      "evra": "2.26.0-1.fc32.x86_64"
     },
     "glib2": {
-      "evra": "2.62.5-1.fc31.x86_64"
+      "evra": "2.64.1-1.fc32.x86_64"
     },
     "glibc": {
-      "evra": "2.30-10.fc31.x86_64"
+      "evra": "2.31-2.fc32.x86_64"
     },
     "glibc-all-langpacks": {
-      "evra": "2.30-10.fc31.x86_64"
+      "evra": "2.31-2.fc32.x86_64"
     },
     "glibc-common": {
-      "evra": "2.30-10.fc31.x86_64"
+      "evra": "2.31-2.fc32.x86_64"
     },
     "gmp": {
-      "evra": "1:6.1.2-10.fc31.x86_64"
+      "evra": "1:6.1.2-13.fc32.x86_64"
     },
     "gnupg2": {
-      "evra": "2.2.18-2.fc31.x86_64"
+      "evra": "2.2.19-1.fc32.x86_64"
     },
     "gnutls": {
-      "evra": "3.6.11-1.fc31.x86_64"
+      "evra": "3.6.13-1.fc32.x86_64"
     },
     "gpgme": {
-      "evra": "1.13.1-3.fc31.x86_64"
+      "evra": "1.13.1-6.fc32.x86_64"
     },
     "grep": {
-      "evra": "3.3-3.fc31.x86_64"
+      "evra": "3.3-4.fc32.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.02-105.fc31.noarch"
+      "evra": "1:2.04-12.fc32.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.02-105.fc31.x86_64"
+      "evra": "1:2.04-12.fc32.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.02-105.fc31.x86_64"
+      "evra": "1:2.04-12.fc32.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.02-105.fc31.noarch"
+      "evra": "1:2.04-12.fc32.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.02-105.fc31.x86_64"
-    },
-    "grub2-tools-extra": {
-      "evra": "1:2.02-105.fc31.x86_64"
+      "evra": "1:2.04-12.fc32.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.02-105.fc31.x86_64"
+      "evra": "1:2.04-12.fc32.x86_64"
     },
     "gzip": {
-      "evra": "1.10-1.fc31.x86_64"
+      "evra": "1.10-2.fc32.x86_64"
     },
     "hostname": {
-      "evra": "3.20-9.fc31.x86_64"
+      "evra": "3.23-2.fc32.x86_64"
     },
     "ignition": {
-      "evra": "2.1.1-5.git40c0b57.fc31.x86_64"
-    },
-    "ipcalc": {
-      "evra": "0.3.0-1.fc31.x86_64"
+      "evra": "2.2.1-3.git2d3ff58.fc32.x86_64"
     },
     "iproute": {
-      "evra": "5.4.0-1.fc31.x86_64"
+      "evra": "5.5.0-1.fc32.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.4.0-1.fc31.x86_64"
+      "evra": "5.5.0-1.fc32.x86_64"
     },
     "iptables": {
-      "evra": "1.8.3-7.fc31.x86_64"
+      "evra": "1.8.4-7.fc32.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.3-7.fc31.x86_64"
+      "evra": "1.8.4-7.fc32.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.3-7.fc31.x86_64"
+      "evra": "1.8.4-7.fc32.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.3-7.fc31.x86_64"
+      "evra": "1.8.4-7.fc32.x86_64"
     },
     "iputils": {
-      "evra": "20190515-5.fc31.x86_64"
+      "evra": "20190515-5.fc32.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.4.0-4.fc31.x86_64"
+      "evra": "2:1.4.0-5.fc32.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.0.876-10.gitf3c8e90.fc31.x86_64"
+      "evra": "6.2.1.0-2.git4440e57.fc32.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.0.876-10.gitf3c8e90.fc31.x86_64"
+      "evra": "6.2.1.0-2.git4440e57.fc32.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.97-9.fc31.x86_64"
+      "evra": "0.97-10.fc32.x86_64"
     },
     "jansson": {
-      "evra": "2.12-4.fc31.x86_64"
+      "evra": "2.12-5.fc32.x86_64"
     },
     "jq": {
-      "evra": "1.6-3.fc31.x86_64"
+      "evra": "1.6-4.fc32.x86_64"
     },
     "json-c": {
-      "evra": "0.13.1-8.fc31.x86_64"
+      "evra": "0.13.1-9.fc32.x86_64"
     },
     "json-glib": {
-      "evra": "1.4.4-3.fc31.x86_64"
+      "evra": "1.4.4-4.fc32.x86_64"
     },
     "kbd": {
-      "evra": "2.0.4-14.fc31.x86_64"
+      "evra": "2.2.0-1.fc32.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.0.4-14.fc31.noarch"
+      "evra": "2.2.0-1.fc32.noarch"
     },
     "kbd-misc": {
-      "evra": "2.0.4-14.fc31.noarch"
+      "evra": "2.2.0-1.fc32.noarch"
     },
     "kernel": {
-      "evra": "5.5.8-200.fc31.x86_64"
+      "evra": "5.6.2-300.fc32.x86_64"
     },
     "kernel-core": {
-      "evra": "5.5.8-200.fc31.x86_64"
+      "evra": "5.6.2-300.fc32.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.5.8-200.fc31.x86_64"
+      "evra": "5.6.2-300.fc32.x86_64"
     },
     "keyutils": {
-      "evra": "1.6-3.fc31.x86_64"
+      "evra": "1.6-4.fc32.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6-3.fc31.x86_64"
+      "evra": "1.6-4.fc32.x86_64"
     },
     "kmod": {
-      "evra": "26-4.fc31.x86_64"
+      "evra": "27-1.fc32.x86_64"
     },
     "kmod-libs": {
-      "evra": "26-4.fc31.x86_64"
+      "evra": "27-1.fc32.x86_64"
     },
     "kpartx": {
-      "evra": "0.8.0-3.fc31.x86_64"
+      "evra": "0.8.2-3.fc32.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.17-46.fc31.x86_64"
+      "evra": "1.18-1.fc32.x86_64"
     },
     "less": {
-      "evra": "551-2.fc31.x86_64"
+      "evra": "551-3.fc32.x86_64"
     },
     "libacl": {
-      "evra": "2.2.53-4.fc31.x86_64"
+      "evra": "2.2.53-5.fc32.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-6.fc31.x86_64"
+      "evra": "0.3.111-7.fc32.x86_64"
     },
     "libarchive": {
-      "evra": "3.4.2-1.fc31.x86_64"
+      "evra": "3.4.2-1.fc32.x86_64"
     },
     "libargon2": {
-      "evra": "20171227-3.fc31.x86_64"
+      "evra": "20171227-4.fc32.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.3-2.fc31.x86_64"
+      "evra": "2.5.3-3.fc32.x86_64"
     },
     "libattr": {
-      "evra": "2.4.48-7.fc31.x86_64"
+      "evra": "2.4.48-8.fc32.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-43.fc31.x86_64"
+      "evra": "0.1.1-44.fc32.x86_64"
     },
     "libblkid": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
+    },
+    "libbrotli": {
+      "evra": "1.0.7-10.fc32.x86_64"
     },
     "libcap": {
-      "evra": "2.26-6.fc31.x86_64"
+      "evra": "2.26-7.fc32.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.7.10-1.fc31.x86_64"
+      "evra": "0.7.10-2.fc32.x86_64"
+    },
+    "libcbor": {
+      "evra": "0.5.0-7.fc32.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-43.fc31.x86_64"
+      "evra": "0.7.0-44.fc32.x86_64"
     },
     "libcom_err": {
-      "evra": "1.45.5-1.fc31.x86_64"
+      "evra": "1.45.5-3.fc32.x86_64"
     },
     "libcroco": {
-      "evra": "0.6.13-2.fc31.x86_64"
+      "evra": "0.6.13-3.fc32.x86_64"
     },
     "libcurl": {
-      "evra": "7.66.0-1.fc31.x86_64"
+      "evra": "7.69.1-1.fc32.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-18.fc31.x86_64"
+      "evra": "0.14-19.fc32.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-38.fc31.x86_64"
+      "evra": "5.3.28-40.fc32.x86_64"
     },
     "libdb-utils": {
-      "evra": "5.3.28-38.fc31.x86_64"
+      "evra": "5.3.28-40.fc32.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-43.fc31.x86_64"
+      "evra": "0.5.0-44.fc32.x86_64"
     },
     "libedit": {
-      "evra": "3.1-30.20191211cvs.fc31.x86_64"
+      "evra": "3.1-32.20191231cvs.fc32.x86_64"
     },
     "libevent": {
-      "evra": "2.1.8-7.fc31.x86_64"
+      "evra": "2.1.8-8.fc32.x86_64"
     },
     "libfdisk": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
     },
     "libffi": {
-      "evra": "3.1-23.fc31.x86_64"
+      "evra": "3.1-24.fc32.x86_64"
+    },
+    "libfido2": {
+      "evra": "1.3.1-1.fc32.x86_64"
     },
     "libgcc": {
-      "evra": "9.2.1-1.fc31.x86_64"
+      "evra": "10.0.1-0.11.fc32.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.8.5-1.fc31.x86_64"
+      "evra": "1.8.5-3.fc32.x86_64"
     },
     "libgomp": {
-      "evra": "9.2.1-1.fc31.x86_64"
+      "evra": "10.0.1-0.11.fc32.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.36-2.fc31.x86_64"
+      "evra": "1.36-3.fc32.x86_64"
+    },
+    "libicu": {
+      "evra": "65.1-2.fc32.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.0-1.fc31.x86_64"
+      "evra": "2.3.0-2.fc32.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-43.fc31.x86_64"
+      "evra": "1.3.1-44.fc32.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "libkcapi": {
-      "evra": "1.1.5-1.fc31.x86_64"
+      "evra": "1.1.5-2.fc32.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.1.5-1.fc31.x86_64"
+      "evra": "1.1.5-2.fc32.x86_64"
     },
     "libksba": {
-      "evra": "1.3.5-10.fc31.x86_64"
+      "evra": "1.3.5-11.fc32.x86_64"
     },
     "libldb": {
-      "evra": "2.0.8-1.fc31.x86_64"
+      "evra": "2.1.1-1.fc32.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.2.0-8.fc31.x86_64"
+      "evra": "1.3.2-2.fc32.x86_64"
     },
     "libmetalink": {
-      "evra": "0.1.3-9.fc31.x86_64"
+      "evra": "0.1.3-10.fc32.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.4-10.fc31.x86_64"
+      "evra": "1.0.4-11.fc32.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.9.1-1.fc31.x86_64"
+      "evra": "2.9.1-1.fc32.x86_64"
     },
     "libmount": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
     },
     "libndp": {
-      "evra": "1.7-4.fc31.x86_64"
+      "evra": "1.7-5.fc32.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.7-3.fc31.x86_64"
+      "evra": "1.0.7-4.fc32.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-16.fc31.x86_64"
+      "evra": "1.0.1-17.fc32.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.4.3-0.fc31.x86_64"
+      "evra": "1:2.4.3-0.fc32.x86_64"
     },
     "libnftnl": {
-      "evra": "1.1.3-2.fc31.x86_64"
+      "evra": "1.1.5-2.fc32.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.40.0-2.module_f31+7692+42f50940.x86_64"
+      "evra": "1.40.0-2.module_f32+8199+88b63a05.x86_64"
     },
     "libnl3": {
-      "evra": "3.5.0-1.fc31.x86_64"
+      "evra": "3.5.0-2.fc32.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.5.0-1.fc31.x86_64"
+      "evra": "3.5.0-2.fc32.x86_64"
     },
     "libnsl2": {
-      "evra": "1.2.0-5.20180605git4a062cf.fc31.x86_64"
+      "evra": "1.2.0-6.20180605git4a062cf.fc32.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-43.fc31.x86_64"
+      "evra": "0.2.1-44.fc32.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.9.1-2.fc31.x86_64"
+      "evra": "14:1.9.1-3.fc32.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.6.3-2.fc31.x86_64"
-    },
-    "libpng": {
-      "evra": "2:1.6.37-2.fc31.x86_64"
+      "evra": "1.6.3-3.fc32.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.0-2.fc31.x86_64"
+      "evra": "0.21.0-4.fc32.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.2-1.fc31.x86_64"
+      "evra": "1.4.2-2.fc32.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-43.fc31.x86_64"
+      "evra": "0.1.5-44.fc32.x86_64"
     },
     "librepo": {
-      "evra": "1.11.1-1.fc31.x86_64"
+      "evra": "1.11.1-4.fc32.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.12.0-1.fc31.noarch"
+      "evra": "2.12.0-3.fc32.noarch"
     },
     "libseccomp": {
-      "evra": "2.4.2-2.fc31.x86_64"
+      "evra": "2.4.2-3.fc32.x86_64"
     },
     "libselinux": {
-      "evra": "2.9-5.fc31.x86_64"
+      "evra": "3.0-3.fc32.x86_64"
     },
     "libselinux-utils": {
-      "evra": "2.9-5.fc31.x86_64"
+      "evra": "3.0-3.fc32.x86_64"
     },
     "libsemanage": {
-      "evra": "2.9-3.fc31.x86_64"
+      "evra": "3.0-3.fc32.x86_64"
     },
     "libsepol": {
-      "evra": "2.9-2.fc31.x86_64"
+      "evra": "3.0-3.fc32.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.11-8.fc31.x86_64"
+      "evra": "2.11-10.fc32.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.11.6-0.fc31.x86_64"
+      "evra": "2:4.12.0-6.fc32.1.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.11-1.fc31.x86_64"
+      "evra": "0.7.11-2.fc32.x86_64"
     },
     "libss": {
-      "evra": "1.45.5-1.fc31.x86_64"
+      "evra": "1.45.5-3.fc32.x86_64"
     },
     "libssh": {
-      "evra": "0.9.3-1.fc31.x86_64"
+      "evra": "0.9.3-2.fc32.x86_64"
     },
     "libssh-config": {
-      "evra": "0.9.3-1.fc31.noarch"
+      "evra": "0.9.3-2.fc32.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "libstdc++": {
-      "evra": "9.2.1-1.fc31.x86_64"
+      "evra": "10.0.1-0.11.fc32.x86_64"
     },
     "libtalloc": {
-      "evra": "2.3.0-1.fc31.x86_64"
+      "evra": "2.3.1-2.fc32.x86_64"
     },
     "libtasn1": {
-      "evra": "4.14-2.fc31.x86_64"
+      "evra": "4.16.0-1.fc32.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.2-1.fc31.x86_64"
+      "evra": "1.4.3-2.fc32.x86_64"
     },
     "libteam": {
-      "evra": "1.29-2.fc31.x86_64"
+      "evra": "1.30-2.fc32.x86_64"
     },
     "libtevent": {
-      "evra": "0.10.1-1.fc31.x86_64"
+      "evra": "0.10.2-2.fc32.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.20.1-3.fc31.x86_64"
+      "evra": "0.20.1-4.fc32.x86_64"
     },
     "libtirpc": {
-      "evra": "1.2.5-1.rc2.fc31.x86_64"
+      "evra": "1.2.5-1.rc2.fc32.x86_64"
     },
     "libunistring": {
-      "evra": "0.9.10-6.fc31.x86_64"
+      "evra": "0.9.10-7.fc32.x86_64"
     },
     "libusbx": {
-      "evra": "1.0.22-4.fc31.x86_64"
+      "evra": "1.0.23-1.fc32.x86_64"
     },
     "libuser": {
-      "evra": "0.62-21.fc31.x86_64"
+      "evra": "0.62-24.fc32.x86_64"
     },
     "libutempter": {
-      "evra": "1.1.6-17.fc31.x86_64"
+      "evra": "1.1.6-18.fc32.x86_64"
     },
     "libuuid": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
     },
     "libvarlink-util": {
-      "evra": "18-2.fc31.x86_64"
+      "evra": "18-3.fc32.x86_64"
     },
     "libverto": {
-      "evra": "0.3.0-8.fc31.x86_64"
+      "evra": "0.3.0-9.fc32.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.11.6-0.fc31.x86_64"
+      "evra": "2:4.12.0-6.fc32.1.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.15-1.fc31.x86_64"
+      "evra": "4.4.16-1.fc32.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.10-3.fc31.x86_64"
+      "evra": "2.9.10-3.fc32.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.2-2.fc31.x86_64"
+      "evra": "0.2.2-3.fc32.x86_64"
     },
     "libzstd": {
-      "evra": "1.4.4-1.fc31.x86_64"
+      "evra": "1.4.4-2.fc32.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-25.fc31.x86_64"
+      "evra": "2.5.1-26.fc32.x86_64"
     },
     "linux-firmware": {
-      "evra": "20200122-105.fc31.noarch"
+      "evra": "20200316-106.fc32.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20200122-105.fc31.noarch"
+      "evra": "20200316-106.fc32.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.23-3.fc31.x86_64"
+      "evra": "0.9.24-1.fc32.x86_64"
     },
     "logrotate": {
-      "evra": "3.15.1-1.fc31.x86_64"
+      "evra": "3.15.1-3.fc32.x86_64"
     },
     "lsof": {
-      "evra": "4.93.2-2.fc31.x86_64"
+      "evra": "4.93.2-3.fc32.x86_64"
     },
     "lua-libs": {
-      "evra": "5.3.5-6.fc31.x86_64"
+      "evra": "5.3.5-7.fc32.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.06-1.fc31.x86_64"
+      "evra": "2.03.09-1.fc32.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.06-1.fc31.x86_64"
+      "evra": "2.03.09-1.fc32.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.1-1.fc31.x86_64"
+      "evra": "1.9.1-2.fc32.x86_64"
     },
     "lzo": {
-      "evra": "2.08-16.fc31.x86_64"
+      "evra": "2.10-2.fc32.x86_64"
     },
     "mdadm": {
-      "evra": "4.1-1.fc31.x86_64"
+      "evra": "4.1-4.fc32.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-34.fc31.x86_64"
+      "evra": "2:2.1-35.fc32.x86_64"
     },
     "moby-engine": {
-      "evra": "18.09.8-2.ce.git0dd43dd.fc31.x86_64"
+      "evra": "19.03.8-1.ce.gitafacb8b.fc32.x86_64"
     },
     "mokutil": {
-      "evra": "1:0.3.0-14.fc31.x86_64"
+      "evra": "2:0.3.0-15.fc32.x86_64"
     },
     "mozjs60": {
-      "evra": "60.9.0-5.fc31.x86_64"
+      "evra": "60.9.0-5.fc32.x86_64"
     },
     "mpfr": {
-      "evra": "3.1.6-5.fc31.x86_64"
+      "evra": "4.0.2-3.fc32.x86_64"
     },
     "ncurses": {
-      "evra": "6.1-12.20190803.fc31.x86_64"
+      "evra": "6.1-15.20191109.fc32.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.1-12.20190803.fc31.noarch"
+      "evra": "6.1-15.20191109.fc32.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.1-12.20190803.fc31.x86_64"
+      "evra": "6.1-15.20191109.fc32.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.55.20160912git.fc31.x86_64"
+      "evra": "2.0-0.56.20160912git.fc32.x86_64"
     },
     "nettle": {
-      "evra": "3.5.1-3.fc31.x86_64"
+      "evra": "3.5.1-5.fc32.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.4.3-0.fc31.x86_64"
+      "evra": "1:2.4.3-0.fc32.x86_64"
     },
     "nftables": {
-      "evra": "1:0.9.1-3.fc31.x86_64"
+      "evra": "1:0.9.3-2.fc32.x86_64"
     },
     "npth": {
-      "evra": "1.6-3.fc31.x86_64"
+      "evra": "1.6-4.fc32.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-15.fc31.x86_64"
+      "evra": "2.18.1-16.fc32.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.12-3.fc31.x86_64"
+      "evra": "2.0.12-4.fc32.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.4-1.fc31.x86_64"
+      "evra": "6.9.4-1.fc32.1.x86_64"
     },
     "openldap": {
-      "evra": "2.4.47-3.fc31.x86_64"
+      "evra": "2.4.47-4.fc32.x86_64"
     },
     "openssh": {
-      "evra": "8.1p1-1.fc31.x86_64"
+      "evra": "8.2p1-2.fc32.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.1p1-1.fc31.x86_64"
+      "evra": "8.2p1-2.fc32.x86_64"
     },
     "openssh-server": {
-      "evra": "8.1p1-1.fc31.x86_64"
+      "evra": "8.2p1-2.fc32.x86_64"
     },
     "openssl": {
-      "evra": "1:1.1.1d-2.fc31.x86_64"
+      "evra": "1:1.1.1d-7.fc32.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:1.1.1d-2.fc31.x86_64"
+      "evra": "1:1.1.1d-7.fc32.x86_64"
     },
     "os-prober": {
-      "evra": "1.77-3.fc31.x86_64"
+      "evra": "1.77-4.fc32.x86_64"
     },
     "ostree": {
-      "evra": "2020.3-2.fc31.x86_64"
+      "evra": "2020.3-2.fc32.x86_64"
     },
     "ostree-libs": {
-      "evra": "2020.3-2.fc31.x86_64"
+      "evra": "2020.3-2.fc32.x86_64"
     },
     "p11-kit": {
-      "evra": "0.23.20-1.fc31.x86_64"
+      "evra": "0.23.20-1.fc32.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.23.20-1.fc31.x86_64"
+      "evra": "0.23.20-1.fc32.x86_64"
     },
     "pam": {
-      "evra": "1.3.1-21.fc31.x86_64"
+      "evra": "1.3.1-24.fc32.x86_64"
     },
     "passwd": {
-      "evra": "0.80-7.fc31.x86_64"
+      "evra": "0.80-8.fc32.x86_64"
     },
     "pcre": {
-      "evra": "8.44-1.fc31.x86_64"
+      "evra": "8.44-1.fc32.x86_64"
     },
     "pcre2": {
-      "evra": "10.34-7.fc31.x86_64"
+      "evra": "10.34-9.fc32.x86_64"
+    },
+    "pcre2-syntax": {
+      "evra": "10.34-9.fc32.noarch"
     },
     "pigz": {
-      "evra": "2.4-5.fc31.x86_64"
+      "evra": "2.4-6.fc32.x86_64"
     },
     "pkgconf": {
-      "evra": "1.6.3-2.fc31.x86_64"
+      "evra": "1.6.3-3.fc32.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.6.3-2.fc31.noarch"
+      "evra": "1.6.3-3.fc32.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.6.3-2.fc31.x86_64"
+      "evra": "1.6.3-3.fc32.x86_64"
     },
     "podman": {
-      "evra": "2:1.8.1-2.fc31.x86_64"
+      "evra": "2:1.8.2-2.fc32.x86_64"
     },
     "podman-plugins": {
-      "evra": "2:1.8.1-2.fc31.x86_64"
+      "evra": "2:1.8.2-2.fc32.x86_64"
     },
     "policycoreutils": {
-      "evra": "2.9-5.fc31.x86_64"
+      "evra": "3.0-2.module_f32+7989+651e8914.x86_64"
     },
     "polkit": {
-      "evra": "0.116-4.fc31.1.x86_64"
+      "evra": "0.116-7.fc32.x86_64"
     },
     "polkit-libs": {
-      "evra": "0.116-4.fc31.1.x86_64"
+      "evra": "0.116-7.fc32.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-15.fc31.x86_64"
+      "evra": "0.1-16.fc32.x86_64"
     },
     "popt": {
-      "evra": "1.16-18.fc31.x86_64"
+      "evra": "1.16-19.fc32.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.15-6.fc31.x86_64"
+      "evra": "3.3.15-7.fc32.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.3.1-3.fc31.x86_64"
+      "evra": "1.3.2-2.fc32.x86_64"
     },
     "psmisc": {
-      "evra": "23.3-2.fc31.x86_64"
+      "evra": "23.3-3.fc32.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20190417-2.fc31.noarch"
+      "evra": "20190417-3.fc32.noarch"
     },
     "qrencode-libs": {
-      "evra": "4.0.2-4.fc31.x86_64"
+      "evra": "4.0.2-5.fc32.x86_64"
     },
     "readline": {
-      "evra": "8.0-3.fc31.x86_64"
+      "evra": "8.0-4.fc32.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.5-5.rc1.fc31.x86_64"
+      "evra": "1.2.5-5.rc1.fc32.1.x86_64"
     },
     "rpm": {
-      "evra": "4.15.1-1.fc31.x86_64"
+      "evra": "4.15.1-2.fc32.1.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.15.1-1.fc31.x86_64"
+      "evra": "4.15.1-2.fc32.1.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2020.1.21.ge9011530-2.fc31.x86_64"
+      "evra": "2020.1.21.ge9011530-2.fc32.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2020.1.21.ge9011530-2.fc31.x86_64"
+      "evra": "2020.1.21.ge9011530-2.fc32.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.15.1-1.fc31.x86_64"
+      "evra": "4.15.1-2.fc32.1.x86_64"
     },
     "rsync": {
-      "evra": "3.1.3-10.fc31.x86_64"
+      "evra": "3.1.3-11.fc32.x86_64"
     },
     "runc": {
-      "evra": "2:1.0.0-102.dev.gitdc9208a.fc31.x86_64"
+      "evra": "2:1.0.0-144.dev.gite6555cc.fc32.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.11.6-0.fc31.x86_64"
+      "evra": "2:4.12.0-6.fc32.1.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.11.6-0.fc31.noarch"
+      "evra": "2:4.12.0-6.fc32.1.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.11.6-0.fc31.x86_64"
+      "evra": "2:4.12.0-6.fc32.1.x86_64"
     },
     "sed": {
-      "evra": "4.5-4.fc31.x86_64"
+      "evra": "4.5-5.fc32.x86_64"
     },
     "selinux-policy": {
-      "evra": "3.14.4-49.fc31.noarch"
+      "evra": "3.14.5-32.fc32.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "3.14.4-49.fc31.noarch"
+      "evra": "3.14.5-32.fc32.noarch"
     },
     "setup": {
-      "evra": "2.13.6-1.fc31.noarch"
+      "evra": "2.13.6-2.fc32.noarch"
     },
     "sg3_utils": {
-      "evra": "1.42-8.fc31.x86_64"
+      "evra": "1.44-3.fc32.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.42-8.fc31.x86_64"
+      "evra": "1.44-3.fc32.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.6-17.fc31.x86_64"
+      "evra": "2:4.8.1-2.fc32.x86_64"
     },
     "shim-x64": {
       "evra": "15-8.x86_64"
     },
     "skopeo": {
-      "evra": "1:0.1.41-1.fc31.x86_64"
+      "evra": "1:0.1.41-1.fc32.x86_64"
     },
     "slirp4netns": {
-      "evra": "0.4.0-20.1.dev.gitbbd6f25.fc31.x86_64"
+      "evra": "0.4.3-6.0.dev.gita8414d1.fc32.x86_64"
     },
     "socat": {
-      "evra": "1.7.3.4-1.fc31.x86_64"
+      "evra": "1.7.3.4-2.fc32.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.30.0-1.fc31.x86_64"
+      "evra": "3.31.1-1.fc32.x86_64"
     },
     "sssd": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-client": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-common": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.2.3-13.fc31.x86_64"
+      "evra": "2.2.3-13.fc32.x86_64"
     },
     "sudo": {
-      "evra": "1.9.0-0.1.b1.fc31.x86_64"
+      "evra": "1.9.0-0.1.b4.fc32.x86_64"
     },
     "systemd": {
-      "evra": "243.7-1.fc31.x86_64"
+      "evra": "245.4-1.fc32.x86_64"
     },
     "systemd-container": {
-      "evra": "243.7-1.fc31.x86_64"
+      "evra": "245.4-1.fc32.x86_64"
     },
     "systemd-libs": {
-      "evra": "243.7-1.fc31.x86_64"
+      "evra": "245.4-1.fc32.x86_64"
     },
     "systemd-pam": {
-      "evra": "243.7-1.fc31.x86_64"
+      "evra": "245.4-1.fc32.x86_64"
     },
     "systemd-rpm-macros": {
-      "evra": "243.7-1.fc31.noarch"
+      "evra": "245.4-1.fc32.noarch"
     },
     "systemd-udev": {
-      "evra": "243.7-1.fc31.x86_64"
+      "evra": "245.4-1.fc32.x86_64"
     },
     "tar": {
-      "evra": "2:1.32-2.fc31.x86_64"
+      "evra": "2:1.32-4.fc32.x86_64"
     },
     "teamd": {
-      "evra": "1.29-2.fc31.x86_64"
+      "evra": "1.30-2.fc32.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.18-1.fc31.noarch"
+      "evra": "0.0.18-2.fc32.noarch"
     },
     "tzdata": {
-      "evra": "2019c-2.fc31.noarch"
+      "evra": "2019c-3.fc32.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.11.1-2.fc31.x86_64"
+      "evra": "0.11.1-3.fc32.x86_64"
     },
     "util-linux": {
-      "evra": "2.34-4.fc31.x86_64"
+      "evra": "2.35.1-7.fc32.x86_64"
     },
     "vim-minimal": {
-      "evra": "2:8.2.348-1.fc31.x86_64"
+      "evra": "2:8.2.480-1.fc32.x86_64"
     },
     "which": {
-      "evra": "2.21-15.fc31.x86_64"
-    },
-    "whois-nls": {
-      "evra": "5.5.6-1.fc31.noarch"
+      "evra": "2.21-19.fc32.x86_64"
     },
     "xfsprogs": {
-      "evra": "5.1.0-2.fc31.x86_64"
+      "evra": "5.4.0-3.fc32.x86_64"
     },
     "xz": {
-      "evra": "5.2.4-6.fc31.x86_64"
+      "evra": "5.2.5-1.fc32.x86_64"
     },
     "xz-libs": {
-      "evra": "5.2.4-6.fc31.x86_64"
+      "evra": "5.2.5-1.fc32.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-13.fc31.x86_64"
+      "evra": "2.1.0-14.fc32.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.1.5-1.fc31.x86_64"
+      "evra": "1.1.5-2.fc32.x86_64"
     },
     "zincati": {
-      "evra": "0.0.6-1.fc31.x86_64"
+      "evra": "0.0.9-1.fc31.x86_64"
     },
     "zlib": {
-      "evra": "1.2.11-20.fc31.x86_64"
+      "evra": "1.2.11-21.fc32.x86_64"
     }
   },
   "metadata": {
-    "generated": "2020-03-17T04:55:55Z",
+    "generated": "2020-04-03T18:20:32Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2019-10-23T22:52:47Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2020-03-16T14:55:10Z"
+        "generated": "2020-04-01T20:55:41Z"
       },
-      "fedora-modular": {
-        "generated": "2019-10-23T22:53:13Z"
+      "fedora-next": {
+        "generated": "2020-04-03T11:35:54Z"
       },
-      "fedora-updates": {
-        "generated": "2020-03-17T01:27:07Z"
+      "fedora-next-modular": {
+        "generated": "2020-04-03T10:09:50Z"
       },
-      "fedora-updates-modular": {
-        "generated": "2020-03-15T13:59:58Z"
+      "fedora-next-updates": {
+        "generated": "2018-02-20T19:18:14Z"
+      },
+      "fedora-next-updates-modular": {
+        "generated": "2018-02-20T19:18:14Z"
+      },
+      "local": {
+        "generated": "2020-03-20T16:46:26Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,25 +1,25 @@
-ref: fedora/${basearch}/coreos/testing-devel
+ref: fedora/${basearch}/coreos/next-devel
 include: manifests/fedora-coreos.yaml
 
-releasever: "31"
+releasever: "32"
 
 rojig:
   license: MIT
   name: fedora-coreos
-  summary: Fedora CoreOS testing-devel
+  summary: Fedora CoreOS next-devel
 
 repos:
   - fedora-coreos-pool
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
-  - fedora
-  - fedora-updates
-  - fedora-modular
-  - fedora-updates-modular
+  - fedora-next
+  - fedora-next-updates
+  - fedora-next-modular
+  - fedora-next-updates-modular
 
 add-commit-metadata:
-  fedora-coreos.stream: testing-devel
+  fedora-coreos.stream: next-devel
 
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams


### PR DESCRIPTION
This branch is forked from the testing-devel branch to start a
next-devel stream which will currently track f32. This is something we
should've done for a while now.