### PR TITLE
Revert "image.yaml: set osmet-pack-with-cosa-coreinst to true"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -20,11 +20,6 @@ ostree-remote: fedora
 # https://github.com/ostreedev/ostree/issues/1265
 sysroot-readonly: true
 
-# For now, temporarily use the coreos-installer from COSA in order
-# to work around https://github.com/coreos/coreos-assembler/issues/1761
-# when building F33 based FCOS.
-osmet-pack-with-cosa-coreinst: true
-
 # After this, we plan to add support for the Ignition
 # storage/filesystems sections.  (Although one can do
 # that on boot as well)


### PR DESCRIPTION
This reverts commit 838269245977192b9a4e79f2f0df6fbb6e5fcd7c.

We don't need this anymore now that coreos-assembler correctly uses the
target rootfs directly to run coreos-installer (see
https://github.com/coreos/coreos-assembler/pull/1774).