### PR TITLE
20live: explicitly mount squashfs with `loop` option

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -69,6 +69,7 @@ Before=initrd-root-fs.target
 What=/root.squashfs
 Where=/sysroot
 Type=squashfs
+Options=loop
 EOF
 else
     # And in this case, it's on the ISO
@@ -114,7 +115,7 @@ Type=squashfs
 # Offset of the squashfs within the rootfs cpio.  Assumes newc format
 # and that a file named "root.squashfs" is the first member.  This offset
 # is checked by coreos-assembler cmd-buildextend-live at build time.
-Options=offset=124
+Options=loop,offset=124
 EOF
 fi
 


### PR DESCRIPTION
This should be implied by the fact that we're trying to mount a
filepath, but let's be explicit. For comparison, this is how it's
documented in both squashfs-tools and in tldp:

https://github.com/plougher/squashfs-tools/blob/c570c6188811088b12ffdd9665487a2960c997a0/USAGE#L182

https://tldp.org/HOWTO/html_single/SquashFS-HOWTO/#creating

Spurred by RHBZ#1863466 where seemingly passing `-o loop` makes a
difference, though the root cause is likely somewhere else.