### PR TITLE
[next-devel] overrides: bump ignition, afterburn

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -9,3 +9,9 @@ packages:
     evra: 0.5.0-1.fc32.aarch64
   coreos-installer-bootinfra:
     evra: 0.5.0-1.fc32.aarch64
+  # Fast-track afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
+  afterburn:
+    evra: 4.5.0-1.fc32.aarch64
+  afterburn-dracut:
+    evra: 4.5.0-1.fc32.aarch64

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,8 +1,8 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-646408ac29
   ignition:
-    evra: 2.6.0-1.git947598e.fc32.aarch64
+    evra: 2.6.0-2.git947598e.fc32.aarch64
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
   coreos-installer:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -9,3 +9,9 @@ packages:
     evra: 0.5.0-1.fc32.ppc64le
   coreos-installer-bootinfra:
     evra: 0.5.0-1.fc32.ppc64le
+  # Fast-track afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
+  afterburn:
+    evra: 4.5.0-1.fc32.ppc64le
+  afterburn-dracut:
+    evra: 4.5.0-1.fc32.ppc64le

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,8 +1,8 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-646408ac29
   ignition:
-    evra: 2.6.0-1.git947598e.fc32.ppc64le
+    evra: 2.6.0-2.git947598e.fc32.ppc64le
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
   coreos-installer:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,8 +1,8 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-646408ac29
   ignition:
-    evra: 2.6.0-1.git947598e.fc32.s390x
+    evra: 2.6.0-2.git947598e.fc32.s390x
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
   coreos-installer:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -9,3 +9,9 @@ packages:
     evra: 0.5.0-1.fc32.s390x
   coreos-installer-bootinfra:
     evra: 0.5.0-1.fc32.s390x
+  # Fast-track afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
+  afterburn:
+    evra: 4.5.0-1.fc32.s390x
+  afterburn-dracut:
+    evra: 4.5.0-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -9,3 +9,9 @@ packages:
     evra: 0.5.0-1.fc32.x86_64
   coreos-installer-bootinfra:
     evra: 0.5.0-1.fc32.x86_64
+  # Fast-track afterburn release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
+  afterburn:
+    evra: 4.5.0-1.fc32.x86_64
+  afterburn-dracut:
+    evra: 4.5.0-1.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,8 +1,8 @@
 packages:
   # Fast-track new Ignition release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-646408ac29
   ignition:
-    evra: 2.6.0-1.git947598e.fc32.x86_64
+    evra: 2.6.0-2.git947598e.fc32.x86_64
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-651a2bec22
   coreos-installer:


### PR DESCRIPTION
```
commit b575c8e6d175292d774fe5c2c93589d38bb3e468
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 14 14:49:41 2020 -0400

    overrides: fast-track rust-afterburn-4.5.0-1.fc32
    
    https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6

commit 3277ce94e542b88f1f772c9aa004e00859d0c5e6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 14 14:42:28 2020 -0400

    overrides: bump to ignition-2.6.0-2.git947598e.fc32
    
    There is a newer update [1] and the previous update [2] got obsoleted
    before making it to stable.
    
    [1] https://bodhi.fedoraproject.org/updates/FEDORA-2020-4ac68728c8
    [2] https://bodhi.fedoraproject.org/updates/FEDORA-2020-646408ac29

```