### PR TITLE
manifests/bootloader: Drop armhfp

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -14,8 +14,6 @@ packages:
 # bootloader
 packages-aarch64:
   - grub2-efi-aa64 efibootmgr shim
-packages-armhfp:
-  - extlinux-bootloader
 packages-ppc64le:
   - grub2 ostree-grub2
 packages-s390x:


### PR DESCRIPTION
We don't produce 32 bit ARM images and are unlikely to anytime
in the near future.  Drop this bit which was cargo culted from
the Atomic Host manifests I believe.

Motivated by looking at bootupd work in: https://github.com/coreos/bootupd/issues/50