### PR TITLE
overrides: fast-track console-login-helper-messages-0.19-2.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -11,18 +11,19 @@ packages:
   kernel-modules:
    evra: 5.8.10-200.fc32.aarch64
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -11,18 +11,19 @@ packages:
   kernel-modules:
    evra: 5.8.10-200.fc32.ppc64le
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -11,18 +11,19 @@ packages:
   kernel-modules:
    evra: 5.8.10-200.fc32.s390x
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -11,18 +11,19 @@ packages:
   kernel-modules:
    evra: 5.8.10-200.fc32.x86_64
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes


### PR DESCRIPTION
Addresses https://github.com/coreos/fedora-coreos-config/pull/613#issuecomment-692392043.