### PR TITLE
Move buildroot image here

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Updating this repo:
 1. bump `releasever` in `manifest.yaml`
 2. update the repos in `manifest.yaml` if needed
 3. run `cosa fetch --update-lockfile`
-4. PR the result
+4. bump the base Fedora version in `ci/buildroot/Dockerfile`
+5. PR the result
 
 Update server changes:
 

--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -1,0 +1,13 @@
+# This includes the build dependencies for some key packages
+# such as ignition, rpm-ostree, libpod, systemd, and kernel.
+# If you want another package in this list, submit a PR and
+# we can probably add it.
+#
+# This image is used by CoreOS CI to build software like
+# Ignition, rpm-ostree, ostree, coreos-installer, etc...
+FROM registry.fedoraproject.org/fedora:33
+USER root
+WORKDIR /root/containerbuild
+COPY . tmp
+RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf
+WORKDIR /root

--- a/ci/buildroot/buildroot-buildreqs.txt
+++ b/ci/buildroot/buildroot-buildreqs.txt
@@ -1,0 +1,9 @@
+# This is what the CoreOS developers tend to actively develop/own.
+# If you want to extend this, feel free to file a PR.
+ignition
+ostree
+librepo
+kernel
+systemd
+dracut
+podman

--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -1,0 +1,39 @@
+# This is a list of basic buildrequires; it'd be a bit better to
+# yum -y install @buildsys-build but unfortunately that hits a bug:
+# https://fedoraproject.org/wiki/Common_F30_bugs#Conflicts_between_fedora-release_packages_when_installing_package_groups
+# So here we inline it, minus the -release package.
+bash
+bzip2
+coreutils
+cpio
+diffutils
+findutils
+gawk
+glibc-minimal-langpack
+grep
+gzip
+info
+make
+patch
+redhat-rpm-config
+rpm-build
+sed
+shadow-utils
+tar
+unzip
+util-linux
+which
+xz
+
+# For rust projects like rpm-ostree
+rustfmt
+
+# Used by ostree/rpm-ostree CI
+parallel gjs
+
+# Also, add clang since it's useful at least in CI for C/C++ projects
+clang lld
+# All C/C++ projects should have CI that uses the sanitizers
+libubsan libasan libtsan
+# And all C/C++ projects should use clang-analyzer
+clang-analyzer

--- a/ci/buildroot/buildroot-specs.txt
+++ b/ci/buildroot/buildroot-specs.txt
@@ -1,0 +1,3 @@
+# for projects which have their canonical spec files upstream, use those instead
+# since they're more up to date
+https://raw.githubusercontent.com/coreos/rpm-ostree/master/packaging/rpm-ostree.spec.in

--- a/ci/buildroot/install-buildroot.sh
+++ b/ci/buildroot/install-buildroot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+
+# This is invoked by Dockerfile
+
+echo "Installing base build requirements"
+dnf -y install /usr/bin/xargs 'dnf-command(builddep)'
+deps=$(grep -v '^#' "${dn}"/buildroot-reqs.txt)
+echo "${deps}" | xargs dnf -y install
+
+echo "Installing build dependencies of primary packages"
+brs=$(grep -v '^#' "${dn}"/buildroot-buildreqs.txt)
+echo "${brs}" | xargs dnf -y builddep
+
+echo "Installing build dependencies from canonical spec files"
+specs=$(grep -v '^#' "${dn}"/buildroot-specs.txt)
+tmpd=$(mktemp -d) && trap 'rm -rf ${tmpd}' EXIT
+(cd "${tmpd}" && echo "${specs}" | xargs curl -L --remote-name-all)
+(cd "${tmpd}" && find . -type f -print0 | xargs -0 dnf -y builddep --spec)
+
+echo 'Done!'


### PR DESCRIPTION
When using cosa to build OSes, we've been pretty good at shielding
ourselves from versioning differences between source and target
environments (for example, RHCOS is built by Fedora packages). But when
it comes to building things meant to run *in* that OS, we really should
match the buildroot of the target.

Right now, many of our projects use the buildroot cosa container to
build their projects in CI. But this doesn't necessarily match the
buildroot of the rest of the OS.

Since the buildroot to use is defined here (specifically via the
`releasever` key), let's move the concept of a "buildroot image" from
cosa to here. Specifically, we want a container image with all the deps
to the components we mostly hack on for use by both CI and local
developers.

This can then be used by CoreOS CI for building upstream projects, as
well as by cosa itself for building kolet.

See also: https://github.com/coreos/coreos-assembler/issues/1863