### PR TITLE
Move documentation removal to toplevel manifest

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -40,14 +40,6 @@ check-groups:
 
 default-target: multi-user.target
 
-remove-files:
-  # We don't ship man(1) or info(1)
-  - usr/share/info
-  - usr/share/man
-  # Drop text docs too
-  - usr/share/doc
-
-
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -66,6 +66,13 @@ remove-from-packages:
   # overlay.d/14NetworkManager-plugins
   - [NetworkManager, /usr/lib64/NetworkManager/.*/libnm-settings-plugin-ifcfg-rh.so]
 
+remove-files:
+  # We don't ship man(1) or info(1)
+  - usr/share/info
+  - usr/share/man
+  # Drop text docs too
+  - usr/share/doc
+
 # Things we don't expect to ship on the host.  We currently
 # have recommends: false so these could only come in via
 # hard requirement, in which case the build will fail.

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -56,6 +56,11 @@ if ! lsattr -d / | grep -qe '--i--'; then
 fi
 ok immutable bit
 
+# See remove-files in the manifest
+if test -d /usr/share/info; then
+    fatal "found /usr/share/info"
+fi
+
 switchroot_ts=$(get_journal_msg_timestamp 'Switching root.')
 nm_ts=$(get_journal_msg_timestamp 'NetworkManager .* starting')
 # by default, kola on QEMU shouldn't need to bring up networking


### PR DESCRIPTION
We do want docs for Fedora Silverblue at least.