### PR TITLE
[next-devel] overrides: fast-track ostree-2020.3-4

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,16 @@
+packages:
+  # Fast-track to neuter sysroot.readonly:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/488
+  # https://github.com/ostreedev/ostree/pull/2108
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
+  ostree:
+    evra: 2020.3-4.fc32.aarch64
+  ostree-libs:
+    evra: 2020.3-4.fc32.aarch64
+  # Fast-track new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
+  rpm-ostree:
+    evra: 2020.2-3.fc32.aarch64
+  rpm-ostree-libs:
+    evra: 2020.2-3.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,16 @@
+packages:
+  # Fast-track to neuter sysroot.readonly:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/488
+  # https://github.com/ostreedev/ostree/pull/2108
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
+  ostree:
+    evra: 2020.3-4.fc32.ppc64le
+  ostree-libs:
+    evra: 2020.3-4.fc32.ppc64le
+  # Fast-track new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
+  rpm-ostree:
+    evra: 2020.2-3.fc32.ppc64le
+  rpm-ostree-libs:
+    evra: 2020.2-3.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,16 @@
+packages:
+  # Fast-track to neuter sysroot.readonly:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/488
+  # https://github.com/ostreedev/ostree/pull/2108
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
+  ostree:
+    evra: 2020.3-4.fc32.s390x
+  ostree-libs:
+    evra: 2020.3-4.fc32.s390x
+  # Fast-track new release for:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/481
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
+  rpm-ostree:
+    evra: 2020.2-3.fc32.s390x
+  rpm-ostree-libs:
+    evra: 2020.2-3.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,4 +1,12 @@
 packages:
+  # Fast-track to neuter sysroot.readonly:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/488
+  # https://github.com/ostreedev/ostree/pull/2108
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
+  ostree:
+    evra: 2020.3-4.fc32.x86_64
+  ostree-libs:
+    evra: 2020.3-4.fc32.x86_64
   # Fast-track new release for:
   # https://github.com/coreos/fedora-coreos-tracker/issues/481
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2


### PR DESCRIPTION
Which includes a patch to backport `sysroot.readonly` neutering:

coreos/fedora-coreos-tracker#488
ostreedev/ostree#2108