### PR TITLE
Add support for root-on-LUKS

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -27,3 +27,14 @@ packages:
     evra: 4.5.1-1.fc32.aarch64
   afterburn-dracut:
     evra: 4.5.1-1.fc32.aarch64
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.aarch64
+  clevis-dracut:
+    evra: 14-4.fc32.aarch64
+  clevis-luks:
+    evra: 14-4.fc32.aarch64
+  clevis-systemd:
+    evra: 14-4.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -27,3 +27,14 @@ packages:
     evra: 4.5.1-1.fc32.ppc64le
   afterburn-dracut:
     evra: 4.5.1-1.fc32.ppc64le
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.ppc64le
+  clevis-dracut:
+    evra: 14-4.fc32.ppc64le
+  clevis-luks:
+    evra: 14-4.fc32.ppc64le
+  clevis-systemd:
+    evra: 14-4.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -27,3 +27,14 @@ packages:
     evra: 4.5.1-1.fc32.s390x
   afterburn-dracut:
     evra: 4.5.1-1.fc32.s390x
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.s390x
+  clevis-dracut:
+    evra: 14-4.fc32.s390x
+  clevis-luks:
+    evra: 14-4.fc32.s390x
+  clevis-systemd:
+    evra: 14-4.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -27,3 +27,14 @@ packages:
     evra: 4.5.1-1.fc32.x86_64
   afterburn-dracut:
     evra: 4.5.1-1.fc32.x86_64
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.x86_64
+  clevis-dracut:
+    evra: 14-4.fc32.x86_64
+  clevis-luks:
+    evra: 14-4.fc32.x86_64
+  clevis-systemd:
+    evra: 14-4.fc32.x86_64

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -87,6 +87,18 @@
     "cifs-utils": {
       "evra": "6.9-3.fc32.x86_64"
     },
+    "clevis": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-dracut": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-luks": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-systemd": {
+      "evra": "14-4.fc32.x86_64"
+    },
     "cloud-utils-growpart": {
       "evra": "0.31-6.fc32.noarch"
     },
@@ -402,6 +414,9 @@
     "jansson": {
       "evra": "2.12-5.fc32.x86_64"
     },
+    "jose": {
+      "evra": "10-6.fc32.x86_64"
+    },
     "jq": {
       "evra": "1.6-4.fc32.x86_64"
     },
@@ -546,6 +561,9 @@
     "libipa_hbac": {
       "evra": "2.3.1-2.fc32.x86_64"
     },
+    "libjose": {
+      "evra": "10-6.fc32.x86_64"
+    },
     "libkcapi": {
       "evra": "1.2.0-3.fc32.x86_64"
     },
@@ -557,6 +575,9 @@
     },
     "libldb": {
       "evra": "2.1.4-1.fc32.x86_64"
+    },
+    "libluksmeta": {
+      "evra": "9-7.fc32.x86_64"
     },
     "libmaxminddb": {
       "evra": "1.4.2-1.fc32.x86_64"
@@ -756,6 +777,9 @@
     "lua-libs": {
       "evra": "5.3.5-8.fc32.x86_64"
     },
+    "luksmeta": {
+      "evra": "9-7.fc32.x86_64"
+    },
     "lvm2": {
       "evra": "2.03.09-1.fc32.x86_64"
     },
@@ -809,6 +833,9 @@
     },
     "nftables": {
       "evra": "1:0.9.3-3.fc32.x86_64"
+    },
+    "nmap-ncat": {
+      "evra": "2:7.80-4.fc32.x86_64"
     },
     "npth": {
       "evra": "1.6-4.fc32.x86_64"
@@ -1055,6 +1082,12 @@
     },
     "toolbox": {
       "evra": "0.0.95-1.fc32.x86_64"
+    },
+    "tpm2-tools": {
+      "evra": "4.1.3-1.fc32.x86_64"
+    },
+    "tpm2-tss": {
+      "evra": "2.4.2-1.fc32.x86_64"
     },
     "tzdata": {
       "evra": "2020a-1.fc32.noarch"

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -22,6 +22,8 @@ machineid-compat: false
 packages:
   - ignition
   - dracut-network
+  # for encryption
+  - clevis clevis-luks clevis-dracut clevis-systemd
 
 remove-from-packages:
   # We don't want systemd-firstboot.service. It conceptually conflicts with

--- a/tests/kola/root-reprovision/luks/config.ign
+++ b/tests/kola/root-reprovision/luks/config.ign
@@ -1,0 +1,25 @@
+{
+  "ignition": {
+    "version": "3.2.0-experimental"
+  },
+  "storage": {
+    "luks": [
+      {
+        "name": "myluksdev",
+        "device": "/dev/disk/by-partlabel/root",
+        "clevis": {
+          "tpm2": true
+        },
+        "label": "root"
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/mapper/myluksdev",
+        "format": "xfs",
+        "wipeFilesystem": true,
+        "label": "root"
+      }
+    ]
+  }
+}

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096}
+set -xeuo pipefail
+
+srcdev=$(findmnt -nvr / -o SOURCE)
+[[ ${srcdev} == /dev/mapper/myluksdev ]]
+
+blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
+[[ ${blktype} == crypt ]]
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that growpart didn't run
+      if [ -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart ran"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      grep rd.luks.name= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
We have a new Clevis release now with the fixes we need, so add the
packages to the manifest. This is all that's needed to support
root-on-LUKS since the rest of the rootfs replacement stack is already
LUKS-aware.

See added test for sample Ignition config.