### PR TITLE
manifests/base: add ncurses

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -128,6 +128,8 @@ packages:
   - openssl
   - vim-minimal
   - lsof
+  # Provides terminal tools like clear, reset, tput, and tset
+  - ncurses
   # file-transfer: note fuse-sshfs is not in RHEL
   # so we can't put it in file-transfer.yaml
   - fuse-sshfs


### PR DESCRIPTION
This is currently getting pulled into the base by `coreutils` but won't
be in f33. We do want it though, so let's explicitly add it to the
manifest.

This provides common terminal tools like `clear`, `reset`, `tput`, and
`tset`.