### PR TITLE
[bodhi-updates] manifest: drop fedora-coreos-pool repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,9 +13,6 @@ repos:
   - fedora-updates
   - fedora-modular
   - fedora-updates-modular
-  # We don't actually want this here... it's only until we update the lockfile a
-  # better way, see: https://github.com/coreos/fedora-coreos-tracker/issues/293
-  - fedora-coreos-pool
 
 add-commit-metadata:
   fedora-coreos.stream: bodhi-updates


### PR DESCRIPTION
So... one thing I just realized is that now that we have a bunch of f32
packages in the pool, we really can't have `bodhi-updates` picking up
packages from there unlocked.

So this is sort of forcing our hand to get
https://github.com/coreos/fedora-coreos-tracker/issues/293 fixed very
soon so that we can unblock package bumps again.

As a first step and to prevent `testing-devel` ending up with a bunch of
f32 packages, let's remove the pool from the list of repos here.