### PR TITLE
live: disable audit on Live ISO

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -28,6 +28,6 @@ set timeout=5
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Fedora CoreOS (Live)' --class fedora --class gnu-linux --class gnu --class os {
-	linux /images/vmlinuz @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
+	linux /images/vmlinuz @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal audit=0
 	initrd /images/initramfs.img
 }

--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -67,7 +67,7 @@ label linux
   menu label ^Fedora CoreOS (Live)
   menu default
   kernel /images/vmlinuz
-  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal
+  append initrd=/images/initramfs.img @@KERNEL-ARGS@@ ignition.firstboot ignition.platform.id=metal audit=0
 
 menu separator # insert an empty line
 


### PR DESCRIPTION
This is the nuclear option to fix the issue [1] where we have
audit messages coming to the console of our machines. We
specifically need the messages to be disabled on the Live ISO
because we are trying to support a workflow where a user can
interactively do an install and use TUI interfaces for configuring
networking. The increased user experience provided by a TUI is
completely lost if we have audit messages scrolling on the console
every 10 seconds or so.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/220