### PR TITLE
overrides: fix attempt at fast-track of slirp4netns-1.0.1-1.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -25,3 +25,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
   ignition:
     evra: 2.3.0-2.gitee616d5.fc32.aarch64
+  # Fast-track slirp4netns. The maintainers forgot to submit the update
+  # to bodhi and now we're seeing a "downgrade" when going from Fedora
+  # 31 FCOS to Fedora 32 FCOS.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  slirp4netns:
+    evra: 1.0.1-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -25,3 +25,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
   ignition:
     evra: 2.3.0-2.gitee616d5.fc32.ppc64le
+  # Fast-track slirp4netns. The maintainers forgot to submit the update
+  # to bodhi and now we're seeing a "downgrade" when going from Fedora
+  # 31 FCOS to Fedora 32 FCOS.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  slirp4netns:
+    evra: 1.0.1-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -25,3 +25,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
   ignition:
     evra: 2.3.0-2.gitee616d5.fc32.s390x
+  # Fast-track slirp4netns. The maintainers forgot to submit the update
+  # to bodhi and now we're seeing a "downgrade" when going from Fedora
+  # 31 FCOS to Fedora 32 FCOS.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  slirp4netns:
+    evra: 1.0.1-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -30,4 +30,4 @@ packages:
   # 31 FCOS to Fedora 32 FCOS.
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
-    evra: 1.0.0-1.fc32.x86_64
+    evra: 1.0.1-1.fc32.x86_64


### PR DESCRIPTION
I made a few mistakes in https://github.com/coreos/fedora-coreos-config/pull/443
that I'll attempt to fix here:

- Use the correct version of slirp4netns
- Update all multi-arch overrides files