### PR TITLE
manifests: add initscripts to exclude-packages

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -187,3 +187,6 @@ exclude-packages:
   - dnf
   - grubby
   - cowsay  # Just in case
+  # Let's make sure initscripts doesn't get pulled back in
+  # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
+  - initscripts


### PR DESCRIPTION
Let's just try to make sure nothing tries to bring it back in.