### PR TITLE
live: remove serial line from isolinux.cfg

### DIFF
--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -1,7 +1,6 @@
 # Note this file mostly matches the isolinux.cfg file from the Fedora 
 # Server DVD iso. Diff this file with that file in the future to pick up
 # changes.
-serial 0
 default vesamenu.c32
 # timeout in units of 1/10s. 50 == 5 seconds
 timeout 50


### PR DESCRIPTION
When testing out installing FCOS on a new mini PC that only contains
a serial port (no graphical console) I noticed the isolinux menu wasn't
displaying correctly. I compared this with the Fedora Workstation and
Fedora Server configs and neither of those have the `serial 0` line in
them and the isolinux menu shows up fine via serial console there.

Let's remove it since it seems like serial auto-detection works better
than the `0` setting, which is actively causing some consoles to not
work.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/506