### PR TITLE
overlay: systemd generators: add logging

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -2,6 +2,10 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
 command -v getarg >/dev/null || . /usr/lib/dracut-lib.sh
 
 set -e

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-autologin-generator
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
 UNIT_DIR="${1:-/tmp}"
 
 have_karg() {

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
 UNIT_DIR="${1:-/tmp}"
 
 add_wants() {

--- a/overlay.d/20azure-chrony/usr/lib/systemd/system-generators/coreos-azure-phc
+++ b/overlay.d/20azure-chrony/usr/lib/systemd/system-generators/coreos-azure-phc
@@ -4,8 +4,8 @@ set -euo pipefail
 # and https://github.com/openshift/installer/pull/3513
 
 # Generators don't have logging right now
-exec 1>/dev/kmsg
-exec 2>&1
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
 
 self=$(basename $0)
 


### PR DESCRIPTION
Outputting stdout and stderr to /dev/kmsg is the only option for
logging for generators for now. Let's start using it so we can at
least get some messages if we ever have problems with one of our
generators.