### PR TITLE
tests/kola: restrict DHCP propagation test to qemu

### DIFF
--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -8,7 +8,9 @@
 
 set -xeuo pipefail
 
-# kola: { "tags": "needs-internet" }
+# Just run on QEMU; it should work theoretically on cloud platforms, but many
+# of those have platform-specific sources which take precedence.
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
 
 test_setup() {
 


### PR DESCRIPTION
On cloud platforms, we have platform-specific code which takes
precedence of NTP-via-DHCP so this test won't work (specifically because
we set `PEERNTP=no`).

If there are other platforms which natively use DHCP for NTP setting, we
should enhance this test to handle those (so that e.g. we don't have to
set up dnsmasq at all).