### PR TITLE
tests/kola: use wipeVolume for root-on-LUKS test

### DIFF
--- a/tests/kola/root-reprovision/luks/config.ign
+++ b/tests/kola/root-reprovision/luks/config.ign
@@ -10,7 +10,8 @@
         "clevis": {
           "tpm2": true
         },
-        "label": "root"
+        "label": "root",
+        "wipeVolume": true
       }
     ],
     "filesystems": [


### PR DESCRIPTION
Otherwise, Ignition will refuse to overwrite the original xfs filesystem
on there.