### PR TITLE
[next-devel] overrides: fast-track coreos-installer-0.2.1-2

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -14,3 +14,9 @@ packages:
     evra: 2020.2-3.fc32.aarch64
   rpm-ostree-libs:
     evra: 2020.2-3.fc32.aarch64
+  # Fast-track F32 signing keys
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
+  coreos-installer:
+    evra: 0.2.1-2.fc32.aarch64
+  coreos-installer-systemd:
+    evra: 0.2.1-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -14,3 +14,9 @@ packages:
     evra: 2020.2-3.fc32.ppc64le
   rpm-ostree-libs:
     evra: 2020.2-3.fc32.ppc64le
+  # Fast-track F32 signing keys
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
+  coreos-installer:
+    evra: 0.2.1-2.fc32.ppc64le
+  coreos-installer-systemd:
+    evra: 0.2.1-2.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -14,3 +14,9 @@ packages:
     evra: 2020.2-3.fc32.s390x
   rpm-ostree-libs:
     evra: 2020.2-3.fc32.s390x
+  # Fast-track F32 signing keys
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
+  coreos-installer:
+    evra: 0.2.1-2.fc32.s390x
+  coreos-installer-systemd:
+    evra: 0.2.1-2.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -14,3 +14,9 @@ packages:
     evra: 2020.2-3.fc32.x86_64
   rpm-ostree-libs:
     evra: 2020.2-3.fc32.x86_64
+  # Fast-track F32 signing keys
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
+  coreos-installer:
+    evra: 0.2.1-2.fc32.x86_64
+  coreos-installer-systemd:
+    evra: 0.2.1-2.fc32.x86_64


### PR DESCRIPTION
Pick up F32 signing keys.