### PR TITLE
overrides: add crypto-policies-20200527-1.gitb234a47.fc32 because of lua

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,3 +10,5 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.aarch64
+  crypto-policies:
+    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,5 +10,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.aarch64
+  # Pin crypto-policies to avoid Lua script in newer versions
+  # https://github.com/coreos/fedora-coreos-tracker/issues/540
   crypto-policies:
     evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -10,5 +10,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.ppc64le
+  # Pin crypto-policies to avoid Lua script in newer versions
+  # https://github.com/coreos/fedora-coreos-tracker/issues/540
   crypto-policies:
     evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -10,3 +10,5 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.ppc64le
+  crypto-policies:
+    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -10,5 +10,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.s390x
+  # Pin crypto-policies to avoid Lua script in newer versions
+  # https://github.com/coreos/fedora-coreos-tracker/issues/540
   crypto-policies:
     evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -10,3 +10,5 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.s390x
+  crypto-policies:
+    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -18,5 +18,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
   microcode_ctl:
     evra: 2:2.1-38.fc32.x86_64
+  # Pin crypto-policies to avoid Lua script in newer versions
+  # https://github.com/coreos/fedora-coreos-tracker/issues/540
   crypto-policies:
     evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -18,3 +18,5 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
   microcode_ctl:
     evra: 2:2.1-38.fc32.x86_64
+  crypto-policies:
+    evra: 20200527-1.gitb234a47.fc32.noarch


### PR DESCRIPTION
Package 'crypto-policies' has (currently) unsupported <lua> script in '%post'
Lock on the older version for now.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>