### PR TITLE
[next-devel] manifest: remove duplicate fedora-repos-modular entry

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,13 +24,6 @@ lockfile-repos:
 add-commit-metadata:
   fedora-coreos.stream: next-devel
 
-# Move this section back into fedora-coreos-base.yaml once all streams are
-# on Fedora 33.
-packages:
-  # fedora-repos-modular was converted into its own subpackage in f33
-  # Continue to include it in case users want to use it.
-  - fedora-repos-modular
-
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163


### PR DESCRIPTION
When we switched testing-devel over to Fedora 33 in 09a4df3
we added `fedora-repos-modular` to fedora-coreos-base.yaml, which
makes this entry in manifest.yaml redundant now.