### PR TITLE
kola-denylist: remove chrony.dhcp-propagation reference

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,10 +5,3 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-# The ext.config.chrony.dhcp-propagation test is failing on Fedora 33
-# for now. Exclude running the test on `next` and `next-devel`.
-- pattern: ext.config.chrony.dhcp-propagation
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/643
-  streams:
-    - next
-    - next-devel


### PR DESCRIPTION
Needs https://github.com/coreos/fedora-coreos-config/pull/701
The new version SELinux policy(3.14.6-29) for f-33 fixes an issue with the `chronyd` from reading the sources file that allows chrony to read NTP server data propagated via DHCP. 