### PR TITLE
[testing] overrides: bump to microcode_ctl-2.1-39.fc32

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,6 +15,6 @@ packages:
   # which links to two Fedora specific bugs: BZ1845629 (kernel) and
   # BZ1845630 (microcode_ctl). The kernel update (kernel-5.6.18-300.fc32)
   # already made it to stable. The microcode_ctl update has not yet.
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-7bb2398b6b
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e8835a5f8e
   microcode_ctl:
-    evra: 2:2.1-38.fc32.x86_64
+    evra: 2:2.1-39.fc32.x86_64


### PR DESCRIPTION
Intel released a new microcode to fix some issues users were reporting
with booting with the recent microcode update.

(cherry picked from commit a6fbe03086fd890a10fb0e57cad0c3e33f99321c)