### PR TITLE
manifest/ignition: require Ignition dracut module

### DIFF
--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -8,6 +8,10 @@
 # Include rpm-ostree + kernel + bootloader
 include: bootable-rpm-ostree.yaml
 
+initramfs-args:
+  # make it a hard error if Ignition can't be included
+  - --add=ignition
+
 # Modern defaults we want
 boot-location: modules
 tmp-is-dir: true


### PR DESCRIPTION
Explicitly do `--add=ignition` when calling `dracut` so that we fail if
for whatever reason it couldn't be included.

For more background, see:
https://github.com/coreos/fedora-coreos-tracker/issues/429