### PR TITLE
coreos-growpart: avoid creating ambivalent filesystems

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -15,6 +15,16 @@ shift
 # this shouldn't happen for us but we're being conservative.
 src=$(findmnt -nvr -o SOURCE "$path" | tail -n1)
 
+# Get the filesystem type before extending the partition.  This matters
+# because the partition, once extended, might include leftover superblocks
+# from the previous contents of the disk (notably ZFS), causing blkid to
+# refuse to return any filesystem type at all.
+eval $(blkid -o export "${src}")
+case "${TYPE:-}" in
+    xfs|ext4) ;;
+    *) echo "error: Unsupported filesystem for ${path}: '${TYPE:-}'" 1>&2; exit 1 ;;
+esac
+
 if [[ "${src}" =~ "/dev/mapper" ]]; then
     eval $(udevadm info --query property --export "${src}")
     # get the partition, if any, and the name for the device mapper
@@ -46,13 +56,15 @@ else
     growpart "${parent_device}" "${partition}" || true
 fi
 
-eval $(blkid -o export "${src}")
+# Wipe any filesystem signatures from the extended partition that don't
+# correspond to the FS type we detected earlier.
+wipefs -af -t "no${TYPE}" "${src}"
+
 # TODO: Add XFS to https://github.com/systemd/systemd/blob/master/src/partition/growfs.c
 # and use it instead.
-case "${TYPE:-}" in
+case "${TYPE}" in
     xfs) xfs_growfs /sysroot ;;
     ext4) resize2fs "${src}" ;;
-    *) echo "error: Unsupported filesystem for ${path}: '${TYPE:-}'" 1>&2; exit 1 ;;
 esac
 
 touch /var/lib/coreos-growpart.stamp

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -63,7 +63,7 @@ wipefs -af -t "no${TYPE}" "${src}"
 # TODO: Add XFS to https://github.com/systemd/systemd/blob/master/src/partition/growfs.c
 # and use it instead.
 case "${TYPE}" in
-    xfs) xfs_growfs /sysroot ;;
+    xfs) xfs_growfs "${path}" ;;
     ext4) resize2fs "${src}" ;;
 esac
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -49,10 +49,10 @@ fi
 eval $(blkid -o export "${src}")
 # TODO: Add XFS to https://github.com/systemd/systemd/blob/master/src/partition/growfs.c
 # and use it instead.
-case "${TYPE}" in
+case "${TYPE:-}" in
     xfs) xfs_growfs /sysroot ;;
     ext4) resize2fs "${src}" ;;
-    *) echo "error: Unsupported filesystem for /sysroot: ${TYPE}" 1>&2; exit 1 ;;
+    *) echo "error: Unsupported filesystem for ${path}: '${TYPE:-}'" 1>&2; exit 1 ;;
 esac
 
 touch /var/lib/coreos-growpart.stamp

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -25,18 +25,19 @@ install() {
         uniq
 
     # coreos-growpart deps
-    inst_multiple \
-        basename  \
-        blkid     \
-        cat       \
-        dirname   \
-        findmnt   \
-        growpart  \
-        realpath  \
-        resize2fs \
-        tail      \
-        touch     \
-        xfs_growfs
+    inst_multiple  \
+        basename   \
+        blkid      \
+        cat        \
+        dirname    \
+        findmnt    \
+        growpart   \
+        realpath   \
+        resize2fs  \
+        tail       \
+        touch      \
+        xfs_growfs \
+        wipefs
 
     # growpart deps
     # Mostly generated from the following command:

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -41,19 +41,19 @@ install() {
 
     # growpart deps
     # Mostly generated from the following command:
-    # 	$ bash --rpm-requires /usr/bin/growpart | sort | uniq | grep executable
+    #   $ bash --rpm-requires /usr/bin/growpart | sort | uniq | grep executable
     # with a few false positives (rq, rqe, -v) and one missed (mktemp)
     inst_multiple \
-	awk       \
-	cat       \
-	dd        \
-	grep      \
-	mktemp    \
-	partx     \
-	rm        \
-	sed       \
-	sfdisk    \
-	sgdisk
+        awk       \
+        cat       \
+        dd        \
+        grep      \
+        mktemp    \
+        partx     \
+        rm        \
+        sed       \
+        sfdisk    \
+        sgdisk
 
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service


### PR DESCRIPTION
If `blkid` finds a partition containing superblocks from multiple filesystem types, it'll refuse to report anything about that partition.  If we `growpart` `/sysroot` into space that was previously used by ZFS, we'll pick up a ZFS superblock and then fail to detect the filesystem type for resizing.

Fix this by probing the filesystem type before running `growpart`.  After running `growpart`, but before resizing, run `wipefs(8)` on the newly-grown partition, asking it to delete all superblocks for filesystem types other than the one we just detected.

This is kind of hacky.  We can't guarantee that `wipefs` will only touch the unwritten space past the end of the existing filesystem.  Presumably the existing filesystem contents are safe (either they come from an image, or Ignition has just created the filesystem), but there's no guarantee that `wipefs` won't detect an errant superblock signature and thus modify the filesystem while it's mounted.  Of course, in that case we'd already have an ambivalent filesystem and thus it wouldn't mount properly in the future anyway.

Also exit early if the filesystem type is unrecognized.

Includes https://github.com/coreos/fedora-coreos-config/pull/429.  Fixes coreos/fedora-coreos-tracker#500.