### PR TITLE
99emergency-timeout/virtio-dump: sync before dumping

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/ignition-virtio-dump-journal.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/ignition-virtio-dump-journal.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 port=/dev/virtio-ports/com.coreos.ignition.journal
 if [ -e "${port}" ]; then
+    # Sync to backing filesystem before dumping what's there
+    journalctl --sync
     journalctl -o json > "${port}"
     # And this signals end of stream
     echo '{}' > "${port}"


### PR DESCRIPTION
When systemd activates us as a result of switching to
`emergency.target`, journald might still be collecting and writing back
messages from various services. If we run too early, we'll be missing
out on those.

Let's explicitly make journald sync its logs before dumping the whole
journal.