### PR TITLE
15fcos/usr/systemd/system: Fix coreos-check-ssh-keys.service

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -14,9 +14,10 @@ After=afterburn-sshkeys@core.service
 # get misleading messages. Also handles the case where the journal
 # gets rotated and no longer has the structured log messages.
 ConditionKernelCommandLine=ignition.firstboot
-ProtectHome=read-only
+
 [Service]
 Type=oneshot
+ProtectHome=read-only
 ExecStart=/usr/libexec/coreos-check-ssh-keys.sh
 RemainAfterExit=yes
 [Install]


### PR DESCRIPTION
Seeing this warning: `[  4.347245] systemd[1]: /usr/lib/systemd/system/coreos-check-ssh-keys.service:17: Unknown key name 'ProtectHome' in section 'Unit', ignoring.`. This PR will fix that issue.