### PR TITLE
[next-devel] overrides: fast-track Ignition 2.4.0-2

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,5 +1,5 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e55693d009
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-750faadc24
   ignition:
-    evra: 2.4.0-1.gitd18bf90.fc32.aarch64
+    evra: 2.4.0-2.gitd18bf90.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,5 +1,5 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e55693d009
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-750faadc24
   ignition:
-    evra: 2.4.0-1.gitd18bf90.fc32.ppc64le
+    evra: 2.4.0-2.gitd18bf90.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,5 +1,5 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e55693d009
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-750faadc24
   ignition:
-    evra: 2.4.0-1.gitd18bf90.fc32.s390x
+    evra: 2.4.0-2.gitd18bf90.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,5 +1,5 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e55693d009
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-750faadc24
   ignition:
-    evra: 2.4.0-1.gitd18bf90.fc32.x86_64
+    evra: 2.4.0-2.gitd18bf90.fc32.x86_64


### PR DESCRIPTION
Fix SELinux relabeling of /root on live systems.