### PR TITLE
coreos-copy-firstboot-network.service: Squash race with GPT generator

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
@@ -6,6 +6,7 @@
 #
 # - Need to look for networking configuration on the /boot partition
 #     - i.e. after /dev/disk/by-label/boot is available
+#     - and after the ignition-dracut GPT generator (see below)
 # - Need to run before networking is brought up.
 #     - This is done in nm-run.sh [1] that runs as part of dracut-initqueue [2]
 #     - i.e. Before=dracut-initqueue.service
@@ -32,9 +33,12 @@ DefaultDependencies=false
 Before=ignition-diskful.target
 Before=dracut-initqueue.service
 After=dracut-cmdline.service
+# Any services looking at mounts need to order after this
+# because it causes device re-probing.
+After=coreos-gpt-setup@dev-disk-by\x2dlabel-root.service
 # Since we are mounting /boot/, require the device first
 Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device   
+After=dev-disk-by\x2dlabel-boot.device
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.sh
@@ -15,38 +15,7 @@ realroot_firstboot_network_dir="/boot/${firstboot_network_dir_basename}"
 # are run in a systemd unit with MountFlags=slave so it is unmounted for us.
 # Mount as read-only since we don't strictly need write access and we may be
 # running alongside other code that also has it mounted ro
-mountboot() {
-    # Wait for up to 5 seconds for the boot device to be available
-    # The After=...*boot.device in the systemd unit should be enough
-    # but there appears to be some race in the kernel where the link under
-    # /dev/disk/by-label exists but mount is not able to use the device yet.
-    # We saw errors like this in CI:
-    #
-    #   [    4.045181] systemd[1]: Found device /dev/disk/by-label/boot.
-    #   [  OK  ] Found device /dev/disk/by-label/boot
-    #   [    4.051500] systemd[1]: Starting Copy CoreOS Firstboot Networking Config...
-    #         Starting  Copy CoreOS Firstboot Networking Config
-    #   [    4.060573]  vda: vda1 vda2 vda3 vda4
-    #   [    4.063296] coreos-copy-firstboot-network[479]: mount: /mnt/boot_partition: special device /dev/disk/by-label/boot does not exist.
-    #
-    mounted=0
-    for x in {1..5}; do
-        if mount -o ro ${bootdev} ${bootmnt}; then
-            echo "info: ${bootdev} successfully mounted."
-            mounted=1
-            break
-        else
-            echo "info: retrying ${bootdev} mount in 1 second..."
-            sleep 1
-        fi
-    done
-    if [ "${mounted}" == "0" ]; then
-        echo "error: ${bootdev} mount did not succeed" 1>&2
-        return 1
-    fi
-}
-
-mountboot || exit 1
+mount -o ro ${bootdev} ${bootmnt}
 
 if [ -n "$(ls -A ${initramfs_firstboot_network_dir} 2>/dev/null)" ]; then
     # Clear out any files that may have already been generated from


### PR DESCRIPTION
I believe this is the core issue; on one failing run I see the
services being interleaved.  Remove the "retry mounting" hack
to prove it.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/523