### PR TITLE
tests: add chrony.dhcp-propagation to denylist for f33

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,3 +5,10 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
+# The ext.config.chrony.dhcp-propagation test is failing on Fedora 33
+# for now. Exclude running the test on `next` and `next-devel`.
+- pattern: ext.config.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/643
+  streams:
+    - next
+    - next-devel


### PR DESCRIPTION
The ext.config.chrony.dhcp-propagation test is failing on Fedora 33
for now. Exclude running the test on `next` and `next-devel`.

https://github.com/coreos/fedora-coreos-tracker/issues/643