### PR TITLE
overlay/boot-mount-generator: Mount /boot{,efi} read-only,nodev,nosuid 

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -35,8 +35,9 @@ fi
 mk_mount() {
     local mount_pt="${1}"; shift
     local label="${1}"; shift
-    local path="/dev/disk/by-label/${label}"
+    local options="${1}"; shift
 
+    local path="/dev/disk/by-label/${label}"
     local unit_name=$(systemd-escape -p ${mount_pt} --suffix=mount)
 
     eval $(udevadm info --query property --export "${path}")
@@ -61,15 +62,20 @@ After=systemd-fsck@${device}.service
 [Mount]
 What=${path}
 Where=${mount_pt}
+Options=${options}
 EOF
 
     add_wants "${unit_name}"
 }
 
-
-# Don't create mount units for /boot or /boot/efi on live systems.
+# Don't create mount units for /boot on live systems.
 # ConditionPathExists won't work here because conditions don't affect
 # the dependency on the underlying device unit.
 if [ ! -f /run/ostree-live ]; then
-    mk_mount /boot boot
+    # We mount read-only by default mostly to protect
+    # against accidental damage.  Only a few things
+    # owned by CoreOS should be touching /boot or the ESP.
+    # Use nodev,nosuid because some hardening guides want
+    # that even though it's of minimal value.
+    mk_mount /boot boot ro,nodev,nosuid
 fi

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -51,10 +51,15 @@ if ip link | grep -o -e " eth[0-9]:"; then
 fi
 ok nic naming
 
-if test -w /sysroot; then
-    fatal "found writable /sysroot"
-fi
-ok sysroot ro
+for part in /sysroot /boot; do
+    if ! findmnt -n -o options ${part} | grep -q "ro,"; then
+        fatal "${part} is missing ro option"
+    fi
+    if test -w "${part}" || touch "${part}/somefile" 2>/dev/null; then
+        fatal "${part} is writable"
+    fi
+done
+ok read-only partitions
 
 if ! lsattr -d / | grep -qe '--i--'; then
     fatal "missing immutable bit on /"


### PR DESCRIPTION
ostree has had support for leaving `/boot` mounted read-only
for a long time: https://github.com/ostreedev/ostree/pull/1767
(And then later extended to `/sysroot`)

Particularly for CoreOS, only a few things should be touching
`/boot`, and we control all of them.  Those projects should
create a new mount namespace and remount these partitions
writable just while they need it.

The main thing we're accomplishing here is making the system
more resilient against accidental damage from a sysadmin
root shell as well as configuration management tools like
Puppet/Ansible.  None of those should be directly manipulating
files on these partitions, they should go through the API
of one of our projects (e.g. `rpm-ostree kargs`, `bootupctl`) etc.

While we're here, also andd `nodev,nosuid` because some
OS hardening scanners like to see this.  IMO it's of minimal
value, but hey, might as well.