### PR TITLE
coreos-gpt-setup: Exit if PTUUID is not set

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-gpt-setup.sh
@@ -19,9 +19,12 @@ else
     eval $(lsblk --output PTUUID,PKNAME --pairs --paths --nodeps "$1")
 fi
 
-# s390x DASD disks don't have PTUUID and any of the other traditional partition
-# table attributes of GPT disks
-([ -z ${PTUUID:-} ] || [ "$PTUUID" != "$UNINITIALIZED_GUID" ]) && exit 0
+# Skip in the following two cases:
+#  - The PTUUID is != $UNINITIALIZED_GUID
+#  - The PTUUID is empty. This happens on s390x where DASD disks don't
+#    have PTUUID or any of the other traditional partition table
+#    attributes of GPT disks.
+[ "${PTUUID:-}" != "$UNINITIALIZED_GUID" ] && exit 0
 
 sgdisk --disk-guid=R --move-second-header "$PKNAME"
 udevadm settle

--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-gpt-setup.sh
@@ -19,7 +19,9 @@ else
     eval $(lsblk --output PTUUID,PKNAME --pairs --paths --nodeps "$1")
 fi
 
-[ "$PTUUID" != "$UNINITIALIZED_GUID" ] && exit 0
+# s390x DASD disks don't have PTUUID and any of the other traditional partition
+# table attributes of GPT disks
+([ -z ${PTUUID:-} ] || [ "$PTUUID" != "$UNINITIALIZED_GUID" ]) && exit 0
 
 sgdisk --disk-guid=R --move-second-header "$PKNAME"
 udevadm settle


### PR DESCRIPTION
On s390x zVM with DASD disks, coreos-gpt-setup fails because there are no partition table attributes available for DASD disks.
Bail out if PTUUID variable is unset.