### PR TITLE
overrides: fast-track rust-afterburn-4.5.1-1.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -19,3 +19,11 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
+  # Fast track afterburn 4.5.1
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
+  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
+  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
+  afterburn:
+    evra: 4.5.1-1.fc32.aarch64
+  afterburn-dracut:
+    evra: 4.5.1-1.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -19,3 +19,11 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
+  # Fast track afterburn 4.5.1
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
+  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
+  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
+  afterburn:
+    evra: 4.5.1-1.fc32.ppc64le
+  afterburn-dracut:
+    evra: 4.5.1-1.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -19,3 +19,11 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
+  # Fast track afterburn 4.5.1
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
+  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
+  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
+  afterburn:
+    evra: 4.5.1-1.fc32.s390x
+  afterburn-dracut:
+    evra: 4.5.1-1.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -19,3 +19,11 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
+  # Fast track afterburn 4.5.1
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
+  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
+  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
+  afterburn:
+    evra: 4.5.1-1.fc32.x86_64
+  afterburn-dracut:
+    evra: 4.5.1-1.fc32.x86_64


### PR DESCRIPTION
Fast track rust-afterburn-4.5.1-1.fc32
https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.