### PR TITLE
overlay/15fcos: remove CLHM dependency

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -2,7 +2,6 @@
 # no Ignition config is provided.
 [Unit]
 Description=Check if Ignition config is provided
-Before=console-login-helper-messages-issuegen.service
 # Only perform checks on the first (Ignition) boot as they are
 # mostly useful only on that boot. This ensures systems started
 # before Ignition/Afterburn started logging structured data don't

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -2,7 +2,6 @@
 # by Ignition/Afterburn
 [Unit]
 Description=Check that ssh-keys are added by Afterburn/Ignition
-Before=console-login-helper-messages-issuegen.service
 # https://github.com/coreos/afterburn/issues/417 is created
 # to track the issue that would allow other units to synchronize 
 # around any instance of `afterburn-sshkeys@` and not just the 


### PR DESCRIPTION
Follow up PR to address https://github.com/coreos/fedora-coreos-config/pull/344#discussion_r455952922
With https://github.com/coreos/console-login-helper-messages/pull/55 change, there's no explicit systemd dependency on CLHM
/cc @rfairley 