### PR TITLE
40ignition-ostree: relabel /root after copying skel files

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-populate-var.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-populate-var.sh
@@ -35,9 +35,11 @@ for varsubdir in lib log home roothome opt srv usrlocal mnt media; do
         systemd-tmpfiles --create --boot --root=/sysroot --prefix="/var/${varsubdir}"
     fi
 
+    if [[ $varsubdir == roothome ]]; then
+        # TODO move this to tmpfiles.d once systemd-tmpfiles handles C! with --root correctly.
+        # See https://github.com/coreos/fedora-coreos-config/pull/137
+        cp /sysroot/etc/skel/.bash* /sysroot/var/${varsubdir}
+    fi
+
     coreos-relabel "/var/${varsubdir}"
 done
-
-# TODO move this to tmpfiles.d once systemd-tmpfiles handles C! with --root correctly.
-# See https://github.com/coreos/fedora-coreos-config/pull/137
-cp /sysroot/etc/skel/.bash* /sysroot/root


### PR DESCRIPTION
Otherwise they can end up unlabeled. We don't hit this right now because
Ignition is just doing a blind relabeling on all of `/var/roothome`
whenever any user is configured (which is always because we have a base
config which configures the `core` user). We shouldn't rely on this
though:

https://github.com/coreos/ignition/pull/996

And more generally, each piece of software should be responsible for
relabeling the bits that it touched.