### PR TITLE
overrides: pin ostree to fix live image boot failure

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,6 +15,12 @@ packages:
     evra: 4.4.2-1.fc32.aarch64
   afterburn-dracut:
     evra: 4.4.2-1.fc32.aarch64
+  # Pin ostree to fix live image boot failure
+  # https://github.com/coreos/fedora-coreos-tracker/issues/589
+  ostree:
+    evra: 2020.3-5.fc32.aarch64
+  ostree-libs:
+    evra: 2020.3-5.fc32.aarch64
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,6 +15,12 @@ packages:
     evra: 4.4.2-1.fc32.ppc64le
   afterburn-dracut:
     evra: 4.4.2-1.fc32.ppc64le
+  # Pin ostree to fix live image boot failure
+  # https://github.com/coreos/fedora-coreos-tracker/issues/589
+  ostree:
+    evra: 2020.3-5.fc32.ppc64le
+  ostree-libs:
+    evra: 2020.3-5.fc32.ppc64le
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,6 +15,12 @@ packages:
     evra: 4.4.2-1.fc32.s390x
   afterburn-dracut:
     evra: 4.4.2-1.fc32.s390x
+  # Pin ostree to fix live image boot failure
+  # https://github.com/coreos/fedora-coreos-tracker/issues/589
+  ostree:
+    evra: 2020.3-5.fc32.s390x
+  ostree-libs:
+    evra: 2020.3-5.fc32.s390x
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,6 +15,12 @@ packages:
     evra: 4.4.2-1.fc32.x86_64
   afterburn-dracut:
     evra: 4.4.2-1.fc32.x86_64
+  # Pin ostree to fix live image boot failure
+  # https://github.com/coreos/fedora-coreos-tracker/issues/589
+  ostree:
+    evra: 2020.3-5.fc32.x86_64
+  ostree-libs:
+    evra: 2020.3-5.fc32.x86_64
   # Pin podman major version for now while we let the next major
   # version soak in the `next` stream.
   # https://github.com/coreos/fedora-coreos-tracker/issues/560


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/589