### PR TITLE
overlay: 14NetworkManager-plugins: update comment in conf dropin

### DIFF
--- a/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
+++ b/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
@@ -1,7 +1,9 @@
 # Stop NetworkManager from trying to load the ifcfg-rh plugin by default,
 # which we don't ship.  This actually disables all default plugins, of which
-# ifcfg-rh is currently the only one.  That approach is brittle,
-# unfortunately, but -= syntax doesn't seem to work with compiled-in
-# defaults.
+# ifcfg-rh is currently the only one.  
+#
+# Note that we must do this for now because `-=` syntax doesn't work
+# with compiled-in defaults. Proposed upstream fix:
+# https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/491
 [main]
 plugins=


### PR DESCRIPTION
There is an upstream proposal for fixing the bug referenced in the
configuration dropin. Let's link to the bug so we can follow and fix
it.