### PR TITLE
Revert "image.yaml: enable sysroot-readonly"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -13,10 +13,6 @@ extra-kargs:
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora
 
-# We want read-only /sysroot to protect from unintentional damage.
-# https://github.com/ostreedev/ostree/issues/1265
-sysroot-readonly: true
-
 # After this, we plan to add support for the Ignition
 # storage/filesystems sections.  (Although one can do
 # that on boot as well)


### PR DESCRIPTION
This reverts commit 5b2660915c2f4812a3471bddf84964f7e1c349d0 - we
really need to rework this in ostree upstream to do the setup
in the initramfs.  Anything else is just going to be chock full
of race conditions.