### PR TITLE
overlay.d/05core: add preset for CLHM-{issuegen,motdgen}.path

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -1,6 +1,9 @@
 # Presets here that eventually should live in the generic fedora presets
 enable coreos-growpart.service
+# console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
+enable console-login-helper-messages-issuegen.path
 enable console-login-helper-messages-issuegen.service
+enable console-login-helper-messages-motdgen.path
 enable console-login-helper-messages-motdgen.service
 # CA certs (probably to add to base fedora eventually)
 enable coreos-update-ca-trust.service


### PR DESCRIPTION
Add a preset for `console-login-helper-messages-issuegen.path` and
`console-login-helper-messages-motdgen.path`, which enable
dynamic regeneration of the issue/MOTD after dropping files into
the runtime directory. E.g.:

```
echo "test" > /run/console-login-helper-messages/issue.d/test.issue
```

will cause `test` to appear in the displayed issue from agetty.
This was added in the v0.18.2 release: https://github.com/coreos/console-login-helper-messages/releases/tag/v0.18.2