### PR TITLE
coreos-enable-network: reword Description field

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-enable-network.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Start network if needed
+Description=CoreOS Enable Network
 ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 After=basic.target


### PR DESCRIPTION
Noticed this in the serial console output:

```
[   51.084580] systemd[1]: Condition check resulted in Start network if needed being skipped.
```

which is kinda hard to read. Let's make our description less wordy and
use the standard Title Case.