### PR TITLE
overlay/15fcos: coreos-check-ssh-keys: add missing newline to output

### DIFF
--- a/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
@@ -28,6 +28,10 @@ main() {
         output+="$ignitionusers"
     fi
     if [ -n "$afterburnusers" ]; then
+        # add newline if needed
+        if [ -n "$output" ]; then
+            output+=$'\n'
+        fi
         output+="$afterburnusers"
     fi
 


### PR DESCRIPTION
Currently we're missing a newline when printing information
about the SSH keys on the console:

```
Ignition: user provided config was applied
Ignition: wrote ssh authorized keys file for user: coreAfterburn: wrote ssh authorized keys file for user: core
```

Let's add a newline if needed.