### PR TITLE
40ignition-conf: support .d dir for base config fragments

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/00-core.ign
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/00-core.ign
@@ -1,0 +1,19 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "gecos": "CoreOS Admin",
+        "groups": [
+          "adm",
+          "sudo",
+          "systemd-journal",
+          "wheel"
+        ]
+      }
+    ]
+  }
+}

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/module-setup.sh
@@ -7,6 +7,9 @@ depends() {
 }
 
 install() {
+    mkdir -p "$initdir/usr/lib/ignition/base.d"
+    inst "$moddir/00-core.ign" \
+        "/usr/lib/ignition/base.d/00-core.ign"
     inst "$moddir/base.ign" \
         "/usr/lib/ignition/base.ign"
 }

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/30-afterburn-sshkeys-core.ign
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/30-afterburn-sshkeys-core.ign
@@ -1,0 +1,13 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "afterburn-sshkeys@core.service"
+      }
+    ]
+  }
+}

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/README.md
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/README.md
@@ -1,0 +1,1 @@
+FCOS enables `afterburn-sshkeys@core.service` from `30-afterburn-sshkeys-core.ign`, allowing the user to prevent Ignition from enabling the service with a user config if the user wants to change the username. Unlike FCOS, RHCOS doesn't fetch SSH keys from cloud providers and thus doesn't need `afterburn-sshkeys@core.service`.

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo ignition
+}
+
+install() {
+    mkdir -p "$initdir/usr/lib/ignition/base.d"
+    inst "$moddir/30-afterburn-sshkeys-core.ign" \
+        "/usr/lib/ignition/base.d/30-afterburn-sshkeys-core.ign"
+}


### PR DESCRIPTION
Fixes https://github.com/coreos/ignition/issues/1101
This change is required for https://github.com/coreos/ignition/pull/1108
Ignition PR allows the two distros i.e. RHCOS and FCOS to carry different `base.ign` files with common elements and will provide some flexibility as we start to see more divergence there.