### PR TITLE
tests/kola/misc-ro: verify that kdump isn't active

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -26,6 +26,11 @@ for unit in logrotate; do
         fatal "Unit ${unit} should be enabled"
     fi
 done
+# Make sure that kdump didn't start (it's either disabled, or enabled but
+# conditional on crashkernel= karg, which we don't bake).
+if ! systemctl show -p ActiveState kdump.service | grep -q ActiveState=inactive; then
+    fatal "Unit kdump.service shouldn't be active"
+fi
 # systemd-resolved should be disabled on f32 but
 # enabled on f33+.
 source /etc/os-release

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -36,11 +36,11 @@ fi
 source /etc/os-release
 if systemctl is-enabled systemd-resolved 1>/dev/null; then
     if [ "$VERSION_ID" == "32" ]; then
-        fatal "Unit ${unit} should not be enabled"
+        fatal "Unit systemd-resolved should not be enabled"
     fi
 else
     if [ "$VERSION_ID" != "32" ]; then
-        fatal "Unit ${unit} should be enabled"
+        fatal "Unit systemd-resolved should be enabled"
     fi
 fi
 ok services


### PR DESCRIPTION
For now, it should only be enabled on user request. In the future, it
will be enabled all the time, but still conditional on `crashkernel`:

src.fedoraproject.org/rpms/kexec-tools/pull-request/5