### PR TITLE
Add systemd-networkd packages back into FCOS

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -44,16 +44,6 @@ remove-from-packages:
   # We're not using resolved yet.
   - [systemd, /usr/lib/systemd/systemd-resolved,
               /usr/lib/systemd/system/systemd-resolved.service]
-  # We're not using networkd.
-  - [systemd, /etc/systemd/networkd.conf,
-              /usr/lib/systemd/systemd-networkd,
-              /usr/lib/systemd/systemd-networkd-wait-online,
-              /usr/lib/systemd/network/.*,
-              /usr/lib/systemd/system/systemd-networkd.service,
-              /usr/lib/systemd/system/systemd-networkd.socket,
-              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
-  - [systemd-container, /usr/lib/systemd/network/.*]
-
 
 remove-files:
   # We don't ship man(1) or info(1)


### PR DESCRIPTION
This PR re-adds the systemd-networkd packages on FCOS. It is totally fine that the project wants to use NetworkManager is the de-facto networking configuration implementation so there is a single supported way to configure the network on boot via Ignition. This PR won't change that fact.

Removing the systemd-networkd packages limits end user choices on how they want to configure the network on their FCOS deployments after the system is booted. Fedora doesn't remove systemd-networkd and it can live beside NetworkManager without any issues. Adding it back in allows people to consume FCOS as they see fit for their use cases. We shouldn't be dictating how users setup and configure their networks post boot.