### PR TITLE
manifests: Add wireguard-tools

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1068,6 +1068,9 @@
     "which": {
       "evra": "2.21-19.fc32.x86_64"
     },
+    "wireguard-tools": {
+      "evra": "1.0.20200513-1.fc32.x86_64"
+    },
     "xfsprogs": {
       "evra": "5.4.0-3.fc32.x86_64"
     },

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -111,6 +111,8 @@ packages:
   - iptables nftables iptables-nft iptables-services
   # Interactive Networking configuration during coreos-install
   - NetworkManager-tui
+  # WireGuard https://github.com/coreos/fedora-coreos-tracker/issues/362
+  - wireguard-tools
   # Storage
   - cloud-utils-growpart
   - lvm2 iscsi-initiator-utils sg3_utils


### PR DESCRIPTION
This adds the required base utilities for configuring and troubleshooting WireGuard connections.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/362