### PR TITLE
README.md: add `koji untag` to releasever bump SOP

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,14 @@ CoreOS Installer changes:
 Release engineering changes:
 
 1. verify that the `f${releasever}-coreos-signing-pending` Koji tag has
-   been created
+   been created (this should have already been done by releng scripts on
+   branching)
 2. update RoboSignatory config so that:
     - [tagged packages are signed with the right key](https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/robosignatory/templates/robosignatory.toml.j2?id=c27f4644d4bc2f7916c9c85dc1c1a9ee9a724cc0#n181)
     - [CoreOS artifacts are signed with the right key](https://infrastructure.fedoraproject.org/cgit/ansible.git/tree/roles/robosignatory/templates/robosignatory.toml.j2?id=c27f4644d4bc2f7916c9c85dc1c1a9ee9a724cc0#n458)
+3. `koji untag` N-2 packages from the pool (at some point we'll have GC
+   in place to do this for us, but for now we must remember to do this
+   manually or otherwise distRepo will fail once the signed packages are
+   GC'ed). For example:
+    - `koji list-tagged coreos-pool --quiet | grep fc30 | cut -f1 -d' ' | sort | uniq`
+    - Sanity-check the output, then pipe it to `xargs koji untag-build coreos-pool`


### PR DESCRIPTION
We encountered this this morning: FCOS f30 signed packages were garbage
collected (even though the Koji builds themselves were not since they're
tagged in the pool), and this caused the `distRepo` task to fail because
it expects the signed packages to be there.

Ideally, we'd have proper GC for pool packages in place, but for now
let's add a step there to untag packages from the `N-2` release. This
interestingly does put a natural upper bound on how long to keep
packages; until the release in which it shipped goes EOL, which I think
is completely reasonable.