### PR TITLE
90-coreos-device-mapper.rules: refinement on udev for device-mapper.

### DIFF
--- a/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
@@ -3,18 +3,23 @@ SUBSYSTEM!="block", GOTO="dm_label_end"
 KERNEL!="dm-*", GOTO="dm_label_end"
 
 # Ensure that the device mapper target is active
+# And the required attributes exist.
 ENV{DM_ACTIVATION}!="1", GOTO="dm_label_end"
-
-# Unless we have a label, skip
 ENV{ID_FS_LABEL_ENC}!="?*", GOTO="dm_label_end"
+ENV{ID_FS_UUID_ENC}!="?*", GOTO="dm_label_end"
 
-# Only act on filesystems
+# Only act on filesystems. This should prevent layered devices
+# such as Raid on Multipath devices from appearing.
 ENV{ID_FS_USAGE}!="filesystem", GOTO="dm_label_end"
 
-ENV{DM_MPATH}=="?*", \
-    ENV{DM_SUSPENDED}=="Active",
-    SYMLINK+="disk/by-label/dm-mpath-$env{ID_FS_LABEL_ENC}",
-    SYMLINK+="disk/by-uuid/dm-mpath-$env{ID_FS_UUID_ENC}"
+# Setup up Multipath labels and UUID's. Match on DM_UUID which
+# is stable regardless of whether friendly names are used or not.
+# 66-kpartx.rules use DM_UUID to match for linear mappings on multipath
+# targets.
+ENV{DM_UUID}=="*mpath*" \
+  , ENV{DM_SUSPENDED}=="Active" \
+  , ENV{DM_TABLES_LOADED}=="Live" \
+  , SYMLINK+="disk/by-label/dm-mpath-$env{ID_FS_LABEL_ENC}" \
+  , SYMLINK+="disk/by-uuid/dm-mpath-$env{ID_FS_UUID_ENC}"
 
 LABEL="dm_label_end"
-


### PR DESCRIPTION
Cleanup on the device-mapper rules to make it a bit clearer and follow
other rules conventions.

Signed-off-by: Ben Howard <ben.howard@redhat.com>