### PR TITLE
[stable] manifest.yaml: host systemd-networkd removal bits in manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,3 +13,17 @@ repos:
 
 add-commit-metadata:
   fedora-coreos.stream: stable
+
+# Put this in manifest.yaml for now and we'll delete when we move to
+# F33 where all of these files have been broken out to the systemd-networkd
+# subpackage.
+remove-from-packages:
+  # We're not using networkd.
+  - [systemd, /etc/systemd/networkd.conf,
+              /usr/lib/systemd/systemd-networkd,
+              /usr/lib/systemd/systemd-networkd-wait-online,
+              /usr/lib/systemd/network/.*,
+              /usr/lib/systemd/system/systemd-networkd.service,
+              /usr/lib/systemd/system/systemd-networkd.socket,
+              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
+  - [systemd-container, /usr/lib/systemd/network/.*]

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -40,21 +40,6 @@ check-groups:
 
 default-target: multi-user.target
 
-remove-from-packages:
-  # We're not using resolved yet.
-  - [systemd, /usr/lib/systemd/systemd-resolved,
-              /usr/lib/systemd/system/systemd-resolved.service]
-  # We're not using networkd.
-  - [systemd, /etc/systemd/networkd.conf,
-              /usr/lib/systemd/systemd-networkd,
-              /usr/lib/systemd/systemd-networkd-wait-online,
-              /usr/lib/systemd/network/.*,
-              /usr/lib/systemd/system/systemd-networkd.service,
-              /usr/lib/systemd/system/systemd-networkd.socket,
-              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
-  - [systemd-container, /usr/lib/systemd/network/.*]
-
-
 remove-files:
   # We don't ship man(1) or info(1)
   - usr/share/info


### PR DESCRIPTION
In Fedora 33 systemd-networkd will be broken out into a subpackage and
we won't need to explicitly remove the files from the package. To
prepare for that let's move the `remove-from-packages` bit into the
manifest.yaml which doesn't get synced across branches with config-bot.

This will allow testing-devel, testing, and stable to keep removing
the networkd bits until they move to Fedora 33, while at the same time
allowing next-devel and next to not have the remove-from-packages bit.

(cherry picked from commit f7c0d22426355b1e1d51cd760f2409a54df90423)