### PR TITLE
`core` user: specifically enable afterburn-sshkeys@core.service

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/README.md
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/README.md
@@ -1,0 +1,7 @@
+FCOS enables `afterburn-sshkeys@core.service` from `base.ign`, allowing the user
+to prevent Ignition from enabling the service with a user config if the user
+wants to change the username. Unlike FCOS, RHCOS doesn't fetch SSH keys and thus
+doesn't need `afterburn-sshkeys@core.service`. Therefore, RHCOS maintains its
+own copy of `base.ign`, and changes to one copy need to be synced to the other
+copy.
+See https://github.com/coreos/fedora-coreos-config/pull/626

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/base.ign
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/base.ign
@@ -15,5 +15,13 @@
         ]
       }
     ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "afterburn-sshkeys@core.service"
+      }
+    ]
   }
 }

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -16,8 +16,6 @@ enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
 # Target to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys.target
-# Service to write SSH key snippets from cloud providers.
-enable afterburn-sshkeys@.service
 # Update agent
 enable zincati.service
 # Testing aid


### PR DESCRIPTION
This only enables afterburn-sshkeys@core.service, which is the
default instance of afterburn-sshkeys@.service, when the `core`
user is created.
Tested it works. Ready for review.