### PR TITLE
overrides: fast-track rpm-ostree 2020.2

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -5,13 +5,13 @@ packages:
   # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
   crypto-policies:
     evra: 20191128-5.gitcd267a5.fc32.noarch
-  # Cherry-pick rpm-ostree git snapshot to resolve issues with /read-only
-  # sysroot. We can nuke this when we cut a new release.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  # Fast-forward new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-400ece1e9c
   rpm-ostree:
-    evra: 2020.1.21.ge9011530-2.fc31.aarch64
+    evra: 2020.2-3.fc31.aarch64
   rpm-ostree-libs:
-    evra: 2020.1.21.ge9011530-2.fc31.aarch64
+    evra: 2020.2-3.fc31.aarch64
   # Hold back fedora-release-common rpm because of lua script
   # https://github.com/coreos/fedora-coreos-tracker/issues/459
   fedora-release-common:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -5,13 +5,13 @@ packages:
   # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
   crypto-policies:
     evra: 20191128-5.gitcd267a5.fc32.noarch
-  # Cherry-pick rpm-ostree git snapshot to resolve issues with /read-only
-  # sysroot. We can nuke this when we cut a new release.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  # Fast-forward new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-400ece1e9c
   rpm-ostree:
-    evra: 2020.1.21.ge9011530-2.fc31.ppc64le
+    evra: 2020.2-3.fc31.ppc64le
   rpm-ostree-libs:
-    evra: 2020.1.21.ge9011530-2.fc31.ppc64le
+    evra: 2020.2-3.fc31.ppc64le
   # Hold back fedora-release-common rpm because of lua script
   # https://github.com/coreos/fedora-coreos-tracker/issues/459
   fedora-release-common:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -5,13 +5,13 @@ packages:
   # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
   crypto-policies:
     evra: 20191128-5.gitcd267a5.fc32.noarch
-  # Cherry-pick rpm-ostree git snapshot to resolve issues with /read-only
-  # sysroot. We can nuke this when we cut a new release.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  # Fast-forward new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-400ece1e9c
   rpm-ostree:
-    evra: 2020.1.21.ge9011530-2.fc31.s390x
+    evra: 2020.2-3.fc31.s390x
   rpm-ostree-libs:
-    evra: 2020.1.21.ge9011530-2.fc31.s390x
+    evra: 2020.2-3.fc31.s390x
   # Hold back fedora-release-common rpm because of lua script
   # https://github.com/coreos/fedora-coreos-tracker/issues/459
   fedora-release-common:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -5,13 +5,13 @@ packages:
   # https://src.fedoraproject.org/rpms/crypto-policies/pull-request/6#comment-35958
   crypto-policies:
     evra: 20191128-5.gitcd267a5.fc32.noarch
-  # Cherry-pick rpm-ostree git snapshot to resolve issues with /read-only
-  # sysroot. We can nuke this when we cut a new release.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/343
+  # Fast-forward new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-400ece1e9c
   rpm-ostree:
-    evra: 2020.1.21.ge9011530-2.fc31.x86_64
+    evra: 2020.2-3.fc31.x86_64
   rpm-ostree-libs:
-    evra: 2020.1.21.ge9011530-2.fc31.x86_64
+    evra: 2020.2-3.fc31.x86_64
   # Hold back fedora-release-common rpm because of lua script
   # https://github.com/coreos/fedora-coreos-tracker/issues/459
   fedora-release-common:


### PR DESCRIPTION
For https://github.com/coreos/fedora-coreos-tracker/issues/481.