### PR TITLE
overlay/ignition-ostree-growfs: Don't run if root= karg

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.service
@@ -2,6 +2,9 @@
 Description=Ignition OSTree: Grow root filesystem
 DefaultDependencies=false
 ConditionKernelCommandLine=ostree
+# Similar to the other mount rules, suppress invocation if we detect
+# we are running from a legacy setup created by Anaconda.
+ConditionKernelCommandLine=!root
 ConditionPathExists=!/run/ostree-live
 Before=initrd-root-fs.target
 After=ignition-ostree-mount-firstboot-sysroot.service


### PR DESCRIPTION
This occurs in the currently artificial scenario of the RHCOS
upgrade tests from previous 4.2 Anaconda-based builds.  This wouldn't
happen in practice because growfs is already keyed off only executing
on the Ignition boot, and there's no way we'd rebase this code and
release updated 4.2 bootimages.  But, we already have similar exclusions in
the mount code, so let's do the same for growfs.