### PR TITLE
tests: add ext.config.root-reprovision to denylist for f33

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,3 +12,10 @@
   streams:
     - next
     - next-devel
+# The ext.config.root-reprovision* tests are failing on Fedora 33
+# for now. Exclude running the test on `next` and `next-devel`.
+- pattern: ext.config.root-reprovision.*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/644
+  streams:
+    - next
+    - next-devel


### PR DESCRIPTION
The ext.config.root-reprovision* tests are failing on Fedora 33
for now. Exclude running the test on `next` and `next-devel`.

https://github.com/coreos/fedora-coreos-tracker/issues/644