### PR TITLE
overlay/ignition-ostree: Add a Requires: for sysroot in growpart

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.service
@@ -8,6 +8,7 @@ ConditionKernelCommandLine=!root
 ConditionPathExists=!/run/ostree-live
 Before=initrd-root-fs.target
 After=ignition-ostree-mount-firstboot-sysroot.service
+Requires=ignition-ostree-mount-firstboot-sysroot.service
 # This shouldn't be strictly necessary, but it's cleaner to not have OSTree muck
 # around with moving mounts while we're still resizing the filesystem.
 Before=ostree-prepare-root.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -15,6 +15,7 @@ After=ignition-disks.service
 # Note we don't have a Requires: /dev/disk/by-label/root here like
 # the -subsequent service does because ignition-disks may have
 # regenerated it.
+Requires=ignition-disks.service
 # These have an explicit dependency on After=sysroot.mount today
 Before=ostree-prepare-root.service ignition-remount-sysroot.service
 


### PR DESCRIPTION
A user reported on IRC seeing this service crash; I think that
might happen if the service runs even without the rootfs mounted
which could happen if the firstboot mount failed.

Add a `Requires:` to express the fact this is a hard dependency.