### PR TITLE
overlay/live: support booting from live ISO without networking

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -28,6 +28,6 @@ set timeout=5
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
-	linux /images/vmlinuz @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+	linux /images/vmlinuz @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
 	initrd /images/initramfs.img
 }

--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -67,7 +67,7 @@ label linux
   menu label ^Fedora CoreOS (Live)
   menu default
   kernel /images/vmlinuz
-  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
 
 menu separator # insert an empty line
 

--- a/live/zipl.prm
+++ b/live/zipl.prm
@@ -1,1 +1,1 @@
-@@KERNEL-ARGS@@ rd.neednet=1 ip=dhcp ignition.firstboot ignition.platform.id=metal
+@@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.service
@@ -1,0 +1,50 @@
+# This unit will run very early before the dracut-cmdline
+# service and detect if we want to request dracut bring up
+# networking or not. We do want to request networking if:
+#
+# - the user is booting the live ISO
+# - the user didn't already request networking via rd.neednet
+# - the user provided a ignition.config.url karg, implying
+#   the need for networking
+# - there is an embedded ignition config
+#
+# For the case of the embedded Ignition config there could be a
+# case where the user embeds an Ignition config (via coreos-installer
+# iso embed) but doesn't want networking. In that case we'll have
+# smarter detection in the future (https://github.com/coreos/fedora-coreos-tracker/issues/443)
+# but the user can override with `rd.neednet=0` now if needed.
+#
+# If we do determine we need network and there are no other
+# `ip=` kargs then we'll use `ip=dhcp,dhcp6` by default.
+#
+# The requesting of network will be done by writing relevant
+# dracut networking args into /etc/cmdline.d/coreos-live-network-kargs.conf
+# so that it gets picked up by the dracut networking scripts later
+# on in boot.
+#
+# This is all done because we want to support a mode where
+# the user can boot the live ISO and get to an interactive
+# prompt without requiring networking on boot. The user can
+# then configure the networking interactively.
+#
+[Unit]
+Description=Request live ISO networking
+DefaultDependencies=no
+Before=dracut-cmdline.service
+
+# Make sure we are in the initramfs. We are booted to the live
+# ISO and rd.neednet wasn't already passed somewhere else
+ConditionPathExists=/usr/lib/initrd-release
+ConditionKernelCommandLine=!rd.neednet
+ConditionKernelCommandLine=coreos.liveiso
+ConditionPathExists=/run/ostree-live
+
+# We'll assume we need network in either of these two following
+# cases (see description from above)
+ConditionKernelCommandLine=|ignition.config.url
+ConditionPathExists=|/config.ign
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/coreos-liveiso-network-kargs

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+# For a description of how this is used see coreos-liveiso-network-kargs.service
+
+# Load the dracut library for getarg
+source /usr/lib/dracut-lib.sh
+
+main() {
+
+    # If we're running this script we already know we need networking
+    # (determined by conditionals in the systemd unit).
+    echo 'info: Requesting networking in the initramfs'
+    echo 'rd.neednet=1' > /etc/cmdline.d/10-coreos-liveiso-network-kargs.conf
+
+    # If there is not already a ip= CLI arg use ip=dhcp,dhcp6 as default.
+    if ! getarg 'ip' &>/dev/null; then
+        echo 'info: using ip=dhcp,dhcp6 default networking configuration'
+        echo 'ip=dhcp,dhcp6' >> /etc/cmdline.d/10-coreos-liveiso-network-kargs.conf
+    else
+        echo 'info: using already set karg ip= information'
+    fi
+}
+
+main

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-reconfigure-nm-wait-online.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-reconfigure-nm-wait-online.service
@@ -1,0 +1,23 @@
+# Configure NetworkManager-wait-online in the real root for the
+# Live ISO to timeout quicker and also not explicitly fail since
+# booting the Live ISO without network is a valid use case.
+#
+# Doing this improves the user experience when booting the
+# Live ISO without network.
+
+[Unit]
+Description=Reconfigure NetworkManager-wait-online service
+DefaultDependencies=no
+# Make sure we are in the initramfs and we are booted to the live ISO
+ConditionPathExists=/usr/lib/initrd-release
+ConditionKernelCommandLine=coreos.liveiso
+ConditionPathExists=/run/ostree-live
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Note keep this in sync with NetworkManager-wait-online.service
+# Right now we are keeping the same ExecStart but we are making it
+# OK to fail (`-`) and timeout sooner (5 seconds vs 30).
+ExecStartPre=/usr/bin/mkdir -p /run/systemd/system/NetworkManager-wait-online.service.d
+ExecStart=/bin/bash -c 'echo -e "[Service]\nExecStart=\nExecStart=-/usr/bin/nm-online -s -q --timeout=5" > /run/systemd/system/NetworkManager-wait-online.service.d/liveiso.conf'

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -27,6 +27,8 @@ add_requires sysroot.mount     initrd-root-fs.target
 add_requires sysroot-etc.mount initrd-root-fs.target
 add_requires sysroot-var.mount initrd-root-fs.target
 
+add_requires coreos-liveiso-network-kargs.service              initrd.target
+
 mkdir -p "${UNIT_DIR}/ostree-prepare-root.service.d"
 cat > "${UNIT_DIR}/ostree-prepare-root.service.d/10-live.conf" <<EOF
 # With live PXE there's no ostree= argument on the kernel command line, so

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -28,6 +28,7 @@ add_requires sysroot-etc.mount initrd-root-fs.target
 add_requires sysroot-var.mount initrd-root-fs.target
 
 add_requires coreos-liveiso-network-kargs.service              initrd.target
+add_requires coreos-liveiso-reconfigure-nm-wait-online.service initrd.target
 
 mkdir -p "${UNIT_DIR}/ostree-prepare-root.service.d"
 cat > "${UNIT_DIR}/ostree-prepare-root.service.d/10-live.conf" <<EOF

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -9,8 +9,9 @@ set -e
 UNIT_DIR="${1:-/tmp}"
 
 add_requires() {
-    local name="$1"
-    local requires_dir="${UNIT_DIR}/initrd-root-fs.target.requires"
+    local name="$1"; shift
+    local target="$1"; shift
+    local requires_dir="${UNIT_DIR}/${target}.requires"
     mkdir -p "${requires_dir}"
     ln -sf "../${name}" "${requires_dir}/${name}"
 }
@@ -22,9 +23,9 @@ fi
 # Create stamp file that everything else should use to detect a live boot
 > /run/ostree-live
 
-add_requires sysroot.mount
-add_requires sysroot-etc.mount
-add_requires sysroot-var.mount
+add_requires sysroot.mount     initrd-root-fs.target
+add_requires sysroot-etc.mount initrd-root-fs.target
+add_requires sysroot-var.mount initrd-root-fs.target
 
 mkdir -p "${UNIT_DIR}/ostree-prepare-root.service.d"
 cat > "${UNIT_DIR}/ostree-prepare-root.service.d/10-live.conf" <<EOF

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
@@ -36,4 +36,7 @@ install() {
 
     inst_simple "$moddir/coreos-liveiso-network-kargs.service" \
         "$systemdsystemunitdir/coreos-liveiso-network-kargs.service"
+
+    inst_simple "$moddir/coreos-liveiso-reconfigure-nm-wait-online.service" \
+        "$systemdsystemunitdir/coreos-liveiso-reconfigure-nm-wait-online.service"
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
@@ -30,4 +30,10 @@ install() {
 
     inst_simple "$moddir/writable.mount" \
         "$systemdsystemunitdir/writable.mount"
+
+    inst_simple "$moddir/coreos-liveiso-network-kargs.sh" \
+        "/usr/sbin/coreos-liveiso-network-kargs"
+
+    inst_simple "$moddir/coreos-liveiso-network-kargs.service" \
+        "$systemdsystemunitdir/coreos-liveiso-network-kargs.service"
 }


### PR DESCRIPTION
There is a scenario where the user wants to configure networking
after they get to the interactive bash prompt. Let's support this.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/349