### PR TITLE
[next-devel]: overrides: fast-track ostree-2020.6-2.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,9 +6,3 @@ packages:
     evra: 2:2.0.6-1.fc32.aarch64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.aarch64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.aarch64
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.aarch64

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.aarch64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.aarch64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.aarch64
+  ostree-libs:
+    evra: 2020.6-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.ppc64le
   podman-plugins:
     evra: 2:2.0.6-1.fc32.ppc64le
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.ppc64le
+  ostree-libs:
+    evra: 2020.6-2.fc32.ppc64le

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -6,9 +6,3 @@ packages:
     evra: 2:2.0.6-1.fc32.ppc64le
   podman-plugins:
     evra: 2:2.0.6-1.fc32.ppc64le
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.ppc64le
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.s390x
   podman-plugins:
     evra: 2:2.0.6-1.fc32.s390x
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.s390x
+  ostree-libs:
+    evra: 2020.6-2.fc32.s390x

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -6,9 +6,3 @@ packages:
     evra: 2:2.0.6-1.fc32.s390x
   podman-plugins:
     evra: 2:2.0.6-1.fc32.s390x
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.s390x
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,9 +6,3 @@ packages:
     evra: 2:2.0.6-1.fc32.x86_64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.x86_64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-993ba29131
-  coreos-installer:
-    evra: 0.6.0-1.fc32.x86_64
-  coreos-installer-bootinfra:
-    evra: 0.6.0-1.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -6,3 +6,10 @@ packages:
     evra: 2:2.0.6-1.fc32.x86_64
   podman-plugins:
     evra: 2:2.0.6-1.fc32.x86_64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.x86_64
+  ostree-libs:
+    evra: 2020.6-2.fc32.x86_64


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d

This includes a fix for:
https://github.com/coreos/fedora-coreos-tracker/issues/617
