### PR TITLE
overlay.d/05core: update CLHM presets

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -2,9 +2,9 @@
 enable coreos-growpart.service
 # console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
 enable console-login-helper-messages-issuegen.path
-enable console-login-helper-messages-issuegen.service
 enable console-login-helper-messages-motdgen.path
-enable console-login-helper-messages-motdgen.service
+enable console-login-helper-messages-gensnippet-os-release.service
+enable console-login-helper-messages-gensnippet-ssh-keys.service
 # CA certs (probably to add to base fedora eventually)
 enable coreos-update-ca-trust.service
 # This one is from https://github.com/coreos/ignition-dracut


### PR DESCRIPTION
Remove preset for CLHM-{issuegen,motdgen}.service since the `.path`
units are now the only triggers to run the `-issuegen.service` and
`-motdgen.service` units.
https://github.com/coreos/console-login-helper-messages/pull/55

Add preset to enable `CLHM-gensnippet-os-release.service` and
`CLHM-gensnippet-ssh-keys.service` units. These are new units that
were split out from `issuegen.service` and `motdgen.service`, and
should be enabled by default.
https://github.com/coreos/console-login-helper-messages/pull/57

This was added in the v0.19 release: https://github.com/coreos/console-login-helper-messages/releases/tag/v0.19