### PR TITLE
manifests: fedora-coreos-base: add zram-generator

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1130,6 +1130,9 @@
     },
     "zlib": {
       "evra": "1.2.11-21.fc32.x86_64"
+    },
+    "zram-generator": {
+      "evra": "0.2.0-1.fc32.x86_64"
     }
   },
   "metadata": {

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -159,6 +159,9 @@ packages:
   - jq
   # nvme-cli for managing nvme disks
   - nvme-cli
+  # zram-generator (but not zram-generator-defaults) for F33 change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/509
+  - zram-generator
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -115,3 +115,11 @@ if [ ! -f /usr/share/rpm/Packages ]; then
     fatal "Didn't find bdb file /usr/share/rpm/Packages"
 fi
 ok rpmdb is bdb
+
+# make sure we don't default to having swap on zram
+# https://github.com/coreos/fedora-coreos-tracker/issues/509
+# https://github.com/coreos/fedora-coreos-config/pull/687
+if [ -e /dev/zram0 ]; then
+    fatal "zram0 swap device set up on default install"
+fi
+ok no zram swap by default

--- a/tests/kola/swap-on-zram/config.fcc
+++ b/tests/kola/swap-on-zram/config.fcc
@@ -1,0 +1,10 @@
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    - path: /etc/systemd/zram-generator.conf
+      mode: 0644
+      contents:
+        inline: |
+          # This config file enables a /dev/zram0 device with the default settings
+          [zram0]

--- a/tests/kola/swap-on-zram/test.sh
+++ b/tests/kola/swap-on-zram/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This test makes sure that swap on zram devices can be set up
+# using the zram-generator as defined in the docs at
+# https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-configure-swaponzram/
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if ! grep -q 'zram0' /proc/swaps; then
+    fatal "expected zram0 to be set up"
+fi
+ok "swap on zram was set up correctly"


### PR DESCRIPTION
This was part of a F33 proposed change. We'll include the generator
but not the defaults subpackage because we don't want it enabled by
default just yet. We'll add docs for users instructing them how to
enable it by dropping down a file via Ignition/FCCT. The following
snippet is an example:

```
variant: fcos
version: 1.1.0
passwd:
  users:
    - name: core
      ssh_authorized_keys:
        - ssh-rsa AAAAB user@example.com
storage:
  files:
    - path: /etc/systemd/zram-generator.conf
      mode: 0644
      contents:
        inline: |
          # This config file enables a /dev/zram0 device with the default settings
          [zram0]
```

Closes https://github.com/coreos/fedora-coreos-tracker/issues/509