### PR TITLE
overlay: handle unbound var in coreos-growpart

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -49,10 +49,10 @@ fi
 eval $(blkid -o export "${src}")
 # TODO: Add XFS to https://github.com/systemd/systemd/blob/master/src/partition/growfs.c
 # and use it instead.
-case "${TYPE}" in
+case "${TYPE:-}" in
     xfs) xfs_growfs /sysroot ;;
     ext4) resize2fs "${src}" ;;
-    *) echo "error: Unsupported filesystem for /sysroot: ${TYPE}" 1>&2; exit 1 ;;
+    *) echo "error: Unsupported filesystem for ${path}: '${TYPE:-}'" 1>&2; exit 1 ;;
 esac
 
 touch /var/lib/coreos-growpart.stamp


### PR DESCRIPTION
This will make it so we get the desired error message
rather than an error about an unbound variable.

Ref: https://discussion.fedoraproject.org/t/installer-not-creating-xfs-on-sda4/20141