### PR TITLE
[testing] use old version of coreos-pool yum repo

### DIFF
--- a/fedora-coreos-pool.repo
+++ b/fedora-coreos-pool.repo
@@ -1,6 +1,6 @@
 [fedora-coreos-pool]
 name=Fedora coreos pool repository - $basearch
-baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/$basearch/
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/1427579/$basearch/
 enabled=1
 repo_gpgcheck=0
 type=rpm-md


### PR DESCRIPTION
We need this because the f32 packages from next-devel that are now
in coreos-pool are causing packages to leak into our f31 based Fedora
CoreOS builds. Use a version of the yum repo from before the packages
were tagged in for now.