### PR TITLE
Preparation for new version of console-login-helper-messages

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -96,6 +96,20 @@ postprocess:
     DNSStubListener=no
     EOF
 
+  # Edit `login.defs` to configure `login(1)` to read from `/run/motd.d` for
+  # displaying the MOTD. This is required for newer versions of
+  # `console-login-helper-messages` to function properly.
+  # This will be dropped once Fedora util-linux adds `/run/motd.d` as a default
+  # in Fedora 34.
+  # https://src.fedoraproject.org/rpms/util-linux/pull-request/8
+  # https://github.com/coreos/fedora-coreos-tracker/issues/704#issuecomment-772862174
+  - |
+    #!/usr/bin/env bash
+    source /etc/os-release
+    if [ ${VERSION_ID} -lt 34 ]; then
+      echo 'MOTD_FILE=/usr/share/misc/motd:/run/motd:/run/motd.d:/etc/motd:/etc/motd.d' >> /etc/login.defs
+    fi
+
 packages:
   # Security
   - selinux-policy-targeted


### PR DESCRIPTION
In order for newer versions of `console-login-helper-messages` to display issue files before login properly, the `--issue-file` option for `agetty` must be set to read from `/run/issue.d`. We also need to add `/run/motd.d` as one of the directories that `login(1)` reads from to display the MOTD after login through a console.