### PR TITLE
[testing] overlay/fcos: pin legacy ifnames on existing machines

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -3,3 +3,6 @@ enable fedora-coreos-pinger.service
 # Provide information if no ignition is provided
 enable coreos-check-ignition-config.service
 enable coreos-check-ssh-keys.service
+# Pinning script for legacy interface names, see
+# https://github.com/coreos/fedora-coreos-tracker/issues/484
+enable coreos-keep-legacy-ifnames.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-keep-legacy-ifnames.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-keep-legacy-ifnames.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CoreOS Keep Legacy Network Interface Names
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/484
+RequiresMountsFor=/boot
+ConditionPathExists=!/usr/lib/systemd/network/99-default.link
+# NOTE: we do not conditionalize on ConditionKernelCommandLine= here because
+# kernel args might have been tweaked manually just for this boot; we still
+# want to change the BLS entries in that case.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/coreos-keep-legacy-ifnames
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-keep-legacy-ifnames
+++ b/overlay.d/15fcos/usr/libexec/coreos-keep-legacy-ifnames
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is a pinning script to keep legacy ifnames on machines that were
+# installed on an OS version where `99-default.link` was missing due to
+# https://github.com/coreos/fedora-coreos-tracker/issues/484
+
+set -euo pipefail
+
+injected=0
+
+if test -e /usr/lib/systemd/network/99-default.link; then
+    echo "unit /usr/lib/systemd/network/99-default.link found, no actions performed"
+    exit 0;
+fi
+
+for f in /boot/loader/entries/*.conf; do
+    options=$(grep '^options ' "$f" | cut -f2- -d' ')
+
+    # If it is already specified, do not touch whatever value is there.
+    # This is in order to avoid messing with user customization, and to
+    # make the logic idempotent.
+    if grep -q "net.ifnames" <<< "$options"; then
+        continue
+    fi
+
+    # Otherwise, make sure we stay on legacy ifnames.
+    sed -e "/^options / s/$/ net.ifnames=0/" -i "$f"
+    echo "$(basename "$f"): injected net.ifnames=0"
+    injected=1
+done
+
+if [[ $injected -eq 0 ]]; then
+    echo "existing net.ifnames karg detected, no actions performed"
+fi
+


### PR DESCRIPTION
This introduces a `coreos-keep-legacy-ifnames` service to pin
network interface names to the legacy scheme on machines
where `99-default.link` is missing.
This is in order to ensure that those machines do not jump
into the new scheme via auto-updates as soon as FCOS starts
shipping such unit in the OS.

(cherry picked from commit d67f11e)