### PR TITLE
20live: log rootfs fetch errors

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
@@ -34,7 +34,7 @@ elif [[ -n "${rootfs_url}" ]]; then
     # image hash.
     # bsdtar can read cpio archives and we already depend on it for
     # coreos-liveiso-persist-osmet.service, so use it instead of cpio.
-    if ! curl --silent --insecure --location --retry 5 "${rootfs_url}" | \
+    if ! curl --silent --show-error --insecure --location --retry 5 "${rootfs_url}" | \
             rdcore stream-hash /etc/coreos-live-want-rootfs | \
             bsdtar -xf - -C / ; then
         echo "Couldn't fetch, verify, and unpack image specified by coreos.live.rootfs_url=" >&2


### PR DESCRIPTION
When rootfs fetch fails, ensure we have some useful logging for tracking down the problem.

`--show-error` has existed in curl since 1999 and I'm not sure why I didn't use it originally.