### PR TITLE
[next-devel] overrides: Fast-track podman-2.1.0-2.fc32 for baking on the `next` stream.

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,15 +1,4 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.aarch64
-  kernel-core:
-   evra: 5.8.10-200.fc32.aarch64
-  kernel-modules:
-   evra: 5.8.10-200.fc32.aarch64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,4 +1,8 @@
 packages:
+  # Fast-track podman-2.1.0-2.fc32 for baking on the `next` stream.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-76fcd0ba34
+  podman:                            
+    evra: 2:2.1.0-2.fc32.aarch64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
   # Update fixes the issue where a large amount of errors occur

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,17 +1,18 @@
 packages:
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,15 +1,4 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.ppc64le
-  kernel-core:
-   evra: 5.8.10-200.fc32.ppc64le
-  kernel-modules:
-   evra: 5.8.10-200.fc32.ppc64le
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,4 +1,8 @@
 packages:
+  # Fast-track podman-2.1.0-2.fc32 for baking on the `next` stream.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-76fcd0ba34
+  podman:                            
+    evra: 2:2.1.0-2.fc32.ppc64le
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
   # Update fixes the issue where a large amount of errors occur

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,17 +1,18 @@
 packages:
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,15 +1,4 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.s390x
-  kernel-core:
-   evra: 5.8.10-200.fc32.s390x
-  kernel-modules:
-   evra: 5.8.10-200.fc32.s390x
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,17 +1,18 @@
 packages:
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,4 +1,8 @@
 packages:
+  # Fast-track podman-2.1.0-2.fc32 for baking on the `next` stream.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-76fcd0ba34
+  podman:                            
+    evra: 2:2.1.0-2.fc32.s390x
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
   # Update fixes the issue where a large amount of errors occur

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,15 +1,4 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.x86_64
-  kernel-core:
-   evra: 5.8.10-200.fc32.x86_64
-  kernel-modules:
-   evra: 5.8.10-200.fc32.x86_64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
   # New updates in console-login-helper-messages v0.19 are required for 

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,17 +1,18 @@
 packages:
   # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ac71e211b4
-  # New updates in console-login-helper-messages v0.19 are required for 
-  # c-l-h-m's kola tests to pass, and subsequently have c-l-h-m added to the 
-  # CoreOS CI.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
   console-login-helper-messages:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-1.fc32.noarch
+    evra: 0.19-2.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,4 +1,8 @@
 packages:
+  # Fast-track podman-2.1.0-2.fc32 for baking on the `next` stream.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-76fcd0ba34
+  podman:                            
+    evra: 2:2.1.0-2.fc32.x86_64
   # Fast-track console-login-helper-messages release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
   # Update fixes the issue where a large amount of errors occur


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2020-76fcd0ba34