### PR TITLE
manifests: drop whois-nls

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -153,7 +153,6 @@ packages:
   - coreos-installer coreos-installer-systemd
   # i18n
   - kbd
-  - whois-nls
   # Parsing/Interacting with JSON data
   - jq
 


### PR DESCRIPTION
No one really knows what it's needed for and no other
package seems to require it.