### PR TITLE
coreos-boot-edit: add triggering condition on coreos-copy-firstboot-network.stamp

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-boot-edit.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-boot-edit.service
@@ -8,7 +8,13 @@ ConditionPathExists=/usr/lib/initrd-release
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-# Since we are mounting /boot, require the device first
+# These are the conditions for which we may need to modify /boot. Otherwise,
+# let's avoid mounting it entirely.
+# Currently, we only have one trigger.
+ConditionPathExists=|/run/coreos-copy-firstboot-network.stamp
+
+# Since we are mounting /boot, require the device first. This isn't strictly
+# necessary since we run late, but on principle let's make clear the dependency.
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
 # Start after Ignition has finished


### PR DESCRIPTION
That way we completely avoid mounting `/boot` rw if we don't need to.
Also clarify comment about the boot dependency. Additional roles for
this service ideally would follow the same pattern.

Minor follow-up to #743.