### PR TITLE
40ignition-ostree: use `lsblk --paths` instead of -o PATH

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -26,9 +26,9 @@ if [ "${path}" == /sysroot ] && [ -f "${saved_partstate}" ]; then
     # following: if the rootfs partition was moved off of the boot disk or it
     # was resized, then we don't growpart.
     #
-    # To detect this, we compare the output of `lsblk -o PATH,SIZE` before and
-    # after `ignition-disks.service`.
-    partstate=$(lsblk "${src}" --nodeps --json -b -o PATH,SIZE | jq -c .)
+    # To detect this, we compare the output of `lsblk --paths -o NAME,SIZE`
+    # before and after `ignition-disks.service`.
+    partstate=$(lsblk "${src}" --nodeps --paths --json -b -o NAME,SIZE | jq -c .)
     if [ "${partstate}" != "$(cat "${saved_partstate}")" ]; then
         echo "coreos-growpart: detected rootfs partition changes; not auto-growing"
         exit 0

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-dracut-rootfs.sh
@@ -27,7 +27,7 @@ case "${1:-}" in
         echo "Moving rootfs to RAM..."
         cp -aT /sysroot "${saved_sysroot}"
         # also store the state of the partition
-        lsblk "${rootdisk}" --nodeps --json -b -o PATH,SIZE | jq -c . > "${partstate}"
+        lsblk "${rootdisk}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate}"
         ;;
     restore)
         # This one is in a private mount namespace since we're not "offically" mounting


### PR DESCRIPTION
RHEL8's `lsblk` doesn't support `-o PATH` but it does support `--paths`
which outputs the device path as the device's `NAME`. So switch to using
that instead.