### PR TITLE
[next-devel] overrides: fast-track new coreos-installer-0.5.0-1.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -3,3 +3,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
   ignition:
     evra: 2.6.0-1.git947598e.fc32.aarch64
+  # Fast-track coreos-installer release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
+  coreos-installer:
+    evra: 0.5.0-1.fc32.aarch64
+  coreos-installer-bootinfra:
+    evra: 0.5.0-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -3,3 +3,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
   ignition:
     evra: 2.6.0-1.git947598e.fc32.ppc64le
+  # Fast-track coreos-installer release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
+  coreos-installer:
+    evra: 0.5.0-1.fc32.ppc64le
+  coreos-installer-bootinfra:
+    evra: 0.5.0-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -3,3 +3,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
   ignition:
     evra: 2.6.0-1.git947598e.fc32.s390x
+  # Fast-track coreos-installer release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
+  coreos-installer:
+    evra: 0.5.0-1.fc32.s390x
+  coreos-installer-bootinfra:
+    evra: 0.5.0-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -3,3 +3,9 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
   ignition:
     evra: 2.6.0-1.git947598e.fc32.x86_64
+  # Fast-track coreos-installer release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
+  coreos-installer:
+    evra: 0.5.0-1.fc32.x86_64
+  coreos-installer-bootinfra:
+    evra: 0.5.0-1.fc32.x86_64


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22