### PR TITLE
fedora-coreos-base: add nm-cloud-setup, forward platform variables

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -3,6 +3,9 @@
     "NetworkManager": {
       "evra": "1:1.26.6-1.fc33.x86_64"
     },
+    "NetworkManager-cloud-setup": {
+      "evra": "1:1.26.6-1.fc33.x86_64"
+    },
     "NetworkManager-libnm": {
       "evra": "1:1.26.6-1.fc33.x86_64"
     },

--- a/manifests/networking-tools.yaml
+++ b/manifests/networking-tools.yaml
@@ -10,6 +10,9 @@ packages:
   # Teaming https://github.com/coreos/fedora-coreos-config/pull/289 
   # and http://bugzilla.redhat.com/1758162
   - NetworkManager-team teamd
+  # Support for cloud quirks and dynamic config in real rootfs:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/320
+  - NetworkManager-cloud-setup
   # Route manipulation and QoS
   - iproute iproute-tc
   # Firewall manipulation

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-aws-nm-cloud-setup.ign
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-aws-nm-cloud-setup.ign
@@ -1,0 +1,16 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/systemd/system/nm-cloud-setup.service.d/env-aws.conf",
+        "contents": {
+          "source": "data:,%5BService%5D%0AEnvironment%3DNM_CLOUD_SETUP_EC2%3Dyes%0A"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-azure-nm-cloud-setup.ign
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-azure-nm-cloud-setup.ign
@@ -1,0 +1,16 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/systemd/system/nm-cloud-setup.service.d/env-azure.conf",
+        "contents": {
+          "source": "data:,%5BService%5D%0AEnvironment%3DNM_CLOUD_SETUP_AZURE%3Dyes%0A"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-gcp-nm-cloud-setup.ign
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/20-gcp-nm-cloud-setup.ign
@@ -1,0 +1,16 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/systemd/system/nm-cloud-setup.service.d/env-gcp.conf",
+        "contents": {
+          "source": "data:,%5BService%5D%0AEnvironment%3DNM_CLOUD_SETUP_GCP%3Dyes%0A"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
@@ -8,6 +8,24 @@ depends() {
 
 install() {
     mkdir -p "$initdir/usr/lib/ignition/base.d"
+    mkdir -p "$initdir/usr/lib/ignition/base.platform.d"
+
+    # Common entries
     inst "$moddir/30-afterburn-sshkeys-core.ign" \
         "/usr/lib/ignition/base.d/30-afterburn-sshkeys-core.ign"
+
+    # Platform specific: aws
+    mkdir -p "$initdir/usr/lib/ignition/base.platform.d/aws"
+    inst "$moddir/20-aws-nm-cloud-setup.ign" \
+        "/usr/lib/ignition/base.platform.d/aws/20-aws-nm-cloud-setup.ign"
+
+    # Platform specific: azure
+    mkdir -p "$initdir/usr/lib/ignition/base.platform.d/azure"
+    inst "$moddir/20-azure-nm-cloud-setup.ign" \
+        "/usr/lib/ignition/base.platform.d/azure/20-azure-nm-cloud-setup.ign"
+
+    # Platform specific: gcp
+    mkdir -p "$initdir/usr/lib/ignition/base.platform.d/gcp"
+    inst "$moddir/20-gcp-nm-cloud-setup.ign" \
+        "/usr/lib/ignition/base.platform.d/gcp/20-gcp-nm-cloud-setup.ign"
 }


### PR DESCRIPTION
This adds nm-cloud-setup package to fedora-coreos-base set,
and configures the relevant environment variable for AWS, Azure,
and GCP.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/320