### PR TITLE
coreos-teardown-initramfs: use `cp -v` to copy NM configs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
@@ -54,7 +54,7 @@ propagate_initramfs_networking() {
         echo "info: no networking config is defined in the real root"
         if [ -n "$(ls -A /run/NetworkManager/system-connections/)" ]; then
             echo "info: propagating initramfs networking config to the real root"
-            cp /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
+            cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
             selinux_relabel /etc/NetworkManager/system-connections/
         else
             echo "info: no initramfs networking information to propagate"


### PR DESCRIPTION
That way it clearly shows in the journal the files that were actually
copied.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1895979