### PR TITLE
[next-devel] overrides: Fast-track fedora-repos-33-0.14

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -9,3 +9,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
   podman:
     evra: 2:2.1.1-11.fc33.aarch64
+  # Fast-track fedora-repos-33-0.14 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
+  fedora-repos:
+    evra: 33-0.14.noarch
+  fedora-repos-ostree:
+    evra: 33-0.14.noarch
+  fedora-repos-archive:
+    evra: 33-0.14.noarch
+  fedora-repos-modular:
+    evra: 33-0.14.noarch
+  fedora-gpg-keys:
+    evra: 33-0.14.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -9,3 +9,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
   podman:
     evra: 2:2.1.1-11.fc33.ppc64le
+  # Fast-track fedora-repos-33-0.14 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
+  fedora-repos:
+    evra: 33-0.14.noarch
+  fedora-repos-ostree:
+    evra: 33-0.14.noarch
+  fedora-repos-archive:
+    evra: 33-0.14.noarch
+  fedora-repos-modular:
+    evra: 33-0.14.noarch
+  fedora-gpg-keys:
+    evra: 33-0.14.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -9,3 +9,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
   podman:
     evra: 2:2.1.1-11.fc33.s390x
+  # Fast-track fedora-repos-33-0.14 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
+  fedora-repos:
+    evra: 33-0.14.noarch
+  fedora-repos-ostree:
+    evra: 33-0.14.noarch
+  fedora-repos-archive:
+    evra: 33-0.14.noarch
+  fedora-repos-modular:
+    evra: 33-0.14.noarch
+  fedora-gpg-keys:
+    evra: 33-0.14.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -9,3 +9,15 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
   podman:
     evra: 2:2.1.1-11.fc33.x86_64
+  # Fast-track fedora-repos-33-0.14 to get archive repo
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
+  fedora-repos:
+    evra: 33-0.14.noarch
+  fedora-repos-ostree:
+    evra: 33-0.14.noarch
+  fedora-repos-archive:
+    evra: 33-0.14.noarch
+  fedora-repos-modular:
+    evra: 33-0.14.noarch
+  fedora-gpg-keys:
+    evra: 33-0.14.noarch

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -259,7 +259,7 @@
       "evra": "0.0.4-7.fc33.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "33-0.13.noarch"
+      "evra": "33-0.14.noarch"
     },
     "fedora-release-common": {
       "evra": "33-0.15.noarch"
@@ -271,13 +271,16 @@
       "evra": "33-0.15.noarch"
     },
     "fedora-repos": {
-      "evra": "33-0.13.noarch"
+      "evra": "33-0.14.noarch"
+    },
+    "fedora-repos-archive": {
+      "evra": "33-0.14.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "33-0.13.noarch"
+      "evra": "33-0.14.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "33-0.13.noarch"
+      "evra": "33-0.14.noarch"
     },
     "file": {
       "evra": "5.39-3.fc33.x86_64"


### PR DESCRIPTION
It contains the fedora-repos-archive rpm.

https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb