### PR TITLE
coreos-update-ca-trust: Run After=sysinit.target

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/coreos-update-ca-trust.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-update-ca-trust.service
@@ -11,6 +11,9 @@ ConditionDirectoryNotEmpty=/etc/pki/ca-trust/source/anchors/
 # that may speak TLS to external services.  In the future,
 # it may make sense to do this in the initramfs too.
 DefaultDependencies=no
+# This ensures we run after important bits like ostree-prepare-root.service
+After=sysinit.target
+Requires=sysinit.target
 
 [Service]
 ExecStart=/usr/bin/update-ca-trust extract


### PR DESCRIPTION
I am seeing this service fail in RHCOS when rebasing ostree
to a version that supports https://github.com/ostreedev/ostree/pull/1767

When using `DefaultDependencies=no`, one really wants to specify *some*
dependency - very few units have no dependencies at all.

In this case, let's run "early" which means after `sysinit.target`
but before `basic.target`, which will ensure we run after `ostree-prepare-root.service`.