### PR TITLE
overrides: fasttrack ignition-2.2.1-5.git2d3ff58.fc31

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -14,7 +14,7 @@ cosaPod {
         cosa buildprep https://builds.coreos.fedoraproject.org/prod/streams/${env.CHANGE_TARGET}/builds
     """)
 
-    fcosBuild(skipInit: true)
+    fcosBuild(skipInit: true, extraFetchArgs: '--with-cosa-overrides')
 
     // also print the pkgdiff as a separate stage to make it more visible
     stage("RPM Diff") {

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,10 +1,4 @@
 packages:
-  # Fast-tracking to get exoscale support working
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3b08fdffe8
-  afterburn:
-    evra: 4.3.2-1.fc31.x86_64
-  afterburn-dracut:
-    evra: 4.3.2-1.fc31.x86_64
   # crypto-policies without python dependencies
   # We're pulling from f32 here as this is a brand new change
   # and the maintainer is not comfortable sending it to F31 yet.
@@ -18,20 +12,6 @@ packages:
     evra: 2020.1.21.ge9011530-2.fc31.x86_64
   rpm-ostree-libs:
     evra: 2020.1.21.ge9011530-2.fc31.x86_64
-  # Fast track new Ignition with initramfs network takedown
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9bcebc7e9a
-  ignition:
-    evra: 2.2.1-3.git2d3ff58.fc31.x86_64
-  # Fast track new zincati with proxy support
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-6877a1f53d
-  zincati:
-    evra: 0.0.9-1.fc31.x86_64
-  # Fast track new coreos-installer for additional testing
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9b60fbda9e
-  coreos-installer:
-    evra: 0.1.3-1.fc31.x86_64
-  coreos-installer-systemd:
-    evra: 0.1.3-1.fc31.x86_64
   # Hold back fedora-release-common rpm because of lua script
   # https://github.com/coreos/fedora-coreos-tracker/issues/459
   fedora-release-common:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -22,3 +22,7 @@ packages:
   # This is a major version bump we need to consider.
   moby-engine:
     evra: 18.09.8-2.ce.git0dd43dd.fc31.x86_64
+  # Fast track new Ignition with more networking fixes
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0a3fdd111c
+  ignition:
+    evra: 2.2.1-5.git2d3ff58.fc31.x86_64


### PR DESCRIPTION
This gets us new networking improvements added in https://github.com/coreos/ignition-dracut/pull/174.
