### PR TITLE
40ignition-ostree: add service for deleting /etc enablements

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-delete-etc-services.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-delete-etc-services.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Delete /etc Service Enablements
+DefaultDependencies=false
+ConditionKernelCommandLine=|ostree
+ConditionPathExists=|/run/ostree-live
+
+# Really, we don't really expect mount points for /etc, so we could just order
+# after initrd-root-fs.target, but meh... doesn't hurt to pretend we support
+# that.
+After=ignition-mount.service
+
+# But *before* any user-specified enablement
+Before=ignition-files.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# use glob instead of nuking /etc/systemd/system itself so that we don't end up
+# recreating it from the initrd as unlabeled for RHCOS
+ExecStart=/usr/bin/sh -c "rm -rf /sysroot/etc/systemd/system/*"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -68,4 +68,6 @@ install() {
     inst_script "$moddir/coreos-growpart" /usr/libexec/coreos-growpart
 
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel
+
+    install_ignition_unit ignition-ostree-delete-etc-services.service
 }


### PR DESCRIPTION
A lot of backstory on this, but essentially right now, we always bake a
run of `systemctl preset-all` into the OSTree because upgrading hosts
rely on these links for service enablement.

In hindsight, we should've just stuck with pure systemd preset only as
canonicaly from the get go, though it's a bit difficult now to
transition from one to the other without breaking things. (Though I'll
note not impossible, since we do have update barriers which could allow
us to e.g. run a script to restore lost symlinks).

For now though, let's at least fix the ability to disable services,
which is a pretty big gap in our Ignition configuration story right now.

Related: https://github.com/systemd/systemd/pull/15205
Related: https://github.com/coreos/fedora-coreos-config/pull/77

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/392