### PR TITLE
manifests: move the permissions on chrony files to fedora-coreos-base.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -47,13 +47,3 @@ postprocess:
     mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
-    # In order to make chrony use NTP settings from DHCP 
-    # (https://github.com/coreos/fedora-coreos-config/pull/412), we need 
-    # to chmod the following files to unset the writable permissions.
-    # Git tracks only the executable bit of the permissions so when
-    # the files get pulled locally they could have the group write bit set.
-    # When that happens we get an error like:
-    # `Cannot execute '/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp': writable by group or other`
-    chmod 755 /etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
-    chmod 755 /usr/libexec/coreos-chrony-helper
-    chmod 755 /usr/lib/systemd/system-generators/coreos-platform-chrony

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -69,6 +69,20 @@ postprocess:
     setsebool -P -N container_use_cephfs on  # RHBZ#1692369
     setsebool -P -N virt_use_samba on  # RHBZ#1754825
 
+  # No tracker issue filed. This handled build environment variation.
+  # In order to make chrony use NTP settings from DHCP 
+  # (https://github.com/coreos/fedora-coreos-config/pull/412), we need 
+  # to chmod the following files to unset the writable permissions.
+  # Git tracks only the executable bit of the permissions so when
+  # the files get pulled locally they could have the group write bit set.
+  # When that happens we get an error like:
+  # `Cannot execute '/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp': writable by group or other`
+  - |
+    #!/usr/bin/env bash
+    chmod 755 /etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
+    chmod 755 /usr/libexec/coreos-chrony-helper
+    chmod 755 /usr/lib/systemd/system-generators/coreos-platform-chrony
+
 packages:
   # Security
   - selinux-policy-targeted


### PR DESCRIPTION
This code was originally introduced in 0352445.

We need to move it out of manifest.yaml because that file doesn't get
synced across branches. We want it to get synced everywhere.