### PR TITLE
[next-devel]  Revert "overrides: pin ostree to fix live image boot failure" 

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,9 +15,3 @@ packages:
     evra: 4.4.2-1.fc32.aarch64
   afterburn-dracut:
     evra: 4.4.2-1.fc32.aarch64
-  # Pin ostree to fix live image boot failure
-  # https://github.com/coreos/fedora-coreos-tracker/issues/589
-  ostree:
-    evra: 2020.3-5.fc32.aarch64
-  ostree-libs:
-    evra: 2020.3-5.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,9 +15,3 @@ packages:
     evra: 4.4.2-1.fc32.ppc64le
   afterburn-dracut:
     evra: 4.4.2-1.fc32.ppc64le
-  # Pin ostree to fix live image boot failure
-  # https://github.com/coreos/fedora-coreos-tracker/issues/589
-  ostree:
-    evra: 2020.3-5.fc32.ppc64le
-  ostree-libs:
-    evra: 2020.3-5.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,9 +15,3 @@ packages:
     evra: 4.4.2-1.fc32.s390x
   afterburn-dracut:
     evra: 4.4.2-1.fc32.s390x
-  # Pin ostree to fix live image boot failure
-  # https://github.com/coreos/fedora-coreos-tracker/issues/589
-  ostree:
-    evra: 2020.3-5.fc32.s390x
-  ostree-libs:
-    evra: 2020.3-5.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,9 +15,3 @@ packages:
     evra: 4.4.2-1.fc32.x86_64
   afterburn-dracut:
     evra: 4.4.2-1.fc32.x86_64
-  # Pin ostree to fix live image boot failure
-  # https://github.com/coreos/fedora-coreos-tracker/issues/589
-  ostree:
-    evra: 2020.3-5.fc32.x86_64
-  ostree-libs:
-    evra: 2020.3-5.fc32.x86_64


### PR DESCRIPTION
This is fixed now in the latest coreos-assembler:
https://github.com/coreos/coreos-assembler/pull/1633

This reverts commit 9c6d80e36ce735305c30de1392afc8f2874dab71.