### PR TITLE
tests/kola/root-reprovision: bump the amount of RAM to 6G as 4G is not enough on ppc64le

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096}
+# kola: {"platforms": "qemu", "minMemory": 6144}
 set -xeuo pipefail
 
 fstype=$(findmnt -nvr / -o FSTYPE)

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+# kola: {"platforms": "qemu", "minMemory": 6144, "additionalDisks": ["5G", "5G"]}
 set -xeuo pipefail
 
 srcdev=$(findmnt -nvr / -o SOURCE)


### PR DESCRIPTION
Re-provision tests runs will fail(log in attachment), with something that seems as not enough memory on ppc64le. Increasing the memory size to the 6G enables the tests pass(obtained by trail and error). I assume that this is most probably caused by the image being roughly ~200M bigger than on the x86_64 and by usage of the 64k pages on the ppc64le.`
[ppc64le-raid1.log](https://github.com/coreos/fedora-coreos-config/files/5317325/ppc64le-raid1.log)
