### PR TITLE
Move to conditional networking

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -9,9 +9,9 @@ extra-kargs:
     # https://fedoraproject.org/wiki/Changes/CGroupsV2
     - systemd.unified_cgroup_hierarchy=0
 
-# Kernel arguments to be used on first-boot.
-ignition-network-kcmdline:
-    - 'rd.neednet=1'
+# Disable networking by default on firstboot. We can drop this once cosa stops
+# defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
+ignition-network-kcmdline: []
 
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora

--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
@@ -43,6 +43,10 @@ After=coreos-gpt-setup@dev-disk-by\x2dlabel-root.service
 # Since we are mounting /boot/, require the device first
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
+# Need to run after fetch-offline stage since it may re-run the NM cmdline
+# hook which will generate NM configs from the network kargs, but we want to
+# have precedence.
+After=ignition-fetch-offline.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.service
@@ -24,6 +24,10 @@
 # prompt without requiring networking on boot. The user can
 # then configure the networking interactively.
 #
+# Note that this script is only used on RHCOS now. We should be able to remove
+# it once RHCOS moves to spec3. On FCOS/spec3, this is replaced by the
+# conditional networking work:
+# https://github.com/coreos/fedora-coreos-config/pull/426
 [Unit]
 Description=Request live ISO networking
 DefaultDependencies=no

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-liveiso-network-kargs.sh
@@ -2,6 +2,11 @@
 
 # For a description of how this is used see coreos-liveiso-network-kargs.service
 
+# Note that this script is only used on RHCOS now. We should be able to remove
+# it once RHCOS moves to spec3. On FCOS/spec3, this is replaced by the
+# conditional networking work:
+# https://github.com/coreos/fedora-coreos-config/pull/426
+
 # Load the dracut library for getarg
 source /usr/lib/dracut-lib.sh
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -31,7 +31,11 @@ add_requires sysroot.mount     initrd-root-fs.target
 add_requires sysroot-etc.mount initrd-root-fs.target
 add_requires sysroot-var.mount initrd-root-fs.target
 
-add_requires coreos-liveiso-network-kargs.service              initrd.target
+# Need to be flexible here until RHCOS moves to spec3.
+if ! (ignition -help || :) |& grep -q 'fetch-offline'; then
+    add_requires coreos-liveiso-network-kargs.service              initrd.target
+fi
+
 add_requires coreos-liveiso-reconfigure-nm-wait-online.service initrd.target
 
 mkdir -p "${UNIT_DIR}/ostree-prepare-root.service.d"

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -101,8 +101,22 @@ fi
 # If the user supplied an Ignition config, they have the ability to enable
 # autologin themselves.  Don't automatically render them insecure, since
 # they might be running in production and booting via e.g. IPMI.
-if [ -e /run/ignition.json ] ; then
-    exit 0
+
+# This is a hack for RHCOS Ignition which doesn't have
+# https://github.com/coreos/ignition/pull/958. This works because right now both
+# RHCOS and FCOS unconditionally bake in a base config. Once RHCOS moves to
+# Ignition v2, we can drop this and just leave the else block.
+ign_basecfg_msg=$(journalctl -q MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb IGNITION_CONFIG_TYPE=base)
+if [ -z "${ign_basecfg_msg}" ]; then
+    if [ -e /run/ignition.json ]; then
+        exit 0
+    fi
+else
+    # See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
+    ign_usercfg_msg=$(journalctl -q MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb IGNITION_CONFIG_TYPE=user)
+    if [ -n "${ign_usercfg_msg}" ]; then
+        exit 0
+    fi
 fi
 
 write_dropin "getty@.service"        "--noclear"

--- a/overlay.d/05core/usr/lib/systemd/system/coreos-liveiso-success.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-liveiso-success.service
@@ -4,8 +4,7 @@
 [Unit]
 Description=CoreOS Live ISO virtio success
 Documentation=https://github.com/coreos/fedora-coreos-config
-# Only run on the Live ISO, and only if there's no Ignition config;
-# the second bits here invert the conditionals in coreos-liveiso-network-kargs.service.
+# Only run on the Live ISO, and only if there's no Ignition config
 ConditionKernelCommandLine=coreos.liveiso
 ConditionPathExists=!/config.ign
 ConditionVirtualization=|kvm

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -11,6 +11,15 @@ fatal() {
     exit 1
 }
 
+on_platform() {
+    grep -q " ignition.platform.id=$1 " /proc/cmdline
+}
+
+get_journal_msg_timestamp() {
+    journalctl -o json -b 0 --grep "$1" \
+        | jq -r --slurp '.[0]["__MONOTONIC_TIMESTAMP"]'
+}
+
 systemctl is-enabled logrotate.service
 ok logrotate
 
@@ -19,3 +28,16 @@ if ip link | grep -o -e " eth[0-9]:"; then
     fatal "detected eth* NIC naming on node"
 fi
 ok nic naming
+
+switchroot_ts=$(get_journal_msg_timestamp 'Switching root.')
+nm_ts=$(get_journal_msg_timestamp 'NetworkManager .* starting')
+# by default, kola on QEMU shouldn't need to bring up networking
+# https://github.com/coreos/fedora-coreos-config/pull/426
+if [[ $nm_ts -lt $switchroot_ts ]] && on_platform qemu; then
+    fatal "NetworkManager started in initramfs!"
+# and as a sanity-check that this test works, verify that on AWS
+# we did bring up networking in the initrd
+elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
+    fatal "NetworkManager not started in initramfs!"
+fi
+ok conditional initrd networking

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is a place to put random quick read-only tests.
-set -euo pipefail
+set -xeuo pipefail
 
 ok() {
     echo "ok" "$@"
@@ -15,5 +15,7 @@ systemctl is-enabled logrotate.service
 ok logrotate
 
 # https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
-systemd-run -P -p ConditionVirtualization=kvm --wait /bin/sh -c 'set -euo pipefail; ip link | grep -o -e " ens[0-9]:"'
+if ip link | grep -o -e " eth[0-9]:"; then
+    fatal "detected eth* NIC naming on node"
+fi
 ok nic naming


### PR DESCRIPTION
We have all the piece in place now to move to conditional networking. So
let's drop the firstboot kargs, as well as
coreos-liveiso-network-kargs.service, which is no longer needed (i.e.
the live ISO will now enable initrd networking as required given the
embedded Ignition config).

Fixes: coreos/fedora-coreos-tracker#443