### PR TITLE
misc-ro: Validate that we have the immutable bit on /

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -34,6 +34,11 @@ if test -w /sysroot; then
 fi
 ok sysroot ro
 
+if ! lsattr -d / | grep -qe '--i--'; then
+    fatal "missing immutable bit on /"
+fi
+ok immutable bit
+
 switchroot_ts=$(get_journal_msg_timestamp 'Switching root.')
 nm_ts=$(get_journal_msg_timestamp 'NetworkManager .* starting')
 # by default, kola on QEMU shouldn't need to bring up networking


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1867601 for motivation;
basically there's a likely ostree bug affecting s390x, and this
would have caught it.

(Sadly I don't think ostree's upstream suite has this, but
 adding it there wouldn't be useful until we start actually
 running upstream suites on our main releases and/or have
 upstream CI on !x86_64)