### PR TITLE
overrides: fast-track catatonit 0.1.5-3

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,11 +1,4 @@
 packages:
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.aarch64
-  ostree-libs:
-    evra: 2020.6-2.fc32.aarch64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 
@@ -19,14 +12,6 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
-  # Fast track afterburn 4.5.1
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
-  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
-  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
-  afterburn:
-    evra: 4.5.1-1.fc32.aarch64
-  afterburn-dracut:
-    evra: 4.5.1-1.fc32.aarch64
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -23,3 +23,10 @@ packages:
     evra: 14-4.fc32.aarch64
   clevis-systemd:
     evra: 14-4.fc32.aarch64
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,11 +1,4 @@
 packages:
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.ppc64le
-  ostree-libs:
-    evra: 2020.6-2.fc32.ppc64le
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 
@@ -19,14 +12,6 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
-  # Fast track afterburn 4.5.1
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
-  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
-  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
-  afterburn:
-    evra: 4.5.1-1.fc32.ppc64le
-  afterburn-dracut:
-    evra: 4.5.1-1.fc32.ppc64le
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -23,3 +23,10 @@ packages:
     evra: 14-4.fc32.ppc64le
   clevis-systemd:
     evra: 14-4.fc32.ppc64le
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,11 +1,4 @@
 packages:
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.s390x
-  ostree-libs:
-    evra: 2020.6-2.fc32.s390x
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 
@@ -19,14 +12,6 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
-  # Fast track afterburn 4.5.1
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
-  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
-  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
-  afterburn:
-    evra: 4.5.1-1.fc32.s390x
-  afterburn-dracut:
-    evra: 4.5.1-1.fc32.s390x
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -23,3 +23,10 @@ packages:
     evra: 14-4.fc32.s390x
   clevis-systemd:
     evra: 14-4.fc32.s390x
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -23,3 +23,10 @@ packages:
     evra: 14-4.fc32.x86_64
   clevis-systemd:
     evra: 14-4.fc32.x86_64
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,11 +1,4 @@
 packages:
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.x86_64
-  ostree-libs:
-    evra: 2020.6-2.fc32.x86_64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 
@@ -19,14 +12,6 @@ packages:
     evra: 0.19-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.19-1.fc32.noarch
-  # Fast track afterburn 4.5.1
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-84e7af0cba
-  # Afterburn 4.5.1 includes https://github.com/coreos/afterburn/pull/481
-  # so https://github.com/coreos/fedora-coreos-config/pull/571 not blocked.
-  afterburn:
-    evra: 4.5.1-1.fc32.x86_64
-  afterburn-dracut:
-    evra: 4.5.1-1.fc32.x86_64
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes


### PR DESCRIPTION
For some reason the package went backwards in Fedora because
rhcontainerbot built 0.1.5-1 *after* lokesh had built 0.1.5-2.
Let's fast-track 0.1.5-3 so we don't downgrade catatonit,
which is currently what is happening.
