### PR TITLE
overlay/15fcos: update `afterburn-sshkeys@core.service`

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -12,6 +12,8 @@ enable ignition-firstboot-complete.service
 # Boot checkin services for cloud providers.
 enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
+# Target to write SSH key snippets from cloud providers.
+enable afterburn-sshkeys.target
 # Service to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys@.service
 # Update agent

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -2,11 +2,10 @@
 # by Ignition/Afterburn
 [Unit]
 Description=Check that ssh-keys are added by Afterburn/Ignition
-# https://github.com/coreos/afterburn/issues/417 is created
-# to track the issue that would allow other units to synchronize 
-# around any instance of `afterburn-sshkeys@` and not just the 
-# `core` user.
-After=afterburn-sshkeys@core.service
+# It allows other units to synchronize around any instance
+# of `afterburn-sshkeys@` and not just the `core` user.
+# See https://github.com/coreos/afterburn/pull/481
+After=afterburn-sshkeys.target
 # Only perform checks on the first (Ignition) boot as they are
 # mostly useful only on that boot. This ensures systems started
 # before Ignition/Afterburn started logging structured data don't


### PR DESCRIPTION
this updates `afterburn-sshkeys@core.service` to `afterburn-sshkeys.target`
in order to synchronize around any instance of `afterburn-sshkeys@`.

Follow up https://github.com/coreos/afterburn/issues/417 and
https://github.com/coreos/afterburn/pull/481