### PR TITLE
manifests: add NetworkManager-tui

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -117,6 +117,8 @@ packages:
   - NetworkManager-team teamd
   # Static firewalling
   - iptables nftables iptables-nft iptables-services
+  # Interactive Networking configuration during coreos-install
+  - NetworkManager-tui
   # Storage
   - cloud-utils-growpart
   - lvm2 iscsi-initiator-utils sg3_utils


### PR DESCRIPTION
`nmtui` allows for a user to interactively set up networking. Using Fedora
CoreOS interactively is usually not what we encourage with Fedora CoreOS, relying
on automation instead. The one exception to this is the Live ISO environment
where our current documented workflow is for a user to boot the Live ISO and
run coreos-installer interactively (of course, there is an automation workflow
as well). In this flow it would be useful for a user to be able to have an
interactive tool that helped them set up networking if they need static networking.