### PR TITLE
tests/kola: add test for separate /var mount

### DIFF
--- a/tests/kola/var-mount/config.ign
+++ b/tests/kola/var-mount/config.ign
@@ -1,0 +1,36 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/vda",
+        "partitions": [
+          {
+            "label": "var",
+            "sizeMiB": 0,
+            "startMiB": 5000
+          }
+        ],
+        "wipeTable": false
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-partlabel/var",
+        "format": "xfs",
+        "path": "/var"
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nBefore=local-fs.target\nRequires=systemd-fsck@/dev/disk/by-partlabel/var\nAfter=systemd-fsck@/dev/disk/by-partlabel/var\n\n[Mount]\nWhere=/var\nWhat=/dev/disk/by-partlabel/var\nType=xfs\n\n[Install]\nRequiredBy=local-fs.target",
+        "enabled": true,
+        "name": "var.mount"
+      }
+    ]
+  }
+}

--- a/tests/kola/var-mount/test.sh
+++ b/tests/kola/var-mount/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# restrict to qemu for now because the primary disk path is platform-dependent
+# kola: {"platforms": "qemu"}
+
+src=$(findmnt -nvr /var -o SOURCE)
+[[ $(realpath "$src") == $(realpath /dev/disk/by-partlabel/var) ]]
+
+fstype=$(findmnt -nvr /var -o FSTYPE)
+[[ $fstype == xfs ]]


### PR DESCRIPTION
We regressed on this a few times. Let's add a test for it.