### PR TITLE
coreos-copy-firstboot-network.service: run before multipathd

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
@@ -34,7 +34,11 @@ Before=dracut-initqueue.service
 After=dracut-cmdline.service
 # Since we are mounting /boot/, require the device first
 Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device   
+After=dev-disk-by\x2dlabel-boot.device
+
+# We want to make sure we're not racing with multipath taking ownership of the
+# boot device.
+Before=multipathd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is required because the unit needs read-only access to `/boot` in
order to extract any baked in network config and multipathd might claim
ownership.

See similar patch for `ignition-setup-user.service`:
https://github.com/coreos/ignition-dracut/pull/185

For more information, see:
https://github.com/coreos/ignition-dracut/pull/183#issuecomment-627628526