### PR TITLE
overlay: Introduce /run/bin

### DIFF
--- a/overlay.d/05core/usr/lib/tmpfiles.d/coreos-run-bin.conf
+++ b/overlay.d/05core/usr/lib/tmpfiles.d/coreos-run-bin.conf
@@ -1,0 +1,3 @@
+# See https://github.com/coreos/fedora-coreos-tracker/issues/354
+# TL;DR we want people to be able to run *transient* binaries from the host context
+d /run/bin 0755 - - -

--- a/tests/kola/basic
+++ b/tests/kola/basic
@@ -1,2 +1,10 @@
 #!/bin/bash
-exec systemctl is-enabled logrotate.service
+# Miscellaneous read-only/nondestructive tests.
+set -xeuo pipefail
+
+systemctl is-enabled logrotate.service
+
+if ! test -d /run/bin; then
+  echo "Missing /run/bin" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/354

Basically we want to support things like containers that contain
binaries designed to execute on the host.  These should really
be "lifecycle bound" to the container image.  Let's at least
have an obvious place to drop them that goes away on reboot.