### PR TITLE
{manifests,overlay}: add ssh-key-dir

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,2 +1,5 @@
-# no overrides at this time
-packages: {}
+packages:
+  # Fast-track initial build of ssh-key-dir
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
+  ssh-key-dir:
+    evra: 0.1.2-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,2 +1,5 @@
-# no overrides at this time
-packages: {}
+packages:
+  # Fast-track initial build of ssh-key-dir
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
+  ssh-key-dir:
+    evra: 0.1.2-2.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,2 +1,5 @@
-# no overrides at this time
-packages: {}
+packages:
+  # Fast-track initial build of ssh-key-dir
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
+  ssh-key-dir:
+    evra: 0.1.2-2.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,2 +1,5 @@
-# no overrides at this time
-packages: {}
+packages:
+  # Fast-track initial build of ssh-key-dir
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
+  ssh-key-dir:
+    evra: 0.1.2-2.fc32.x86_64

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -94,6 +94,7 @@ packages:
   - passwd
   # SSH
   - openssh-server openssh-clients
+  - ssh-key-dir
   # Containers
   - podman skopeo runc systemd-container catatonit
   - fuse-overlayfs slirp4netns

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -2,7 +2,7 @@
 # plus other default tweaks.  Things in this file should be something we expect
 # basically everyone using both Ignition and (rpm-)ostree to want.
 # It may be used as an inheritance base by other projects like Fedora Silverblue or RHCOS.
-# One good model is to add feodra-coreos-config as a git submodule.  See:
+# One good model is to add fedora-coreos-config as a git submodule.  See:
 # https://github.com/coreos/coreos-assembler/pull/639
 
 # Include rpm-ostree + kernel + bootloader

--- a/overlay.d/15fcos/etc/ssh/sshd_config.d/20-authorized-keys.conf
+++ b/overlay.d/15fcos/etc/ssh/sshd_config.d/20-authorized-keys.conf
@@ -1,3 +1,0 @@
-# Read authorized_keys fragments written by Ignition and Afterburn
-# https://github.com/coreos/fedora-coreos-tracker/issues/139
-AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys.d/ignition .ssh/authorized_keys.d/afterburn


### PR DESCRIPTION
Drop `sshd_config.d` fragment overriding `AuthorizedKeysFile`, since ssh-key-dir will pull in the Ignition and Afterburn fragments now.