### PR TITLE
kola-denylist: disable root-reprovision.luks while releasing

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,3 +12,15 @@
   streams:
     - next
     - next-devel
+# The ext.config.root-reprovision.luks test is targeting the 
+# 3.2.0-experimental Ignition spec which is currently being
+# stabilized. Disable for now until the package is bumped and the
+# test is updated to use the 3.2.0 spec to prevent CI lockstepping.
+- pattern: ext.config.root-reprovision.luks
+  tracker: https://github.com/coreos/ignition/issues/1110
+  streams:
+    - next
+    - next-devel
+    - testing
+    - testing-devel
+    - stable


### PR DESCRIPTION
Disable the ext.config.root-reprovision.luks test while an Ignition
release is being performed containing a spec stabilization. This
unblocks Ignition CI (which is currently failing) and prevents failures
in this repository or coreos-assembler when bumping the package /
vendor.