### PR TITLE
tests/kola/root-reprovision: limit to x86_64

### DIFF
--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096}
+# kola: {"platforms": "qemu", "minMemory": 4096, "architectures": "x86_64"}
 set -xeuo pipefail
 
 srcdev=$(findmnt -nvr / -o SOURCE)


### PR DESCRIPTION
TPM devices are only available there for now. A cleaner approach would
be for kola to automatically do this if we tag a test with `tpm`.

Closes: #651