### PR TITLE
15coreos-network: Remove 15-coreos-firstboot-network.conf

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-copy-firstboot-network.sh
@@ -26,10 +26,6 @@ if [ -n "$(ls -A ${initramfs_firstboot_network_dir} 2>/dev/null)" ]; then
     echo "info: copying files from ${initramfs_firstboot_network_dir} to ${initramfs_network_dir}"
     mkdir -p ${initramfs_network_dir}
     cp -v ${initramfs_firstboot_network_dir}/* ${initramfs_network_dir}/
-    # If we make it to the realroot (successfully ran ignition) then
-    # clean up the files in the firstboot network dir
-    echo "R ${realroot_firstboot_network_dir} - - - - -" > \
-        /run/tmpfiles.d/15-coreos-firstboot-network.conf
 else
     echo "info: no files to copy from ${initramfs_firstboot_network_dir}. skipping"
 fi


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-config/pull/659 attempts to
mount `/boot` read-only. `15-coreos-firstboot-network.conf`'s job
should be handled by `ignition-firstboot-complete.service` which
remounts writable (privately/temporarily) `/boot` from the real root.