### PR TITLE
overlay/15fcos: Print information regarding an ignition config and authorized keys

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -1,2 +1,5 @@
 # User metrics client
 enable fedora-coreos-pinger.service
+# Provide information if no ignition is provided
+enable coreos-check-ignition-config.service
+enable coreos-check-ssh-keys.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -1,0 +1,11 @@
+# This service is used for printing a message if 
+# no ignition config is provided.
+[Unit]
+Description=Check if ignition config is provided
+Before=console-login-helper-messages-issuegen.service
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-check-ignition-config.sh
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -1,0 +1,17 @@
+# This service is used for printing a message if no ssh keys were added 
+# by ignition/afterburn
+[Unit]
+Description=Check that ssh-keys are added by aferburn/ignition
+Before=console-login-helper-messages-issuegen.service
+# https://github.com/coreos/afterburn/issues/417 is created
+# to track the issue that would allow other units to synchronize 
+# around any instance of `afterburn-sshkeys@` and not just the 
+# `core` user.
+After=afterburn-sshkeys@core.service
+ProtectHome=read-only
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-check-ssh-keys.sh
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+# The logic for the message_id is handled in 
+# https://github.com/coreos/ignition/pull/958
+# In this script, we need to capture the journald 
+# log with the particular message_id and query using 
+#`jq` utility to check if a user config is provided.
+
+# Change the output color to yellow
+warn='\033[0;33m'
+# No color
+nc='\033[0m'
+
+# See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
+# It will track the journal messages related to an ignition config provided 
+# by the user.
+output=$(journalctl -o json-pretty MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb | jq -s '.[] | select(.IGNITION_CONFIG_TYPE == "user")'| wc -l)
+
+if [[ $output -gt  0 ]];then
+   echo "Ignition: user provided config was applied" > /run/console-login-helper-messages/issue.d/30_ignition_config_info.issue
+else
+  echo -e "${warn}Ignition: no config provided by user${nc}" > /run/console-login-helper-messages/issue.d/30_ignition_config_info.issue
+fi

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+# This script will print a message in the serial console 
+# if no ssh keys were added by ignition/afterburn.
+main() {
+    # Change the output color to yellow
+    warn='\033[0;33m'
+    # No color
+    nc='\033[0m'
+
+    # See https://github.com/coreos/ignition/pull/964 for the MESSAGE_ID 
+    # source. It will track the authorized-ssh-keys entries in journald 
+    # provided via ignition.
+    ignitionusers=$(journalctl -o json-pretty MESSAGE_ID=225067b87bbd4a0cb6ab151f82fa364b | jq -r '.MESSAGE')
+
+    # See https://github.com/coreos/afterburn/pull/397 for the MESSAGE_ID 
+    # source. It will track the authorized-ssh-keys entries in journald  
+    # provided via afterburn.
+    afterburnusers=$(journalctl -o json-pretty MESSAGE_ID=0f7d7a502f2d433caa1323440a6b4190 | jq -r '.MESSAGE')
+
+    output=''
+    if [ -n "$ignitionusers" ]; then
+        output+="$ignitionusers"
+    fi
+    if [ -n "$afterburnusers" ]; then
+        output+="$afterburnusers"
+    fi
+
+    if [ -n "$output" ]; then
+        echo "$output" > /run/console-login-helper-messages/issue.d/30_ssh_authorized_keys.issue
+    else
+        echo -e "${warn}No ssh authorized keys provided by Ignition or Afterburn${nc}" \
+             > /run/console-login-helper-messages/issue.d/30_ssh_authorized_keys.issue
+    fi
+}
+
+main


### PR DESCRIPTION
Fixes #[279](https://github.com/coreos/fedora-coreos-tracker/issues/279)
Note:
As per the resolution provided in the above issue(https://github.com/coreos/fedora-coreos-tracker/issues/279#issuecomment-533731715),
-  The first bullet point is yet to finish (waiting for https://github.com/coreos/ignition/pull/958 to get merged)
- have already pushed the code for the second bullet point.