### PR TITLE
40-coreos.preset: enable afterburn.service

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -14,6 +14,8 @@ enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
 # Target to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys.target
+# And the main Afterburn service itself for cloud metadata.
+enable afterburn.service
 # Service to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys@.service
 # Update agent


### PR DESCRIPTION
We were enabling a bunch of related afterburn services, but not
`afterburn.service` itself.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/626