### PR TITLE
liveiso-autologin-generator: fix up motd formatting

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -58,7 +58,7 @@ from memory, making it a good candidate for hardware discovery and
 installing persistently to disk. Here is an example of running an install
 to disk via coreos-installer:
 
-sudo coreos-installer install /dev/sda \
+sudo coreos-installer install /dev/sda \\
     --ignition-url https://example.com/example.ign
 
 You may configure networking via 'sudo nmcli' or 'sudo nmtui' and have


### PR DESCRIPTION
Fix formatting for motd line break. We want it to show in the output
so we need to escape it. Followup to 24adb7a.