### PR TITLE
[next-devel] manifest: don't use modular repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,8 +14,6 @@ repos:
   # still pinned
   - fedora
   - fedora-updates
-  - fedora-modular
-  - fedora-updates-modular
 
 # All Fedora CoreOS streams share the same pool for locked files.
 # This will be in fedora-coreos.yaml in the future so it can be more easily be


### PR DESCRIPTION
Remove modular repos from the list in this file, as we no longer
require sourcing modular content. Part of:
https://github.com/coreos/fedora-coreos-tracker/issues/525

(cherry picked from commit 74c98c227cbe10c184fdd3f1e23b69348cbb9a40)