### PR TITLE
[testing-devel] overrides: fasttrack ignition-2.3.0-1.gitee616d5.fc31

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -22,10 +22,10 @@ packages:
   # This is a major version bump we need to consider.
   moby-engine:
     evra: 18.09.8-2.ce.git0dd43dd.fc31.x86_64
-  # Fast track new Ignition with more networking fixes
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0a3fdd111c
+  # Fast track new Ignition with spec 3.1.0
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-6a3eb9c2ce
   ignition:
-    evra: 2.2.1-5.git2d3ff58.fc31.x86_64
+    evra: 2.3.0-1.gitee616d5.fc31.x86_64
   # Latest version has a hard dep on selinux-policy-minimal, which wants python
   # https://src.fedoraproject.org/rpms/container-selinux/pull-request/3
   container-selinux:


### PR DESCRIPTION
Stabilize spec 3.1.0.