### PR TITLE
manifest: Include systemd-resolved for F33 change

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -41,9 +41,6 @@ check-groups:
 default-target: multi-user.target
 
 remove-from-packages:
-  # We're not using resolved yet.
-  - [systemd, /usr/lib/systemd/systemd-resolved,
-              /usr/lib/systemd/system/systemd-resolved.service]
   # We're not using networkd.
   - [systemd, /etc/systemd/networkd.conf,
               /usr/lib/systemd/systemd-networkd,

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -20,8 +20,11 @@ get_journal_msg_timestamp() {
         | jq -r --slurp '.[0]["__MONOTONIC_TIMESTAMP"]'
 }
 
-systemctl is-enabled logrotate.service
-ok logrotate
+for unit in logrotate systemd-resolved; do
+    if ! systemctl is-enabled ${unit}; then
+        fatal "Unit ${unit} should be enabled"
+    fi
+done
 
 # https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
 if ip link | grep -o -e " eth[0-9]:"; then


### PR DESCRIPTION
This PR adds the systemd-resolved packages into FCOS. It is going to be used by default in Fedora 33 per this change request: https://fedoraproject.org/wiki/Changes/systemd-resolved

Adding the systemd-resolved packages back in gets us ready for this change. It won't impact how DNS is configured or used and it let's users get ready for the change in Fedora 33. 