### PR TITLE
overlay/ignition-ostree: Print a clear error if we fail to find root

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -12,6 +12,9 @@ ConditionPathExists=!/run/ostree-live
 Conflicts=ignition-ostree-mount-subsequent-sysroot.service
 Before=initrd-root-fs.target
 After=ignition-disks.service
+# Note we don't have a Requires: /dev/disk/by-label/root here like
+# the -subsequent service does because ignition-disks may have
+# regenerated it.
 # These have an explicit dependency on After=sysroot.mount today
 Before=ostree-prepare-root.service ignition-remount-sysroot.service
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 # or not we've reprovisioned the rootfs, since we don't want to
 # force on prjquota there.
 rootpath=/dev/disk/by-label/root
+if ! [ -b "${rootpath}" ]; then
+  echo "ignition-ostree-mount-sysroot: Failed to find ${rootpath}" 1>&2
+  exit 1
+fi
 eval $(blkid -o export ${rootpath})
 mountflags=
 if [ "${TYPE}" == "xfs" ]; then


### PR DESCRIPTION
Previously we'd just crash with an `unbound TYPE` error; this should
help lead people in the right direction.