### PR TITLE
[stable] tree: promote changes from testing at 9cbd9cb 

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -16,6 +16,22 @@ cosaPod {
 
     fcosBuild(skipInit: true, extraFetchArgs: '--with-cosa-overrides')
 
+    parallel metal: {
+        shwrap("cd /srv/fcos && cosa buildextend-metal")
+    }, metal4k: {
+        shwrap("cd /srv/fcos && cosa buildextend-metal4k")
+    }
+
+    stage("Test ISO") {
+        shwrap("cd /srv/fcos && cosa buildextend-live")
+        try {
+            shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,pxe-offline-install,iso-install,iso-offline-install --output-dir tmp/kola-testiso-metal")
+        } finally {
+            shwrap("cd /srv/fcos && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso-metal.tar.xz'
+        }
+    }
+
     // also print the pkgdiff as a separate stage to make it more visible
     stage("RPM Diff") {
         shwrap("jq .pkgdiff /srv/fcos/builds/latest/x86_64/meta.json")

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,18 +1,15 @@
 packages:
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
-  # Update fixes the issue where a large amount of errors occur
-  # when the `console-login-helper-messages` %pre script runs during
-  # a `cosa build`.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  # Pin console-login-helper-messages to avoid hitting
+  # `gensnippet_if` segfaults.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1884236
   console-login-helper-messages:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,26 +1,49 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.aarch64
-  kernel-core:
-   evra: 5.8.10-200.fc32.aarch64
-  kernel-modules:
-   evra: 5.8.10-200.fc32.aarch64
-  # Fast track podman 2.0.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/575
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
-  podman:
-    evra: 2:2.0.6-1.fc32.aarch64
-  podman-plugins:
-    evra: 2:2.0.6-1.fc32.aarch64
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.aarch64
-  ostree-libs:
-    evra: 2020.6-2.fc32.aarch64
+  # Fast-track console-login-helper-messages release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  console-login-helper-messages:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-issuegen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-motdgen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-profile:
+    evra: 0.19-2.fc32.noarch
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.aarch64
+  clevis-dracut:
+    evra: 14-4.fc32.aarch64
+  clevis-luks:
+    evra: 14-4.fc32.aarch64
+  clevis-systemd:
+    evra: 14-4.fc32.aarch64
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.aarch64
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.aarch64
+  systemd-container:
+    evra: 245.8-2.fc32.aarch64  
+  systemd-libs:
+    evra: 245.8-2.fc32.aarch64
+  systemd-pam:
+    evra: 245.8-2.fc32.aarch64
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,18 +1,15 @@
 packages:
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
-  # Update fixes the issue where a large amount of errors occur
-  # when the `console-login-helper-messages` %pre script runs during
-  # a `cosa build`.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  # Pin console-login-helper-messages to avoid hitting
+  # `gensnippet_if` segfaults.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1884236
   console-login-helper-messages:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,26 +1,49 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.ppc64le
-  kernel-core:
-   evra: 5.8.10-200.fc32.ppc64le
-  kernel-modules:
-   evra: 5.8.10-200.fc32.ppc64le
-  # Fast track podman 2.0.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/575
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
-  podman:
-    evra: 2:2.0.6-1.fc32.ppc64le
-  podman-plugins:
-    evra: 2:2.0.6-1.fc32.ppc64le
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.ppc64le
-  ostree-libs:
-    evra: 2020.6-2.fc32.ppc64le
+  # Fast-track console-login-helper-messages release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  console-login-helper-messages:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-issuegen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-motdgen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-profile:
+    evra: 0.19-2.fc32.noarch
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.ppc64le
+  clevis-dracut:
+    evra: 14-4.fc32.ppc64le
+  clevis-luks:
+    evra: 14-4.fc32.ppc64le
+  clevis-systemd:
+    evra: 14-4.fc32.ppc64le
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.ppc64le
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-container:
+    evra: 245.8-2.fc32.ppc64le 
+  systemd-libs:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-pam:
+    evra: 245.8-2.fc32.ppc64le
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,18 +1,15 @@
 packages:
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
-  # Update fixes the issue where a large amount of errors occur
-  # when the `console-login-helper-messages` %pre script runs during
-  # a `cosa build`.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  # Pin console-login-helper-messages to avoid hitting
+  # `gensnippet_if` segfaults.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1884236
   console-login-helper-messages:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,26 +1,49 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.s390x
-  kernel-core:
-   evra: 5.8.10-200.fc32.s390x
-  kernel-modules:
-   evra: 5.8.10-200.fc32.s390x
-  # Fast track podman 2.0.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/575
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
-  podman:
-    evra: 2:2.0.6-1.fc32.s390x
-  podman-plugins:
-    evra: 2:2.0.6-1.fc32.s390x
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.s390x
-  ostree-libs:
-    evra: 2020.6-2.fc32.s390x
+  # Fast-track console-login-helper-messages release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  console-login-helper-messages:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-issuegen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-motdgen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-profile:
+    evra: 0.19-2.fc32.noarch
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.s390x
+  clevis-dracut:
+    evra: 14-4.fc32.s390x
+  clevis-luks:
+    evra: 14-4.fc32.s390x
+  clevis-systemd:
+    evra: 14-4.fc32.s390x
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.s390x
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.s390x
+  systemd-container:
+    evra: 245.8-2.fc32.s390x
+  systemd-libs:
+    evra: 245.8-2.fc32.s390x
+  systemd-pam:
+    evra: 245.8-2.fc32.s390x
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,26 +1,49 @@
 packages:
-  # Fast-track new kernel. This kernel has both a fix for a recent
-  # CVE and a fix for a recent set of NFS issues.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1875699
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1873720
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9f10c3dfae
-  kernel:
-   evra: 5.8.10-200.fc32.x86_64
-  kernel-core:
-   evra: 5.8.10-200.fc32.x86_64
-  kernel-modules:
-   evra: 5.8.10-200.fc32.x86_64
-  # Fast track podman 2.0.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/575
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0c1986cdf7
-  podman:
-    evra: 2:2.0.6-1.fc32.x86_64
-  podman-plugins:
-    evra: 2:2.0.6-1.fc32.x86_64
-  # Fast track ostree 2020.6
-  # https://github.com/coreos/fedora-coreos-tracker/issues/617
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-eb29bce63d
-  ostree:
-    evra: 2020.6-2.fc32.x86_64
-  ostree-libs:
-    evra: 2020.6-2.fc32.x86_64
+  # Fast-track console-login-helper-messages release
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
+  # Update fixes the issue where a large amount of errors occur
+  # when the `console-login-helper-messages` %pre script runs during
+  # a `cosa build`.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  console-login-helper-messages:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-issuegen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-motdgen:
+    evra: 0.19-2.fc32.noarch
+  console-login-helper-messages-profile:
+    evra: 0.19-2.fc32.noarch
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
+  # To get root-on-LUKS earlier for testing
+  # 14-1 is in stable, but is missing some fixes
+  clevis:
+    evra: 14-4.fc32.x86_64
+  clevis-dracut:
+    evra: 14-4.fc32.x86_64
+  clevis-luks:
+    evra: 14-4.fc32.x86_64
+  clevis-systemd:
+    evra: 14-4.fc32.x86_64
+  # Fast-track catatonit 0.1.5-3. For some reason the package went
+  # backwards in Fedora because rhcontainerbot built 0.1.5-1 *after*
+  # lokesh had built 0.1.5-2. Let's fast-track 0.1.5-3 so we don't
+  # downgrade catatonit, which is currently what is happening.
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-33358ae219
+  catatonit:
+    evra: 0.1.5-3.fc32.x86_64
+  # Fast-track systemd 245.8-2 to support preset operations for 
+  # non-service instantiated units.
+  # related to https://github.com/coreos/ignition/issues/1064
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-0d29e88946
+  systemd:
+    evra: 245.8-2.fc32.x86_64
+  systemd-container:
+    evra: 245.8-2.fc32.x86_64
+  systemd-libs:
+    evra: 245.8-2.fc32.x86_64
+  systemd-pam:
+    evra: 245.8-2.fc32.x86_64
+  systemd-rpm-macros:
+    evra: 245.8-2.fc32.noarch
+  systemd-udev:
+    evra: 245.8-2.fc32.x86_64

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,18 +1,15 @@
 packages:
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9701ebbdfd
-  # Update fixes the issue where a large amount of errors occur
-  # when the `console-login-helper-messages` %pre script runs during
-  # a `cosa build`.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1879233
+  # Pin console-login-helper-messages to avoid hitting
+  # `gensnippet_if` segfaults.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1884236
   console-login-helper-messages:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-issuegen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-motdgen:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   console-login-helper-messages-profile:
-    evra: 0.19-2.fc32.noarch
+    evra: 0.18.2-1.fc32.noarch
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-af9f9ccb12
   # To get root-on-LUKS earlier for testing
   # 14-1 is in stable, but is missing some fixes

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -19,10 +19,10 @@
       "evra": "0.9.0-1.fc32.x86_64"
     },
     "afterburn": {
-      "evra": "4.5.0-1.fc32.x86_64"
+      "evra": "4.5.1-1.fc32.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "4.5.0-1.fc32.x86_64"
+      "evra": "4.5.1-1.fc32.x86_64"
     },
     "alternatives": {
       "evra": "1.11-6.fc32.x86_64"
@@ -79,13 +79,25 @@
       "evra": "2020.2.41-1.1.fc32.noarch"
     },
     "catatonit": {
-      "evra": "0.1.5-2.fc32.x86_64"
+      "evra": "0.1.5-3.fc32.x86_64"
     },
     "chrony": {
       "evra": "3.5.1-1.fc32.x86_64"
     },
     "cifs-utils": {
       "evra": "6.9-3.fc32.x86_64"
+    },
+    "clevis": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-dracut": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-luks": {
+      "evra": "14-4.fc32.x86_64"
+    },
+    "clevis-systemd": {
+      "evra": "14-4.fc32.x86_64"
     },
     "cloud-utils-growpart": {
       "evra": "0.31-6.fc32.noarch"
@@ -94,22 +106,22 @@
       "evra": "5.2-36.fc32.x86_64"
     },
     "conmon": {
-      "evra": "2:2.0.19-1.fc32.x86_64"
+      "evra": "2:2.0.21-2.fc32.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.18.2-1.fc32.noarch"
+      "evra": "0.19-2.fc32.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.18.2-1.fc32.noarch"
+      "evra": "0.19-2.fc32.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.18.2-1.fc32.noarch"
+      "evra": "0.19-2.fc32.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.18.2-1.fc32.noarch"
+      "evra": "0.19-2.fc32.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.144.0-2.fc32.noarch"
+      "evra": "2:2.145.0-1.fc32.noarch"
     },
     "containerd": {
       "evra": "1.3.3-1.fc32.x86_64"
@@ -139,7 +151,7 @@
       "evra": "2.9.6-22.fc32.x86_64"
     },
     "crun": {
-      "evra": "0.14.1-4.fc32.x86_64"
+      "evra": "0.14.1-5.fc32.x86_64"
     },
     "crypto-policies": {
       "evra": "20200619-1.git781bbd4.fc32.noarch"
@@ -154,7 +166,7 @@
       "evra": "1:2.3.3-13.fc32.x86_64"
     },
     "curl": {
-      "evra": "7.69.1-5.fc32.x86_64"
+      "evra": "7.69.1-6.fc32.x86_64"
     },
     "cyrus-sasl-gssapi": {
       "evra": "2.1.27-4.fc32.x86_64"
@@ -166,7 +178,7 @@
       "evra": "1:1.12.20-1.fc32.x86_64"
     },
     "dbus-broker": {
-      "evra": "23-2.fc32.x86_64"
+      "evra": "24-1.fc32.x86_64"
     },
     "dbus-common": {
       "evra": "1:1.12.20-1.fc32.noarch"
@@ -226,13 +238,13 @@
       "evra": "37-7.fc32.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.179-2.fc32.noarch"
+      "evra": "0.181-1.fc32.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.179-2.fc32.x86_64"
+      "evra": "0.181-1.fc32.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.179-2.fc32.x86_64"
+      "evra": "0.181-1.fc32.x86_64"
     },
     "expat": {
       "evra": "2.2.8-2.fc32.x86_64"
@@ -271,7 +283,7 @@
       "evra": "0.8.3-1.fc32.noarch"
     },
     "flatpak-session-helper": {
-      "evra": "1.6.5-1.fc32.x86_64"
+      "evra": "1.8.2-2.fc32.x86_64"
     },
     "fstrm": {
       "evra": "0.5.0-2.fc32.x86_64"
@@ -340,22 +352,22 @@
       "evra": "3.3-4.fc32.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.04-21.fc32.noarch"
+      "evra": "1:2.04-23.fc32.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.04-21.fc32.x86_64"
+      "evra": "1:2.04-23.fc32.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.04-21.fc32.x86_64"
+      "evra": "1:2.04-23.fc32.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.04-21.fc32.noarch"
+      "evra": "1:2.04-23.fc32.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.04-21.fc32.x86_64"
+      "evra": "1:2.04-23.fc32.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.04-21.fc32.x86_64"
+      "evra": "1:2.04-23.fc32.x86_64"
     },
     "gzip": {
       "evra": "1.10-2.fc32.x86_64"
@@ -367,10 +379,10 @@
       "evra": "2.6.0-2.git947598e.fc32.x86_64"
     },
     "iproute": {
-      "evra": "5.6.0-1.fc32.x86_64"
+      "evra": "5.7.0-1.fc32.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.6.0-1.fc32.x86_64"
+      "evra": "5.7.0-1.fc32.x86_64"
     },
     "iptables": {
       "evra": "1.8.4-9.fc32.x86_64"
@@ -402,6 +414,9 @@
     "jansson": {
       "evra": "2.12-5.fc32.x86_64"
     },
+    "jose": {
+      "evra": "10-6.fc32.x86_64"
+    },
     "jq": {
       "evra": "1.6-4.fc32.x86_64"
     },
@@ -421,13 +436,13 @@
       "evra": "2.2.0-1.fc32.noarch"
     },
     "kernel": {
-      "evra": "5.8.6-201.fc32.x86_64"
+      "evra": "5.8.10-200.fc32.x86_64"
     },
     "kernel-core": {
-      "evra": "5.8.6-201.fc32.x86_64"
+      "evra": "5.8.10-200.fc32.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.8.6-201.fc32.x86_64"
+      "evra": "5.8.10-200.fc32.x86_64"
     },
     "keyutils": {
       "evra": "1.6-4.fc32.x86_64"
@@ -445,7 +460,7 @@
       "evra": "0.8.2-4.fc32.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.18.2-20.fc32.x86_64"
+      "evra": "1.18.2-22.fc32.x86_64"
     },
     "less": {
       "evra": "551-3.fc32.x86_64"
@@ -493,7 +508,7 @@
       "evra": "1.45.5-3.fc32.x86_64"
     },
     "libcurl": {
-      "evra": "7.69.1-5.fc32.x86_64"
+      "evra": "7.69.1-6.fc32.x86_64"
     },
     "libdaemon": {
       "evra": "0.14-19.fc32.x86_64"
@@ -546,6 +561,9 @@
     "libipa_hbac": {
       "evra": "2.3.1-2.fc32.x86_64"
     },
+    "libjose": {
+      "evra": "10-6.fc32.x86_64"
+    },
     "libkcapi": {
       "evra": "1.2.0-3.fc32.x86_64"
     },
@@ -557,6 +575,9 @@
     },
     "libldb": {
       "evra": "2.1.4-1.fc32.x86_64"
+    },
+    "libluksmeta": {
+      "evra": "9-7.fc32.x86_64"
     },
     "libmaxminddb": {
       "evra": "1.4.2-1.fc32.x86_64"
@@ -583,7 +604,7 @@
       "evra": "1.0.1-17.fc32.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.5.1-2.rc3.fc32.x86_64"
+      "evra": "1:2.5.1-4.rc4.fc32.x86_64"
     },
     "libnftnl": {
       "evra": "1.1.5-2.fc32.x86_64"
@@ -649,7 +670,7 @@
       "evra": "2.35.2-1.fc32.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.12.6-0.fc32.x86_64"
+      "evra": "2:4.12.7-0.fc32.x86_64"
     },
     "libsolv": {
       "evra": "0.7.14-1.fc32.x86_64"
@@ -658,10 +679,10 @@
       "evra": "1.45.5-3.fc32.x86_64"
     },
     "libssh": {
-      "evra": "0.9.4-3.fc32.x86_64"
+      "evra": "0.9.5-1.fc32.x86_64"
     },
     "libssh-config": {
-      "evra": "0.9.4-3.fc32.noarch"
+      "evra": "0.9.5-1.fc32.noarch"
     },
     "libsss_certmap": {
       "evra": "2.3.1-2.fc32.x86_64"
@@ -721,13 +742,13 @@
       "evra": "0.3.0-9.fc32.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.12.6-0.fc32.x86_64"
+      "evra": "2:4.12.7-0.fc32.x86_64"
     },
     "libxcrypt": {
       "evra": "4.4.17-1.fc32.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.10-3.fc32.x86_64"
+      "evra": "2.9.10-7.fc32.x86_64"
     },
     "libyaml": {
       "evra": "0.2.2-3.fc32.x86_64"
@@ -739,10 +760,10 @@
       "evra": "2.5.1-26.fc32.x86_64"
     },
     "linux-firmware": {
-      "evra": "20200817-111.fc32.noarch"
+      "evra": "20200918-112.fc32.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20200817-111.fc32.noarch"
+      "evra": "20200918-112.fc32.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.25-1.fc32.x86_64"
@@ -755,6 +776,9 @@
     },
     "lua-libs": {
       "evra": "5.3.5-8.fc32.x86_64"
+    },
+    "luksmeta": {
+      "evra": "9-7.fc32.x86_64"
     },
     "lvm2": {
       "evra": "2.03.09-1.fc32.x86_64"
@@ -805,10 +829,13 @@
       "evra": "0.52.21-6.fc32.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.5.1-2.rc3.fc32.x86_64"
+      "evra": "1:2.5.1-4.rc4.fc32.x86_64"
     },
     "nftables": {
       "evra": "1:0.9.3-3.fc32.x86_64"
+    },
+    "nmap-ncat": {
+      "evra": "2:7.80-4.fc32.x86_64"
     },
     "npth": {
       "evra": "1.6-4.fc32.x86_64"
@@ -826,7 +853,7 @@
       "evra": "6.9.5-1.rev1.fc32.x86_64"
     },
     "openldap": {
-      "evra": "2.4.47-4.fc32.x86_64"
+      "evra": "2.4.47-5.fc32.x86_64"
     },
     "openssh": {
       "evra": "8.3p1-3.fc32.x86_64"
@@ -868,10 +895,10 @@
       "evra": "8.44-1.fc32.x86_64"
     },
     "pcre2": {
-      "evra": "10.35-4.fc32.x86_64"
+      "evra": "10.35-6.fc32.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.35-4.fc32.noarch"
+      "evra": "10.35-6.fc32.noarch"
     },
     "pigz": {
       "evra": "2.4-6.fc32.x86_64"
@@ -907,7 +934,7 @@
       "evra": "1.16-19.fc32.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.15-7.fc32.x86_64"
+      "evra": "3.3.16-1.fc32.x86_64"
     },
     "protobuf-c": {
       "evra": "1.3.2-2.fc32.x86_64"
@@ -934,10 +961,10 @@
       "evra": "4.15.1-3.fc32.1.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2020.4-1.fc32.x86_64"
+      "evra": "2020.5-1.fc32.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2020.4-1.fc32.x86_64"
+      "evra": "2020.5-1.fc32.x86_64"
     },
     "rpm-plugin-selinux": {
       "evra": "4.15.1-3.fc32.1.x86_64"
@@ -949,13 +976,13 @@
       "evra": "2:1.0.0-144.dev.gite6555cc.fc32.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.12.6-0.fc32.x86_64"
+      "evra": "2:4.12.7-0.fc32.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.12.6-0.fc32.noarch"
+      "evra": "2:4.12.7-0.fc32.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.12.6-0.fc32.x86_64"
+      "evra": "2:4.12.7-0.fc32.x86_64"
     },
     "sed": {
       "evra": "4.5-5.fc32.x86_64"
@@ -1027,25 +1054,25 @@
       "evra": "2.3.1-2.fc32.x86_64"
     },
     "sudo": {
-      "evra": "1.9.0-0.1.b4.fc32.x86_64"
+      "evra": "1.9.2-1.fc32.x86_64"
     },
     "systemd": {
-      "evra": "245.7-1.fc32.x86_64"
+      "evra": "245.8-2.fc32.x86_64"
     },
     "systemd-container": {
-      "evra": "245.7-1.fc32.x86_64"
+      "evra": "245.8-2.fc32.x86_64"
     },
     "systemd-libs": {
-      "evra": "245.7-1.fc32.x86_64"
+      "evra": "245.8-2.fc32.x86_64"
     },
     "systemd-pam": {
-      "evra": "245.7-1.fc32.x86_64"
+      "evra": "245.8-2.fc32.x86_64"
     },
     "systemd-rpm-macros": {
-      "evra": "245.7-1.fc32.noarch"
+      "evra": "245.8-2.fc32.noarch"
     },
     "systemd-udev": {
-      "evra": "245.7-1.fc32.x86_64"
+      "evra": "245.8-2.fc32.x86_64"
     },
     "tar": {
       "evra": "2:1.32-5.fc32.x86_64"
@@ -1055,6 +1082,12 @@
     },
     "toolbox": {
       "evra": "0.0.95-1.fc32.x86_64"
+    },
+    "tpm2-tools": {
+      "evra": "4.1.3-1.fc32.x86_64"
+    },
+    "tpm2-tss": {
+      "evra": "2.4.2-1.fc32.x86_64"
     },
     "tzdata": {
       "evra": "2020a-1.fc32.noarch"
@@ -1097,16 +1130,16 @@
     }
   },
   "metadata": {
-    "generated": "2020-09-07T21:06:53Z",
+    "generated": "2020-09-23T21:06:35Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2020-04-22T22:22:36Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2020-09-03T22:22:37Z"
+        "generated": "2020-09-23T16:12:22Z"
       },
       "fedora-updates": {
-        "generated": "2020-09-07T16:50:53Z"
+        "generated": "2020-09-23T17:02:24Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -109,16 +109,16 @@
       "evra": "2:2.0.21-2.fc32.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.19-2.fc32.noarch"
+      "evra": "0.18.2-1.fc32.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.19-2.fc32.noarch"
+      "evra": "0.18.2-1.fc32.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.19-2.fc32.noarch"
+      "evra": "0.18.2-1.fc32.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.19-2.fc32.noarch"
+      "evra": "0.18.2-1.fc32.noarch"
     },
     "container-selinux": {
       "evra": "2:2.145.0-1.fc32.noarch"

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -22,6 +22,8 @@ machineid-compat: false
 packages:
   - ignition
   - dracut-network
+  # for encryption
+  - clevis clevis-luks clevis-dracut clevis-systemd
 
 remove-from-packages:
   # We don't want systemd-firstboot.service. It conceptually conflicts with

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/live-generator
@@ -69,6 +69,7 @@ Before=initrd-root-fs.target
 What=/root.squashfs
 Where=/sysroot
 Type=squashfs
+Options=loop
 EOF
 else
     # And in this case, it's on the ISO
@@ -87,9 +88,12 @@ EOF
 
 [Unit]
 DefaultDependencies=false
-After=initrd-root-device.target
 # HACK for https://github.com/coreos/fedora-coreos-config/issues/437
-After=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
+# Note that `man bootup` implies that initrd-root-device is After=basic.target
+# but that appears to not be the case.  We explicitly order after sysinit.target
+After=sysinit.target
+After=initrd-root-device.target
 Before=initrd-root-fs.target
 
 [Mount]
@@ -114,7 +118,7 @@ Type=squashfs
 # Offset of the squashfs within the rootfs cpio.  Assumes newc format
 # and that a file named "root.squashfs" is the first member.  This offset
 # is checked by coreos-assembler cmd-buildextend-live at build time.
-Options=offset=124
+Options=loop,offset=124
 EOF
 fi
 
@@ -165,9 +169,6 @@ After=sysroot.mount
 # And after OSTree has set up the chroot() equivalent
 After=ostree-prepare-root.service
 
-# We're part of assembling the root fs
-Before=initrd-root-fs.target
-
 [Service]
 Type=oneshot
 RemainAfterExit=yes
@@ -183,6 +184,8 @@ DefaultDependencies=false
 # Make sure our tmpfs is available
 Requires=sysroot-xfs-ephemeral-setup.service
 After=sysroot-xfs-ephemeral-setup.service
+# We're part of assembling the root fs
+Before=initrd-root-fs.target
 EOF
 }
 

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -2,9 +2,9 @@
 enable coreos-growpart.service
 # console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
 enable console-login-helper-messages-issuegen.path
-enable console-login-helper-messages-issuegen.service
 enable console-login-helper-messages-motdgen.path
-enable console-login-helper-messages-motdgen.service
+enable console-login-helper-messages-gensnippet-os-release.service
+enable console-login-helper-messages-gensnippet-ssh-keys.service
 # CA certs (probably to add to base fedora eventually)
 enable coreos-update-ca-trust.service
 # This one is from https://github.com/coreos/ignition-dracut
@@ -12,6 +12,8 @@ enable ignition-firstboot-complete.service
 # Boot checkin services for cloud providers.
 enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service
+# Target to write SSH key snippets from cloud providers.
+enable afterburn-sshkeys.target
 # Service to write SSH key snippets from cloud providers.
 enable afterburn-sshkeys@.service
 # Update agent

--- a/overlay.d/05core/usr/share/licenses/fedora-coreos-config/LICENSE
+++ b/overlay.d/05core/usr/share/licenses/fedora-coreos-config/LICENSE
@@ -1,0 +1,21 @@
+Copyright 2018 Fedora CoreOS Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/overlay.d/05core/usr/share/licenses/fedora-coreos-config/README.md
+++ b/overlay.d/05core/usr/share/licenses/fedora-coreos-config/README.md
@@ -1,0 +1,17 @@
+# fedora-coreos-config
+
+Today most components of Fedora CoreOS are built as RPMs; this
+is the main exception.  fedora-coreos-config is "architecture-independent glue"
+and the overhead of building an RPM for each change is onerous.
+
+It's also *the* central point of management (e.g. it contains lockfiles), so having it be
+an RPM too would become circular.  Instead, coreos-assembler directly consumes it.
+
+The upstream git repository is: https://github.com/coreos/fedora-coreos-config
+
+From a running system, to find the source commit use:
+```
+$ rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."coreos-assembler.config-gitrev"'
+c8dbed9ce223bf86737c82dd763670c8a34e950f
+$
+```

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -2,7 +2,6 @@
 # no Ignition config is provided.
 [Unit]
 Description=Check if Ignition config is provided
-Before=console-login-helper-messages-issuegen.service
 # Only perform checks on the first (Ignition) boot as they are
 # mostly useful only on that boot. This ensures systems started
 # before Ignition/Afterburn started logging structured data don't

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -2,12 +2,10 @@
 # by Ignition/Afterburn
 [Unit]
 Description=Check that ssh-keys are added by Afterburn/Ignition
-Before=console-login-helper-messages-issuegen.service
-# https://github.com/coreos/afterburn/issues/417 is created
-# to track the issue that would allow other units to synchronize 
-# around any instance of `afterburn-sshkeys@` and not just the 
-# `core` user.
-After=afterburn-sshkeys@core.service
+# It allows other units to synchronize around any instance
+# of `afterburn-sshkeys@` and not just the `core` user.
+# See https://github.com/coreos/afterburn/pull/481
+After=afterburn-sshkeys.target
 # Only perform checks on the first (Ignition) boot as they are
 # mostly useful only on that boot. This ensures systems started
 # before Ignition/Afterburn started logging structured data don't

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -52,6 +52,10 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
 fi
 ok conditional initrd networking
 
+if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
+    fatal missing LICENSE
+fi
+
 # check that no files are unlabeled
 unlabeled=$(find /var /etc -context '*:unlabeled_t:*')
 if [ -n "${unlabeled}" ]; then
@@ -60,3 +64,10 @@ if [ -n "${unlabeled}" ]; then
     exit 1
 fi
 ok no files with unlabeled_t SELinux label
+
+# make sure we stick with bdb until we're ready to move to sqlite
+# https://github.com/coreos/fedora-coreos-tracker/issues/623
+if [ ! -f /usr/share/rpm/Packages ]; then
+    fatal "Didn't find bdb file /usr/share/rpm/Packages"
+fi
+ok rpmdb is bdb

--- a/tests/kola/root-reprovision/filesystem-only/config.ign
+++ b/tests/kola/root-reprovision/filesystem-only/config.ign
@@ -1,0 +1,15 @@
+{
+    "ignition": {
+        "version": "3.0.0"
+    },
+    "storage": {
+        "filesystems": [
+            {
+                "device": "/dev/disk/by-label/root",
+                "wipeFilesystem": true,
+                "format": "ext4",
+                "label": "root"
+            }
+        ]
+    }
+}

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096}
+set -xeuo pipefail
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ $fstype == ext4 ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that the partition was grown
+      if [ ! -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart did not run"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac

--- a/tests/kola/root-reprovision/luks/config.ign
+++ b/tests/kola/root-reprovision/luks/config.ign
@@ -1,0 +1,26 @@
+{
+  "ignition": {
+    "version": "3.2.0-experimental"
+  },
+  "storage": {
+    "luks": [
+      {
+        "name": "myluksdev",
+        "device": "/dev/disk/by-partlabel/root",
+        "clevis": {
+          "tpm2": true
+        },
+        "label": "root",
+        "wipeVolume": true
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/mapper/myluksdev",
+        "format": "xfs",
+        "wipeFilesystem": true,
+        "label": "root"
+      }
+    ]
+  }
+}

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096}
+set -xeuo pipefail
+
+srcdev=$(findmnt -nvr / -o SOURCE)
+[[ ${srcdev} == /dev/mapper/myluksdev ]]
+
+blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
+[[ ${blktype} == crypt ]]
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that growpart didn't run
+      if [ -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart ran"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      grep rd.luks.name= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac

--- a/tests/kola/root-reprovision/raid1/config.ign
+++ b/tests/kola/root-reprovision/raid1/config.ign
@@ -1,0 +1,25 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "raid": [
+      {
+        "devices": [
+          "/dev/disk/by-id/virtio-disk1",
+          "/dev/disk/by-id/virtio-disk2"
+        ],
+        "level": "raid1",
+        "name": "foobar"
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/md/foobar",
+        "format": "xfs",
+        "wipeFilesystem": true,
+        "label": "root"
+      }
+    ]
+  }
+}

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+set -xeuo pipefail
+
+srcdev=$(findmnt -nvr / -o SOURCE)
+[[ ${srcdev} == $(realpath /dev/md/foobar) ]]
+
+blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
+[[ ${blktype} == raid1 ]]
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that growpart didn't run
+      if [ -e /run/coreos-growpart.stamp ]; then
+          echo "coreos-growpart ran"
+          exit 1
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      grep rd.md.uuid= /proc/cmdline
+      ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
This additionally pins console-login-helper-messages to 0.18.2-1 in order to
avoid hitting `gensnippet_if` segfaults, as per https://github.com/coreos/fedora-coreos-streams/issues/200#issuecomment-703334791.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1884236