### PR TITLE
[next-devel] manifest: point to release repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,7 +12,7 @@ repos:
   # these repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned
-  - fedora-next
+  - fedora
   - fedora-updates
 
 # All Fedora CoreOS streams share the same pool for locked files.


### PR DESCRIPTION
The f33 repos are no longer in the `development/` path. Use the release
repos now.