### PR TITLE
ignition-ostree-rootfs: use our own tmpfs with size=80%

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,10 +12,3 @@
   streams:
     - next
     - next-devel
-# The ext.config.root-reprovision* tests are failing on Fedora 33
-# for now. Exclude running the test on `next` and `next-devel`.
-- pattern: ext.config.root-reprovision.*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/644
-  streams:
-    - next
-    - next-devel

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
@@ -29,8 +29,7 @@ case "${1:-}" in
         # This one is in a private mount namespace since we're not "offically" mounting
         mount "${rootdisk}" /sysroot
         echo "Restoring rootfs from RAM..."
-        cd "${saved_sysroot}"
-        find . -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
+        find "${saved_sysroot}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
         chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         ;;
     *)

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
@@ -15,3 +15,4 @@ After=systemd-udevd.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs detect
+ExecStop=/usr/libexec/ignition-ostree-dracut-rootfs cleanup

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-detect.service
@@ -14,5 +14,4 @@ After=systemd-udevd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-EnvironmentFile=/run/ignition.env
 ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs detect

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-restore.service
@@ -11,7 +11,6 @@ ConditionPathIsDirectory=/run/ignition-ostree-rootfs
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-EnvironmentFile=/run/ignition.env
 # So we can transiently mount sysroot
 MountFlags=slave
 ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs restore

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-rootfs-save.service
@@ -12,7 +12,6 @@ After=coreos-gpt-setup.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-EnvironmentFile=/run/ignition.env
 # So we can transiently mount sysroot
 MountFlags=slave
 ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs save


### PR DESCRIPTION
In f33 systemd, /run is now mounted with a smaller size cap instead of
the default 50%:

systemd/systemd#15424

This was causing the rootfs reprovisioning code to run out of space.

Let's use this as an opportunity to be more explicit about the memory
semantics we want. Notably, we don't care about starving the host here;
either we have enough memory to reprovision the rootfs, or we should
fail. So let's just mount our own tmpfs with `size=80%`.

This in turn means that machines need even *less* RAM for rootfs
reprovisioning to work. A local test shows 2.5G seems to be enough.
Though let's keep recommending 4G in the docs to be safe.

A minor thing this also fixes is that we now clean up a leftover
directory and file from `/run` before we switchroot.

Closes: coreos/fedora-coreos-tracker#644