### PR TITLE
[stable] manifest.yaml: Move to Fedora 33!

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 ref: fedora/${basearch}/coreos/stable
 include: manifests/fedora-coreos.yaml
 
-releasever: "32"
+releasever: "33"
 
 rojig:
   license: MIT
@@ -13,17 +13,3 @@ repos:
 
 add-commit-metadata:
   fedora-coreos.stream: stable
-
-# Put this in manifest.yaml for now and we'll delete when we move to
-# F33 where all of these files have been broken out to the systemd-networkd
-# subpackage.
-remove-from-packages:
-  # We're not using networkd.
-  - [systemd, /etc/systemd/networkd.conf,
-              /usr/lib/systemd/systemd-networkd,
-              /usr/lib/systemd/systemd-networkd-wait-online,
-              /usr/lib/systemd/network/.*,
-              /usr/lib/systemd/system/systemd-networkd.service,
-              /usr/lib/systemd/system/systemd-networkd.socket,
-              /usr/lib/systemd/system/systemd-networkd-wait-online.service]
-  - [systemd-container, /usr/lib/systemd/network/.*]


### PR DESCRIPTION
Import manifest changes from https://github.com/coreos/fedora-coreos-config/commit/09a4df329f00bbb812ef08a9d0163b9f822f9ae2

(cherry picked from commit 399117235c58fa1a7d22050142f214f5749d6329)