### PR TITLE
WIP: Run NM via systemd unit, don't depend on ip=dhcp kargs

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -28,6 +28,6 @@ set timeout=5
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
-	linux /images/vmlinuz @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+	linux /images/vmlinuz @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
 	initrd /images/initramfs.img
 }

--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -67,7 +67,7 @@ label linux
   menu label ^Fedora CoreOS (Live)
   menu default
   kernel /images/vmlinuz
-  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
 
 menu separator # insert an empty line
 

--- a/live/zipl.prm
+++ b/live/zipl.prm
@@ -1,1 +1,1 @@
-@@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+@@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal

--- a/overlay.d/05core/usr/lib/dracut/modules.d/39coreos-ignitionnetwork/coreos-NetworkManager.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/39coreos-ignitionnetwork/coreos-NetworkManager.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Network Manager (CoreOS initrd)
+Wants=network.target
+After=network-pre.target dbus.service
+Before=network.target network.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/nm-initrd-generator rd.neednet=1 ip=dhcp,dhcp6
+ExecStart=/usr/sbin/NetworkManager --configure-and-quit=initrd --no-daemon
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_DAC_OVERRIDE CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_KILL CAP_SYS_CHROOT

--- a/overlay.d/05core/usr/lib/dracut/modules.d/39coreos-ignitionnetwork/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/39coreos-ignitionnetwork/module-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo ignition network-manager
+}
+
+install_and_enable_unit() {
+    unit="$1"; shift
+    target="$1"; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
+    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$unit"
+}
+
+install() {
+    # We're forcibly overriding NM to be run as a service
+    install_and_enable_unit coreos-NetworkManager.service network-online.target
+}


### PR DESCRIPTION
See https://github.com/coreos/ignition-dracut/issues/94
and https://github.com/coreos/ignition/pull/948

Needs pairing with a cosa PR to drop the default `ip=dhcp` kargs.

And yes we really want to upstream this into NM by default or so.