### PR TITLE
dracut/ignition-ostree: Regenerate UUIDs for /boot and /

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+# https://github.com/coreos/fedora-coreos-tracker/issues/465
+# coreos-assembler generates disk images which are installed bit-for-bit
+# or booted directly in the cloud.
+# Generate new UUID on firstboot; this is general best practice, but in the future
+# we may use this for mounting by e.g. adding a boot=<uuid> and root=<uuid> kernel args.
+# Note this code should be changed when we land https://github.com/coreos/fedora-coreos-tracker/issues/94
+# so that we only generate a new UUID if we're using the default one.
+
+label=$1
+
+# Keep this in sync with https://github.com/coreos/coreos-assembler/blob/e3905fd2e138de04184c1cd86b99b0fd83cbe5cf/src/create_disk.sh#L17
+bootfs_uuid="96d15588-3596-4b3c-adca-a2ff7279ea63"
+rootfs_uuid="910678ff-f77e-4a7d-8d53-86f2ac47a823"
+
+target=/dev/disk/by-label/${label}
+if ! [ -b "${target}" ]; then
+  echo "$0: Failed to find block device ${target}" 1>&2
+  exit 1
+fi
+
+eval $(blkid -o export ${target})
+case "${label}" in
+  root) orig_uuid="${rootfs_uuid}"; orig_type=xfs ;;
+  boot) orig_uuid="${bootfs_uuid}"; orig_type=ext4 ;;
+  *) echo "unexpected ${label}"; exit 1 ;;
+esac
+
+if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
+  case "${TYPE}" in
+    # For now we need to fsck first, see https://github.com/coreos/coreos-assembler/pull/1452
+    # Basically we're not passing `metadata_csum_seed` as a mkfs.ext4 option
+    # because grub2 barfs on it.
+    ext4) e2fsck -y "${target}" && tune2fs -U random "${target}" ;;
+    xfs) xfs_admin -U generate "${target}" ;;
+    *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
+  esac
+  echo "Regenerated UUID for ${target}"
+else
+  echo "No changes required for ${target} TYPE=${TYPE} UUID=${UUID}"
+fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-boot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-boot.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Ignition OSTree: Regenerate filesystem UUID (boot)
+DefaultDependencies=false
+ConditionPathExists=/usr/lib/initrd-release
+ConditionKernelCommandLine=ostree
+ConditionPathExists=!/run/ostree-live
+# We run pretty early
+Before=coreos-copy-firstboot-network.service
+Before=ignition-fetch.service
+Before=ignition-setup-base.service
+Before=ignition-setup-user.service
+
+Before=systemd-fsck@dev-disk-by\x2dlabel-boot.service
+Requires=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-boot.device
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/ignition-ostree-firstboot-uuid boot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Ignition OSTree: Regenerate filesystem UUID (root)
+# These conditions match mount-firstboot-sysroot.service
+DefaultDependencies=false
+ConditionKernelCommandLine=!root
+ConditionKernelCommandLine=ostree
+ConditionPathExists=!/run/ostree-live
+Before=initrd-root-fs.target
+After=ignition-disks.service
+
+# Avoid racing with fsck
+Before=systemd-fsck@dev-disk-by\x2dlabel-boot.service
+
+# Note we don't have a Requires: /dev/disk/by-label/root here like
+# the -subsequent service does because ignition-disks may have
+# regenerated it.
+Before=ignition-ostree-mount-firstboot-sysroot.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/ignition-ostree-firstboot-uuid root

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -33,9 +33,11 @@ install() {
         findmnt   \
         growpart  \
         realpath  \
+        tune2fs   \
         resize2fs \
         tail      \
         touch     \
+        xfs_admin \
         xfs_growfs
 
     # growpart deps
@@ -60,6 +62,11 @@ install() {
     done
 
     install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service diskful
+    for p in boot root; do
+        install_ignition_unit ignition-ostree-uuid-${p}.service diskful
+    done
+    inst_script "$moddir/ignition-ostree-firstboot-uuid" \
+        "/usr/sbin/ignition-ostree-firstboot-uuid"
     install_ignition_unit ignition-ostree-mount-subsequent-sysroot.service diskful-subsequent
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \
         "/usr/sbin/ignition-ostree-mount-sysroot"


### PR DESCRIPTION
This is a general best practice; the intention of filesystem
UUIDs is that they're unique.  It helps backup systems and the like
if we change this.

But in the future, we may also switch to using these UUIDs for subsequent
boots; see: https://github.com/coreos/fedora-coreos-tracker/issues/465