### PR TITLE
ci: buildprep from stream matching branch name

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -11,7 +11,7 @@ cosaPod {
         curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/master/scripts/download-overrides.py
         python3 download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
-        cosa buildprep https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds
+        cosa buildprep https://builds.coreos.fedoraproject.org/prod/streams/${env.CHANGE_TARGET}/builds
     """)
 
     fcosBuild(skipInit: true)


### PR DESCRIPTION
E.g. on `next-devel` we want CI to `buildprep` from the `next-devel`
stream.

Required for green CI in:
https://github.com/coreos/fedora-coreos-config/pull/306