### PR TITLE
uuid-root: Add an After= for the device

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
@@ -8,6 +8,7 @@ ConditionPathExists=!/run/ostree-live
 Before=initrd-root-fs.target
 After=ignition-disks.service
 
+After=dev-disk-by\x2dlabel-root.device
 # Avoid racing with fsck
 Before=systemd-fsck@dev-disk-by\x2dlabel-root.service
 


### PR DESCRIPTION
This should help with RHCOS updating to the latest, and
is general best practice anyways.