### PR TITLE
[testing] overrides: bump podman and friends to fix podman 1.9 regression

### DIFF
--- a/kola-blacklist.yaml
+++ b/kola-blacklist.yaml
@@ -1,3 +1,8 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically blacklist some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
+
+# ignore coreos.ignition.journald-log since ignition-2.3.0-1.gitee616d5.fc31
+# hasn't made it to this stream yet
+- pattern: coreos.ignition.journald-log
+  tracker: none

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -48,3 +48,14 @@ packages:
     evra: 4.3.3-1.fc32.aarch64
   afterburn-dracut:
     evra: 4.3.3-1.fc32.aarch64
+  # Bug fix for podman (includes conmon and containernetworking-plugins)
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-bebbeaab8b
+  # https://github.com/coreos/fedora-coreos-tracker/issues/479
+  podman:
+    evra: 2:1.9.2-1.fc31.aarch64
+  podman-plugins:
+    evra: 2:1.9.2-1.fc31.aarch64
+  conmon:
+    evra: 2:2.0.16-2.fc31.aarch64
+  containernetworking-plugins:
+    evra: 0.8.6-1.fc31.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -48,3 +48,14 @@ packages:
     evra: 4.3.3-1.fc32.ppc64le
   afterburn-dracut:
     evra: 4.3.3-1.fc32.ppc64le
+  # Bug fix for podman (includes conmon and containernetworking-plugins)
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-bebbeaab8b
+  # https://github.com/coreos/fedora-coreos-tracker/issues/479
+  podman:
+    evra: 2:1.9.2-1.fc31.ppc64le
+  podman-plugins:
+    evra: 2:1.9.2-1.fc31.ppc64le
+  conmon:
+    evra: 2:2.0.16-2.fc31.ppc64le
+  containernetworking-plugins:
+    evra: 0.8.6-1.fc31.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -48,3 +48,14 @@ packages:
     evra: 4.3.3-1.fc32.s390x
   afterburn-dracut:
     evra: 4.3.3-1.fc32.s390x
+  # Bug fix for podman (includes conmon and containernetworking-plugins)
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-bebbeaab8b
+  # https://github.com/coreos/fedora-coreos-tracker/issues/479
+  podman:
+    evra: 2:1.9.2-1.fc31.s390x
+  podman-plugins:
+    evra: 2:1.9.2-1.fc31.s390x
+  conmon:
+    evra: 2:2.0.16-2.fc31.s390x
+  containernetworking-plugins:
+    evra: 0.8.6-1.fc31.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -48,3 +48,14 @@ packages:
     evra: 4.3.3-1.fc32.x86_64
   afterburn-dracut:
     evra: 4.3.3-1.fc32.x86_64
+  # Bug fix for podman (includes conmon and containernetworking-plugins)
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-bebbeaab8b
+  # https://github.com/coreos/fedora-coreos-tracker/issues/479
+  podman:
+    evra: 2:1.9.2-1.fc31.x86_64
+  podman-plugins:
+    evra: 2:1.9.2-1.fc31.x86_64
+  conmon:
+    evra: 2:2.0.16-2.fc31.x86_64
+  containernetworking-plugins:
+    evra: 0.8.6-1.fc31.x86_64


### PR DESCRIPTION
overrides changes cherry picked from 3751c4d54b7540dbb388edf29865224e4d918b18

Also includes adding coreos.ignition.journald-log to the blacklist because the new version of Ignition isn't in this stream yet.