### PR TITLE
[next-devel] overrides: fast-track systemd 245.8-2

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -41,3 +41,19 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
   catatonit:
     evra: 0.1.5-3.fc32.aarch64
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.aarch64
+  systemd-container:
+    evra: 245.8-2.fc32.aarch64  
+  systemd-libs:
+    evra: 245.8-2.fc32.aarch64
+  systemd-pam:
+    evra: 245.8-2.fc32.aarch64
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -41,3 +41,19 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
   catatonit:
     evra: 0.1.5-3.fc32.ppc64le
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-container:
+    evra: 245.8-2.fc32.ppc64le 
+  systemd-libs:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-pam:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -41,3 +41,19 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
   catatonit:
     evra: 0.1.5-3.fc32.s390x
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.s390x
+  systemd-container:
+    evra: 245.8-2.fc32.s390x
+  systemd-libs:
+    evra: 245.8-2.fc32.s390x
+  systemd-pam:
+    evra: 245.8-2.fc32.s390x
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -41,3 +41,19 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
   catatonit:
     evra: 0.1.5-3.fc32.x86_64
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.x86_64
+  systemd-container:
+    evra: 245.8-2.fc32.x86_64
+  systemd-libs:
+    evra: 245.8-2.fc32.x86_64
+  systemd-pam:
+    evra: 245.8-2.fc32.x86_64
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.x86_64


### PR DESCRIPTION
This version has a fix for the Ignition issue (https://github.com/coreos/ignition/issues/1064)