### PR TITLE
99emergency-timeout: fix log display from failed units

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/timeout.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/timeout.sh
@@ -29,7 +29,7 @@ _prompt_for_timeout() {
     if [[ -e /.emergency-shell-confirmed ]]; then
         return
     fi
-    failed=$(systemctl --failed --no-legend | cut -f 1 -d ' ')
+    failed=$(systemctl --failed --no-legend --plain | cut -f 1 -d ' ')
     if [ -n "${failed}" ]; then
         # Something failed, suppress kernel logs so that it's more likely
         # the useful bits from the journal are available.


### PR DESCRIPTION
`timeout.sh` was getting confused by `systemctl` output that looked like this:

    ● ignition-disks.service loaded failed failed Ignition (disks)

The result was output like this:

    Displaying logs from failed units: ●
    Invalid unit name "●" escaped as "\xe2\x97\x8f" (maybe you should use systemd-escape?).
    -- Logs begin at Fri 2020-12-04 04:09:20 UTC, end at Fri 2020-12-04 04:09:33 UTC. --
    -- No entries --
    Press Enter for emergency shell or wait 5 minutes for reboot.