### PR TITLE
[testing-devel] overrides: fast-track podman-2.0.6-1.fc32, ostree-2020.6-2.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,15 +6,3 @@ packages:
     evra: 2:1.9.3-1.fc32.aarch64
   podman-plugins:
     evra: 2:1.9.3-1.fc32.aarch64
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.aarch64
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.aarch64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.aarch64
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.aarch64

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.aarch64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.aarch64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.aarch64
+  ostree-libs:
+    evra: 2020.6-2.fc32.aarch64

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,8 +1,8 @@
 packages:
-  # Pin podman major version for now while we let the next major
-  # version soak in the `next` stream.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
   podman:
-    evra: 2:1.9.3-1.fc32.aarch64
+    evra: 2:2.0.6-1.fc32.aarch64
   podman-plugins:
-    evra: 2:1.9.3-1.fc32.aarch64
+    evra: 2:2.0.6-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,8 +1,8 @@
 packages:
-  # Pin podman major version for now while we let the next major
-  # version soak in the `next` stream.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
   podman:
-    evra: 2:1.9.3-1.fc32.ppc64le
+    evra: 2:2.0.6-1.fc32.ppc64le
   podman-plugins:
-    evra: 2:1.9.3-1.fc32.ppc64le
+    evra: 2:2.0.6-1.fc32.ppc64le

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.ppc64le
   podman-plugins:
     evra: 2:2.0.6-1.fc32.ppc64le
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.ppc64le
+  ostree-libs:
+    evra: 2020.6-2.fc32.ppc64le

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,15 +6,3 @@ packages:
     evra: 2:1.9.3-1.fc32.ppc64le
   podman-plugins:
     evra: 2:1.9.3-1.fc32.ppc64le
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.ppc64le
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.ppc64le
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.ppc64le
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.s390x
   podman-plugins:
     evra: 2:2.0.6-1.fc32.s390x
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.s390x
+  ostree-libs:
+    evra: 2020.6-2.fc32.s390x

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,15 +6,3 @@ packages:
     evra: 2:1.9.3-1.fc32.s390x
   podman-plugins:
     evra: 2:1.9.3-1.fc32.s390x
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.s390x
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.s390x
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.s390x
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.s390x

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,8 +1,8 @@
 packages:
-  # Pin podman major version for now while we let the next major
-  # version soak in the `next` stream.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
   podman:
-    evra: 2:1.9.3-1.fc32.s390x
+    evra: 2:2.0.6-1.fc32.s390x
   podman-plugins:
-    evra: 2:1.9.3-1.fc32.s390x
+    evra: 2:2.0.6-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,8 +1,8 @@
 packages:
-  # Pin podman major version for now while we let the next major
-  # version soak in the `next` stream.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/560
+  # Fast track podman 2.0.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/575
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
   podman:
-    evra: 2:1.9.3-1.fc32.x86_64
+    evra: 2:2.0.6-1.fc32.x86_64
   podman-plugins:
-    evra: 2:1.9.3-1.fc32.x86_64
+    evra: 2:2.0.6-1.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.x86_64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.x86_64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.x86_64
+  ostree-libs:
+    evra: 2020.6-2.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,15 +6,3 @@ packages:
     evra: 2:1.9.3-1.fc32.x86_64
   podman-plugins:
     evra: 2:1.9.3-1.fc32.x86_64
-  # Fast-track afterburn release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2b573e2ac6
-  afterburn:
-    evra: 4.5.0-1.fc32.x86_64
-  afterburn-dracut:
-    evra: 4.5.0-1.fc32.x86_64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.x86_64
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.x86_64


### PR DESCRIPTION
This fast-tracks the new podman and ostree releases.

```
commit 19fad0b2c9690c7443671c6286031c2c22ec2fe9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 3 16:19:34 2020 -0400

    overrides: fast-track ostree-2020.6-2.fc32
    
    https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
    
    This includes a fix for:
    https://github.com/coreos/fedora-coreos-tracker/issues/617

commit 77744d50f2e2811c136a385a3e419fe329f380ca
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 3 16:03:59 2020 -0400

    overrides: fast-track podman-2.0.6-1.fc32
    
    https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
    
    See also:
    https://github.com/coreos/fedora-coreos-tracker/issues/575
```
