### PR TITLE
manifest: include audit rpm

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -55,6 +55,9 @@ remove-from-packages:
               /usr/lib/systemd/system/systemd-networkd-wait-online.service]
   - [systemd-container, /usr/lib/systemd/network/.*]
   - [systemd-udev, /usr/lib/systemd/network/.*]
+  # We don't want initscripts but audit insists on requiring it
+  # https://src.fedoraproject.org/rpms/audit/pull-request/5
+  - [initscripts, .*]
 
 
 remove-files:
@@ -94,9 +97,10 @@ postprocess:
     setsebool -P -N virt_use_samba on  # RHBZ#1754825
 
 packages:
-  # Security
+  # Security/Auditing
   - selinux-policy-targeted
   - polkit
+  - audit # https://github.com/coreos/fedora-coreos-tracker/issues/220
   # System setup
   - afterburn
   - afterburn-dracut
@@ -187,6 +191,3 @@ exclude-packages:
   - dnf
   - grubby
   - cowsay  # Just in case
-  # Let's make sure initscripts doesn't get pulled back in
-  # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
-  - initscripts


### PR DESCRIPTION
This change will cause the auditd daemon to get included in
Fedora CoreOS and be enabled by default. This is a roundabout
way of fixing [1] where we have audit messages coming to the
primary console of our FCOS machines.

This need for this is increased right now because we are trying
to support a workflow where a user can interactively do an install
using the Live ISO and use TUI interfaces for configuring networking.
The increased user experience provided by a TUI is completely lost
if we have audit messages scrolling on the console every 10 seconds
or so.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/220