### PR TITLE
WIP: Enable initramfs-etc.img as an appended initramfs

### DIFF
--- a/overlay.d/05core/etc/grub.d/03_boot-etc
+++ b/overlay.d/05core/etc/grub.d/03_boot-etc
@@ -1,0 +1,28 @@
+#!/bin/sh
+exec tail -n +3 $0
+
+# NOTE: This is superfluous without setting a password on Grub.
+#       However, this makes it far more difficult for someone to
+#       load up a different initramfs-etc.
+#
+# This code-path is enabled by running as root:
+#    /usr/sbin/initramfs-etc --create
+#
+# Then, in the blsconfig add "$initramfs_etc" to the initrd line, i.e
+#    initrd /initrd $initramfs_etc
+
+set initramfs_etc=""
+if [ -f "/initramfs-etc.img" ]; then
+     set initramfs_etc="/initramfs-etc.img"
+fi
+
+if [ -f "/coreos.checksums" ]; then
+    insmod gcry_sha256
+    hashsum --hash sha256 --check "/coreos.checksums"
+    if [ "$?" != "0" ]; then
+        unset initramfs_etc
+        echo "Failed to checksum"
+        sleep 30
+    fi
+fi
+

--- a/overlay.d/05core/usr/sbin/initramfs-etc
+++ b/overlay.d/05core/usr/sbin/initramfs-etc
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# This creates a config-only initramfs that is signed for use by Grub2.
+#
+
+create() {
+    local archive="/boot/initramfs-etc.img"
+    local includes="${@}";
+
+    if [ ! -d "${key_path}" ]; then
+        key_gen
+    fi
+
+    echo "Generating new ${archive} using Dracut"
+    echo "${archive} will only contain configuration data, no logic"
+
+    local cur_d="${PWD}"
+    local work_d=$(mktemp -d)
+    trap "rm -rf ${work_d}" EXIT
+
+    # Generate a real initrd, but we'll throw it away later
+    # This ensures that we get a "filtered" config, plus the
+    # extra's that we need.
+    dracut "${work_d}/work.img" $(uname -r) \
+           --add "lvm dm multipath" \
+           --hostonly-i18n \
+           --lvmconf \
+           --mdadmconf \
+           --no-hostonly-cmdline \
+           --no-compress \
+           --no-early-microcode \
+           -o "clevis" >> /dev/null
+
+    pushd "${work_d}" >> /dev/null
+    cpio -ic "etc*" < "${work_d}/work.img"
+    for x in "${includes_cfg[@]}"; do
+        test -e "etc/${x}" && cp -auR -t etc "etc/${x}"
+    done
+
+    rm -rf etc/systemd
+    find etc -print | cpio -o -c > "${work_d}/new.img"
+    popd >>/dev/null
+
+    mv "${work_d}/new.img" "${archive}"
+    pushd /boot >> /dev/null
+    ls -1 initramfs* > /boot/coreos.checksums
+    popd >> /dev/null
+    cat /boot/coreos.checksums
+}
+
+create


### PR DESCRIPTION
The idea here is to enable configuration needed during the initramfs
without requiring the re-generation of it.

Previous models including [1] were considered. As counter-idea, it was
suggested to add to Dracut the ability to source in a signed CPIO
archive or at least checksum it (e.g. boot-etc=/boot/foo.cpio:sha256) and then
rely on signed kargs. The chief concerns is that we need to ensure that
the content is machine specific and not enable an easy boot-foot gun.

This solution used Grub as the enforcement mechanism for both
authenticity and authentication of the change and bypasses Dracut
all-together. The core advantage is that admin could enable secure boot,
set the Grub password (to prevent menu editing) and then Grub would only
set "initramfs-etc='...'" if the file checked out.

[1] https://github.com/dracutdevs/dracut/pull/792
