### PR TITLE
manifests/ignition-and-ostree: Disable systemd-repart

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -68,6 +68,12 @@ postprocess:
   - |
     #!/usr/bin/env bash
     systemctl mask dnsmasq.service
+  # Mask systemd-repart. Ignition is responsible for partition setup on first
+  # boot and does not use systemd-repart currently. See also
+  # https://github.com/coreos/fedora-coreos-tracker/issues/570
+  - |
+    #!/usr/bin/env bash
+    systemctl mask systemd-repart.service
 
 packages:
   # Security

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -135,3 +135,10 @@ if [ $(systemctl is-enabled dnsmasq.service) != 'masked' ]; then
     fatal "dnsmasq.service systemd unit should be masked"
 fi
 ok "dnsmasq.service systemd unit is masked"
+
+# make sure systemd-repart is masked
+# https://github.com/coreos/fedora-coreos-config/pull/744
+if [ $(systemctl is-enabled systemd-repart.service) != 'masked' ]; then
+    fatal "systemd-repart.service systemd unit should be masked"
+fi
+ok "systemd-repart.service systemd unit is masked"


### PR DESCRIPTION
Ignition is responsible for partition setup on first boot and does not use systemd-repart currently.
See also https://github.com/coreos/fedora-coreos-tracker/issues/570