### PR TITLE
Revert "live: remove serial line from isolinux.cfg"

### DIFF
--- a/live/isolinux/isolinux.cfg
+++ b/live/isolinux/isolinux.cfg
@@ -1,6 +1,7 @@
 # Note this file mostly matches the isolinux.cfg file from the Fedora 
 # Server DVD iso. Diff this file with that file in the future to pick up
 # changes.
+serial 0
 default vesamenu.c32
 # timeout in units of 1/10s. 50 == 5 seconds
 timeout 50


### PR DESCRIPTION
This reverts commit 0f1183e9ccca9279feff138576f516942e17b0a3.

Apparently removing the serial line means that we no longer get serial
console on a VM when doing something like `virt-install --graphics=none`.
Let's revert this change for now (i.e. go back to how it was before) and
make a subsequent change in the future that tries to handle all cases
better.