### PR TITLE
overlay: Enable bootupd.socket by default

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -20,5 +20,5 @@ enable afterburn-sshkeys.target
 enable zincati.service
 # Testing aid
 enable coreos-liveiso-success.service
-# See bootupd.yaml - not enabled by default right now
-# enable bootupd.socket
+# See bootupd.yaml
+enable bootupd.socket

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -84,13 +84,10 @@ case "$(arch)" in
         if runuser -u core -- ls /boot/efi &>/dev/null; then
             fatal "Was able to access /boot/efi as non-root"
         fi
-        if systemctl is-enabled bootupd.socket; then
-            fatal "Not expecting bootupd.socket to be enabled"
-        fi
         # This is just a basic sanity check; at some point we
         # will implement "project-owned tests run in the pipeline"
-        # and be able to run the existing bootupd tests.
-        systemctl start bootupd.socket
+        # and be able to run the existing bootupd tests:
+        # https://github.com/coreos/fedora-coreos-config/pull/677
         bootupctl status
         ok bootupctl
         ;;


### PR DESCRIPTION
I'm increasingly confident in the testing, so let's enable
the socket by default.

Note that it's still the case that absolutely nothing happens unless
an admin explicitly does a `bootupctl update`.

See also https://github.com/coreos/bootupd/pull/77