### PR TITLE
Add support for root device on multipath via `rd.multipath=default` kernel argument 

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -16,7 +16,6 @@ initramfs-args:
   - --omit=nfs
   # Omit these since we don't use them
   - --omit=lvm
-  - --omit=multipath
   - --omit=iscsi
 
 # Be minimal
@@ -135,7 +134,7 @@ packages:
   - cifs-utils
   # Time sync
   - chrony
-  # Allow communication between sudo and SSSD 
+  # Allow communication between sudo and SSSD
   # for caching sudo rules by SSSD.
   # https://github.com/coreos/fedora-coreos-tracker/issues/445
   - libsss_sudo

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -14,15 +14,37 @@ shift
 # The use of tail is to avoid errors from duplicate mounts;
 # this shouldn't happen for us but we're being conservative.
 src=$(findmnt -nvr -o SOURCE "$path" | tail -n1)
-majmin=$(findmnt -nvr -o MAJ:MIN "$path" | tail -n1)
-devpath=$(realpath "/sys/dev/block/$majmin")
-partition=$(cat "$devpath/partition")
-parent_path=$(dirname "$devpath")
-parent_device=/dev/$(basename "${parent_path}")
 
-# TODO: make this idempotent, and don't error out if
-# we can't resize.
-growpart "${parent_device}" "${partition}" || true
+if [[ "${src}" =~ "/dev/mapper" ]]; then
+    eval $(udevadm info --query property --export "${src}")
+    # get the partition, if any, and the name for the device mapper
+    partition="${ID_PART_ENTRY_NUMBER:-}"
+    dm_name="${DM_NAME//$partition/}"
+    # identify the type of device mapper.
+    subsystem=$(dmsetup info ${dm_name} -C -o subsystem --noheadings)
+
+    # for now, we only support multipath devices
+    if [ "${subsystem}" == "mpath" ] && [ -n "${partition}" ]; then
+        # growpart does not understand device mapper, instead of having sfdisk inform the kernel,
+        # use kpartx to inform the kernel and the device mapper linear maps.
+        echo ", +" | sfdisk --no-reread --no-tell-kernel --force -N "${ID_PART_ENTRY_NUMBER}" "/dev/mapper/${dm_name}"
+        kpartx -fu /dev/mapper/${dm_name}
+    else
+        echo "coreos-growpart: unsupported device-mapper target: ${dm_name}"
+        exit 0
+    fi
+else
+    # Handle traditional disk/partitions
+    majmin=$(findmnt -nvr -o MAJ:MIN "$path" | tail -n1)
+    devpath=$(realpath "/sys/dev/block/$majmin")
+    partition="${partition:-$(cat "$devpath/partition")}"
+    parent_path=$(dirname "$devpath")
+    parent_device=/dev/$(basename "${parent_path}")
+
+    # TODO: make this idempotent, and don't error out if
+    # we can't resize.
+    growpart "${parent_device}" "${partition}" || true
+fi
 
 eval $(blkid -o export "${src}")
 # TODO: Add XFS to https://github.com/systemd/systemd/blob/master/src/partition/growfs.c

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-firstboot-sysroot.service
@@ -22,4 +22,5 @@ Before=ostree-prepare-root.service ignition-remount-sysroot.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=-/run/sysroot.env
 ExecStart=/usr/sbin/ignition-ostree-mount-sysroot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-subsequent-sysroot.service
@@ -21,4 +21,5 @@ Before=ostree-prepare-root.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=-/run/sysroot.env
 ExecStart=/usr/sbin/ignition-ostree-mount-sysroot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 # In the future this will be augmented with a check for whether
 # or not we've reprovisioned the rootfs, since we don't want to
 # force on prjquota there.
-rootpath=/dev/disk/by-label/root
+rootpath="${ROOT_DEVICE_PATH:-/dev/disk/by-label/root}"
+
+# If root is on a multipath device, we use that one.
+# this link is created by our own udev rule.
 if ! [ -b "${rootpath}" ]; then
   echo "ignition-ostree-mount-sysroot: Failed to find ${rootpath}" 1>&2
   exit 1

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -59,6 +59,13 @@ install() {
         inst_script "$moddir/ignition-ostree-${x}-var.sh" "/usr/sbin/ignition-ostree-${x}-var"
     done
 
+    inst_simple \
+        /usr/lib/udev/rules.d/90-coreos-device-mapper.rules
+
+    inst_simple "$moddir/multipath-generator" \
+        "$systemdutildir/system-generators/multipath-generator"
+
+    # Disk support
     install_ignition_unit ignition-ostree-mount-firstboot-sysroot.service diskful
     install_ignition_unit ignition-ostree-mount-subsequent-sysroot.service diskful-subsequent
     inst_script "$moddir/ignition-ostree-mount-sysroot.sh" \

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/multipath-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/multipath-generator
@@ -1,0 +1,83 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# On a regular boot we rely on `/dev/disk/by-label/{boot,root} to exist.
+# However, if multipath is enabled, then automatic discovery of boot/root
+# gets racy. If the user has not put `rd.multipath` then generator exists
+# without making any modifications.
+
+set -e
+
+# Generators don't have logging right now
+# https://github.com/systemd/systemd/issues/15638
+exec 1>/dev/kmsg; exec 2>&1
+
+UNIT_DIR="${1:-/tmp}"
+mkdir -p "${UNIT_DIR}"
+
+skip() {
+    echo "multipath-generator: skipping root on multipath: ${@}"
+    exit 0
+}
+
+# Check if we expect multipath root. These are the commdline options
+# checked by Dracut in https://github.com/dracutdevs/dracut/blob/master/modules.d/90multipath/multipathd.service#L9-L12
+[ -f /etc/multipath.conf ] && mpath=1 || mpath=0
+
+for arg in $(</proc/cmdline);
+do
+    case "${arg}" in
+        multipath=off)                   skip "karg multipath=off";;
+        rd.multipath=0|rd.multipath=off) skip "karg rd.multipath=(0|off)";;
+        rd_NO_MULTIPATH)                 skip "karg rd_NO_MULTIPATH";;
+        root=*)                          skip "karg root= explicit";;
+        rd.multipath=*)                  mpath=1;;
+    esac
+done
+
+# Unless there is a multipath.conf and automatic multipath,
+# then bail.
+if [ "${mpath}" == "0" ]; then
+    echo "no indicator that multipath should be used"
+    exit 0
+fi
+
+echo "multipath-generator: requiring root to be on a multipath device"
+
+cat > /run/sysroot.env <<EOF
+ROOT_DEVICE_PATH=/dev/disk/by-label/dm-mpath-root
+EOF
+
+boot_device="dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device"
+root_device="dev-disk-by\x2dlabel-dm\x2dmpath\x2droot.device"
+
+# Reconfigure ignition-diskful.target.d
+firstboot_cfg="${UNIT_DIR}/ignition-diskful.target.d"
+mkdir -p "${firstboot_cfg}"
+cat > "${firstboot_cfg}/ignition-mpath.conf" <<EOF
+# Added by multipath-generator
+[Unit]
+After=multipathd.service
+Wants=multipathd.service
+
+Requires=${boot_device}
+After=${boot_device}
+
+Requires=${root_device}
+After=${root_device}
+EOF
+
+# Reconfigure ignition-ostree-mount-subsequent-sysroot.service.d, which is
+# required by ignition-diskful-subsquent.target.
+secondboot_cfg="${UNIT_DIR}/ignition-ostree-mount-subsequent-sysroot.service.d"
+mkdir -p "${secondboot_cfg}"
+cat >> "${secondboot_cfg}/ignition-mpath.conf" <<EOF
+# Added by multipath-generator
+[Unit]
+After=multipathd.service
+Wants=multipathd.service
+
+After=${root_device}
+Requires=${root_device}
+EOF

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+export PATH="/usr/bin:/usr/sbin:${PATH}"
 set -euo pipefail
 
 # Generators don't have logging right now
@@ -7,6 +7,12 @@ set -euo pipefail
 exec 1>/dev/kmsg; exec 2>&1
 
 UNIT_DIR="${1:-/tmp}"
+
+# Turn out if you boot with "root=..." $UNIT_DIR is not writable.
+[ -w "${UNIT_DIR}" ] || {
+    echo "skipping coreos-boot-mount-generator: ${UNIT_DIR} is not writable"
+    exit 0
+}
 
 add_wants() {
     local name="$1"; shift
@@ -22,42 +28,54 @@ if findmnt --fstab /boot &>/dev/null; then
     exit 0
 fi
 
+# Generate mount units that work with device mapper. The traditional
+# device unit (dev-disk-by\x2dlabel...) does not work since it is not the
+# device that systemd will fsck. This code ensures that if the label
+# is backed by a device-mapper target the dev-mapper.*.device is used.
+mk_mount() {
+    local unit_name="${1}.mount"; shift
+    local label="${1}"; shift
+    local mount_pt="${1:-/$label}"
+    local path="/dev/disk/by-label/${label}"
+
+    eval $(udevadm info --query property --export "${path}")
+    device="$(systemd-escape ${path})"
+    if [ "${DM_NAME:-x}" != "x" ]; then
+        path="/dev/mapper/${DM_NAME}"
+        device="$(systemd-escape dev/mapper/${DM_NAME})"
+    fi
+    device="${device//-dev/dev}"
+    echo "coreos-boot-mount-generator: using ${device} for ${label} mount to ${mount_pt}"
+
+    cat > "${UNIT_DIR}/${unit_name}" <<EOF
+# Automatically created by coreos-boot-mount-generator
+[Unit]
+Description=CoreOS Dynamic Mount for ${mount_pt}
+Documentation=https://github.com/coreos/fedora-coreos-config
+
+Before=local-fs.target
+Requires=systemd-fsck@${device}.service
+After=systemd-fsck@${device}.service
+
+[Mount]
+What=${path}
+Where=${mount_pt}
+EOF
+
+    add_wants "${unit_name}"
+}
+
+
 # Don't create mount units for /boot or /boot/efi on live systems.
 # ConditionPathExists won't work here because conditions don't affect
 # the dependency on the underlying device unit.
 if [ ! -f /run/ostree-live ]; then
-    add_wants boot.mount
-    cat > "${UNIT_DIR}/boot.mount" <<EOF
-# Automatically created by coreos-boot-mount-generator
-[Unit]
-Description=Boot partition
-Documentation=https://github.com/coreos/fedora-coreos-config
-Before=local-fs.target
-Requires=systemd-fsck@dev-disk-by\x2dlabel-boot.service
-After=systemd-fsck@dev-disk-by\x2dlabel-boot.service
-
-[Mount]
-What=/dev/disk/by-label/boot
-Where=/boot
-EOF
+    mk_mount boot boot
 
     # Only mount the EFI System Partition on machines where it exists,
     # which are 1) machines actually booted through EFI, and 2) x86_64
     # when booted through BIOS.
     if [ "$(uname -m)" = "x86_64" -o -d /sys/firmware/efi ]; then
-        add_wants boot-efi.mount
-        cat > "${UNIT_DIR}/boot-efi.mount" <<EOF
-# Automatically created by coreos-boot-mount-generator
-[Unit]
-Description=EFI System Partition
-Documentation=https://github.com/coreos/fedora-coreos-config
-Before=local-fs.target
-Requires=systemd-fsck@dev-disk-by\x2dlabel-EFI\x2dSYSTEM.service
-After=systemd-fsck@dev-disk-by\x2dlabel-EFI\x2dSYSTEM.service
-
-[Mount]
-What=/dev/disk/by-label/EFI-SYSTEM
-Where=/boot/efi
-EOF
+        mk_mount boot-efi EFI-SYSTEM "/boot/efi"
     fi
 fi

--- a/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
@@ -1,0 +1,20 @@
+ACTION=="remove", GOTO="dm_label_end"
+SUBSYSTEM!="block", GOTO="dm_label_end"
+KERNEL!="dm-*", GOTO="dm_label_end"
+
+# Ensure that the device mapper target is active
+ENV{DM_ACTIVATION}!="1", GOTO="dm_label_end"
+
+# Unless we have a label, skip
+ENV{ID_FS_LABEL_ENC}!="?*", GOTO="dm_label_end"
+
+# Only act on filesystems
+ENV{ID_FS_USAGE}!="filesystem", GOTO="dm_label_end"
+
+ENV{DM_MPATH}=="?*", \
+    ENV{DM_SUSPENDED}=="Active"
+    SYMLINK+="disk/by-label/dm-mpath-$env{ID_FS_LABEL_ENC}",
+    SYMLINK+="disk/by-uuid/dm-mpath-$env{ID_FS_UUID_ENC}"
+
+LABEL="dm_label_end"
+

--- a/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
@@ -12,7 +12,7 @@ ENV{ID_FS_LABEL_ENC}!="?*", GOTO="dm_label_end"
 ENV{ID_FS_USAGE}!="filesystem", GOTO="dm_label_end"
 
 ENV{DM_MPATH}=="?*", \
-    ENV{DM_SUSPENDED}=="Active"
+    ENV{DM_SUSPENDED}=="Active",
     SYMLINK+="disk/by-label/dm-mpath-$env{ID_FS_LABEL_ENC}",
     SYMLINK+="disk/by-uuid/dm-mpath-$env{ID_FS_UUID_ENC}"
 


### PR DESCRIPTION
This provides for an ergonomic means for a user to enable multipath without having to manually define ugly kargs. When rd.multipath= is set for a "on" option, then the ostree mount units will use   `/dev/disk/by-label/dm-mpath-root` instead.
    
This can be tested with:
      `cosa run --kargs multipath=default --qemu-multipath`
