### PR TITLE
overlay: Install /usr/share/licenses/fedora-coreos-config/LICENSE

### DIFF
--- a/overlay.d/05core/usr/share/licenses/fedora-coreos-config/LICENSE
+++ b/overlay.d/05core/usr/share/licenses/fedora-coreos-config/LICENSE
@@ -1,0 +1,21 @@
+Copyright 2018 Fedora CoreOS Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/overlay.d/05core/usr/share/licenses/fedora-coreos-config/README.md
+++ b/overlay.d/05core/usr/share/licenses/fedora-coreos-config/README.md
@@ -1,0 +1,17 @@
+# fedora-coreos-config
+
+Today most components of Fedora CoreOS are built as RPMs; this
+is the main exception.  fedora-coreos-config is "architecture-independent glue"
+and the overhead of building an RPM for each change is onerous.
+
+It's also *the* central point of management (e.g. it contains lockfiles), so having it be
+an RPM too would become circular.  Instead, coreos-assembler directly consumes it.
+
+The upstream git repository is: https://github.com/coreos/fedora-coreos-config
+
+From a running system, to find the source commit use:
+```
+$ rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."coreos-assembler.config-gitrev"'
+c8dbed9ce223bf86737c82dd763670c8a34e950f
+$
+```

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -52,6 +52,10 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
 fi
 ok conditional initrd networking
 
+if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
+    fatal missing LICENSE
+fi
+
 # check that no files are unlabeled
 unlabeled=$(find /var /etc -context '*:unlabeled_t:*')
 if [ -n "${unlabeled}" ]; then


### PR DESCRIPTION
Thought about this after seeing
https://discussion.fedoraproject.org/t/fedora-core-os-redistribution/23134

Today fedora-coreos-config is special in that it's one of the only things
not an RPM.  Today one can use e.g. `rpm -qf /path/to/file` to find the
source RPM then map that to `/usr/share/licenses/$pkg/` to find the license,
but that's not true of stuff we ship here.

This doesn't solve the `rpm -qf` part, but it does put a file in the
expected place.