### PR TITLE
liveiso: make motd install hint consistent with docs

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -59,9 +59,7 @@ installing persistently to disk. Here is an example of running an install
 to disk via coreos-installer:
 
 curl -O https://example.com/example.ign
-sudo coreos-installer install /dev/sda \\
-         --ignition-file ./example.ign \\
-         --image-url https://example.com/image.raw.xz
+sudo coreos-installer install /dev/sda --ignition-file ./example.ign 
 
 You may configure networking via 'sudo nmcli' or 'sudo nmtui' and have
 that configuration persist into the installed system by passing the


### PR DESCRIPTION
- Edited the /etc/motd to be consistent with the help docs.
REF:
https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/#_installing_from_live_iso

It seems that you don't need the image line if you've booted off the
ISO, which this clears that up.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>