### PR TITLE
manifests: Addition of nvme-cli

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -819,6 +819,9 @@
     "numactl-libs": {
       "evra": "2.0.12-4.fc32.x86_64"
     },
+    "nvme-cli": {
+      "evra": "1.10.1-1.fc32.x86_64"
+    },
     "oniguruma": {
       "evra": "6.9.5-1.rev1.fc32.x86_64"
     },

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -157,6 +157,8 @@ packages:
   - kbd
   # Parsing/Interacting with JSON data
   - jq
+  # nvme-cli for managing nvme disks
+  - nvme-cli
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;


### PR DESCRIPTION
It adds `nvme-cli` to provide an interface that allows host software utilities to communicate with nvme disks.
 
The missing `nvme` binary was brought up over in a tracker issue [1] and also discussed during the 08/12 meeting [2] where there was agreement that we should include this utility in the host.
 
[1] https://github.com/coreos/fedora-coreos-tracker/issues/601
[2] https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/message/5E66QVX7F6HRZXMY4GEWQW6SU3GUOQ3G/