### PR TITLE
overlay.d/05core: Remove workaround for logrotate.timer

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/41-fcos-workarounds.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/41-fcos-workarounds.preset
@@ -1,2 +1,0 @@
-# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1655153#c4
-enable logrotate.timer


### PR DESCRIPTION
This is workaround is no longer needed now that we moved to Fedora 32 which has the fix from https://src.fedoraproject.org/rpms/fedora-release/pull-request/111