### PR TITLE
Rename tests/kola/basic to misc-ro

### DIFF
--- a/tests/kola/basic
+++ b/tests/kola/basic
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec systemctl is-enabled logrotate.service

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This is a place to put random quick read-only tests.
+set -euo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+systemctl is-enabled logrotate.service
+ok logrotate
+
+# https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
+systemd-run -P -p ConditionVirtualization=kvm --wait /bin/sh -c 'set -euo pipefail; ip link | grep -o -e " ens[0-9]:"'
+ok nic naming


### PR DESCRIPTION
And add a test case for the NIC naming.  I think we should
make "extend misc-ro" a standard procedure for a lot of recent changes.