### PR TITLE
dracut/15coreos-network: enable initramfs networking on Azure

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/coreos-enable-network.service
@@ -4,9 +4,13 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 After=basic.target
 
-# Triggering conditions for cases where we need network
+# Triggering conditions for cases where we need network:
+#  * when Ignition signals that it is required for provisioning.
+#  * on live systems fetching the remote rootfs in initramfs.
+#  * on Azure, for hostname fetching (metadata endpoint) and boot check-in (wireserver).
 ConditionPathExists=|/run/ignition/neednet
 ConditionKernelCommandLine=|coreos.live.rootfs_url
+ConditionKernelCommandLine=|ignition.platform.id=azure
 
 # Creates /run/ignition/neednet
 After=ignition-fetch-offline.service


### PR DESCRIPTION
This enables networking in initramfs on Azure, via a platform
condition.
While the Ignition configuration may be self-contained locally
on the config-drive, other bits referenced by the provisioning
flow (e.g. Afterburn hostname and boot check-in) always require
reaching remote endpoints.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/689