### PR TITLE
overrides: bump to microcode_ctl-2.1-39.fc32

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,15 +10,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.x86_64
+  # Pin crypto-policies to avoid Lua script in newer versions
+  # https://github.com/coreos/fedora-coreos-tracker/issues/540
+  crypto-policies:
+    evra: 20200527-1.gitb234a47.fc32.noarch
   # Fast-track a build of microcode_ctl that is part of a set of fixes
   # for a recent CVE (CVE-2020-0543). The bug for the CVE is BZ1827165
   # which links to two Fedora specific bugs: BZ1845629 (kernel) and
   # BZ1845630 (microcode_ctl). The kernel update (kernel-5.6.18-300.fc32)
   # already made it to stable. The microcode_ctl update has not yet.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e8835a5f8e
   microcode_ctl:
-    evra: 2:2.1-38.fc32.x86_64
-  # Pin crypto-policies to avoid Lua script in newer versions
-  # https://github.com/coreos/fedora-coreos-tracker/issues/540
-  crypto-policies:
-    evra: 20200527-1.gitb234a47.fc32.noarch
+    evra: 2:2.1-39.fc32.x86_64


### PR DESCRIPTION
Intel released a new microcode to fix some issues users were reporting
with booting with the recent microcode update.