### PR TITLE
[next] manifest: point to release repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,10 +13,10 @@ repos:
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
-  - fedora-next
-  - fedora-next-updates
-  - fedora-next-modular
-  - fedora-next-updates-modular
+  - fedora
+  - fedora-updates
+  - fedora-modular
+  - fedora-updates-modular
 
 add-commit-metadata:
   fedora-coreos.stream: next


### PR DESCRIPTION
The f32 repos are no longer in the `development/` path. Use the release
repos now.