### PR TITLE
20live: add missing coreos-livepxe-rootfs dep to persist-osmet

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-live-persist-osmet.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-live-persist-osmet.service
@@ -2,6 +2,8 @@
 Description=Persist osmet files
 DefaultDependencies=false
 ConditionPathExists=/run/ostree-live
+# Downloads and unpacks the osmet files if not already appended
+After=coreos-livepxe-rootfs.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.service
@@ -8,8 +8,6 @@ ConditionPathExists=/etc/coreos-live-want-rootfs
 After=basic.target
 # Network is enabled here
 After=dracut-initqueue.service
-# Needs /root.squashfs
-Before=sysroot.mount
 
 # If we fail, the boot will fail.  Be explicit about it.
 OnFailure=emergency.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -60,6 +60,8 @@ if [ -f /etc/coreos-live-want-rootfs ]; then
 
 [Unit]
 DefaultDependencies=false
+# Verifies that we have the right root.squashfs, or downloads it if needed
+After=coreos-livepxe-rootfs.service
 Before=initrd-root-fs.target
 
 [Mount]


### PR DESCRIPTION
If we're downloading the rootfs ourselves, and we don't wait for that to finish before copying osmet files, coreos-installer will fall back to installing FCOS stable.