### PR TITLE
WIP. Enablement for root on multipath devices

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -8,7 +8,7 @@ extra-kargs:
     # https://github.com/coreos/fedora-coreos-tracker/issues/292
     # https://fedoraproject.org/wiki/Changes/CGroupsV2
     - systemd.unified_cgroup_hierarchy=0
-
+    - rd.multipath=default
 
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -16,7 +16,6 @@ initramfs-args:
   - --omit=nfs
   # Omit these since we don't use them
   - --omit=lvm
-  - --omit=multipath
   - --omit=iscsi
 
 # Be minimal
@@ -135,7 +134,7 @@ packages:
   - cifs-utils
   # Time sync
   - chrony
-  # Allow communication between sudo and SSSD 
+  # Allow communication between sudo and SSSD
   # for caching sudo rules by SSSD.
   # https://github.com/coreos/fedora-coreos-tracker/issues/445
   - libsss_sudo

--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/coreos-copy-firstboot-network.service
@@ -29,17 +29,14 @@
 Description=Copy CoreOS Firstboot Networking Config
 ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
-Before=ignition-diskful.target
+Before=ignition-prepare.target
 Before=dracut-initqueue.service
 After=dracut-cmdline.service
-# Since we are mounting /boot/, require the device first
-Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device   
+
+Requires=boot.mount
+After=boot.mount
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# The MountFlags=slave is so the umount of /boot is guaranteed to happen
-# /boot will only be mounted for the lifetime of the unit.
-MountFlags=slave
 ExecStart=/usr/sbin/coreos-copy-firstboot-network

--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/coreos-copy-firstboot-network.sh
@@ -3,50 +3,11 @@ set -euo pipefail
 
 # For a description of how this is used see coreos-copy-firstboot-network.service
 
-bootmnt=/mnt/boot_partition
-mkdir -p ${bootmnt}
 bootdev=/dev/disk/by-label/boot
 firstboot_network_dir_basename="coreos-firstboot-network"
-initramfs_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
+initramfs_firstboot_network_dir="/boot/${firstboot_network_dir_basename}"
 initramfs_network_dir="/run/NetworkManager/system-connections/"
 realroot_firstboot_network_dir="/boot/${firstboot_network_dir_basename}"
-
-# Mount /boot. Note that we mount /boot but we don't unmount boot because we
-# are run in a systemd unit with MountFlags=slave so it is unmounted for us.
-# Mount as read-only since we don't strictly need write access and we may be
-# running alongside other code that also has it mounted ro
-mountboot() {
-    # Wait for up to 5 seconds for the boot device to be available
-    # The After=...*boot.device in the systemd unit should be enough
-    # but there appears to be some race in the kernel where the link under
-    # /dev/disk/by-label exists but mount is not able to use the device yet.
-    # We saw errors like this in CI:
-    #
-    #   [    4.045181] systemd[1]: Found device /dev/disk/by-label/boot.
-    #   [  OK  ] Found device /dev/disk/by-label/boot
-    #   [    4.051500] systemd[1]: Starting Copy CoreOS Firstboot Networking Config...
-    #         Starting  Copy CoreOS Firstboot Networking Config
-    #   [    4.060573]  vda: vda1 vda2 vda3 vda4
-    #   [    4.063296] coreos-copy-firstboot-network[479]: mount: /mnt/boot_partition: special device /dev/disk/by-label/boot does not exist.
-    #
-    mounted=0
-    for x in {1..5}; do
-        if mount -o ro ${bootdev} ${bootmnt}; then
-            echo "info: ${bootdev} successfully mounted."
-            mounted=1
-            break
-        else
-            echo "info: retrying ${bootdev} mount in 1 second..."
-            sleep 1
-        fi
-    done
-    if [ "${mounted}" == "0" ]; then
-        echo "error: ${bootdev} mount did not succeed" 1>&2
-        return 1
-    fi
-}
-
-mountboot || exit 1
 
 if [ -n "$(ls -A ${initramfs_firstboot_network_dir} 2>/dev/null)" ]; then
     # Clear out any files that may have already been generated from

--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-copy-firstboot-network/module-setup.sh
@@ -12,5 +12,5 @@ install() {
     # Only run this when ignition runs and only when the system
     # has disks. ignition-diskful.target should suffice.
     install_and_enable_unit "coreos-copy-firstboot-network.service" \
-        "ignition-diskful.target"
+        "ignition-prepare.target"
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -11,6 +11,7 @@ ConditionPathExists=!/run/ostree-live
 # There can be only one, Highlander style
 Conflicts=ignition-ostree-mount-subsequent-sysroot.service
 Before=initrd-root-fs.target
+After=ignition-diskful-udev.service
 After=ignition-disks.service
 # Note we don't have a Requires: /dev/disk/by-label/root here like
 # the -subsequent service does because ignition-disks may have

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
@@ -14,6 +14,7 @@ Conflicts=ignition-ostree-mount-firstboot-sysroot.service
 # the root device to be ready.
 Requires=dev-disk-by\x2dlabel-root.device
 After=dev-disk-by\x2dlabel-root.device
+After=ignition-diskful-udev.service
 Before=initrd-root-fs.target
 # This has an explicit dependency on After=sysroot.mount today
 Before=ostree-prepare-root.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -64,7 +64,7 @@ install() {
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \
         "/usr/sbin/ignition-ostree-mount-sysroot"
 
-    install_ignition_unit ignition-ostree-growfs.service
+    install_ignition_unit ignition-ostree-growfs.service ignition-prepare.target
     inst_script "$moddir/coreos-growpart" /usr/libexec/coreos-growpart
 
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -15,3 +15,6 @@ enable afterburn-sshkeys@.service
 enable zincati.service
 # Testing aid
 enable coreos-liveiso-success.service
+# Enable multipathd
+enable multipathd-configure.service
+enable multipathd.service

--- a/overlay.d/05core/usr/lib/systemd/system/multipathd-configure.service
+++ b/overlay.d/05core/usr/lib/systemd/system/multipathd-configure.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Device-Mapper Multipath Default Configuration
+Before=iscsi.service iscsid.service lvm2-activation-early.service
+Wants=systemd-udev-trigger.service systemd-udev-settle.service local-fs-pre.target
+After=systemd-udev-trigger.service systemd-udev-settle.service
+Before=local-fs-pre.target multipathd.service
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+ConditionKernelCommandLine=rd.multipath=default
+ConditionPathExists=!/etc/multipath.conf
+
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/bin/mkdir -p /etc/multipath/multipath.conf.d
+ExecStart=/usr/sbin/mpathconf --enable
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
As part of [1, 2, 3] the preparatory work for enabling multipath root
emerged. Once FCOS and RHCOS has [4], most users will be able to enable
multipath with `rd.multipath=default`.

Blocked by:
[1] coreos/ignition-dracut#179
[2] coreos/ignition-dracut#182
[3] #390
[4] dracutdevs/dracut@b8a92b7

All of this fixes https://github.com/coreos/ignition-dracut/issues/154