### PR TITLE
manifests: Move exclude-packages to toplevel

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -174,19 +174,3 @@ packages-ppc64le:
   - irqbalance
 packages-aarch64:
   - irqbalance
-
-# Things we don't expect to ship on the host.  We currently
-# have recommends: false so these could only come in via
-# hard requirement, in which case the build will fail.
-exclude-packages:
-  - python
-  - python2
-  - python3
-  - perl
-  - nodejs
-  - dnf
-  - grubby
-  - cowsay  # Just in case
-  # Let's make sure initscripts doesn't get pulled back in
-  # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
-  - initscripts

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -73,3 +73,19 @@ remove-from-packages:
   # Drop NetworkManager support for ifcfg files, see also corresponding
   # overlay.d/14NetworkManager-plugins
   - [NetworkManager, /usr/lib64/NetworkManager/.*/libnm-settings-plugin-ifcfg-rh.so]
+
+# Things we don't expect to ship on the host.  We currently
+# have recommends: false so these could only come in via
+# hard requirement, in which case the build will fail.
+exclude-packages:
+  - python
+  - python2
+  - python3
+  - perl
+  - nodejs
+  - dnf
+  - grubby
+  - cowsay  # Just in case
+  # Let's make sure initscripts doesn't get pulled back in
+  # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
+  - initscripts


### PR DESCRIPTION
FCOSB (Fedora Silverblue based on FCOS) has way too much stuff
that depends on python, but I'd like to inherit from `fedora-coreos-base`
since there's a lot of useful stuff there.

Similarly, IoT today includes `python` because they want to support
Ansible, and this would make it a bit easier for them to derive
from FCOS too.