### PR TITLE
overrides: drop crypto-policies pin

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,7 +10,3 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.aarch64
-  # Pin crypto-policies to avoid Lua script in newer versions
-  # https://github.com/coreos/fedora-coreos-tracker/issues/540
-  crypto-policies:
-    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -10,7 +10,3 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.ppc64le
-  # Pin crypto-policies to avoid Lua script in newer versions
-  # https://github.com/coreos/fedora-coreos-tracker/issues/540
-  crypto-policies:
-    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -10,7 +10,3 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.s390x
-  # Pin crypto-policies to avoid Lua script in newer versions
-  # https://github.com/coreos/fedora-coreos-tracker/issues/540
-  crypto-policies:
-    evra: 20200527-1.gitb234a47.fc32.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,10 +10,6 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-a4f6437bd1
   fedora-coreos-pinger:
     evra: 0.0.4-4.fc32.x86_64
-  # Pin crypto-policies to avoid Lua script in newer versions
-  # https://github.com/coreos/fedora-coreos-tracker/issues/540
-  crypto-policies:
-    evra: 20200527-1.gitb234a47.fc32.noarch
   # Fast-track a build of microcode_ctl that is part of a set of fixes
   # for a recent CVE (CVE-2020-0543). The bug for the CVE is BZ1827165
   # which links to two Fedora specific bugs: BZ1845629 (kernel) and


### PR DESCRIPTION
No longer needed with rpm-ostree 2020.3 in the COSA container.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/540.