### PR TITLE
[next-devel] overrides: fast-track kernel-5.8.10-200.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,4 +1,15 @@
 packages:
+  # Fast-track new kernel. This kernel has both a fix for a recent
+  # CVE and a fix for a recent set of NFS issues.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
+  kernel:
+   evra: 5.8.10-200.fc32.aarch64
+  kernel-core:
+   evra: 5.8.10-200.fc32.aarch64
+  kernel-modules:
+   evra: 5.8.10-200.fc32.aarch64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,4 +1,15 @@
 packages:
+  # Fast-track new kernel. This kernel has both a fix for a recent
+  # CVE and a fix for a recent set of NFS issues.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
+  kernel:
+   evra: 5.8.10-200.fc32.ppc64le
+  kernel-core:
+   evra: 5.8.10-200.fc32.ppc64le
+  kernel-modules:
+   evra: 5.8.10-200.fc32.ppc64le
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,4 +1,15 @@
 packages:
+  # Fast-track new kernel. This kernel has both a fix for a recent
+  # CVE and a fix for a recent set of NFS issues.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
+  kernel:
+   evra: 5.8.10-200.fc32.s390x
+  kernel-core:
+   evra: 5.8.10-200.fc32.s390x
+  kernel-modules:
+   evra: 5.8.10-200.fc32.s390x
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,4 +1,15 @@
 packages:
+  # Fast-track new kernel. This kernel has both a fix for a recent
+  # CVE and a fix for a recent set of NFS issues.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
+  kernel:
+   evra: 5.8.10-200.fc32.x86_64
+  kernel-core:
+   evra: 5.8.10-200.fc32.x86_64
+  kernel-modules:
+   evra: 5.8.10-200.fc32.x86_64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 


### PR DESCRIPTION
This kernel has both a fix for a recent CVE and a fix for a
recent set of NFS issues.

- https://bugzilla.redhat.com/show_bug.cgi?id=1875699
- https://bugzilla.redhat.com/show_bug.cgi?id=1873720
- https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae

(cherry picked from commit 1f24ad0266ef992b9535a6f71ee683ad60f73844)