### PR TITLE
overrides: drop podman override

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -5,10 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.aarch64
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.aarch64
-  # Fast-track podman-2.1.1-11.fc33
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
-  podman:
-    evra: 2:2.1.1-11.fc33.aarch64
   # Fast-track fedora-repos-33-0.14 to get archive repo
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
   fedora-repos:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -5,10 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.ppc64le
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.ppc64le
-  # Fast-track podman-2.1.1-11.fc33
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
-  podman:
-    evra: 2:2.1.1-11.fc33.ppc64le
   # Fast-track fedora-repos-33-0.14 to get archive repo
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
   fedora-repos:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -5,10 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.s390x
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.s390x
-  # Fast-track podman-2.1.1-11.fc33
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
-  podman:
-    evra: 2:2.1.1-11.fc33.s390x
   # Fast-track fedora-repos-33-0.14 to get archive repo
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
   fedora-repos:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -5,10 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.x86_64
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.x86_64
-  # Fast-track podman-2.1.1-11.fc33
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-99d3d89771
-  podman:
-    evra: 2:2.1.1-11.fc33.x86_64
   # Fast-track fedora-repos-33-0.14 to get archive repo
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
   fedora-repos:


### PR DESCRIPTION
The update was unpushed upstream because it re-added varlink support.
The next update upstream podman-2.1.1-12.fc33 re-disables it and is
the same as podman-2.1.1-10.fc33. We'll just drop the override and
carry whatever is in the repos (10 or 12 are equivalent).