### PR TITLE
[next-devel] fasttrack coreos-installer-0.2.0-1.fc32 and afterburn-4.3.3-1.fc32

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -28,3 +28,10 @@ packages:
     evra: 0.2.0-1.fc32.x86_64
   coreos-installer-systemd:
     evra: 0.2.0-1.fc32.x86_64
+  # Fast track new afterburn to have latest released changes, including
+  # vmware support, present in upcoming FCOS release.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-abdcced19a
+  afterburn:
+    evra: 4.3.3-1.fc32.x86_64
+  afterburn-dracut:
+    evra: 4.3.3-1.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,11 +10,6 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0a3fdd111c
   ignition:
     evra: 2.2.1-5.git2d3ff58.fc32.x86_64
-  # Cherry-pick from f31 for now since we don't have f32 builds for these yet
-  coreos-installer:
-    evra: 0.1.3-1.fc31.x86_64
-  coreos-installer-systemd:
-    evra: 0.1.3-1.fc31.x86_64
   # Fast-track zincati but also we want it here because there's no zincati in
   # the f32 repos right now
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-722047b7e5
@@ -26,3 +21,10 @@ packages:
     evra: 1:0.2.0-1.fc32.x86_64
   containers-common:
     evra: 1:0.2.0-1.fc32.x86_64
+  # Fast track new coreos-installer to have latest released changes
+  # present in upcoming FCOS release.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-abdcced19a
+  coreos-installer:
+    evra: 0.2.0-1.fc32.x86_64
+  coreos-installer-systemd:
+    evra: 0.2.0-1.fc32.x86_64


### PR DESCRIPTION
See commit messages for details.

Currently not verified locally - testing in a COSA build locally gives `error: Couldn't find locked package 'afterburn-4.3.3-1.fc32.x86_64' (pkgs matching NEVRA: 0; mismatched checksums: 0)`). I think `coreos-koji-tagger` will pick this change up once merged, which will fix this.