### PR TITLE
tests/manual: nettest: remove workaround for teaming bug

### DIFF
--- a/tests/manual/coreos-network-testing.sh
+++ b/tests/manual/coreos-network-testing.sh
@@ -638,14 +638,11 @@ main() {
     # TODO persist the net.ifnames karg and do another check after a reboot.
     destroy_vm
 
-    # Note 'static_team0' initramfs teaming doesn't work so leave it out for now
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1814038#c1
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1784363
     initramfsloop=(
         dhcp_nic0
         static_nic0
         static_bond0
-       #static_team0
+        static_team0
         static_br0
     )
 


### PR DESCRIPTION
The NM in 1.26+ (F33+ and RHEL8.3+) has been updated to fix this
problem so we can drop the commented out test. See

- https://bugzilla.redhat.com/show_bug.cgi?id=1784363
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/d689380cfc5734a29b1302d68027190e1a606265