### PR TITLE
99emergency-timeout/virtio-dump: add dependency on journald service

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/ignition-virtio-dump-journal.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/ignition-virtio-dump-journal.service
@@ -4,6 +4,8 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 ConditionVirtualization=|kvm
 ConditionVirtualization=|qemu
+Requires=systemd-journald.service
+After=systemd-journald.service
 After=basic.target
 
 [Service]


### PR DESCRIPTION
On ppc64le/s390x I am noticing that there is sort of a race condition where the virtio-dump service starts when the journald
is down. Adding a dependency on it so the unit starts only after journald is up