### PR TITLE
coreos-boot-mount-generator: Use Options=umask=077 for /boot/efi

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -77,5 +77,12 @@ if [ ! -f /run/ostree-live ]; then
     # when booted through BIOS.
     if [ "$(uname -m)" = "x86_64" -o -d /sys/firmware/efi ]; then
         mk_mount boot-efi EFI-SYSTEM "/boot/efi"
+        # In the general case the ESP might have per-machine or private
+        # data on it.  Let's not make it world readable on general
+        # principle.
+        # https://github.com/coreos/fedora-coreos-tracker/issues/640
+        cat >>${UNIT_DIR}/boot-efi.mount << EOF
+Options=umask=0077
+EOF
     fi
 fi

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -59,6 +59,9 @@ ok LICENSE
 
 case "$(arch)" in
     x86_64|aarch64)
+        if runuser -u core -- ls /boot/efi &>/dev/null; then
+            fatal "Was able to access /boot/efi as non-root"
+        fi
         if systemctl is-enabled bootupd.socket; then
             fatal "Not expecting bootupd.socket to be enabled"
         fi


### PR DESCRIPTION
This is basically a consensus; the default systemd mount generator
does this.  While it's not a concern for CoreOS specifically
on general dual boot and other scenarios one might have private
or machine-specific data in there.

While there's no reason to prevent unprivileged users from
reading our pre-built bootloader binaries, I think it's reasonable
for e.g. security scanning systems to check this.

I'm mostly doing this because for bootupd I want to validate
our permissions handling and having things be common here
is better.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/640