### PR TITLE
fedora-coreos-base: use NetworkManager for networking in the initramfs

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -22,3 +22,7 @@ packages:
     evra: 2020.1.21.ge9011530-2.fc31.x86_64
   rpm-ostree-libs:
     evra: 2020.1.21.ge9011530-2.fc31.x86_64
+  # Fast track new Ignition with initramfs network takedown
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-6db5551bf6
+  ignition:
+    evra: 2.2.1-1.git2d3ff58.fc31.x86_64

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -55,9 +55,6 @@ remove-from-packages:
               /usr/lib/systemd/system/systemd-networkd-wait-online.service]
   - [systemd-container, /usr/lib/systemd/network/.*]
   - [systemd-udev, /usr/lib/systemd/network/.*]
-  # We're still using the legacy dracut network module for now. Dracut keys off
-  # of this: https://github.com/dracutdevs/dracut/blob/1fcc70fe57eea0ea658aa2de5c0044683fe85cf1/modules.d/40network/module-setup.sh#L11
-  - [NetworkManager, /usr/libexec/nm-initrd-generator]
 
 
 remove-files:
@@ -116,10 +113,6 @@ packages:
   - NetworkManager hostname
   - iproute-tc
   - adcli
-  # We still need this for now, but may drop it once we have NM in the initrd
-  # https://github.com/coreos/fedora-coreos-tracker/issues/394
-  # https://github.com/coreos/fedora-coreos-tracker/issues/429
-  - dhcp-client
   ## Teaming https://github.com/coreos/fedora-coreos-config/pull/289 and http://bugzilla.redhat.com/1758162
   - NetworkManager-team teamd
   # Static firewalling


### PR DESCRIPTION
Moving to NetworkManager in the initrd should help us solve some
problems we've been having with Networking. For what we want to
do in Fedora CoreOS doing this right requires the network to be
torn down in the initrd and also possibly propagated forward.

Requires: https://github.com/coreos/ignition-dracut/pull/159
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/394