### PR TITLE
manifests: fedora-coreos: add archive repo to FCOS

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -22,3 +22,13 @@ packages:
     evra: 0.20.1-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.20.1-1.fc32.noarch
+  # Fast-track fedora-repos-32-7 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ab02250f9d
+  fedora-repos:
+    evra: 32-7.noarch
+  fedora-repos-ostree:
+    evra: 32-7.noarch
+  fedora-repos-archive:
+    evra: 32-7.noarch
+  fedora-gpg-keys:
+    evra: 32-7.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -22,3 +22,13 @@ packages:
     evra: 0.20.1-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.20.1-1.fc32.noarch
+  # Fast-track fedora-repos-32-7 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ab02250f9d
+  fedora-repos:
+    evra: 32-7.noarch
+  fedora-repos-ostree:
+    evra: 32-7.noarch
+  fedora-repos-archive:
+    evra: 32-7.noarch
+  fedora-gpg-keys:
+    evra: 32-7.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -22,3 +22,13 @@ packages:
     evra: 0.20.1-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.20.1-1.fc32.noarch
+  # Fast-track fedora-repos-32-7 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ab02250f9d
+  fedora-repos:
+    evra: 32-7.noarch
+  fedora-repos-ostree:
+    evra: 32-7.noarch
+  fedora-repos-archive:
+    evra: 32-7.noarch
+  fedora-gpg-keys:
+    evra: 32-7.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -22,3 +22,13 @@ packages:
     evra: 0.20.1-1.fc32.noarch
   console-login-helper-messages-profile:
     evra: 0.20.1-1.fc32.noarch
+  # Fast-track fedora-repos-32-7 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-ab02250f9d
+  fedora-repos:
+    evra: 32-7.noarch
+  fedora-repos-ostree:
+    evra: 32-7.noarch
+  fedora-repos-archive:
+    evra: 32-7.noarch
+  fedora-gpg-keys:
+    evra: 32-7.noarch

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -256,7 +256,7 @@
       "evra": "0.0.4-7.fc32.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "32-6.noarch"
+      "evra": "32-7.noarch"
     },
     "fedora-release-common": {
       "evra": "32-3.noarch"
@@ -265,10 +265,13 @@
       "evra": "32-3.noarch"
     },
     "fedora-repos": {
-      "evra": "32-6.noarch"
+      "evra": "32-7.noarch"
+    },
+    "fedora-repos-archive": {
+      "evra": "32-7.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "32-6.noarch"
+      "evra": "32-7.noarch"
     },
     "file": {
       "evra": "5.38-2.fc32.x86_64"

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -10,6 +10,9 @@ mutate-os-release: "${releasever}"
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree
+  # the archive repo for more reliable package layering
+  # https://github.com/coreos/fedora-coreos-tracker/issues/400
+  - fedora-repos-archive
   # CL ships this.
   - moby-engine
   # User metrics


### PR DESCRIPTION
This is the culmination of a lot of work to make package layering
more reliable. This archive repo provides all packages that have
ever been in the updates repository, which means there should always
be a solution that will depsolve given the existing set of base layer
packages.

Pairing this along with https://github.com/coreos/rpm-ostree/pull/2125
means that we should finally see less of the split base layer vs update
repo problem and see less `Forbidden base package replacements` errors.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/400