### PR TITLE
[testing] Revert "use old version of coreos-pool yum repo"

### DIFF
--- a/fedora-coreos-pool.repo
+++ b/fedora-coreos-pool.repo
@@ -1,6 +1,6 @@
 [fedora-coreos-pool]
 name=Fedora coreos pool repository - $basearch
-baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/1427579/$basearch/
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/$basearch/
 enabled=1
 repo_gpgcheck=0
 type=rpm-md


### PR DESCRIPTION
This reverts commit e1db186d312c41095581d3fe8c5bf495c4a59e06.

Now that we have our lockfile story in a better place we should no
longer need this.