### PR TITLE
manifest: move pool repo to lockfile-repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,7 +9,6 @@ rojig:
   summary: Fedora CoreOS testing-devel
 
 repos:
-  - fedora-coreos-pool
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
@@ -17,6 +16,12 @@ repos:
   - fedora-updates
   - fedora-modular
   - fedora-updates-modular
+
+# All Fedora CoreOS streams share the same pool for locked files.
+# This will be in fedora-coreos.yaml in the future so it can be more easily be
+# shared between all the streams
+lockfile-repos:
+  - fedora-coreos-pool
 
 add-commit-metadata:
   fedora-coreos.stream: testing-devel


### PR DESCRIPTION
The pool repo isn't semantically an ordinary like the others. It
contains past and present locked packages used in any Fedora CoreOS
stream. Mark it as a lockfile repo instead to tell rpm-ostree to only
use this repo for fetching locked packages and never to try to freely
depsolve with it on.