### PR TITLE
[next-devel] lockfiles: drop graduated override fedora-repos

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -5,18 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.aarch64
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.aarch64
-  # Fast-track fedora-repos-33-0.14 to get archive repo
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
-  fedora-repos:
-    evra: 33-0.14.noarch
-  fedora-repos-ostree:
-    evra: 33-0.14.noarch
-  fedora-repos-archive:
-    evra: 33-0.14.noarch
-  fedora-repos-modular:
-    evra: 33-0.14.noarch
-  fedora-gpg-keys:
-    evra: 33-0.14.noarch
   # Fast-track rust-afterburn-4.5.1-3.fc33 for SSH key fetching on OpenStack
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9b29bc5487
   afterburn:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -5,18 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.ppc64le
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.ppc64le
-  # Fast-track fedora-repos-33-0.14 to get archive repo
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
-  fedora-repos:
-    evra: 33-0.14.noarch
-  fedora-repos-ostree:
-    evra: 33-0.14.noarch
-  fedora-repos-archive:
-    evra: 33-0.14.noarch
-  fedora-repos-modular:
-    evra: 33-0.14.noarch
-  fedora-gpg-keys:
-    evra: 33-0.14.noarch
   # Fast-track rust-afterburn-4.5.1-3.fc33 for SSH key fetching on OpenStack
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9b29bc5487
   afterburn:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -5,18 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.s390x
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.s390x
-  # Fast-track fedora-repos-33-0.14 to get archive repo
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
-  fedora-repos:
-    evra: 33-0.14.noarch
-  fedora-repos-ostree:
-    evra: 33-0.14.noarch
-  fedora-repos-archive:
-    evra: 33-0.14.noarch
-  fedora-repos-modular:
-    evra: 33-0.14.noarch
-  fedora-gpg-keys:
-    evra: 33-0.14.noarch
   # Fast-track rust-afterburn-4.5.1-3.fc33 for SSH key fetching on OpenStack
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9b29bc5487
   afterburn:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -5,18 +5,6 @@ packages:
     evra: 0.7.0-4.fc33.x86_64
   coreos-installer-bootinfra:
     evra: 0.7.0-4.fc33.x86_64
-  # Fast-track fedora-repos-33-0.14 to get archive repo
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-868d76a5eb
-  fedora-repos:
-    evra: 33-0.14.noarch
-  fedora-repos-ostree:
-    evra: 33-0.14.noarch
-  fedora-repos-archive:
-    evra: 33-0.14.noarch
-  fedora-repos-modular:
-    evra: 33-0.14.noarch
-  fedora-gpg-keys:
-    evra: 33-0.14.noarch
   # Fast-track rust-afterburn-4.5.1-3.fc33 for SSH key fetching on OpenStack
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-9b29bc5487
   afterburn:

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -22,10 +22,10 @@
       "evra": "0.9.0-4.fc33.x86_64"
     },
     "afterburn": {
-      "evra": "4.5.1-1.fc33.x86_64"
+      "evra": "4.5.1-3.fc33.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "4.5.1-1.fc33.x86_64"
+      "evra": "4.5.1-3.fc33.x86_64"
     },
     "alternatives": {
       "evra": "1.14-3.fc33.x86_64"
@@ -219,6 +219,9 @@
     "dmidecode": {
       "evra": "1:3.2-8.fc33.x86_64"
     },
+    "dnsmasq": {
+      "evra": "2.82-3.fc33.x86_64"
+    },
     "dosfstools": {
       "evra": "4.1-12.fc33.x86_64"
     },
@@ -259,28 +262,28 @@
       "evra": "0.0.4-7.fc33.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "33-0.14.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "33-0.15.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "33-0.15.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "33-0.15.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-repos": {
-      "evra": "33-0.14.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "33-0.14.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "33-0.14.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "33-0.14.noarch"
+      "evra": "33-1.noarch"
     },
     "file": {
       "evra": "5.39-3.fc33.x86_64"
@@ -349,7 +352,7 @@
       "evra": "2.66.0-1.fc33.x86_64"
     },
     "glib2": {
-      "evra": "2.66.1-1.fc33.x86_64"
+      "evra": "2.66.1-3.fc33.x86_64"
     },
     "glibc": {
       "evra": "2.32-1.fc33.x86_64"
@@ -406,7 +409,7 @@
       "evra": "0.340-1.fc33.noarch"
     },
     "ignition": {
-      "evra": "2.6.0-2.git947598e.fc33.x86_64"
+      "evra": "2.7.0-1.git5be43fd.fc33.x86_64"
     },
     "iproute": {
       "evra": "5.8.0-1.fc33.x86_64"
@@ -466,13 +469,13 @@
       "evra": "2.3.0-2.fc33.noarch"
     },
     "kernel": {
-      "evra": "5.8.14-300.fc33.x86_64"
+      "evra": "5.8.15-301.fc33.x86_64"
     },
     "kernel-core": {
-      "evra": "5.8.14-300.fc33.x86_64"
+      "evra": "5.8.15-301.fc33.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.8.14-300.fc33.x86_64"
+      "evra": "5.8.15-301.fc33.x86_64"
     },
     "keyutils": {
       "evra": "1.6-5.fc33.x86_64"
@@ -990,6 +993,9 @@
     "podman": {
       "evra": "2:2.1.1-10.fc33.x86_64"
     },
+    "podman-plugins": {
+      "evra": "2:2.1.1-10.fc33.x86_64"
+    },
     "policycoreutils": {
       "evra": "3.1-4.fc33.x86_64"
     },
@@ -1162,7 +1168,7 @@
       "evra": "1.31-2.fc33.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.95-1.fc33.x86_64"
+      "evra": "0.0.96-1.fc33.x86_64"
     },
     "tpm2-tools": {
       "evra": "4.3.0-1.fc33.x86_64"
@@ -1208,16 +1214,19 @@
     },
     "zlib": {
       "evra": "1.2.11-22.fc33.x86_64"
+    },
+    "zram-generator": {
+      "evra": "0.2.0-4.fc33.x86_64"
     }
   },
   "metadata": {
-    "generated": "2020-10-13T21:06:25Z",
+    "generated": "2020-10-19T13:35:27Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2020-10-13T19:09:20Z"
+        "generated": "2020-10-15T21:25:13Z"
       },
       "fedora-next": {
-        "generated": "2020-10-13T10:53:44Z"
+        "generated": "2020-10-19T10:52:41Z"
       },
       "fedora-updates": {
         "generated": "2018-02-20T19:18:14Z"


### PR DESCRIPTION
This is causing dependency resolution issues in `bump-lockfile` because
the latest `fedora-release` relies on the latest `fedora-repos`.