### PR TITLE
[next-devel] overrides: fast-track coreos-installer, afterburn

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,6 +6,12 @@ packages:
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e078b3c893
   coreos-installer:
-    evra: 0.3.0-2.fc32.aarch64
-  coreos-installer-systemd:
-    evra: 0.3.0-2.fc32.aarch64
+    evra: 0.4.0-1.fc32.aarch64
+  coreos-installer-bootinfra:
+    evra: 0.4.0-1.fc32.aarch64
+  # Fast-track Afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f589f65bbd
+  afterburn:
+    evra: 4.4.2-1.fc32.aarch64
+  afterburn-dracut:
+    evra: 4.4.2-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,6 +6,12 @@ packages:
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e078b3c893
   coreos-installer:
-    evra: 0.3.0-2.fc32.ppc64le
-  coreos-installer-systemd:
-    evra: 0.3.0-2.fc32.ppc64le
+    evra: 0.4.0-1.fc32.ppc64le
+  coreos-installer-bootinfra:
+    evra: 0.4.0-1.fc32.ppc64le
+  # Fast-track Afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f589f65bbd
+  afterburn:
+    evra: 4.4.2-1.fc32.ppc64le
+  afterburn-dracut:
+    evra: 4.4.2-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,6 +6,12 @@ packages:
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e078b3c893
   coreos-installer:
-    evra: 0.3.0-2.fc32.s390x
-  coreos-installer-systemd:
-    evra: 0.3.0-2.fc32.s390x
+    evra: 0.4.0-1.fc32.s390x
+  coreos-installer-bootinfra:
+    evra: 0.4.0-1.fc32.s390x
+  # Fast-track Afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f589f65bbd
+  afterburn:
+    evra: 4.4.2-1.fc32.s390x
+  afterburn-dracut:
+    evra: 4.4.2-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,6 +6,12 @@ packages:
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e078b3c893
   coreos-installer:
-    evra: 0.3.0-2.fc32.x86_64
-  coreos-installer-systemd:
-    evra: 0.3.0-2.fc32.x86_64
+    evra: 0.4.0-1.fc32.x86_64
+  coreos-installer-bootinfra:
+    evra: 0.4.0-1.fc32.x86_64
+  # Fast-track Afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f589f65bbd
+  afterburn:
+    evra: 4.4.2-1.fc32.x86_64
+  afterburn-dracut:
+    evra: 4.4.2-1.fc32.x86_64

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -19,10 +19,10 @@
       "evra": "0.9.0-1.fc32.x86_64"
     },
     "afterburn": {
-      "evra": "4.4.0-1.fc32.x86_64"
+      "evra": "4.4.2-1.fc32.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "4.4.0-1.fc32.x86_64"
+      "evra": "4.4.2-1.fc32.x86_64"
     },
     "alternatives": {
       "evra": "1.11-6.fc32.x86_64"
@@ -118,10 +118,10 @@
       "evra": "1:1.1.0-1.fc32.x86_64"
     },
     "coreos-installer": {
-      "evra": "0.3.0-2.fc32.x86_64"
+      "evra": "0.4.0-1.fc32.x86_64"
     },
-    "coreos-installer-systemd": {
-      "evra": "0.3.0-2.fc32.x86_64"
+    "coreos-installer-bootinfra": {
+      "evra": "0.4.0-1.fc32.x86_64"
     },
     "coreutils": {
       "evra": "8.32-4.fc32.1.x86_64"

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -150,7 +150,7 @@ packages:
   - console-login-helper-messages-profile
   - toolbox
   # CoreOS Installer
-  - coreos-installer coreos-installer-systemd
+  - coreos-installer coreos-installer-bootinfra
   # i18n
   - kbd
   # Parsing/Interacting with JSON data


### PR DESCRIPTION
- coreos-installer-0.4.0-1.fc32.x86_64
- rust-afterburn-4.4.2-1.fc32.x86_64