### PR TITLE
tests: misc-ro: make systemd-resolved service check conditional

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -41,9 +41,6 @@ check-groups:
 default-target: multi-user.target
 
 remove-from-packages:
-  # We're not using resolved yet.
-  - [systemd, /usr/lib/systemd/systemd-resolved,
-              /usr/lib/systemd/system/systemd-resolved.service]
   # We're not using networkd.
   - [systemd, /etc/systemd/networkd.conf,
               /usr/lib/systemd/systemd-networkd,

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -20,11 +20,25 @@ get_journal_msg_timestamp() {
         | jq -r --slurp '.[0]["__MONOTONIC_TIMESTAMP"]'
 }
 
-for unit in logrotate systemd-resolved; do
-    if ! systemctl is-enabled ${unit}; then
+# Test some services are enabled or disabled appropriately
+for unit in logrotate; do
+    if ! systemctl is-enabled ${unit} 1>/dev/null; then
         fatal "Unit ${unit} should be enabled"
     fi
 done
+# systemd-resolved should be disabled on f32 but
+# enabled on f33+.
+source /etc/os-release
+if systemctl is-enabled systemd-resolved 1>/dev/null; then
+    if [ "$VERSION_ID" == "32" ]; then
+        fatal "Unit ${unit} should not be enabled"
+    fi
+else
+    if [ "$VERSION_ID" != "32" ]; then
+        fatal "Unit ${unit} should be enabled"
+    fi
+fi
+ok services
 
 # https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
 if ip link | grep -o -e " eth[0-9]:"; then

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -20,8 +20,11 @@ get_journal_msg_timestamp() {
         | jq -r --slurp '.[0]["__MONOTONIC_TIMESTAMP"]'
 }
 
-systemctl is-enabled logrotate.service
-ok logrotate
+for unit in logrotate systemd-resolved; do
+    if ! systemctl is-enabled ${unit}; then
+        fatal "Unit ${unit} should be enabled"
+    fi
+done
 
 # https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
 if ip link | grep -o -e " eth[0-9]:"; then


### PR DESCRIPTION
Make the systemd-resolved service check conditional on Fedora major
version. In Fedora 32 it should be disabled. In Fedora 33+ it should
be enabled by default.