### PR TITLE
manual update of lockfile

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -38,3 +38,7 @@ packages:
     evra: 31-2.noarch
   fedora-release-coreos:
     evra: 31-2.noarch
+  # Hold back moby engine. It has been bumped to 19.03 in stable.
+  # This is a major version bump we need to consider.
+  moby-engine:
+    evra: 18.09.8-2.ce.git0dd43dd.fc31.x86_64

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -313,7 +313,7 @@
       "evra": "0.20.1-3.fc31.x86_64"
     },
     "git-core": {
-      "evra": "2.25.3-1.fc31.x86_64"
+      "evra": "2.25.4-1.fc31.x86_64"
     },
     "glib2": {
       "evra": "2.62.6-1.fc31.x86_64"
@@ -343,25 +343,25 @@
       "evra": "3.3-3.fc31.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.02-107.fc31.noarch"
+      "evra": "1:2.02-108.fc31.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.02-107.fc31.x86_64"
+      "evra": "1:2.02-108.fc31.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.02-107.fc31.x86_64"
+      "evra": "1:2.02-108.fc31.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.02-107.fc31.noarch"
+      "evra": "1:2.02-108.fc31.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.02-107.fc31.x86_64"
+      "evra": "1:2.02-108.fc31.x86_64"
     },
     "grub2-tools-extra": {
-      "evra": "1:2.02-107.fc31.x86_64"
+      "evra": "1:2.02-108.fc31.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.02-107.fc31.x86_64"
+      "evra": "1:2.02-108.fc31.x86_64"
     },
     "gzip": {
       "evra": "1.10-1.fc31.x86_64"
@@ -412,7 +412,7 @@
       "evra": "1.6-3.fc31.x86_64"
     },
     "json-c": {
-      "evra": "0.13.1-8.fc31.x86_64"
+      "evra": "0.13.1-11.fc31.x86_64"
     },
     "json-glib": {
       "evra": "1.4.4-3.fc31.x86_64"
@@ -427,13 +427,13 @@
       "evra": "2.0.4-14.fc31.noarch"
     },
     "kernel": {
-      "evra": "5.5.17-200.fc31.x86_64"
+      "evra": "5.6.6-200.fc31.x86_64"
     },
     "kernel-core": {
-      "evra": "5.5.17-200.fc31.x86_64"
+      "evra": "5.6.6-200.fc31.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.5.17-200.fc31.x86_64"
+      "evra": "5.6.6-200.fc31.x86_64"
     },
     "keyutils": {
       "evra": "1.6-3.fc31.x86_64"
@@ -649,7 +649,7 @@
       "evra": "2.34-4.fc31.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.11.7-0.fc31.x86_64"
+      "evra": "2:4.11.7-1.fc31.x86_64"
     },
     "libsolv": {
       "evra": "0.7.11-1.fc31.x86_64"
@@ -721,7 +721,7 @@
       "evra": "0.3.0-8.fc31.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.11.7-0.fc31.x86_64"
+      "evra": "2:4.11.7-1.fc31.x86_64"
     },
     "libxcrypt": {
       "evra": "4.4.16-1.fc31.x86_64"
@@ -775,7 +775,7 @@
       "evra": "2:2.1-34.fc31.x86_64"
     },
     "moby-engine": {
-      "evra": "18.09.8-2.ce.git0dd43dd.fc31.x86_64"
+      "evra": "19.03.8-1.ce.gitafacb8b.fc31.x86_64"
     },
     "mokutil": {
       "evra": "1:0.3.0-14.fc31.x86_64"
@@ -946,13 +946,13 @@
       "evra": "2:1.0.0-102.dev.gitdc9208a.fc31.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.11.7-0.fc31.x86_64"
+      "evra": "2:4.11.7-1.fc31.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.11.7-0.fc31.noarch"
+      "evra": "2:4.11.7-1.fc31.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.11.7-0.fc31.x86_64"
+      "evra": "2:4.11.7-1.fc31.x86_64"
     },
     "sed": {
       "evra": "4.5-4.fc31.x86_64"
@@ -1088,7 +1088,7 @@
     }
   },
   "metadata": {
-    "generated": "2020-04-20T20:44:01Z",
+    "generated": "2020-04-27T16:08:24Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2019-10-23T22:52:47Z"
@@ -1100,10 +1100,10 @@
         "generated": "2019-10-23T22:53:13Z"
       },
       "fedora-updates": {
-        "generated": "2020-04-19T22:18:07Z"
+        "generated": "2020-04-27T02:36:17Z"
       },
       "fedora-updates-modular": {
-        "generated": "2020-04-19T23:10:56Z"
+        "generated": "2020-04-25T05:28:19Z"
       }
     }
   }


### PR DESCRIPTION
Another manual update of the lockfile while we have the
bodhi-updates pipeline down. Of note, I decided to hold
the update to moby-engine back for now.