### PR TITLE
image: inject firstboot kargs (ignition-network-kcmdline)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -9,6 +9,10 @@ extra-kargs:
     # https://fedoraproject.org/wiki/Changes/CGroupsV2
     - systemd.unified_cgroup_hierarchy=0
 
+# Kernel arguments to be used on first-boot.
+ignition-network-kcmdline:
+    - 'rd.neednet=1'
+    - 'ip=dhcp,dhcp6'
 
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora


### PR DESCRIPTION
This updates `image` manifest to capture current firstboot kernel
arguments. Those are effectively the same parameters used by GRUB
and overridable by coreos-installer, which so far have been
hardcoded inside `grub.cfg`.

Ref: https://github.com/coreos/coreos-assembler/pull/1373