### PR TITLE
Revert "Revert "Add root reprovisioning tests""

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/config.ign
+++ b/tests/kola/root-reprovision/filesystem-only/config.ign
@@ -1,0 +1,15 @@
+{
+    "ignition": {
+        "version": "3.0.0"
+    },
+    "storage": {
+        "filesystems": [
+            {
+                "device": "/dev/disk/by-label/root",
+                "wipeFilesystem": true,
+                "format": "ext4",
+                "label": "root"
+            }
+        ]
+    }
+}

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096}
+set -xeuo pipefail
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ $fstype == ext4 ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that the partition was grown
+      if [ ! -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart did not run"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac

--- a/tests/kola/root-reprovision/raid1/config.ign
+++ b/tests/kola/root-reprovision/raid1/config.ign
@@ -1,0 +1,25 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "raid": [
+      {
+        "devices": [
+          "/dev/disk/by-id/virtio-disk1",
+          "/dev/disk/by-id/virtio-disk2"
+        ],
+        "level": "raid1",
+        "name": "foobar"
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/md/foobar",
+        "format": "xfs",
+        "wipeFilesystem": true,
+        "label": "root"
+      }
+    ]
+  }
+}

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+set -xeuo pipefail
+
+srcdev=$(findmnt -nvr / -o SOURCE)
+[[ ${srcdev} == $(realpath /dev/md/foobar) ]]
+
+blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
+[[ ${blktype} == raid1 ]]
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that growpart didn't run
+      if [ -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart ran"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      grep rd.md.uuid= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
This reverts commit 77787a021688720b90036cf95323b6c31ff04ccf.

I can't reproduce the failures in
coreos/fedora-coreos-tracker#619 locally or on
the CI cluster, and the logs from previous failures are stale. Let's
re-enable the tests and if it comes back we'll debug more deeply.