### PR TITLE
[next-devel] manifest: point to release repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,10 +12,10 @@ repos:
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
-  - fedora-next
-  - fedora-next-updates
-  - fedora-next-modular
-  - fedora-next-updates-modular
+  - fedora
+  - fedora-updates
+  - fedora-modular
+  - fedora-updates-modular
 
 # All Fedora CoreOS streams share the same pool for locked files.
 # This will be in fedora-coreos.yaml in the future so it can be more easily be


### PR DESCRIPTION
The f32 repos are no longer in the `development/` path. Use the release
repos now.