### PR TITLE
manifest: add catatonit

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -78,6 +78,9 @@
     "ca-certificates": {
       "evra": "2020.2.40-1.1.fc31.noarch"
     },
+    "catatonit": {
+        "evra": "0.1.5-2.fc31.x86_64"
+    },
     "chrony": {
       "evra": "3.5-4.fc31.x86_64"
     },

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -111,7 +111,7 @@ packages:
   # SSH
   - openssh-server openssh-clients
   # Containers
-  - podman skopeo runc systemd-container
+  - podman skopeo runc systemd-container catatonit
   - fuse-overlayfs slirp4netns
   # Remote IPC for podman
   - libvarlink-util


### PR DESCRIPTION
podman needs catatonit in order to use `--init`, which is important for
long-running containerized services.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/478