### PR TITLE
tests: Add gshadow test, migrated from coreos-assembler

### DIFF
--- a/tests/kola/gshadow
+++ b/tests/kola/gshadow
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeuo pipefail
+# Verify that glibc's parsing of /etc/gshadow does not cause systemd-sysusers
+# to segfault on specially constructed lines.
+#
+# One line must fit into the character buffer (1024 bytes, unless a previous
+# line was longer) but have enough group members such that
+#
+#     line length + alignment + sizeof(char *) * (#adm + 1 + #mem + 1) > 1024.
+#
+# The parser would return early to avoid overflow, leaving the static result
+# struct pointing to pointers from the previous line which are now invalid,
+# causing segfaults when those pointers are dereferenced.
+#
+# Tests: https://github.com/coreos/bugs/issues/1394
+echo 'grp0:*::root' >> /etc/gshadow
+echo 'grp1:*::somebody.a1,somebody.a2,somebody.a3,somebody.a4,somebody.a5,somebody.a6,somebody.a7,somebody.a8,somebody.a9,somebody.a10,somebody.a11,somebody.a12,somebody.a13,somebody.a14,somebody.a15,somebody.a16,somebody.a17,somebody.a18,somebody.a19,somebody.a20,somebody.a21,somebody.a22,somebody.a23,somebody.a24,somebody.a25,somebody.a26,somebody.a27,somebody.a28,somebody.a29,somebody.a30,somebody.a31,somebody.a32,somebody.a33,somebody.a34,somebody.a35,somebody.a36,somebody.a37,somebody.a38,somebody.a39,somebody.a40,somebody.a41,somebody.a42,somebody.a43,somebody.a44,somebody.a45,somebody.a46,somebody.a47,a1234' >> /etc/gshadow
+echo 'grp2:*::root' >> /etc/gshadow
+systemd-sysusers
+echo "ok sysusers gshadow"


### PR DESCRIPTION
See https://github.com/coreos/coreos-assembler/pull/1522

The idea is our default for new external tests would be this repo.