### PR TITLE
[next] manifest: remove non fedora-coreos-pool repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,13 +10,6 @@ rojig:
 
 repos:
   - fedora-coreos-pool
-  # these repos are there to make it easier to add new packages to the OS and to
-  # use `cosa fetch --update-lockfile`; but note that all package versions are
-  # still pinned
-  - fedora
-  - fedora-updates
-  - fedora-modular
-  - fedora-updates-modular
 
 add-commit-metadata:
   fedora-coreos.stream: next


### PR DESCRIPTION
We've done this for the `testing` and `stable` branches already
so it should probably be done here for `next` too.