### PR TITLE
bootable-rpm-ostree: move to s390utils-core to get rid of perl dependency on mainframe

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -17,7 +17,7 @@ packages-aarch64:
 packages-ppc64le:
   - grub2 ostree-grub2
 packages-s390x:
-  - s390utils-base
+  - s390utils-core
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl


### PR DESCRIPTION
SSIA