### PR TITLE
overlay/mounts: Mount /boot and /boot/efi ro,nodev,nosuid

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -18,6 +18,10 @@ if findmnt --fstab /boot &>/dev/null; then
     exit 0
 fi
 
+# Some security hardening guidelines like to see this.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1627633
+boot_options="ro,nodev,nosuid"
+
 # Don't create mount units for /boot or /boot/efi on live systems.
 # ConditionPathExists won't work here because conditions don't affect
 # the dependency on the underlying device unit.
@@ -35,6 +39,7 @@ After=systemd-fsck@dev-disk-by\x2dlabel-boot.service
 [Mount]
 What=/dev/disk/by-label/boot
 Where=/boot
+Options=${boot_options}
 EOF
 
     # Only mount the EFI System Partition on machines where it exists,
@@ -54,6 +59,7 @@ After=systemd-fsck@dev-disk-by\x2dlabel-EFI\x2dSYSTEM.service
 [Mount]
 What=/dev/disk/by-label/EFI-SYSTEM
 Where=/boot/efi
+Options=${boot_options}
 EOF
     fi
 fi

--- a/tests/kola/basic
+++ b/tests/kola/basic
@@ -1,2 +1,20 @@
 #!/bin/bash
-exec systemctl is-enabled logrotate.service
+set -euo pipefail
+systemctl is-enabled logrotate.service
+echo "ok logrotate"
+
+validate_not_writable_mount() {
+    local mnt=$1
+    shift
+    findmnt "${mnt}" -o OPTIONS | grep -q ro
+    if test -w "${mnt}"; then
+        echo "writable ${mnt}"
+        exit 1
+    fi
+    echo "ok not writable ${mnt}"
+}
+
+validate_not_writable_mount /boot
+if test -d /boot/efi; then
+    validate_not_writable_mount /boot/efi
+fi


### PR DESCRIPTION
Ironically ostree has had support for a `ro` boot for a long time,
and only more recently did we land the [sysroot readonly](https://github.com/coreos/coreos-assembler/pull/736).

But we never actually went and made `/boot` `ro` for FCOS, so let's
do it now.

This was actually motivated by someone wanting to "security harden" RHCOS
running through a checklist saying certain mounts should be `nodev`.
Let's add `nosuid` while we're here.