### PR TITLE
liveiso-autologin-generator: showcase --ignition-url

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -58,8 +58,8 @@ from memory, making it a good candidate for hardware discovery and
 installing persistently to disk. Here is an example of running an install
 to disk via coreos-installer:
 
-curl -O https://example.com/example.ign
-sudo coreos-installer install /dev/sda --ignition-file ./example.ign 
+sudo coreos-installer install /dev/sda \
+    --ignition-url https://example.com/example.ign
 
 You may configure networking via 'sudo nmcli' or 'sudo nmtui' and have
 that configuration persist into the installed system by passing the


### PR DESCRIPTION
Now that coreos-installer supports it, we can simplify the example
`coreos-installer` command here further.