### PR TITLE
live-generator: Add Options=ro to our mounts

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -90,6 +90,7 @@ Requires=${isosrc_escaped}
 [Mount]
 What=/${isosrc}
 Where=/run/media/iso
+Options=ro
 Type=iso9660
 EOF
 


### PR DESCRIPTION
The default is a writable mount, and right now the
kernel emits a warning when the mount succeeds
because the underlying block device is read-only.

Which...actually turns out to *also* be the cause behind
the races we've been seeing mounting the ISO
https://github.com/coreos/fedora-coreos-config/issues/437

I believe what's happening is one of the bits of udev
is probing the ISO and doing a read-only mount at the same time we're
trying to mount it.

From the kernel perspective it's fine to have multiple concurrent
read-only mounts, but because ours was requested as writable,
if we happend to be trying to do our mount at the same time
as the probing the kernel will reject it.