### PR TITLE
[next] overrides: fast-track fedora-coreos-pinger-0.0.4-4.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -31,3 +31,8 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.aarch64
+  # Fast-track a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
+  fedora-coreos-pinger:
+    evra: 0.0.4-4.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -31,3 +31,8 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.ppc64le
+  # Fast-track a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
+  fedora-coreos-pinger:
+    evra: 0.0.4-4.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -31,3 +31,8 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.s390x
+  # Fast-track a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
+  fedora-coreos-pinger:
+    evra: 0.0.4-4.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -31,3 +31,8 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
   slirp4netns:
     evra: 1.0.1-1.fc32.x86_64
+  # Fast-track a build of fedora-coreos-pinger that doesn't use
+  # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
+  fedora-coreos-pinger:
+    evra: 0.0.4-4.fc32.x86_64

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -70,7 +70,7 @@
       "evra": "1.0.8-2.fc32.x86_64"
     },
     "c-ares": {
-      "evra": "1.16.0-1.module_f32+8723+aeaf79ed.x86_64"
+      "evra": "1.15.0-5.fc32.x86_64"
     },
     "ca-certificates": {
       "evra": "2020.2.40-3.fc32.noarch"
@@ -235,7 +235,7 @@
       "evra": "2.2.8-2.fc32.x86_64"
     },
     "fedora-coreos-pinger": {
-      "evra": "0.0.4-1.module_f32+6507+a4e4adf6.x86_64"
+      "evra": "0.0.4-3.fc32.x86_64"
     },
     "fedora-gpg-keys": {
       "evra": "32-2.noarch"
@@ -889,7 +889,7 @@
       "evra": "2:1.9.2-1.fc32.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.0-2.module_f32+7989+651e8914.x86_64"
+      "evra": "3.0-2.fc32.x86_64"
     },
     "polkit": {
       "evra": "0.116-7.fc32.x86_64"


### PR DESCRIPTION
(cherry picked from commit 8eceea9a79be6d8e89776fc29c36bfa79ab109ea)