### PR TITLE
coreos-copy-firstboot-network.service: Update GPT generator unit name

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-firstboot-network/coreos-copy-firstboot-network.service
@@ -35,6 +35,10 @@ Before=dracut-initqueue.service
 After=dracut-cmdline.service
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
+After=coreos-gpt-setup.service
+# Older unit name kept for compatibility. This will be safe to remove once the
+# dracut-ignition changes from [1] are available in the latest ignition RPM.
+# [1] https://github.com/coreos/ignition-dracut/pull/191
 After=coreos-gpt-setup@dev-disk-by\x2dlabel-root.service
 # Since we are mounting /boot/, require the device first
 Requires=dev-disk-by\x2dlabel-boot.device


### PR DESCRIPTION
The GPT setup unit was simplified to reflect the fact that it will only
be called once for the disk with the partition labeled 'boot'.

This keeps the old unit name for now for compatibility.