### PR TITLE
[next-devel] manifest-lock: add bsdtar

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -57,6 +57,9 @@
     "bind-utils": {
       "evra": "32:9.11.21-1.fc32.x86_64"
     },
+    "bsdtar": {
+      "evra": "3.4.3-1.fc32.x86_64"
+    },
     "btrfs-progs": {
       "evra": "5.7-4.fc32.x86_64"
     },


### PR DESCRIPTION
This piece of 8f482cf327c9 wasn't automatically copied from testing-devel by 9d26d4604e36.