### PR TITLE
manifest: Drop ostree-grub2 from ppc64le bootloader

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -17,7 +17,7 @@ packages-aarch64:
 packages-armhfp:
   - extlinux-bootloader
 packages-ppc64le:
-  - grub2 ostree-grub2
+  - grub2
 packages-s390x:
   - s390utils-base
 packages-x86_64:


### PR DESCRIPTION
We temporarily re-added this in
1f399c3019169bf3f72cf512af1f06b8d3f8ba81
But we've long since dropped Anaconda on all architectures.

In particular this bit applies for ppc64le:
https://github.com/coreos/coreos-assembler/blob/a73ad29717e9f16e321b9c0b47cb7eeda31ba330/src/create_disk.sh#L314

Note though this is only true for FCOS; for RHCOS
we still ship ostree-grub2 because we need to handle
4.1/4.2 bootimages sadly.