### PR TITLE
overlay: initramfs teardown: handle vlan devices during teardown

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
@@ -146,6 +146,14 @@ down_interfaces() {
                     continue
                     ;;
             esac
+            # When we start taking down devices some other devices can
+            # start to disappear (for example vlan on top of interface).
+            # If the device we're about to take down has disappeared
+            # since the start of this loop then skip taking it down.
+            if [ ! -e "$f" ]; then
+                echo "info: skipping teardown of ${interface}; no longer exists."
+                continue
+            fi
             down_interface $interface
         done
     fi


### PR DESCRIPTION
When we are taking down network devices it's possible that taking
down one will remove another (if they are connected in some way).
This will cause the `down_interface()` call to fail if the device
has already disappeared. Let's do another check to see if the device
still exists right before trying to take it down.

For an example of this failing. If we have kargs of

```
rd.neednet=1
vlan=vlan251:bond0
ip=192.168.122.111::192.168.122.1:255.255.255.0:initrdhost:vlan251:none:192.168.122.1
bond=bond0:ens2,ens3:mode=active-backup,miimon=100
```

Then we have a vlan on top of a bond and we get an error during teardown:

```
[  191.091838] coreos-teardown-initramfs[746]: info: taking down network device: ens2
[  191.093836] coreos-teardown-initramfs[763]: RTNETLINK answers: Operation not supported
[  191.098439] coreos-teardown-initramfs[746]: info: taking down network device: ens3
[  191.100318] coreos-teardown-initramfs[767]: RTNETLINK answers: Operation not supported
[  191.105143] coreos-teardown-initramfs[746]: info: taking down network device: vlan251
[  191.110188] coreos-teardown-initramfs[772]: Cannot find device "vlan251"
[  191.114853] coreos-teardown-initramfs[775]: Cannot find device "vlan251"
[  191.117254] systemd[1]: coreos-teardown-initramfs.service: Control process exited, code=exited, status=1/FAILURE
[  191.119333] systemd[1]: coreos-teardown-initramfs.service: Failed with result 'exit-code'.
```