### PR TITLE
40ignition-ostree: Fix Before= for fsck for root

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
@@ -9,7 +9,7 @@ Before=initrd-root-fs.target
 After=ignition-disks.service
 
 # Avoid racing with fsck
-Before=systemd-fsck@dev-disk-by\x2dlabel-boot.service
+Before=systemd-fsck@dev-disk-by\x2dlabel-root.service
 
 # Note we don't have a Requires: /dev/disk/by-label/root here like
 # the -subsequent service does because ignition-disks may have


### PR DESCRIPTION
I was investigating a rare flake in repeated runs of rootfs reprovisioning,
and I noticed that the `Before=` line here incorrectly referenced `boot`
instead of `root`.

Then, I noticed in fact for root it's special and should simply be
`systemd-fsck-root.service` - which due to a different bug, we
aren't even running at the moment.

Anyways, let's fix this so that if we do fix that in the future
we won't race.