### PR TITLE
[testing-devel]: Move to Fedora 33!

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,13 +1,1 @@
-packages:
-  # Fast-track ostree-2020.7-2.fc32 for testing and to unblock initramfs-etc
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e2f1868876
-  ostree:
-    evra: 2020.7-2.fc32.aarch64
-  ostree-libs:
-    evra: 2020.7-2.fc32.aarch64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d992496d18
-  coreos-installer:
-    evra: 0.7.2-1.fc32.aarch64
-  coreos-installer-bootinfra:
-    evra: 0.7.2-1.fc32.aarch64
+packages: {}

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,13 +1,1 @@
-packages:
-  # Fast-track ostree-2020.7-2.fc32 for testing and to unblock initramfs-etc
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e2f1868876
-  ostree:
-    evra: 2020.7-2.fc32.ppc64le
-  ostree-libs:
-    evra: 2020.7-2.fc32.ppc64le
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d992496d18
-  coreos-installer:
-    evra: 0.7.2-1.fc32.ppc64le
-  coreos-installer-bootinfra:
-    evra: 0.7.2-1.fc32.ppc64le
+packages: {}

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,13 +1,1 @@
-packages:
-  # Fast-track ostree-2020.7-2.fc32 for testing and to unblock initramfs-etc
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e2f1868876
-  ostree:
-    evra: 2020.7-2.fc32.s390x
-  ostree-libs:
-    evra: 2020.7-2.fc32.s390x
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d992496d18
-  coreos-installer:
-    evra: 0.7.2-1.fc32.s390x
-  coreos-installer-bootinfra:
-    evra: 0.7.2-1.fc32.s390x
+packages: {}

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,13 +1,1 @@
-packages:
-  # Fast-track ostree-2020.7-2.fc32 for testing and to unblock initramfs-etc
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-e2f1868876
-  ostree:
-    evra: 2020.7-2.fc32.x86_64
-  ostree-libs:
-    evra: 2020.7-2.fc32.x86_64
-  # Fast-track coreos-installer release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-d992496d18
-  coreos-installer:
-    evra: 0.7.2-1.fc32.x86_64
-  coreos-installer-bootinfra:
-    evra: 0.7.2-1.fc32.x86_64
+packages: {}

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1208 +1,1232 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.22.16-1.fc32.x86_64"
+      "evra": "1:1.26.4-1.fc33.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.22.16-1.fc32.x86_64"
+      "evra": "1:1.26.4-1.fc33.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.22.16-1.fc32.x86_64"
+      "evra": "1:1.26.4-1.fc33.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.22.16-1.fc32.x86_64"
+      "evra": "1:1.26.4-1.fc33.x86_64"
     },
     "acl": {
-      "evra": "2.2.53-5.fc32.x86_64"
+      "evra": "2.2.53-9.fc33.x86_64"
     },
     "adcli": {
-      "evra": "0.9.0-1.fc32.x86_64"
+      "evra": "0.9.0-4.fc33.x86_64"
     },
     "afterburn": {
-      "evra": "4.5.3-1.fc32.x86_64"
+      "evra": "4.5.3-1.fc33.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "4.5.3-1.fc32.x86_64"
+      "evra": "4.5.3-1.fc33.x86_64"
     },
     "alternatives": {
-      "evra": "1.11-6.fc32.x86_64"
+      "evra": "1.14-3.fc33.x86_64"
     },
     "attr": {
-      "evra": "2.4.48-8.fc32.x86_64"
+      "evra": "2.4.48-10.fc33.x86_64"
     },
     "audit-libs": {
-      "evra": "3.0-0.19.20191104git1c2f876.fc32.x86_64"
+      "evra": "3.0-0.21.20191104git1c2f876.fc33.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.7-24.fc32.x86_64"
+      "evra": "0.8-6.fc33.x86_64"
     },
     "basesystem": {
-      "evra": "11-9.fc32.noarch"
+      "evra": "11-10.fc33.noarch"
     },
     "bash": {
-      "evra": "5.0.17-1.fc32.x86_64"
+      "evra": "5.0.17-2.fc33.x86_64"
     },
     "bash-completion": {
-      "evra": "1:2.8-8.fc32.noarch"
+      "evra": "1:2.8-9.fc33.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.11.23-1.fc32.x86_64"
+      "evra": "32:9.11.24-2.fc33.x86_64"
     },
     "bind-libs-lite": {
-      "evra": "32:9.11.23-1.fc32.x86_64"
+      "evra": "32:9.11.24-2.fc33.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.11.23-1.fc32.noarch"
+      "evra": "32:9.11.24-2.fc33.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.11.23-1.fc32.x86_64"
+      "evra": "32:9.11.24-2.fc33.x86_64"
     },
     "bootupd": {
-      "evra": "0.1.3-2.fc32.x86_64"
+      "evra": "0.2.2-2.fc33.x86_64"
     },
     "bsdtar": {
-      "evra": "3.4.3-1.fc32.x86_64"
+      "evra": "3.4.3-3.fc33.x86_64"
     },
     "btrfs-progs": {
-      "evra": "5.7-4.fc32.x86_64"
+      "evra": "5.7-5.fc33.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.4.1-1.fc32.x86_64"
+      "evra": "0.4.1-2.fc33.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-2.fc32.x86_64"
+      "evra": "1.0.8-4.fc33.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-2.fc32.x86_64"
+      "evra": "1.0.8-4.fc33.x86_64"
     },
     "c-ares": {
-      "evra": "1.15.0-5.fc32.x86_64"
+      "evra": "1.16.1-3.fc33.x86_64"
     },
     "ca-certificates": {
-      "evra": "2020.2.41-1.1.fc32.noarch"
+      "evra": "2020.2.41-4.fc33.noarch"
     },
     "catatonit": {
-      "evra": "0.1.5-3.fc32.x86_64"
+      "evra": "0.1.5-3.fc33.x86_64"
     },
     "chrony": {
-      "evra": "3.5.1-1.fc32.x86_64"
+      "evra": "4.0-1.fc33.x86_64"
     },
     "cifs-utils": {
-      "evra": "6.9-3.fc32.x86_64"
+      "evra": "6.9-4.fc33.x86_64"
     },
     "clevis": {
-      "evra": "15-2.fc32.x86_64"
+      "evra": "15-2.fc33.x86_64"
     },
     "clevis-dracut": {
-      "evra": "15-2.fc32.x86_64"
+      "evra": "15-2.fc33.x86_64"
     },
     "clevis-luks": {
-      "evra": "15-2.fc32.x86_64"
+      "evra": "15-2.fc33.x86_64"
     },
     "clevis-systemd": {
-      "evra": "15-2.fc32.x86_64"
+      "evra": "15-2.fc33.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-6.fc32.noarch"
+      "evra": "0.31-7.fc33.noarch"
     },
     "compat-readline5": {
-      "evra": "5.2-36.fc32.x86_64"
+      "evra": "5.2-37.fc33.x86_64"
     },
     "conmon": {
-      "evra": "2:2.0.21-2.fc32.x86_64"
+      "evra": "2:2.0.21-3.fc33.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.20.2-1.fc32.noarch"
+      "evra": "0.20.2-1.fc33.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.20.2-1.fc32.noarch"
+      "evra": "0.20.2-1.fc33.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.20.2-1.fc32.noarch"
+      "evra": "0.20.2-1.fc33.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.20.2-1.fc32.noarch"
+      "evra": "0.20.2-1.fc33.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.145.0-1.fc32.noarch"
+      "evra": "2:2.151.0-1.fc33.noarch"
     },
     "containerd": {
-      "evra": "1.3.3-1.fc32.x86_64"
+      "evra": "1.4.1-2.fc33.x86_64"
     },
     "containernetworking-plugins": {
-      "evra": "0.8.7-1.fc32.x86_64"
+      "evra": "0.8.7-1.fc33.x86_64"
     },
     "containers-common": {
-      "evra": "1:1.2.0-2.fc32.x86_64"
+      "evra": "1:1.2.0-3.fc33.x86_64"
     },
     "coreos-installer": {
-      "evra": "0.7.2-1.fc32.x86_64"
+      "evra": "0.7.2-1.fc33.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.7.2-1.fc32.x86_64"
+      "evra": "0.7.2-1.fc33.x86_64"
     },
     "coreutils": {
-      "evra": "8.32-4.fc32.1.x86_64"
+      "evra": "8.32-12.fc33.x86_64"
     },
     "coreutils-common": {
-      "evra": "8.32-4.fc32.1.x86_64"
+      "evra": "8.32-12.fc33.x86_64"
     },
     "cpio": {
-      "evra": "2.13-4.fc32.x86_64"
+      "evra": "2.13-8.fc33.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.6-22.fc32.x86_64"
+      "evra": "2.9.6-24.fc33.x86_64"
     },
     "crun": {
-      "evra": "0.15-5.fc32.x86_64"
+      "evra": "0.15.1-1.fc33.x86_64"
     },
     "crypto-policies": {
-      "evra": "20200619-1.git781bbd4.fc32.noarch"
+      "evra": "20200918-1.git85dccc5.fc33.noarch"
     },
     "cryptsetup": {
-      "evra": "2.3.4-1.fc32.x86_64"
+      "evra": "2.3.4-1.fc33.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.3.4-1.fc32.x86_64"
+      "evra": "2.3.4-1.fc33.x86_64"
     },
     "cups-libs": {
-      "evra": "1:2.3.3-13.fc32.x86_64"
+      "evra": "1:2.3.3-16.fc33.x86_64"
     },
     "curl": {
-      "evra": "7.69.1-6.fc32.x86_64"
+      "evra": "7.71.1-7.fc33.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.27-4.fc32.x86_64"
+      "evra": "2.1.27-6.fc33.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.27-4.fc32.x86_64"
+      "evra": "2.1.27-6.fc33.x86_64"
     },
     "dbus": {
-      "evra": "1:1.12.20-1.fc32.x86_64"
+      "evra": "1:1.12.20-2.fc33.x86_64"
     },
     "dbus-broker": {
-      "evra": "24-1.fc32.x86_64"
+      "evra": "24-1.fc33.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.12.20-1.fc32.noarch"
+      "evra": "1:1.12.20-2.fc33.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.12.20-1.fc32.x86_64"
+      "evra": "1:1.12.20-2.fc33.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.171-1.fc32.x86_64"
+      "evra": "1.02.173-1.fc33.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.171-1.fc32.x86_64"
+      "evra": "1.02.173-1.fc33.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.171-1.fc32.x86_64"
+      "evra": "1.02.173-1.fc33.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.171-1.fc32.x86_64"
+      "evra": "1.02.173-1.fc33.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.8.2-4.fc32.x86_64"
+      "evra": "0.8.4-7.fc33.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.8.2-4.fc32.x86_64"
+      "evra": "0.8.4-7.fc33.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.8.5-3.fc32.x86_64"
+      "evra": "0.8.5-4.fc33.x86_64"
     },
     "diffutils": {
-      "evra": "3.7-4.fc32.x86_64"
+      "evra": "3.7-7.fc33.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.81-5.fc32.x86_64"
+      "evra": "2.82-3.fc33.x86_64"
     },
     "dosfstools": {
-      "evra": "4.1-10.fc32.x86_64"
+      "evra": "4.1-12.fc33.x86_64"
     },
     "dracut": {
-      "evra": "050-61.git20200529.fc32.x86_64"
+      "evra": "050-64.git20200529.fc33.x86_64"
     },
     "dracut-network": {
-      "evra": "050-61.git20200529.fc32.x86_64"
+      "evra": "050-64.git20200529.fc33.x86_64"
     },
     "dracut-squash": {
-      "evra": "050-61.git20200529.fc32.x86_64"
+      "evra": "050-64.git20200529.fc33.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.45.5-3.fc32.x86_64"
+      "evra": "1.45.6-4.fc33.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.45.5-3.fc32.x86_64"
+      "evra": "1.45.6-4.fc33.x86_64"
     },
     "efi-filesystem": {
-      "evra": "4-4.fc32.noarch"
+      "evra": "4-5.fc33.noarch"
     },
     "efibootmgr": {
-      "evra": "16-7.fc32.x86_64"
+      "evra": "16-9.fc33.x86_64"
     },
     "efivar-libs": {
-      "evra": "37-7.fc32.x86_64"
+      "evra": "37-14.fc33.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.181-1.fc32.noarch"
+      "evra": "0.182-1.fc33.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.181-1.fc32.x86_64"
+      "evra": "0.182-1.fc33.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.181-1.fc32.x86_64"
+      "evra": "0.182-1.fc33.x86_64"
     },
     "ethtool": {
-      "evra": "2:5.9-1.fc32.x86_64"
+      "evra": "2:5.9-1.fc33.x86_64"
     },
     "expat": {
-      "evra": "2.2.8-2.fc32.x86_64"
+      "evra": "2.2.8-3.fc33.x86_64"
     },
     "fedora-coreos-pinger": {
-      "evra": "0.0.4-7.fc32.x86_64"
+      "evra": "0.0.4-7.fc33.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "32-7.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "32-3.noarch"
+      "evra": "33-2.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "32-3.noarch"
+      "evra": "33-2.noarch"
+    },
+    "fedora-release-identity-coreos": {
+      "evra": "33-2.noarch"
     },
     "fedora-repos": {
-      "evra": "32-7.noarch"
+      "evra": "33-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "32-7.noarch"
+      "evra": "33-1.noarch"
+    },
+    "fedora-repos-modular": {
+      "evra": "33-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "32-7.noarch"
+      "evra": "33-1.noarch"
     },
     "file": {
-      "evra": "5.38-4.fc32.x86_64"
+      "evra": "5.39-3.fc33.x86_64"
     },
     "file-libs": {
-      "evra": "5.38-4.fc32.x86_64"
+      "evra": "5.39-3.fc33.x86_64"
     },
     "filesystem": {
-      "evra": "3.14-2.fc32.x86_64"
+      "evra": "3.14-3.fc33.x86_64"
     },
     "findutils": {
-      "evra": "1:4.7.0-4.fc32.x86_64"
+      "evra": "1:4.7.0-7.fc33.x86_64"
     },
     "firewalld-filesystem": {
-      "evra": "0.8.4-1.fc32.noarch"
+      "evra": "0.8.4-1.fc33.noarch"
     },
     "flatpak-session-helper": {
-      "evra": "1.8.2-2.fc32.x86_64"
+      "evra": "1.8.2-2.fc33.x86_64"
     },
     "fstrm": {
-      "evra": "0.5.0-2.fc32.x86_64"
+      "evra": "0.6.0-1.fc33.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-9.fc32.x86_64"
+      "evra": "2.9.9-10.fc33.x86_64"
     },
     "fuse-common": {
-      "evra": "3.9.1-1.fc32.x86_64"
+      "evra": "3.9.4-1.fc33.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-9.fc32.x86_64"
+      "evra": "2.9.9-10.fc33.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.2.0-1.fc32.x86_64"
+      "evra": "1.2.0-1.fc33.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.0-3.fc32.x86_64"
+      "evra": "3.7.0-4.fc33.x86_64"
     },
     "fuse3": {
-      "evra": "3.9.1-1.fc32.x86_64"
+      "evra": "3.9.4-1.fc33.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.9.1-1.fc32.x86_64"
+      "evra": "3.9.4-1.fc33.x86_64"
     },
     "fwupd": {
-      "evra": "1.5.1-1.fc32.x86_64"
+      "evra": "1.5.1-1.fc33.x86_64"
     },
     "gawk": {
-      "evra": "5.0.1-7.fc32.x86_64"
+      "evra": "5.1.0-2.fc33.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.5-1.fc32.x86_64"
+      "evra": "1.0.5-2.fc33.x86_64"
     },
     "gettext": {
-      "evra": "0.21-1.fc32.x86_64"
+      "evra": "0.21-3.fc33.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.21-1.fc32.x86_64"
+      "evra": "0.21-3.fc33.x86_64"
     },
     "git-core": {
-      "evra": "2.26.2-1.fc32.x86_64"
+      "evra": "2.28.0-1.fc33.x86_64"
     },
     "glib-networking": {
-      "evra": "2.64.3-1.fc32.x86_64"
+      "evra": "2.66.0-1.fc33.x86_64"
     },
     "glib2": {
-      "evra": "2.64.6-1.fc32.x86_64"
+      "evra": "2.66.2-1.fc33.x86_64"
     },
     "glibc": {
-      "evra": "2.31-4.fc32.x86_64"
+      "evra": "2.32-1.fc33.x86_64"
     },
     "glibc-all-langpacks": {
-      "evra": "2.31-4.fc32.x86_64"
+      "evra": "2.32-1.fc33.x86_64"
     },
     "glibc-common": {
-      "evra": "2.31-4.fc32.x86_64"
+      "evra": "2.32-1.fc33.x86_64"
     },
     "gmp": {
-      "evra": "1:6.1.2-13.fc32.x86_64"
+      "evra": "1:6.2.0-5.fc33.x86_64"
     },
     "gnupg2": {
-      "evra": "2.2.20-2.fc32.x86_64"
+      "evra": "2.2.23-1.fc33.x86_64"
     },
     "gnutls": {
-      "evra": "3.6.15-1.fc32.x86_64"
+      "evra": "3.6.15-1.fc33.x86_64"
     },
     "gpgme": {
-      "evra": "1.14.0-1.fc32.x86_64"
+      "evra": "1.14.0-2.fc33.x86_64"
     },
     "grep": {
-      "evra": "3.3-4.fc32.x86_64"
+      "evra": "3.4-5.fc33.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.04-23.fc32.noarch"
+      "evra": "1:2.04-31.fc33.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.04-23.fc32.x86_64"
+      "evra": "1:2.04-31.fc33.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.04-23.fc32.x86_64"
+      "evra": "1:2.04-31.fc33.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.04-23.fc32.noarch"
+      "evra": "1:2.04-31.fc33.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.04-23.fc32.x86_64"
+      "evra": "1:2.04-31.fc33.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.04-23.fc32.x86_64"
+      "evra": "1:2.04-31.fc33.x86_64"
     },
     "gsettings-desktop-schemas": {
-      "evra": "3.36.1-1.fc32.x86_64"
+      "evra": "3.38.0-1.fc33.x86_64"
     },
     "gzip": {
-      "evra": "1.10-2.fc32.x86_64"
+      "evra": "1.10-3.fc33.x86_64"
     },
     "hostname": {
-      "evra": "3.23-2.fc32.x86_64"
+      "evra": "3.23-3.fc33.x86_64"
+    },
+    "hwdata": {
+      "evra": "0.340-1.fc33.noarch"
     },
     "ignition": {
-      "evra": "2.7.0-1.git5be43fd.fc32.x86_64"
+      "evra": "2.7.0-1.git5be43fd.fc33.x86_64"
     },
     "iproute": {
-      "evra": "5.7.0-1.fc32.x86_64"
+      "evra": "5.8.0-1.fc33.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.7.0-1.fc32.x86_64"
+      "evra": "5.8.0-1.fc33.x86_64"
     },
     "iptables": {
-      "evra": "1.8.4-9.fc32.x86_64"
+      "evra": "1.8.5-3.fc33.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.4-9.fc32.x86_64"
+      "evra": "1.8.5-3.fc33.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.4-9.fc32.x86_64"
+      "evra": "1.8.5-3.fc33.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.4-9.fc32.x86_64"
+      "evra": "1.8.5-3.fc33.x86_64"
     },
     "iputils": {
-      "evra": "20190515-7.fc32.x86_64"
+      "evra": "20200821-1.fc33.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.4.0-5.fc32.x86_64"
+      "evra": "2:1.7.0-4.fc33.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.0-2.git4440e57.fc32.x86_64"
+      "evra": "6.2.1.1-0.gitac87641.fc33.2.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.0-2.git4440e57.fc32.x86_64"
+      "evra": "6.2.1.1-0.gitac87641.fc33.2.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.97-10.fc32.x86_64"
+      "evra": "0.97-11.fc33.x86_64"
     },
     "jansson": {
-      "evra": "2.12-5.fc32.x86_64"
+      "evra": "2.13.1-1.fc33.x86_64"
     },
     "jose": {
-      "evra": "10-6.fc32.x86_64"
+      "evra": "10-8.fc33.x86_64"
     },
     "jq": {
-      "evra": "1.6-4.fc32.x86_64"
+      "evra": "1.6-5.fc33.x86_64"
     },
     "json-c": {
-      "evra": "0.13.1-13.fc32.x86_64"
+      "evra": "0.14-7.fc33.x86_64"
     },
     "json-glib": {
-      "evra": "1.4.4-4.fc32.x86_64"
+      "evra": "1.6.0-1.fc33.x86_64"
     },
     "kbd": {
-      "evra": "2.2.0-1.fc32.x86_64"
+      "evra": "2.3.0-2.fc33.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.2.0-1.fc32.noarch"
+      "evra": "2.3.0-2.fc33.noarch"
     },
     "kbd-misc": {
-      "evra": "2.2.0-1.fc32.noarch"
+      "evra": "2.3.0-2.fc33.noarch"
     },
     "kernel": {
-      "evra": "5.8.18-200.fc32.x86_64"
+      "evra": "5.8.18-300.fc33.x86_64"
     },
     "kernel-core": {
-      "evra": "5.8.18-200.fc32.x86_64"
+      "evra": "5.8.18-300.fc33.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.8.18-200.fc32.x86_64"
+      "evra": "5.8.18-300.fc33.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.20-17.fc32.x86_64"
+      "evra": "2.0.20-17.fc33.x86_64"
     },
     "keyutils": {
-      "evra": "1.6-4.fc32.x86_64"
+      "evra": "1.6-5.fc33.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6-4.fc32.x86_64"
+      "evra": "1.6-5.fc33.x86_64"
     },
     "kmod": {
-      "evra": "27-1.fc32.x86_64"
+      "evra": "27-3.fc33.x86_64"
     },
     "kmod-libs": {
-      "evra": "27-1.fc32.x86_64"
+      "evra": "27-3.fc33.x86_64"
     },
     "kpartx": {
-      "evra": "0.8.2-4.fc32.x86_64"
+      "evra": "0.8.4-7.fc33.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.18.2-27.fc32.x86_64"
+      "evra": "1.18.2-29.fc33.x86_64"
     },
     "less": {
-      "evra": "551-3.fc32.x86_64"
+      "evra": "551-4.fc33.x86_64"
     },
     "libacl": {
-      "evra": "2.2.53-5.fc32.x86_64"
+      "evra": "2.2.53-9.fc33.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-7.fc32.x86_64"
+      "evra": "0.3.111-10.fc33.x86_64"
     },
     "libarchive": {
-      "evra": "3.4.3-1.fc32.x86_64"
+      "evra": "3.4.3-3.fc33.x86_64"
     },
     "libargon2": {
-      "evra": "20171227-4.fc32.x86_64"
+      "evra": "20171227-5.fc33.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.3-3.fc32.x86_64"
+      "evra": "2.5.3-4.fc33.x86_64"
     },
     "libattr": {
-      "evra": "2.4.48-8.fc32.x86_64"
+      "evra": "2.4.48-10.fc33.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-44.fc32.x86_64"
+      "evra": "0.1.1-46.fc33.x86_64"
     },
     "libblkid": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "libbrotli": {
-      "evra": "1.0.9-3.fc32.x86_64"
+      "evra": "1.0.9-3.fc33.x86_64"
     },
     "libcap": {
-      "evra": "2.26-7.fc32.x86_64"
+      "evra": "2.26-8.fc33.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.7.11-1.fc32.x86_64"
+      "evra": "0.8-1.fc33.x86_64"
     },
     "libcbor": {
-      "evra": "0.5.0-7.fc32.x86_64"
+      "evra": "0.5.0-7.fc33.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-44.fc32.x86_64"
+      "evra": "0.7.0-46.fc33.x86_64"
     },
     "libcom_err": {
-      "evra": "1.45.5-3.fc32.x86_64"
+      "evra": "1.45.6-4.fc33.x86_64"
     },
     "libcurl": {
-      "evra": "7.69.1-6.fc32.x86_64"
+      "evra": "7.71.1-7.fc33.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-19.fc32.x86_64"
+      "evra": "0.14-20.fc33.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-40.fc32.x86_64"
-    },
-    "libdb-utils": {
-      "evra": "5.3.28-40.fc32.x86_64"
+      "evra": "5.3.28-44.fc33.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-44.fc32.x86_64"
+      "evra": "0.5.0-46.fc33.x86_64"
+    },
+    "libeconf": {
+      "evra": "0.3.8-4.fc33.x86_64"
     },
     "libedit": {
-      "evra": "3.1-32.20191231cvs.fc32.x86_64"
+      "evra": "3.1-33.20191231cvs.fc33.x86_64"
     },
     "libevent": {
-      "evra": "2.1.8-8.fc32.x86_64"
+      "evra": "2.1.8-10.fc33.x86_64"
     },
     "libfdisk": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "libffi": {
-      "evra": "3.1-24.fc32.x86_64"
+      "evra": "3.1-26.fc33.x86_64"
     },
     "libfido2": {
-      "evra": "1.3.1-2.fc32.x86_64"
+      "evra": "1.4.0-3.fc33.x86_64"
     },
     "libgcab1": {
-      "evra": "1.4-2.fc32.x86_64"
+      "evra": "1.4-3.fc33.x86_64"
     },
     "libgcc": {
-      "evra": "10.2.1-6.fc32.x86_64"
+      "evra": "10.2.1-6.fc33.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.8.5-3.fc32.x86_64"
+      "evra": "1.8.6-4.fc33.x86_64"
     },
     "libgomp": {
-      "evra": "10.2.1-6.fc32.x86_64"
+      "evra": "10.2.1-6.fc33.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.36-3.fc32.x86_64"
+      "evra": "1.37-2.fc33.x86_64"
     },
     "libgudev": {
-      "evra": "232-7.fc32.x86_64"
+      "evra": "234-1.fc33.x86_64"
     },
     "libgusb": {
-      "evra": "0.3.5-1.fc32.x86_64"
+      "evra": "0.3.5-1.fc33.x86_64"
+    },
+    "libibverbs": {
+      "evra": "32.0-1.fc33.x86_64"
     },
     "libicu": {
-      "evra": "65.1-2.fc32.x86_64"
+      "evra": "67.1-4.fc33.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.0-2.fc32.x86_64"
+      "evra": "2.3.0-4.fc33.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-44.fc32.x86_64"
+      "evra": "1.3.1-46.fc33.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.2-2.fc32.x86_64"
+      "evra": "0.1.4-1.fc33.x86_64"
     },
     "libjose": {
-      "evra": "10-6.fc32.x86_64"
+      "evra": "10-8.fc33.x86_64"
     },
     "libkcapi": {
-      "evra": "1.2.0-3.fc32.x86_64"
+      "evra": "1.2.0-3.fc33.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.2.0-3.fc32.x86_64"
+      "evra": "1.2.0-3.fc33.x86_64"
     },
     "libksba": {
-      "evra": "1.3.5-11.fc32.x86_64"
+      "evra": "1.3.5-13.fc33.x86_64"
     },
     "libldb": {
-      "evra": "2.1.4-1.fc32.x86_64"
+      "evra": "2.2.0-4.fc33.x86_64"
     },
     "libluksmeta": {
-      "evra": "9-7.fc32.x86_64"
+      "evra": "9-8.fc33.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.4.2-1.fc32.x86_64"
+      "evra": "1.4.2-3.fc33.x86_64"
     },
     "libmetalink": {
-      "evra": "0.1.3-13.fc32.x86_64"
+      "evra": "0.1.3-13.fc33.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.4-11.fc32.x86_64"
+      "evra": "1.0.4-12.fc33.x86_64"
     },
     "libmodman": {
-      "evra": "2.0.1-21.fc32.x86_64"
+      "evra": "2.0.1-23.fc33.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.9.3-1.fc32.x86_64"
+      "evra": "2.9.4-3.fc33.x86_64"
     },
     "libmount": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "libndp": {
-      "evra": "1.7-5.fc32.x86_64"
+      "evra": "1.7-6.fc33.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.7-4.fc32.x86_64"
+      "evra": "1.0.7-5.fc33.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-17.fc32.x86_64"
+      "evra": "1.0.1-18.fc33.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.5.2-0.fc32.x86_64"
+      "evra": "1:2.5.2-0.fc33.x86_64"
     },
     "libnftnl": {
-      "evra": "1.1.5-2.fc32.x86_64"
+      "evra": "1.1.7-3.fc33.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.41.0-1.fc32.x86_64"
+      "evra": "1.41.0-3.fc33.x86_64"
     },
     "libnl3": {
-      "evra": "3.5.0-2.fc32.x86_64"
+      "evra": "3.5.0-5.fc33.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.5.0-2.fc32.x86_64"
+      "evra": "3.5.0-5.fc33.x86_64"
     },
     "libnsl2": {
-      "evra": "1.2.0-6.20180605git4a062cf.fc32.x86_64"
+      "evra": "1.2.0-8.20180605git4a062cf.fc33.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-44.fc32.x86_64"
+      "evra": "0.2.1-46.fc33.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.9.1-3.fc32.x86_64"
+      "evra": "14:1.9.1-6.fc33.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.6.3-3.fc32.x86_64"
+      "evra": "1.7.3-5.fc33.x86_64"
     },
     "libproxy": {
-      "evra": "0.4.15-19.fc32.x86_64"
+      "evra": "0.4.15-25.fc33.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.0-4.fc32.x86_64"
+      "evra": "0.21.1-2.fc33.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.4-1.fc32.x86_64"
+      "evra": "1.4.4-1.fc33.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-44.fc32.x86_64"
+      "evra": "0.1.5-46.fc33.x86_64"
     },
     "librepo": {
-      "evra": "1.12.1-1.fc32.x86_64"
+      "evra": "1.12.1-1.fc33.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.13.1-5.fc32.noarch"
+      "evra": "2.14.0-13.fc33.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.0-3.fc32.x86_64"
+      "evra": "2.5.0-3.fc33.x86_64"
     },
     "libselinux": {
-      "evra": "3.0-5.fc32.x86_64"
+      "evra": "3.1-2.fc33.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.0-5.fc32.x86_64"
+      "evra": "3.1-2.fc33.x86_64"
     },
     "libsemanage": {
-      "evra": "3.0-3.fc32.x86_64"
+      "evra": "3.1-2.fc33.x86_64"
     },
     "libsepol": {
-      "evra": "3.0-4.fc32.x86_64"
+      "evra": "3.1-3.fc33.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.11-10.fc32.x86_64"
+      "evra": "2.11-11.fc33.x86_64"
     },
     "libslirp": {
-      "evra": "4.3.1-1.fc32.x86_64"
+      "evra": "4.3.1-2.fc33.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.12.10-0.fc32.x86_64"
+      "evra": "2:4.13.2-1.fc33.x86_64"
     },
     "libsmbios": {
-      "evra": "2.4.2-7.fc32.x86_64"
+      "evra": "2.4.2-10.fc33.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.14-1.fc32.x86_64"
+      "evra": "0.7.15-1.fc33.x86_64"
     },
     "libsoup": {
-      "evra": "2.70.0-1.fc32.x86_64"
+      "evra": "2.72.0-3.fc33.x86_64"
     },
     "libss": {
-      "evra": "1.45.5-3.fc32.x86_64"
+      "evra": "1.45.6-4.fc33.x86_64"
     },
     "libssh": {
-      "evra": "0.9.5-1.fc32.x86_64"
+      "evra": "0.9.5-1.fc33.x86_64"
     },
     "libssh-config": {
-      "evra": "0.9.5-1.fc32.noarch"
+      "evra": "0.9.5-1.fc33.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "libstdc++": {
-      "evra": "10.2.1-6.fc32.x86_64"
+      "evra": "10.2.1-6.fc33.x86_64"
     },
     "libtalloc": {
-      "evra": "2.3.1-2.fc32.x86_64"
+      "evra": "2.3.1-5.fc33.x86_64"
     },
     "libtasn1": {
-      "evra": "4.16.0-1.fc32.x86_64"
+      "evra": "4.16.0-3.fc33.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.3-2.fc32.x86_64"
+      "evra": "1.4.3-5.fc33.x86_64"
     },
     "libteam": {
-      "evra": "1.31-2.fc32.x86_64"
+      "evra": "1.31-2.fc33.x86_64"
     },
     "libtevent": {
-      "evra": "0.10.2-2.fc32.x86_64"
+      "evra": "0.10.2-5.fc33.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.21-1.fc32.x86_64"
+      "evra": "0.21-3.fc33.x86_64"
     },
     "libtirpc": {
-      "evra": "1.2.6-1.rc4.fc32.x86_64"
+      "evra": "1.2.6-2.rc4.fc33.x86_64"
     },
     "libunistring": {
-      "evra": "0.9.10-7.fc32.x86_64"
+      "evra": "0.9.10-9.fc33.x86_64"
     },
     "libusbx": {
-      "evra": "1.0.23-1.fc32.x86_64"
+      "evra": "1.0.23-2.fc33.x86_64"
     },
     "libuser": {
-      "evra": "0.62-24.fc32.x86_64"
+      "evra": "0.62-26.fc33.x86_64"
     },
     "libutempter": {
-      "evra": "1.1.6-18.fc32.x86_64"
+      "evra": "1.2.1-2.fc33.x86_64"
     },
     "libuuid": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "libvarlink-util": {
-      "evra": "18-3.fc32.x86_64"
+      "evra": "19-3.fc33.x86_64"
     },
     "libverto": {
-      "evra": "0.3.0-9.fc32.x86_64"
+      "evra": "0.3.0-10.fc33.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.12.10-0.fc32.x86_64"
+      "evra": "2:4.13.2-1.fc33.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.17-1.fc32.x86_64"
+      "evra": "4.4.17-1.fc33.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.10-7.fc32.x86_64"
+      "evra": "2.9.10-7.fc33.x86_64"
     },
     "libxmlb": {
-      "evra": "0.1.14-2.fc32.x86_64"
+      "evra": "0.2.1-1.fc33.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.2-3.fc32.x86_64"
+      "evra": "0.2.5-3.fc33.x86_64"
     },
     "libzstd": {
-      "evra": "1.4.5-4.fc32.x86_64"
+      "evra": "1.4.5-5.fc33.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-26.fc32.x86_64"
+      "evra": "2.5.1-27.fc33.x86_64"
     },
     "linux-firmware": {
-      "evra": "20201022-113.fc32.noarch"
+      "evra": "20201022-113.fc33.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20201022-113.fc32.noarch"
+      "evra": "20201022-113.fc33.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.25-1.fc32.x86_64"
+      "evra": "0.9.27-1.fc33.x86_64"
     },
     "logrotate": {
-      "evra": "3.15.1-3.fc32.x86_64"
+      "evra": "3.17.0-3.fc33.x86_64"
     },
     "lsof": {
-      "evra": "4.93.2-3.fc32.x86_64"
+      "evra": "4.93.2-4.fc33.x86_64"
     },
     "lua-libs": {
-      "evra": "5.3.5-8.fc32.x86_64"
+      "evra": "5.4.1-1.fc33.x86_64"
     },
     "luksmeta": {
-      "evra": "9-7.fc32.x86_64"
+      "evra": "9-8.fc33.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.09-1.fc32.x86_64"
+      "evra": "2.03.10-1.fc33.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.09-1.fc32.x86_64"
+      "evra": "2.03.10-1.fc33.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.1-2.fc32.x86_64"
+      "evra": "1.9.1-3.fc33.x86_64"
     },
     "lzo": {
-      "evra": "2.10-2.fc32.x86_64"
+      "evra": "2.10-3.fc33.x86_64"
     },
     "mdadm": {
-      "evra": "4.1-5.fc32.x86_64"
+      "evra": "4.1-6.fc33.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-39.fc32.x86_64"
+      "evra": "2:2.1-40.fc33.x86_64"
     },
     "moby-engine": {
-      "evra": "19.03.11-1.ce.git42e35e6.fc32.x86_64"
+      "evra": "19.03.13-1.ce.git4484c46.fc33.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.3.0-15.fc32.x86_64"
+      "evra": "2:0.4.0-2.fc33.x86_64"
     },
-    "mozjs60": {
-      "evra": "60.9.0-5.fc32.x86_64"
+    "mozjs78": {
+      "evra": "78.4.0-1.fc33.x86_64"
     },
     "mpfr": {
-      "evra": "4.0.2-5.fc32.x86_64"
+      "evra": "4.1.0-2.fc33.x86_64"
     },
     "ncurses": {
-      "evra": "6.1-15.20191109.fc32.x86_64"
+      "evra": "6.2-3.20200222.fc33.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.1-15.20191109.fc32.noarch"
+      "evra": "6.2-3.20200222.fc33.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.1-15.20191109.fc32.x86_64"
+      "evra": "6.2-3.20200222.fc33.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.57.20160912git.fc32.x86_64"
+      "evra": "2.0-0.58.20160912git.fc33.x86_64"
     },
     "nettle": {
-      "evra": "3.5.1-5.fc32.x86_64"
+      "evra": "3.6-3.fc33.x86_64"
     },
     "newt": {
-      "evra": "0.52.21-6.fc32.x86_64"
+      "evra": "0.52.21-8.fc33.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.5.2-0.fc32.x86_64"
+      "evra": "1:2.5.2-0.fc33.x86_64"
     },
     "nftables": {
-      "evra": "1:0.9.3-3.fc32.x86_64"
+      "evra": "1:0.9.3-6.fc33.x86_64"
     },
     "nmap-ncat": {
-      "evra": "2:7.80-4.fc32.x86_64"
+      "evra": "2:7.80-5.fc33.x86_64"
     },
     "npth": {
-      "evra": "1.6-4.fc32.x86_64"
+      "evra": "1.6-5.fc33.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-16.fc32.x86_64"
+      "evra": "2.18.1-17.fc33.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.12-4.fc32.x86_64"
+      "evra": "2.0.14-1.fc33.x86_64"
     },
     "nvme-cli": {
-      "evra": "1.10.1-1.fc32.x86_64"
+      "evra": "1.11.1-2.fc33.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.5-4.rev1.fc32.x86_64"
+      "evra": "6.9.6-0.4.rc4.fc33.x86_64"
     },
     "openldap": {
-      "evra": "2.4.47-5.fc32.x86_64"
+      "evra": "2.4.50-5.fc33.x86_64"
     },
     "openssh": {
-      "evra": "8.3p1-3.fc32.x86_64"
+      "evra": "8.4p1-2.fc33.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.3p1-3.fc32.x86_64"
+      "evra": "8.4p1-2.fc33.x86_64"
     },
     "openssh-server": {
-      "evra": "8.3p1-3.fc32.x86_64"
+      "evra": "8.4p1-2.fc33.x86_64"
     },
     "openssl": {
-      "evra": "1:1.1.1g-1.fc32.x86_64"
+      "evra": "1:1.1.1h-1.fc33.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:1.1.1g-1.fc32.x86_64"
+      "evra": "1:1.1.1h-1.fc33.x86_64"
     },
     "os-prober": {
-      "evra": "1.77-6.fc32.x86_64"
+      "evra": "1.77-6.fc33.x86_64"
     },
     "ostree": {
-      "evra": "2020.7-2.fc32.x86_64"
+      "evra": "2020.7-3.fc33.x86_64"
     },
     "ostree-libs": {
-      "evra": "2020.7-2.fc32.x86_64"
+      "evra": "2020.7-3.fc33.x86_64"
     },
     "p11-kit": {
-      "evra": "0.23.21-2.fc32.x86_64"
+      "evra": "0.23.21-2.fc33.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.23.21-2.fc32.x86_64"
+      "evra": "0.23.21-2.fc33.x86_64"
     },
     "pam": {
-      "evra": "1.3.1-27.fc32.x86_64"
+      "evra": "1.4.0-6.fc33.x86_64"
     },
     "passwd": {
-      "evra": "0.80-8.fc32.x86_64"
+      "evra": "0.80-9.fc33.x86_64"
+    },
+    "pciutils": {
+      "evra": "3.6.4-2.fc33.x86_64"
+    },
+    "pciutils-libs": {
+      "evra": "3.6.4-2.fc33.x86_64"
     },
     "pcre": {
-      "evra": "8.44-2.fc32.x86_64"
+      "evra": "8.44-2.fc33.x86_64"
     },
     "pcre2": {
-      "evra": "10.35-8.fc32.x86_64"
+      "evra": "10.35-8.fc33.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.35-8.fc32.noarch"
+      "evra": "10.35-8.fc33.noarch"
     },
     "pigz": {
-      "evra": "2.4-6.fc32.x86_64"
+      "evra": "2.4-7.fc33.x86_64"
     },
     "pkgconf": {
-      "evra": "1.6.3-3.fc32.x86_64"
+      "evra": "1.7.3-5.fc33.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.6.3-3.fc32.noarch"
+      "evra": "1.7.3-5.fc33.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.6.3-3.fc32.x86_64"
+      "evra": "1.7.3-5.fc33.x86_64"
     },
     "podman": {
-      "evra": "2:2.1.1-7.fc32.x86_64"
+      "evra": "2:2.1.1-12.fc33.x86_64"
     },
     "podman-plugins": {
-      "evra": "2:2.1.1-7.fc32.x86_64"
+      "evra": "2:2.1.1-12.fc33.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.0-2.fc32.x86_64"
+      "evra": "3.1-4.fc33.x86_64"
     },
     "polkit": {
-      "evra": "0.116-7.fc32.x86_64"
+      "evra": "0.117-2.fc33.x86_64"
     },
     "polkit-libs": {
-      "evra": "0.116-7.fc32.x86_64"
+      "evra": "0.117-2.fc33.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-16.fc32.x86_64"
+      "evra": "0.1-18.fc33.x86_64"
     },
     "popt": {
-      "evra": "1.16-19.fc32.x86_64"
+      "evra": "1.18-2.fc33.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.16-1.fc32.x86_64"
+      "evra": "3.3.16-1.fc33.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.3.2-2.fc32.x86_64"
+      "evra": "1.3.3-3.fc33.x86_64"
     },
     "psmisc": {
-      "evra": "23.3-3.fc32.x86_64"
+      "evra": "23.3-4.fc33.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20190417-3.fc32.noarch"
+      "evra": "20190417-4.fc33.noarch"
     },
     "qrencode-libs": {
-      "evra": "4.0.2-5.fc32.x86_64"
+      "evra": "4.0.2-6.fc33.x86_64"
+    },
+    "rdma-core": {
+      "evra": "32.0-1.fc33.x86_64"
     },
     "readline": {
-      "evra": "8.0-4.fc32.x86_64"
+      "evra": "8.0-5.fc33.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.5-5.rc1.fc32.1.x86_64"
+      "evra": "1.2.5-5.rc1.fc33.3.x86_64"
     },
     "rpm": {
-      "evra": "4.15.1-3.fc32.1.x86_64"
+      "evra": "4.16.0-1.fc33.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.15.1-3.fc32.1.x86_64"
+      "evra": "4.16.0-1.fc33.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2020.7-1.fc32.x86_64"
+      "evra": "2020.5-1.fc33.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2020.7-1.fc32.x86_64"
+      "evra": "2020.5-1.fc33.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.15.1-3.fc32.1.x86_64"
+      "evra": "4.16.0-1.fc33.x86_64"
     },
     "rsync": {
-      "evra": "3.2.3-1.fc32.x86_64"
+      "evra": "3.2.3-1.fc33.x86_64"
     },
     "runc": {
-      "evra": "2:1.0.0-144.dev.gite6555cc.fc32.x86_64"
+      "evra": "2:1.0.0-279.dev.gitdedadbf.fc33.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.12.10-0.fc32.x86_64"
+      "evra": "2:4.13.2-1.fc33.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.12.10-0.fc32.noarch"
+      "evra": "2:4.13.2-1.fc33.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.12.10-0.fc32.x86_64"
+      "evra": "2:4.13.2-1.fc33.x86_64"
+    },
+    "samba-libs": {
+      "evra": "2:4.13.2-1.fc33.x86_64"
     },
     "sed": {
-      "evra": "4.5-5.fc32.x86_64"
+      "evra": "4.8-5.fc33.x86_64"
     },
     "selinux-policy": {
-      "evra": "3.14.5-44.fc32.noarch"
+      "evra": "3.14.6-30.fc33.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "3.14.5-44.fc32.noarch"
+      "evra": "3.14.6-30.fc33.noarch"
     },
     "setup": {
-      "evra": "2.13.6-2.fc32.noarch"
+      "evra": "2.13.7-2.fc33.noarch"
     },
     "sg3_utils": {
-      "evra": "1.44-3.fc32.x86_64"
+      "evra": "1.45-3.fc33.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.44-3.fc32.x86_64"
+      "evra": "1.45-3.fc33.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.8.1-2.fc32.x86_64"
+      "evra": "2:4.8.1-4.fc33.x86_64"
     },
     "shared-mime-info": {
-      "evra": "1.15-3.fc32.x86_64"
+      "evra": "2.0-3.fc33.x86_64"
     },
     "shim-x64": {
       "evra": "15-8.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.2.0-2.fc32.x86_64"
+      "evra": "1:1.2.0-3.fc33.x86_64"
     },
     "slang": {
-      "evra": "2.3.2-7.fc32.x86_64"
+      "evra": "2.3.2-8.fc33.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.1.4-1.fc32.x86_64"
+      "evra": "1.1.4-4.dev.giteecccdb.fc33.x86_64"
     },
     "snappy": {
-      "evra": "1.1.8-2.fc32.x86_64"
+      "evra": "1.1.8-4.fc33.x86_64"
     },
     "socat": {
-      "evra": "1.7.3.4-2.fc32.x86_64"
+      "evra": "1.7.3.4-3.fc33.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.33.0-2.fc32.x86_64"
+      "evra": "3.33.0-2.fc33.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.3-25.fc32.x86_64"
+      "evra": "4.4-2.20200513gitc570c61.fc33.x86_64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.2-2.fc32.x86_64"
+      "evra": "0.1.2-5.fc33.x86_64"
     },
     "sssd": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-client": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-common": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.4.0-1.fc32.x86_64"
+      "evra": "2.4.0-2.fc33.x86_64"
     },
     "sudo": {
-      "evra": "1.9.2-1.fc32.x86_64"
+      "evra": "1.9.2-1.fc33.x86_64"
     },
     "systemd": {
-      "evra": "245.8-2.fc32.x86_64"
+      "evra": "246.6-3.fc33.x86_64"
     },
     "systemd-container": {
-      "evra": "245.8-2.fc32.x86_64"
+      "evra": "246.6-3.fc33.x86_64"
     },
     "systemd-libs": {
-      "evra": "245.8-2.fc32.x86_64"
+      "evra": "246.6-3.fc33.x86_64"
     },
     "systemd-pam": {
-      "evra": "245.8-2.fc32.x86_64"
+      "evra": "246.6-3.fc33.x86_64"
     },
     "systemd-rpm-macros": {
-      "evra": "245.8-2.fc32.noarch"
+      "evra": "246.6-3.fc33.noarch"
     },
     "systemd-udev": {
-      "evra": "245.8-2.fc32.x86_64"
+      "evra": "246.6-3.fc33.x86_64"
     },
     "tar": {
-      "evra": "2:1.32-5.fc32.x86_64"
+      "evra": "2:1.32-6.fc33.x86_64"
     },
     "teamd": {
-      "evra": "1.31-2.fc32.x86_64"
+      "evra": "1.31-2.fc33.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.97-1.fc32.x86_64"
+      "evra": "0.0.97-1.fc33.x86_64"
     },
     "tpm2-tools": {
-      "evra": "4.1.3-1.fc32.x86_64"
+      "evra": "4.3.0-1.fc33.x86_64"
     },
     "tpm2-tss": {
-      "evra": "2.4.3-1.fc32.x86_64"
+      "evra": "3.0.1-1.fc33.x86_64"
     },
     "tzdata": {
-      "evra": "2020d-1.fc32.noarch"
+      "evra": "2020d-1.fc33.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.11.1-3.fc32.x86_64"
+      "evra": "0.12.1-2.fc33.x86_64"
     },
     "util-linux": {
-      "evra": "2.35.2-1.fc32.x86_64"
+      "evra": "2.36-3.fc33.x86_64"
     },
     "vim-minimal": {
-      "evra": "2:8.2.1941-1.fc32.x86_64"
+      "evra": "2:8.2.1961-1.fc33.x86_64"
     },
     "which": {
-      "evra": "2.21-19.fc32.x86_64"
+      "evra": "2.21-20.fc33.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20200827-1.fc32.x86_64"
+      "evra": "1.0.20200827-2.fc33.x86_64"
     },
     "xfsprogs": {
-      "evra": "5.4.0-3.fc32.x86_64"
+      "evra": "5.7.0-1.fc33.x86_64"
     },
     "xz": {
-      "evra": "5.2.5-1.fc32.x86_64"
+      "evra": "5.2.5-3.fc33.x86_64"
     },
     "xz-libs": {
-      "evra": "5.2.5-1.fc32.x86_64"
+      "evra": "5.2.5-3.fc33.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-14.fc32.x86_64"
+      "evra": "2.1.0-15.fc33.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.1.5-2.fc32.x86_64"
+      "evra": "1.1.5-3.fc33.x86_64"
     },
     "zincati": {
-      "evra": "0.0.13-1.fc32.x86_64"
+      "evra": "0.0.13-1.fc33.x86_64"
     },
     "zlib": {
-      "evra": "1.2.11-21.fc32.x86_64"
+      "evra": "1.2.11-22.fc33.x86_64"
     },
     "zram-generator": {
-      "evra": "0.2.0-1.fc32.x86_64"
+      "evra": "0.2.0-4.fc33.x86_64"
     }
   },
   "metadata": {
-    "generated": "2020-11-12T14:09:33Z",
+    "generated": "2020-11-12T18:42:26Z",
     "rpmmd_repos": {
       "fedora": {
-        "generated": "2020-04-22T22:22:36Z"
+        "generated": "2020-10-19T23:27:19Z"
       },
       "fedora-coreos-pool": {
         "generated": "2020-11-10T21:43:02Z"
       },
       "fedora-updates": {
-        "generated": "2020-11-12T02:53:50Z"
+        "generated": "2020-11-12T02:54:15Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 ref: fedora/${basearch}/coreos/testing-devel
 include: manifests/fedora-coreos.yaml
 
-releasever: "32"
+releasever: "33"
 
 rojig:
   license: MIT
@@ -23,20 +23,6 @@ lockfile-repos:
 
 add-commit-metadata:
   fedora-coreos.stream: testing-devel
-
-# Put this in manifest.yaml for now and we'll delete when we move to
-# F33 where all of these files have been broken out to the systemd-networkd
-# subpackage.
-remove-from-packages:
-  # We're not using networkd.
-  - [systemd, /etc/systemd/networkd.conf,
-              /usr/lib/systemd/systemd-networkd,
-              /usr/lib/systemd/systemd-networkd-wait-online,
-              /usr/lib/systemd/network/.*,
-              /usr/lib/systemd/system/systemd-networkd.service,
-              /usr/lib/systemd/system/systemd-networkd.socket,
-              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
-  - [systemd-container, /usr/lib/systemd/network/.*]
 
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -10,6 +10,9 @@ mutate-os-release: "${releasever}"
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree
+  # fedora-repos-modular was converted into its own subpackage in f33
+  # Continue to include it in case users want to use it.
+  - fedora-repos-modular
   # the archive repo for more reliable package layering
   # https://github.com/coreos/fedora-coreos-tracker/issues/400
   - fedora-repos-archive


### PR DESCRIPTION
Now that f33 has been soaking in `next` for a while we're ready to move
`testing` over to a Fedora 33 base.