### PR TITLE
manifest: move sshd config fragments to overlay sshd_config.d on F32

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -77,13 +77,20 @@ postprocess:
     for x in /etc/yum.repos.d/*modular.repo; do
       sed -i -e 's,enabled=[01],enabled=0,' ${x}
     done
-  # Read the Ignition 2 and Afterburn SSH key fragments, pending better tooling
+  # Disable the default-enabled AuthorizedKeysFile directive so we can
+  # override it in a config fragment
   # https://github.com/coreos/fedora-coreos-tracker/issues/139
+  # https://bugzilla.redhat.com/1824913
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
     sed -i 's/^AuthorizedKeysFile[[:blank:]]/#&/' /etc/ssh/sshd_config
-    echo -e '\n# Read authorized_keys fragments written by Ignition and Afterburn\nAuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn' >> /etc/ssh/sshd_config
+    . /etc/os-release
+    if [ "${VERSION_ID}" = 31 ]; then
+      # Fedora 31 doesn't read the config fragment, so we need to do this
+      # here.
+      echo -e '\n# Read authorized_keys fragments written by Ignition and Afterburn\nAuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn' >> /etc/ssh/sshd_config
+    fi
 
   # Enable SELinux booleans used by OpenShift
   # https://github.com/coreos/fedora-coreos-tracker/issues/284

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -50,8 +50,8 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-    sed -Ei 's/^(PasswordAuthentication|PermitRootLogin)[[:blank:]]/#&/' /etc/ssh/sshd_config
-    echo -e '\n# Disable password logins by default\nPasswordAuthentication no\nPermitRootLogin prohibit-password' >> /etc/ssh/sshd_config
+    sed -Ei 's/^PasswordAuthentication[[:blank:]]/#&/' /etc/ssh/sshd_config
+    echo -e '\n# Disable password logins by default\nPasswordAuthentication no' >> /etc/ssh/sshd_config
   # Users shouldn't be configuring `rpm-ostreed.conf`
   # https://github.com/coreos/fedora-coreos-tracker/issues/271
   - |

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -44,14 +44,17 @@ postprocess:
       echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/212\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/95-disable-on-dev.toml
       echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/212\nupdates.enabled = false' > /etc/zincati/config.d/95-disable-on-dev.toml
     fi
-  # Disable SSH password logins by default
-  # Move to overlay once sshd_config fragments are supported
+  # Disable SSH password logins by default on Fedora 31
+  # On newer Fedora we handle this via sshd_config.d
   # https://github.com/coreos/fedora-coreos-tracker/issues/138
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-    sed -Ei 's/^PasswordAuthentication[[:blank:]]/#&/' /etc/ssh/sshd_config
-    echo -e '\n# Disable password logins by default\nPasswordAuthentication no' >> /etc/ssh/sshd_config
+    . /etc/os-release
+    if [ "${VERSION_ID}" = 31 ]; then
+      sed -Ei 's/^PasswordAuthentication[[:blank:]]/#&/' /etc/ssh/sshd_config
+      echo -e '\n# Disable password logins by default\nPasswordAuthentication no' >> /etc/ssh/sshd_config
+    fi
   # Users shouldn't be configuring `rpm-ostreed.conf`
   # https://github.com/coreos/fedora-coreos-tracker/issues/271
   - |

--- a/overlay.d/05core/etc/ssh/sshd_config.d/20-authorized-keys.conf
+++ b/overlay.d/05core/etc/ssh/sshd_config.d/20-authorized-keys.conf
@@ -1,0 +1,5 @@
+# This file is ignored on Fedora 31.
+
+# Read authorized_keys fragments written by Ignition and Afterburn
+# https://github.com/coreos/fedora-coreos-tracker/issues/139
+AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn

--- a/overlay.d/15fcos/etc/ssh/sshd_config.d/04-disable-passwords.conf
+++ b/overlay.d/15fcos/etc/ssh/sshd_config.d/04-disable-passwords.conf
@@ -1,0 +1,7 @@
+# This file is ignored on Fedora 31.
+
+# Disable password logins by default.
+# https://github.com/coreos/fedora-coreos-tracker/issues/138
+# This file must sort before 05-redhat.conf, which enables
+# PasswordAuthentication.
+PasswordAuthentication no


### PR DESCRIPTION
Fedora 32 supports `sshd_config.d`.  Use it.  This allows users to easily re-enable password authentication if desired.

We still need to disable the default `AuthorizedKeysFile` directive, since the `Include` directive appears after it in `sshd_config`.

On Fedora 31, the `sshd_config.d` fragments will be ignored, so continue to edit `sshd_config` there.