### PR TITLE
WIP manifests: add nm-cloud-setup

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -111,6 +111,9 @@ packages:
   - iptables nftables iptables-nft iptables-services
   # Interactive Networking configuration during coreos-install
   - NetworkManager-tui
+  # Automatically configure NetworkManager in cloud
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1822603
+  - NetworkManager-cloud-setup
   # Storage
   - cloud-utils-growpart
   - lvm2 iscsi-initiator-utils sg3_utils


### PR DESCRIPTION
Reference: https://github.com/coreos/fedora-coreos-config/pull/377#issuecomment-651183953
Now that https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/546 got merged, NetworkManager-cloud-setup can support ` GCP` load-balancing routes. We'd need this package on an FCOS machine to run it on the bootstrap node.

More references:
- https://gitlab.cee.redhat.com/coreos/redhat-coreos/-/merge_requests/905
- https://bugzilla.redhat.com/show_bug.cgi?id=1822603

/cc @LorbusChris 