### PR TITLE
Don't use modular repos in manifest, add fedora-coreos-pinger-0.0.4-3.fc32 override

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -31,3 +31,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.aarch64
+  # Override with a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # Currently there is no Bodhi update, due to Koji tag issues,
+  # now pending a side tag build into F32 being done for the more
+  # recently built rust-fedora-coreos-pinger-0.0.4-4.fc33.
+  # In the current Koji deployment a Fedora admin needs to do the
+  # side tag (see https://pagure.io/releng/issue/9229).
+  # TODO: open a Bodhi update for
+  # rust-fedora-coreos-pinger-0.0.4-4.fc32 once built,
+  # and change the override below to use the 0.0.4-4.fc32 build.
+  fedora-coreos-pinger:
+    evra: 0.0.4-3.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -31,3 +31,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.ppc64le
+  # Override with a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # Currently there is no Bodhi update, due to Koji tag issues,
+  # now pending a side tag build into F32 being done for the more
+  # recently built rust-fedora-coreos-pinger-0.0.4-4.fc33.
+  # In the current Koji deployment a Fedora admin needs to do the
+  # side tag (see https://pagure.io/releng/issue/9229).
+  # TODO: open a Bodhi update for
+  # rust-fedora-coreos-pinger-0.0.4-4.fc32 once built,
+  # and change the override below to use the 0.0.4-4.fc32 build.
+  fedora-coreos-pinger:
+    evra: 0.0.4-3.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -31,3 +31,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.s390x
+  # Override with a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # Currently there is no Bodhi update, due to Koji tag issues,
+  # now pending a side tag build into F32 being done for the more
+  # recently built rust-fedora-coreos-pinger-0.0.4-4.fc33.
+  # In the current Koji deployment a Fedora admin needs to do the
+  # side tag (see https://pagure.io/releng/issue/9229).
+  # TODO: open a Bodhi update for
+  # rust-fedora-coreos-pinger-0.0.4-4.fc32 once built,
+  # and change the override below to use the 0.0.4-4.fc32 build.
+  fedora-coreos-pinger:
+    evra: 0.0.4-3.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -31,3 +31,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.x86_64
+  # Override with a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # Currently there is no Bodhi update, due to Koji tag issues,
+  # now pending a side tag build into F32 being done for the more
+  # recently built rust-fedora-coreos-pinger-0.0.4-4.fc33.
+  # In the current Koji deployment a Fedora admin needs to do the
+  # side tag (see https://pagure.io/releng/issue/9229).
+  # TODO: open a Bodhi update for
+  # rust-fedora-coreos-pinger-0.0.4-4.fc32 once built,
+  # and change the override below to use the 0.0.4-4.fc32 build.
+  fedora-coreos-pinger:
+    evra: 0.0.4-3.fc32.x86_64

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,8 +14,6 @@ repos:
   # still pinned
   - fedora
   - fedora-updates
-  - fedora-modular
-  - fedora-updates-modular
 
 # All Fedora CoreOS streams share the same pool for locked files.
 # This will be in fedora-coreos.yaml in the future so it can be more easily be


### PR DESCRIPTION
Opening to test an existing non-modular fedora-coreos-pinger-0.0.4-3.fc32 build sourced from Koji, when modular repos are disabled.

Not building with modular content will fix: https://github.com/coreos/fedora-coreos-tracker/issues/525