### PR TITLE
image: drop hardcoded firstboot network kargs

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -12,7 +12,6 @@ extra-kargs:
 # Kernel arguments to be used on first-boot.
 ignition-network-kcmdline:
     - 'rd.neednet=1'
-    - 'ip=dhcp,dhcp6'
 
 # Optional remote by which to prefix the deployed OSTree ref
 ostree-remote: fedora


### PR DESCRIPTION
This removes the hardcoded `ip=dhcp,dhcp6` from bootloader configuration.
The default value has been moved to Afterburn (>= 4.4.0), making
this dynamically injected at runtime. On some platforms (e.g. VMware),
this also allows user-controlled overriding.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/460