### PR TITLE
overrides: drop graduated, bump slirp4netns, include microcode_ctl for CVE-2020-0543 (SRBDS)

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,30 +1,4 @@
 packages:
-  # Fast-track to neuter sysroot.readonly:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/488
-  # https://github.com/ostreedev/ostree/pull/2108
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
-  ostree:
-    evra: 2020.3-4.fc32.aarch64
-  ostree-libs:
-    evra: 2020.3-4.fc32.aarch64
-  # Fast-track new release for:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/481
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
-  rpm-ostree:
-    evra: 2020.2-3.fc32.aarch64
-  rpm-ostree-libs:
-    evra: 2020.2-3.fc32.aarch64
-  # Fast-track F32 signing keys
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
-  coreos-installer:
-    evra: 0.2.1-2.fc32.aarch64
-  coreos-installer-systemd:
-    evra: 0.2.1-2.fc32.aarch64
-  # Fast-track Ignition for failure handling
-  # https://github.com/coreos/ignition-dracut/pull/188
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
-  ignition:
-    evra: 2.3.0-2.gitee616d5.fc32.aarch64
   # Fast-track slirp4netns. The maintainers forgot to submit the update
   # to bodhi and now we're seeing a "downgrade" when going from Fedora
   # 31 FCOS to Fedora 32 FCOS.

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,10 +1,10 @@
 packages:
-  # Fast-track slirp4netns. The maintainers forgot to submit the update
-  # to bodhi and now we're seeing a "downgrade" when going from Fedora
-  # 31 FCOS to Fedora 32 FCOS.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  # Fast-track slirp4netns. The previous version we were using 
+  # (1.0.1-1.fc32) was obsoleted before it hit stable so we're
+  # now moving to the current candidate in bodhi updates-testing.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-c11b99377e
   slirp4netns:
-    evra: 1.0.1-1.fc32.aarch64
+    evra: 1.1.1-1.fc32.aarch64
   # Fast-track a build of fedora-coreos-pinger that doesn't use
   # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,30 +1,4 @@
 packages:
-  # Fast-track to neuter sysroot.readonly:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/488
-  # https://github.com/ostreedev/ostree/pull/2108
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
-  ostree:
-    evra: 2020.3-4.fc32.ppc64le
-  ostree-libs:
-    evra: 2020.3-4.fc32.ppc64le
-  # Fast-track new release for:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/481
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
-  rpm-ostree:
-    evra: 2020.2-3.fc32.ppc64le
-  rpm-ostree-libs:
-    evra: 2020.2-3.fc32.ppc64le
-  # Fast-track F32 signing keys
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
-  coreos-installer:
-    evra: 0.2.1-2.fc32.ppc64le
-  coreos-installer-systemd:
-    evra: 0.2.1-2.fc32.ppc64le
-  # Fast-track Ignition for failure handling
-  # https://github.com/coreos/ignition-dracut/pull/188
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
-  ignition:
-    evra: 2.3.0-2.gitee616d5.fc32.ppc64le
   # Fast-track slirp4netns. The maintainers forgot to submit the update
   # to bodhi and now we're seeing a "downgrade" when going from Fedora
   # 31 FCOS to Fedora 32 FCOS.

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,10 +1,10 @@
 packages:
-  # Fast-track slirp4netns. The maintainers forgot to submit the update
-  # to bodhi and now we're seeing a "downgrade" when going from Fedora
-  # 31 FCOS to Fedora 32 FCOS.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  # Fast-track slirp4netns. The previous version we were using 
+  # (1.0.1-1.fc32) was obsoleted before it hit stable so we're
+  # now moving to the current candidate in bodhi updates-testing.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-c11b99377e
   slirp4netns:
-    evra: 1.0.1-1.fc32.ppc64le
+    evra: 1.1.1-1.fc32.ppc64le
   # Fast-track a build of fedora-coreos-pinger that doesn't use
   # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,10 +1,10 @@
 packages:
-  # Fast-track slirp4netns. The maintainers forgot to submit the update
-  # to bodhi and now we're seeing a "downgrade" when going from Fedora
-  # 31 FCOS to Fedora 32 FCOS.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  # Fast-track slirp4netns. The previous version we were using 
+  # (1.0.1-1.fc32) was obsoleted before it hit stable so we're
+  # now moving to the current candidate in bodhi updates-testing.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-c11b99377e
   slirp4netns:
-    evra: 1.0.1-1.fc32.s390x
+    evra: 1.1.1-1.fc32.s390x
   # Fast-track a build of fedora-coreos-pinger that doesn't use
   # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,30 +1,4 @@
 packages:
-  # Fast-track to neuter sysroot.readonly:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/488
-  # https://github.com/ostreedev/ostree/pull/2108
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
-  ostree:
-    evra: 2020.3-4.fc32.s390x
-  ostree-libs:
-    evra: 2020.3-4.fc32.s390x
-  # Fast-track new release for:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/481
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
-  rpm-ostree:
-    evra: 2020.2-3.fc32.s390x
-  rpm-ostree-libs:
-    evra: 2020.2-3.fc32.s390x
-  # Fast-track F32 signing keys
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
-  coreos-installer:
-    evra: 0.2.1-2.fc32.s390x
-  coreos-installer-systemd:
-    evra: 0.2.1-2.fc32.s390x
-  # Fast-track Ignition for failure handling
-  # https://github.com/coreos/ignition-dracut/pull/188
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
-  ignition:
-    evra: 2.3.0-2.gitee616d5.fc32.s390x
   # Fast-track slirp4netns. The maintainers forgot to submit the update
   # to bodhi and now we're seeing a "downgrade" when going from Fedora
   # 31 FCOS to Fedora 32 FCOS.

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,3 +10,11 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.x86_64
+  # Fast-track a build of microcode_ctl that is part of a set of fixes
+  # for a recent CVE (CVE-2020-0543). The bug for the CVE is BZ1827165
+  # which links to two Fedora specific bugs: BZ1845629 (kernel) and
+  # BZ1845630 (microcode_ctl). The kernel update (kernel-5.6.18-300.fc32)
+  # already made it to stable. The microcode_ctl update has not yet.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
+  microcode_ctl:
+    evra: 2:2.1-38.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,30 +1,4 @@
 packages:
-  # Fast-track to neuter sysroot.readonly:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/488
-  # https://github.com/ostreedev/ostree/pull/2108
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-344e9b4232
-  ostree:
-    evra: 2020.3-4.fc32.x86_64
-  ostree-libs:
-    evra: 2020.3-4.fc32.x86_64
-  # Fast-track new release for:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/481
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e5dac04be2
-  rpm-ostree:
-    evra: 2020.2-3.fc32.x86_64
-  rpm-ostree-libs:
-    evra: 2020.2-3.fc32.x86_64
-  # Fast-track F32 signing keys
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-3aff453794
-  coreos-installer:
-    evra: 0.2.1-2.fc32.x86_64
-  coreos-installer-systemd:
-    evra: 0.2.1-2.fc32.x86_64
-  # Fast-track Ignition for failure handling
-  # https://github.com/coreos/ignition-dracut/pull/188
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a3f96fc5bd
-  ignition:
-    evra: 2.3.0-2.gitee616d5.fc32.x86_64
   # Fast-track slirp4netns. The maintainers forgot to submit the update
   # to bodhi and now we're seeing a "downgrade" when going from Fedora
   # 31 FCOS to Fedora 32 FCOS.

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,10 +1,10 @@
 packages:
-  # Fast-track slirp4netns. The maintainers forgot to submit the update
-  # to bodhi and now we're seeing a "downgrade" when going from Fedora
-  # 31 FCOS to Fedora 32 FCOS.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-157c71d962
+  # Fast-track slirp4netns. The previous version we were using 
+  # (1.0.1-1.fc32) was obsoleted before it hit stable so we're
+  # now moving to the current candidate in bodhi updates-testing.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-c11b99377e
   slirp4netns:
-    evra: 1.0.1-1.fc32.x86_64
+    evra: 1.1.1-1.fc32.x86_64
   # Fast-track a build of fedora-coreos-pinger that doesn't use
   # modular repos (https://github.com/coreos/fedora-coreos-tracker/issues/525).
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1


### PR DESCRIPTION
```
commit 935898551704a52671204d76d40d627e07e77953
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Jun 15 14:55:56 2020 -0400

    overrides: fast track microcode_ctl for CVE-2020-0543
    
    Fast-track a build of microcode_ctl that is part of a set of fixes
    for a recent CVE (CVE-2020-0543). The bug for the CVE is BZ1827165
    which links to two Fedora specific bugs: BZ1845629 (kernel) and
    BZ1845630 (microcode_ctl). The kernel update (kernel-5.6.18-300.fc32)
    already made it to stable. The microcode_ctl update has not yet.
    
    https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
    
    Note that microcode_ctl only applies to x86_64 so we are explicitly
    not updating the other architecture overrides files.

commit ee7bb6620dfd661afc263209802c050d033f17e0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Jun 15 14:41:50 2020 -0400

    overrides: update slirp4netns override to 1.1.1-1.fc32
    
    The previous version we were using (1.0.1-1.fc32) was obsoleted
    before it hit stable so we're now moving to the current candidate
    in bodhi updates-testing.
    
    https://bodhi.fedoraproject.org/updates/FEDORA-2020-c11b99377e

commit d6283e44106dc1aecdfdcb5065ec26d5de7ec14b
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Jun 15 14:39:23 2020 -0400

    overrides: drop graduated overrides
    
    These have made it to bodhi stable now.
```
