### PR TITLE
coreos-update-ca-trust: order before first-boot-complete.target

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/coreos-update-ca-trust.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-update-ca-trust.service
@@ -6,6 +6,14 @@
 [Unit]
 Description=Run update-ca-trust
 ConditionFirstBoot=true
+# All services which use ConditionFirstBoot=yes should use
+# Before=first-boot-complete.target, which is a target that
+# was introduced in https://github.com/systemd/systemd/issues/4511
+# and hasn't propagated everywhere yet. Once the target propagates
+# everywhere, we can drop the systemd-machine-id-commit.service
+# from the Before= line.
+Before=first-boot-complete.target systemd-machine-id-commit.service
+Wants=first-boot-complete.target
 ConditionDirectoryNotEmpty=/etc/pki/ca-trust/source/anchors/
 # We want to run quite early, in particular before anything
 # that may speak TLS to external services.  In the future,


### PR DESCRIPTION
Otherwise, it's possible we'll never run if the system is rebooted after
`systemd-machine-id-commit.service` but before this unit.

This will be recommended by systemd starting from:
https://github.com/systemd/systemd/pull/16939