### PR TITLE
[next-devel] overrides: fast-track selinux-policy 3.14.6-29

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,3 +15,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-8efd8baff0
   ignition:
     evra: 2.7.0-1.git5be43fd.fc33.aarch64
+  # Related to https://github.com/coreos/fedora-coreos-tracker/issues/643
+  # Fast-track SELinux Policy to fix read access issue with chronyd
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-5cd3fad6d5
+  selinux-policy:
+    evra: 3.14.6-29.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-29.fc33.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,3 +15,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-8efd8baff0
   ignition:
     evra: 2.7.0-1.git5be43fd.fc33.ppc64le
+  # Related to https://github.com/coreos/fedora-coreos-tracker/issues/643
+  # Fast-track SELinux Policy to fix read access issue with chronyd
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-5cd3fad6d5
+  selinux-policy:
+    evra: 3.14.6-29.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-29.fc33.noarch

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,3 +15,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-8efd8baff0
   ignition:
     evra: 2.7.0-1.git5be43fd.fc33.s390x
+  # Related to https://github.com/coreos/fedora-coreos-tracker/issues/643
+  # Fast-track SELinux Policy to fix read access issue with chronyd
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-5cd3fad6d5
+  selinux-policy:
+    evra: 3.14.6-29.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-29.fc33.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,3 +15,10 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-8efd8baff0
   ignition:
     evra: 2.7.0-1.git5be43fd.fc33.x86_64
+  # Related to https://github.com/coreos/fedora-coreos-tracker/issues/643
+  # Fast-track SELinux Policy to fix read access issue with chronyd
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-5cd3fad6d5
+  selinux-policy:
+    evra: 3.14.6-29.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-29.fc33.noarch


### PR DESCRIPTION
related to https://github.com/coreos/fedora-coreos-tracker/issues/643