### PR TITLE
ci: checkout repo to the config/ directory

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,13 +1,13 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
 cosaPod {
-    checkout scm
+    checkoutToDir(scm, 'config')
 
-    shwrap("ci/validate")
+    shwrap("cd config && ci/validate")
 
     shwrap("""
         mkdir -p /srv/fcos && cd /srv/fcos
-        cosa init ${env.WORKSPACE}
+        cosa init ${env.WORKSPACE}/config
         curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/master/scripts/download-overrides.py
         python3 download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages


### PR DESCRIPTION
Instead of checking out the repo directly into the workspace, let's get
in the habit of checking it out into a subdirectory to keep things
clean.

This also helps code which look at the name of the directory in which
the repo is checked out, such as kola external host test handling.

This makes use of a new custom step:

https://github.com/coreos/coreos-ci-lib/pull/40