### PR TITLE
[rhcos-4.6] coreos-copy-firstboot-network: order after coreos-enable-network 

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-copy-firstboot-network.service
@@ -43,10 +43,10 @@ After=coreos-gpt-setup@dev-disk-by\x2dlabel-root.service
 # Since we are mounting /boot/, require the device first
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
-# Need to run after fetch-offline stage since it may re-run the NM cmdline
+# Need to run after coreos-enable-network since it may re-run the NM cmdline
 # hook which will generate NM configs from the network kargs, but we want to
 # have precedence.
-After=ignition-fetch-offline.service
+After=coreos-enable-network.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/coreos-teardown-initramfs.sh
@@ -54,7 +54,7 @@ propagate_initramfs_networking() {
         echo "info: no networking config is defined in the real root"
         if [ -n "$(ls -A /run/NetworkManager/system-connections/)" ]; then
             echo "info: propagating initramfs networking config to the real root"
-            cp /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
+            cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
             selinux_relabel /etc/NetworkManager/system-connections/
         else
             echo "info: no initramfs networking information to propagate"


### PR DESCRIPTION
In a previous iteration, the "conditional networking" logic lived in
`ignition-fetch-offline.service`. This was later moved to its own
service in `coreos-enable-network.service`, but we never updated the
ordering here.

The end result is that sometimes `coreos-enable-network.service` would
run *after* `coreos-copy-firstboot-network.service`, which meant that we
lost any NM config which was copied from `/boot` (i.e. from
`coreos-installer install --copy-network`).

Resolves: bugzilla.redhat.com/show_bug.cgi?id=1895979
(cherry picked from commit 97bd7ff)