### PR TITLE
Support mirroring /boot, ESP, BIOS bootloader on first boot

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
@@ -5,7 +5,7 @@ rootpath=/dev/disk/by-label/root
 
 # If the rootfs was reprovisioned, then the user is free to define their own
 # rootflags.
-if [ -d /run/ignition-ostree-rootfs ]; then
+if [ -d /run/ignition-ostree-transposefs/root ]; then
     exit 0
 fi
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-detect.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-detect.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ignition OSTree: detect rootfs replacement
+Description=Ignition OSTree: Detect Partition Transposition
 DefaultDependencies=false
 After=ignition-fetch.service
 Before=ignition-disks.service
@@ -14,5 +14,5 @@ After=systemd-udevd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs detect
-ExecStop=/usr/libexec/ignition-ostree-dracut-rootfs cleanup
+ExecStart=/usr/libexec/ignition-ostree-transposefs detect
+ExecStop=/usr/libexec/ignition-ostree-transposefs cleanup

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
@@ -1,16 +1,16 @@
 [Unit]
-Description=Ignition OSTree: restore rootfs
+Description=Ignition OSTree: Restore Partitions
 DefaultDependencies=false
 After=ignition-disks.service
 Before=ignition-ostree-growfs.service
 Before=ignition-ostree-mount-firstboot-sysroot.service
 
 ConditionKernelCommandLine=ostree
-ConditionPathIsDirectory=/run/ignition-ostree-rootfs
+ConditionPathIsDirectory=/run/ignition-ostree-transposefs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 # So we can transiently mount sysroot
 MountFlags=slave
-ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs restore
+ExecStart=/usr/libexec/ignition-ostree-transposefs restore

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=Ignition OSTree: save rootfs
+Description=Ignition OSTree: Save Partitions
 DefaultDependencies=false
-After=ignition-ostree-rootfs-detect.service
+After=ignition-ostree-transposefs-detect.service
 Before=ignition-disks.service
 ConditionKernelCommandLine=ostree
-ConditionPathIsDirectory=/run/ignition-ostree-rootfs
+ConditionPathIsDirectory=/run/ignition-ostree-transposefs
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
 After=coreos-gpt-setup.service
@@ -14,4 +14,4 @@ Type=oneshot
 RemainAfterExit=yes
 # So we can transiently mount sysroot
 MountFlags=slave
-ExecStart=/usr/libexec/ignition-ostree-dracut-rootfs save
+ExecStart=/usr/libexec/ignition-ostree-transposefs save

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -10,9 +10,14 @@ saved_data=/run/ignition-ostree-transposefs
 saved_root=${saved_data}/root
 partstate_root=/run/ignition-ostree-rootfs-partstate.json
 
+# Print jq query string for wiped filesystems with label $1
+query_fslabel() {
+    echo ".storage?.filesystems? // [] | map(select(.label == \"$1\" and .wipeFilesystem == true))"
+}
+
 case "${1:-}" in
     detect)
-        wipes_root=$(jq '.storage?.filesystems? // [] | map(select(.label == "root" and .wipeFilesystem == true)) | length' "${ignition_cfg}")
+        wipes_root=$(jq "$(query_fslabel root) | length" "${ignition_cfg}")
         if [ "${wipes_root}" = "0" ]; then
             exit 0
         fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # out a way to ask Ignition directly whether there's a filesystem with label
 # "root" being set up.
 ignition_cfg=/run/ignition.json
-rootdisk=/dev/disk/by-label/root
+root_part=/dev/disk/by-label/root
 saved_data=/run/ignition-ostree-transposefs
 saved_root=${saved_data}/root
 partstate_root=/run/ignition-ostree-rootfs-partstate.json
@@ -24,15 +24,15 @@ case "${1:-}" in
         mount -t tmpfs tmpfs "${saved_data}" -o size=80%
         ;;
     save)
-        mount "${rootdisk}" /sysroot
+        mount "${root_part}" /sysroot
         echo "Moving rootfs to RAM..."
         cp -a /sysroot "${saved_root}"
         # also store the state of the partition
-        lsblk "${rootdisk}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate_root}"
+        lsblk "${root_part}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate_root}"
         ;;
     restore)
         # This one is in a private mount namespace since we're not "offically" mounting
-        mount "${rootdisk}" /sysroot
+        mount "${root_part}" /sysroot
         echo "Restoring rootfs from RAM..."
         find "${saved_root}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
         chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 # "root" being set up.
 ignition_cfg=/run/ignition.json
 rootdisk=/dev/disk/by-label/root
-saved_sysroot=/run/ignition-ostree-rootfs
-partstate=/run/ignition-ostree-rootfs-partstate.json
+saved_data=/run/ignition-ostree-transposefs
+saved_root=${saved_data}/root
+partstate_root=/run/ignition-ostree-rootfs-partstate.json
 
 case "${1:-}" in
     detect)
@@ -16,30 +17,30 @@ case "${1:-}" in
             exit 0
         fi
         echo "Detected rootfs replacement in fetched Ignition config: /run/ignition.json"
-        mkdir "${saved_sysroot}"
+        mkdir "${saved_data}"
         # use 80% of RAM: we want to be greedy since the boot breaks anyway, but
         # we still want to leave room for everything else so it hits ENOSPC and
         # doesn't invoke the OOM killer
-        mount -t tmpfs tmpfs "${saved_sysroot}" -o size=80%
+        mount -t tmpfs tmpfs "${saved_data}" -o size=80%
         ;;
     save)
         mount "${rootdisk}" /sysroot
         echo "Moving rootfs to RAM..."
-        cp -aT /sysroot "${saved_sysroot}"
+        cp -a /sysroot "${saved_root}"
         # also store the state of the partition
-        lsblk "${rootdisk}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate}"
+        lsblk "${rootdisk}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate_root}"
         ;;
     restore)
         # This one is in a private mount namespace since we're not "offically" mounting
         mount "${rootdisk}" /sysroot
         echo "Restoring rootfs from RAM..."
-        find "${saved_sysroot}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
+        find "${saved_root}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
         chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         ;;
     cleanup)
-        if [ -d "${saved_sysroot}" ]; then
-            umount "${saved_sysroot}"
-            rm -rf "${saved_sysroot}" "${partstate}"
+        if [ -d "${saved_data}" ]; then
+            umount "${saved_data}"
+            rm -rf "${saved_data}" "${partstate_root}"
         fi
         ;;
     *)

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -67,9 +67,9 @@ install() {
         /usr/lib/udev/rules.d/90-coreos-device-mapper.rules
 
     inst_multiple jq chattr
-    inst_script "$moddir/ignition-ostree-dracut-rootfs.sh" "/usr/libexec/ignition-ostree-dracut-rootfs"
+    inst_script "$moddir/ignition-ostree-transposefs.sh" "/usr/libexec/ignition-ostree-transposefs"
     for x in detect save restore; do
-        install_ignition_unit ignition-ostree-rootfs-${x}.service
+        install_ignition_unit ignition-ostree-transposefs-${x}.service
     done
 
     # Disk support


### PR DESCRIPTION
Supporting redundant bootable disks for https://github.com/coreos/fedora-coreos-tracker/issues/581.  This change supports the following:

- Moving `/boot` and `/boot/efi` to RAID 1 volumes if the Ignition config has a filesystem with a `boot` or `EFI-SYSTEM` label and `wipe_filesystem: true`, similar to how we move the contents of the root filesystem.  Because BIOS GRUB is configured to set `prefix` to the first disk, it must _not_ have MD-RAID support preloaded (it currently does not).  The MD-RAID superblocks must be at the end of the component partitions (superblock format 1.0) so BIOS GRUB resp. the UEFI firmware can treat `/boot` resp. `/boot/efi` as normal filesystems.
- Copying the BIOS-BOOT partition bits and corresponding boot sector if the Ignition config creates partitions with the requisite type GUIDs.  We don't RAID these because they're not modified by the installed system.  (bootupd thus needs to support multiple independent disks.)
- Copying the ppc64le PReP partition bits if the Ignition config creates partitions with the requisite type GUIDs.  We likewise don't RAID these.

Design document in https://github.com/coreos/enhancements/pull/3.  This functionality can actually be used to completely repartition the boot disk, since we copy everything into RAM before the Ignition disks stage.  The only requirement is that BIOS-BOOT starts at the same offset (which we check for).  The corresponding FCC sugar is in https://github.com/coreos/fcct/pull/162.

Test with:

```sh
qemu-img create -f qcow2 second.qcow2 8G
qemu-system-x86_64 -bios /usr/share/edk2/ovmf/OVMF_CODE.fd -m 4096 -accel kvm -object rng-random,filename=/dev/urandom,id=rng0 -netdev user,id=eth0,hostfwd=tcp::2222-:22,hostname="fcos" -device virtio-net-pci,netdev=eth0 -fw_cfg name=opt/com.coreos/config,file="$(pwd)/example.ign" -drive if=virtio,file=./fedora*.qcow2 -drive if=virtio,file=./second.qcow2
```

Drop `-bios /usr/share/edk2/ovmf/OVMF_CODE.fd` to test in BIOS mode.  Drop `-drive if=virtio,file=./fedora*.qcow2` to test a failure of the first drive.

Use the following FCC (assumes https://github.com/coreos/fcct/pull/162):

```yaml
variant: fcos
version: 1.3.0-experimental
boot_device:
  mirror:
    devices: [/dev/vda, /dev/vdb]
```