### PR TITLE
overlay/05core: Set SYSTEMD_SULOGIN_FORCE=1 for emergency.service

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/emergency.service.d/coreos-sulogin-force.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/emergency.service.d/coreos-sulogin-force.conf
@@ -1,0 +1,6 @@
+# https://github.com/coreos/coreos-installer/commit/15a79263d0bd5d72056a6080f6687dc10cba2dda
+# https://github.com/systemd/systemd/pull/10397
+# We want `systemd.unit=emergency.target` to Just Work even with our locked
+# root account.
+[Service]
+Environment=SYSTEMD_SULOGIN_FORCE=1

--- a/overlay.d/05core/usr/lib/systemd/system/rescue.service.d/coreos-sulogin-force.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/rescue.service.d/coreos-sulogin-force.conf
@@ -1,0 +1,1 @@
+../emergency.service.d/coreos-sulogin-force.conf


### PR DESCRIPTION
This makes
https://github.com/coreos/coreos-installer/commit/15a79263d0bd5d72056a6080f6687dc10cba2dda
global.

We want booting with `systemd.unit=emergency.target` to Just Work even with our locked
root account.