### PR TITLE
[next] manifest: remove duplicate fedora-repos-modular entry

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,10 +13,3 @@ repos:
 
 add-commit-metadata:
   fedora-coreos.stream: next
-
-# Move this section back into fedora-coreos-base.yaml once all streams are
-# on Fedora 33.
-packages:
-  # fedora-repos-modular was converted into its own subpackage in f33
-  # Continue to include it in case users want to use it.
-  - fedora-repos-modular


### PR DESCRIPTION
When we switched testing-devel over to Fedora 33 in 09a4df3
we added `fedora-repos-modular` to fedora-coreos-base.yaml, which
makes this entry in manifest.yaml redundant now.