### PR TITLE
manifest/base: add dhcp-client

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -116,6 +116,10 @@ packages:
   - NetworkManager hostname
   - iproute-tc
   - adcli
+  # We still need this for now, but may drop it once we have NM in the initrd
+  # https://github.com/coreos/fedora-coreos-tracker/issues/394
+  # https://github.com/coreos/fedora-coreos-tracker/issues/429
+  - dhcp-client
   ## Teaming https://github.com/coreos/fedora-coreos-config/pull/289 and http://bugzilla.redhat.com/1758162
   - NetworkManager-team teamd
   # Static firewalling


### PR DESCRIPTION
The latest dracut (050) switched to a rich dependency to accept either
NM or `dhclient` for doing DHCP in the initrd:

https://github.com/dracutdevs/dracut/commit/e8638076857621b28eb4dc36cdd49a94992835b7

which caused us to lose it in FCOS since we do ship NM in the real root.

The dependency there should really be something like "require NM if it's
used in the initrd and the real root, otherwise require dhclient", but
you can't really do that in a spec file.

Until we have NetworkManager in the initrd, we definitely need
`dhclient` available for DHCP there.

Resolves: https://github.com/coreos/fedora-coreos-tracker/issues/429