### PR TITLE
manifests: Move grub2-removals include to fedora-coreos

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -23,8 +23,3 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
-# And remove some cruft from grub2
-arch-include:
-  x86_64: grub2-removals.yaml
-  aarch64: grub2-removals.yaml
-  ppc64le: grub2-removals.yaml

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -92,3 +92,9 @@ exclude-packages:
   # Let's make sure initscripts doesn't get pulled back in
   # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
   - initscripts
+
+# And remove some cruft from grub2
+arch-include:
+  x86_64: grub2-removals.yaml
+  aarch64: grub2-removals.yaml
+  ppc64le: grub2-removals.yaml


### PR DESCRIPTION
Move the include statement for grub2-removals from bootable-rpm-ostree
which is pulled in by fedora-coreos-base to the fedora-coreos manifest.

The exclusion of files in grub2-removals is specific to Fedora
CoreOS but not other potentially derivative operating systems:
- Fedora Silverblue uses `/etc/grub.d/10_reset_boot_success`
and `/etc/grub.d/12_menu_auto_hide`
- Fedora IoT uses `/etc/grub.d/08_fallback_counting` and
`/etc/grub.d/10_reset_boot_success`

This is a step towards making fedora-coreos-base re-usable as base
manifest for these operating systems.