### PR TITLE
overrides: fast-track slirp4netns-1.0.0-1.fc32.x86_64

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -25,3 +25,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
   ignition:
     evra: 2.3.0-2.gitee616d5.fc32.x86_64
+  # Fast-track slirp4netns. The maintainers forgot to submit the update
+  # to bodhi and now we're seeing a "downgrade" when going from Fedora
+  # 31 FCOS to Fedora 32 FCOS.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  slirp4netns:
+    evra: 1.0.0-1.fc32.x86_64


### PR DESCRIPTION
The maintainers originally forgot to submit the update to bodhi
and now we're seeing a "downgrade" when going from Fedora 31 FCOS to
Fedora 32 FCOS.

https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962