### PR TITLE
overlay: only run ignition/afterburn checks on first boot

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -3,6 +3,12 @@
 [Unit]
 Description=Check if ignition config is provided
 Before=console-login-helper-messages-issuegen.service
+# Only perform checks on the first (Ignition) boot as they are
+# mostly useful only on that boot. This ensures systems started
+# before Ignition/Afterburn started logging structured data don't
+# get misleading messages. Also handles the case where the journal
+# gets rotated and no longer has the structured log messages.
+ConditionKernelCommandLine=ignition.firstboot
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/coreos-check-ignition-config.sh

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -8,6 +8,12 @@ Before=console-login-helper-messages-issuegen.service
 # around any instance of `afterburn-sshkeys@` and not just the 
 # `core` user.
 After=afterburn-sshkeys@core.service
+# Only perform checks on the first (Ignition) boot as they are
+# mostly useful only on that boot. This ensures systems started
+# before Ignition/Afterburn started logging structured data don't
+# get misleading messages. Also handles the case where the journal
+# gets rotated and no longer has the structured log messages.
+ConditionKernelCommandLine=ignition.firstboot
 ProtectHome=read-only
 [Service]
 Type=oneshot


### PR DESCRIPTION
Only perform checks on the first (Ignition) boot as they are
mostly useful only on that boot. This ensures systems started
before Ignition/Afterburn started logging structured data don't
get misleading messages. Also handles the case where the journal
gets rotated and no longer has the structured log messages.