### PR TITLE
overlay/20live: persist osmet files

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-live-persist-osmet.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-live-persist-osmet.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Persist osmet files
+DefaultDependencies=false
+ConditionPathExists=/run/ostree-live
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mkdir -p /run/coreos-installer/osmet
+ExecStart=/usr/bin/sh -c "if ls /*.osmet &>/dev/null; then cp /*.osmet /run/coreos-installer/osmet; fi"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
@@ -28,6 +28,9 @@ install() {
     install_and_enable_unit "coreos-live-clear-sssd-cache.service" \
         "ignition-complete.target"
 
+    install_and_enable_unit "coreos-live-persist-osmet.service" \
+        "default.target"
+
     inst_simple "$moddir/writable.mount" \
         "$systemdsystemunitdir/writable.mount"
 


### PR DESCRIPTION
We need to make sure that the osmet files in the initrd are kept
somewhere accessible in the real root where coreos-installer will find
them. Have a simple unit which copies them over to the right spot.