### PR TITLE
[next-devel] overrides: fast-track podman-2.0.6-1.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,12 +6,6 @@ packages:
     evra: 2:2.0.6-1.fc32.aarch64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.aarch64
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.aarch64
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.aarch64
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
   coreos-installer:

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,4 +1,11 @@
 packages:
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
+  podman:
+    evra: 2:2.0.6-1.fc32.aarch64
+  podman-plugins:
+    evra: 2:2.0.6-1.fc32.aarch64
   # Fast-track afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
   afterburn:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,12 +6,6 @@ packages:
     evra: 2:2.0.6-1.fc32.ppc64le
   podman-plugins:
     evra: 2:2.0.6-1.fc32.ppc64le
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.ppc64le
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.ppc64le
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
   coreos-installer:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,4 +1,11 @@
 packages:
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
+  podman:
+    evra: 2:2.0.6-1.fc32.ppc64le
+  podman-plugins:
+    evra: 2:2.0.6-1.fc32.ppc64le
   # Fast-track afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
   afterburn:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,12 +6,6 @@ packages:
     evra: 2:2.0.6-1.fc32.s390x
   podman-plugins:
     evra: 2:2.0.6-1.fc32.s390x
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.s390x
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.s390x
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
   coreos-installer:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,4 +1,11 @@
 packages:
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
+  podman:
+    evra: 2:2.0.6-1.fc32.s390x
+  podman-plugins:
+    evra: 2:2.0.6-1.fc32.s390x
   # Fast-track afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
   afterburn:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,4 +1,11 @@
 packages:
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
+  podman:
+    evra: 2:2.0.6-1.fc32.x86_64
+  podman-plugins:
+    evra: 2:2.0.6-1.fc32.x86_64
   # Fast-track afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
   afterburn:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,12 +6,6 @@ packages:
     evra: 2:2.0.6-1.fc32.x86_64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.x86_64
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.x86_64
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.x86_64
   # Fast-track coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
   coreos-installer:


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7

See also:
https://github.com/coreos/fedora-coreos-tracker/issues/575