### PR TITLE
tests/kola/misc-ro: check that rpmdb is using bdb

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -64,3 +64,10 @@ if [ -n "${unlabeled}" ]; then
     exit 1
 fi
 ok no files with unlabeled_t SELinux label
+
+# make sure we stick with bdb until we're ready to move to sqlite
+# https://github.com/coreos/fedora-coreos-tracker/issues/623
+if [ ! -f /usr/share/rpm/Packages ]; then
+    fatal "Didn't find bdb file /usr/share/rpm/Packages"
+fi
+ok rpmdb is bdb


### PR DESCRIPTION
Make sure we don't unknowingly move over to sqlite until we're ready.
See: https://github.com/coreos/fedora-coreos-tracker/issues/623