### PR TITLE
overrides: pin podman to 1.9.3-1.fc32 for now

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,8 +1,4 @@
 packages:
-  # Fast-track initial build of ssh-key-dir
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
-  ssh-key-dir:
-    evra: 0.1.2-2.fc32.aarch64
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -3,3 +3,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
   ssh-key-dir:
     evra: 0.1.2-2.fc32.aarch64
+  # Pin podman major version for now while we let the next major
+  # version soak in the `next` stream.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  podman:
+    evra: 2:1.9.3-1.fc32.aarch64
+  podman-plugins:
+    evra: 2:1.9.3-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -3,3 +3,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
   ssh-key-dir:
     evra: 0.1.2-2.fc32.ppc64le
+  # Pin podman major version for now while we let the next major
+  # version soak in the `next` stream.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  podman:
+    evra: 2:1.9.3-1.fc32.ppc64le
+  podman-plugins:
+    evra: 2:1.9.3-1.fc32.ppc64le

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,8 +1,4 @@
 packages:
-  # Fast-track initial build of ssh-key-dir
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
-  ssh-key-dir:
-    evra: 0.1.2-2.fc32.ppc64le
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -3,3 +3,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
   ssh-key-dir:
     evra: 0.1.2-2.fc32.s390x
+  # Pin podman major version for now while we let the next major
+  # version soak in the `next` stream.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  podman:
+    evra: 2:1.9.3-1.fc32.s390x
+  podman-plugins:
+    evra: 2:1.9.3-1.fc32.s390x

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,8 +1,4 @@
 packages:
-  # Fast-track initial build of ssh-key-dir
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
-  ssh-key-dir:
-    evra: 0.1.2-2.fc32.s390x
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -3,3 +3,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
   ssh-key-dir:
     evra: 0.1.2-2.fc32.x86_64
+  # Pin podman major version for now while we let the next major
+  # version soak in the `next` stream.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  podman:
+    evra: 2:1.9.3-1.fc32.x86_64
+  podman-plugins:
+    evra: 2:1.9.3-1.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,8 +1,4 @@
 packages:
-  # Fast-track initial build of ssh-key-dir
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2d340985eb
-  ssh-key-dir:
-    evra: 0.1.2-2.fc32.x86_64
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560


### PR DESCRIPTION
Pin podman major version for now while we let the next major
version soak in the `next` stream.
https://github.com/coreos/fedora-coreos-tracker/issues/560
