### PR TITLE
[testing]: overrides: fast-track ostree-2020.6-2.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -22,3 +22,10 @@ packages:
     evra: 4.5.0-1.fc32.aarch64
   afterburn-dracut:
     evra: 4.5.0-1.fc32.aarch64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.aarch64
+  ostree-libs:
+    evra: 2020.6-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -22,3 +22,10 @@ packages:
     evra: 4.5.0-1.fc32.ppc64le
   afterburn-dracut:
     evra: 4.5.0-1.fc32.ppc64le
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.ppc64le
+  ostree-libs:
+    evra: 2020.6-2.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -22,3 +22,10 @@ packages:
     evra: 4.5.0-1.fc32.s390x
   afterburn-dracut:
     evra: 4.5.0-1.fc32.s390x
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.s390x
+  ostree-libs:
+    evra: 2020.6-2.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -22,3 +22,10 @@ packages:
     evra: 4.5.0-1.fc32.x86_64
   afterburn-dracut:
     evra: 4.5.0-1.fc32.x86_64
+  # Fast track ostree 2020.6
+  # https://github.com/coreos/fedora-coreos-tracker/issues/617
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
+  ostree:
+    evra: 2020.6-2.fc32.x86_64
+  ostree-libs:
+    evra: 2020.6-2.fc32.x86_64

--- a/tests/kola/var-mount/config.ign
+++ b/tests/kola/var-mount/config.ign
@@ -1,0 +1,36 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/vda",
+        "partitions": [
+          {
+            "label": "var",
+            "sizeMiB": 0,
+            "startMiB": 5000
+          }
+        ],
+        "wipeTable": false
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-partlabel/var",
+        "format": "xfs",
+        "path": "/var"
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nBefore=local-fs.target\nRequires=systemd-fsck@/dev/disk/by-partlabel/var\nAfter=systemd-fsck@/dev/disk/by-partlabel/var\n\n[Mount]\nWhere=/var\nWhat=/dev/disk/by-partlabel/var\nType=xfs\n\n[Install]\nRequiredBy=local-fs.target",
+        "enabled": true,
+        "name": "var.mount"
+      }
+    ]
+  }
+}

--- a/tests/kola/var-mount/test.sh
+++ b/tests/kola/var-mount/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# restrict to qemu for now because the primary disk path is platform-dependent
+# kola: {"platforms": "qemu"}
+
+src=$(findmnt -nvr /var -o SOURCE)
+[[ $(realpath "$src") == $(realpath /dev/disk/by-partlabel/var) ]]
+
+fstype=$(findmnt -nvr /var -o FSTYPE)
+[[ $fstype == xfs ]]


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d

This includes a fix for:
https://github.com/coreos/fedora-coreos-tracker/issues/617