### PR TITLE
manifests: fedora-coreos-base: add back in podman-plugins, dnsmasq

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -216,6 +216,9 @@
     "diffutils": {
       "evra": "3.7-4.fc32.x86_64"
     },
+    "dnsmasq": {
+      "evra": "2.81-4.fc32.x86_64"
+    },
     "dosfstools": {
       "evra": "4.1-10.fc32.x86_64"
     },
@@ -919,6 +922,9 @@
       "evra": "1.6.3-3.fc32.x86_64"
     },
     "podman": {
+      "evra": "2:2.1.1-7.fc32.x86_64"
+    },
+    "podman-plugins": {
       "evra": "2:2.1.1-7.fc32.x86_64"
     },
     "policycoreutils": {

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -82,6 +82,14 @@ postprocess:
     EOF
     fi
 
+  # Mask dnsmasq. We include dnsmasq for host services that use the dnsmasq
+  # binary but intentionally mask the systemd service so users can't easily
+  # use it as an external dns server. We prefer they use a container for that.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/519
+  - |
+    #!/usr/bin/env bash
+    systemctl mask dnsmasq.service
+
 packages:
   # Security
   - selinux-policy-targeted
@@ -98,6 +106,9 @@ packages:
   # Containers
   - podman skopeo runc systemd-container catatonit
   - fuse-overlayfs slirp4netns
+  # name resolution for podman containers
+  # https://github.com/coreos/fedora-coreos-tracker/issues/519
+  - podman-plugins dnsmasq
   # Remote IPC for podman
   - libvarlink-util
   # Networking

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -123,3 +123,10 @@ if [ -e /dev/zram0 ]; then
     fatal "zram0 swap device set up on default install"
 fi
 ok no zram swap by default
+
+# make sure dnsmasq is masked
+# https://github.com/coreos/fedora-coreos-tracker/issues/519#issuecomment-705140528
+if [ $(systemctl is-enabled dnsmasq.service) != 'masked' ]; then
+    fatal "dnsmasq.service systemd unit should be masked"
+fi
+ok "dnsmasq.service systemd unit is masked"


### PR DESCRIPTION
We've found that there is some demand for host applications (podman,
NetworkManager, etc) using dnsmasq the binary for some various utility
operations. Let's add it back to the base so those host applications
can use the binary but let's mask the systemd service because we really
prefer if users are going to be hosting a DNS server for external
clients they use a container for that.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/519