### PR TITLE
manifests/bootupd: `mkdir /run` for now

### DIFF
--- a/manifests/bootupd.yaml
+++ b/manifests/bootupd.yaml
@@ -7,5 +7,7 @@ postprocess:
   - |
     #!/bin/bash
     set -xeuo pipefail
+    # Until we have https://github.com/coreos/rpm-ostree/pull/2275
+    mkdir -p /run
     # Transforms /usr/lib/ostree-boot into a bootupd-compatible update payload
     /usr/bin/bootupctl backend generate-update-metadata /


### PR DESCRIPTION
This is a quick backport of https://github.com/coreos/rpm-ostree/pull/2275
effectively, so we can proceed with fixing bootupd.