### PR TITLE
coreos-livepxe-rootfs: fix link anchor

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
@@ -53,7 +53,7 @@ after these dates will not boot without a rootfs image:
         next:    August 25, 2020
         testing: September 22, 2020
         stable:  October 6, 2020
-https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/#pxe-rootfs-image[0m
+https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/#_pxe_rootfs_image[0m
 
 EOF
 else


### PR DESCRIPTION
We have one column left.  Use it.