### PR TITLE
overrides: bump to coreos-installer-0.7.0-3.fc32

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -4,8 +4,8 @@ packages:
   zincati:
     evra: 0.0.13-1.fc32.aarch64
   # Fast-track coreos-installer 0.7.0
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2188476aa5
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9062a0b276
   coreos-installer:
-    evra: 0.7.0-2.fc32.aarch64
+    evra: 0.7.0-3.fc32.aarch64
   coreos-installer-bootinfra:
-    evra: 0.7.0-2.fc32.aarch64
+    evra: 0.7.0-3.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -4,8 +4,8 @@ packages:
   zincati:
     evra: 0.0.13-1.fc32.ppc64le
   # Fast-track coreos-installer 0.7.0
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2188476aa5
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9062a0b276
   coreos-installer:
-    evra: 0.7.0-2.fc32.ppc64le
+    evra: 0.7.0-3.fc32.ppc64le
   coreos-installer-bootinfra:
-    evra: 0.7.0-2.fc32.ppc64le
+    evra: 0.7.0-3.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -4,8 +4,8 @@ packages:
   zincati:
     evra: 0.0.13-1.fc32.s390x
   # Fast-track coreos-installer 0.7.0
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2188476aa5
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9062a0b276
   coreos-installer:
-    evra: 0.7.0-2.fc32.s390x
+    evra: 0.7.0-3.fc32.s390x
   coreos-installer-bootinfra:
-    evra: 0.7.0-2.fc32.s390x
+    evra: 0.7.0-3.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -4,8 +4,8 @@ packages:
   zincati:
     evra: 0.0.13-1.fc32.x86_64
   # Fast-track coreos-installer 0.7.0
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-2188476aa5
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9062a0b276
   coreos-installer:
-    evra: 0.7.0-2.fc32.x86_64
+    evra: 0.7.0-3.fc32.x86_64
   coreos-installer-bootinfra:
-    evra: 0.7.0-2.fc32.x86_64
+    evra: 0.7.0-3.fc32.x86_64


### PR DESCRIPTION
This one has the f33 signing key embedded. Not strictly required
for f32 FCOS but we might as well be on the latest.

https://bodhi.fedoraproject.org/updates/FEDORA-2020-9062a0b276