### PR TITLE
40ignition-ostree: be verbose about what we're mounting

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-sysroot.sh
@@ -14,4 +14,5 @@ if ! [ -b "${rootpath}" ]; then
   exit 1
 fi
 
+echo "Mounting ${rootpath} ($(realpath "${rootpath}")) to /sysroot"
 mount -o "$(coreos-rootflags)" "${rootpath}" /sysroot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -32,6 +32,15 @@ query_parttype() {
     echo ".storage?.disks? // [] | map(.partitions?) | flatten | map(select(try .typeGuid catch \"\" | ascii_downcase == \"$1\"))"
 }
 
+
+# Mounts device to directory, with extra logging of the src device
+mount_verbose() {
+    local srcdev=$1; shift
+    local destdir=$1; shift
+    echo "Mounting ${srcdev} ($(realpath "$srcdev")) to $destdir"
+    mount "${srcdev}" "${destdir}"
+}
+
 # Print partition offset for device node $1
 get_partition_offset() {
     local devpath=$(udevadm info --query=path "$1")
@@ -81,7 +90,7 @@ case "${1:-}" in
     save)
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
-            mount "${root_part}" /sysroot
+            mount_verbose "${root_part}" /sysroot
             echo "Moving rootfs to RAM..."
             cp -aT /sysroot "${saved_root}"
             # also store the state of the partition
@@ -89,13 +98,13 @@ case "${1:-}" in
         fi
         if [ -d "${saved_boot}" ]; then
             mkdir -p /sysroot/boot
-            mount "${boot_part}" /sysroot/boot
+            mount_verbose "${boot_part}" /sysroot/boot
             echo "Moving bootfs to RAM..."
             cp -aT /sysroot/boot "${saved_boot}"
         fi
         if [ -d "${saved_esp}" ]; then
             mkdir -p /sysroot/boot/efi
-            mount "${esp_part}" /sysroot/boot/efi
+            mount_verbose "${esp_part}" /sysroot/boot/efi
             echo "Moving EFI System Partition to RAM..."
             cp -aT /sysroot/boot/efi "${saved_esp}"
         fi
@@ -117,21 +126,21 @@ case "${1:-}" in
     restore)
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
-            mount "${root_part}" /sysroot
+            mount_verbose "${root_part}" /sysroot
             echo "Restoring rootfs from RAM..."
             find "${saved_root}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
             chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         fi
         if [ -d "${saved_boot}" ]; then
             mkdir -p /sysroot/boot
-            mount "${boot_part}" /sysroot/boot
+            mount_verbose "${boot_part}" /sysroot/boot
             echo "Restoring bootfs from RAM..."
             find "${saved_boot}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot {} \;
         fi
         if [ -d "${saved_esp}" ]; then
             echo "Restoring EFI System Partition from RAM..."
             mkdir -p /sysroot/boot/efi
-            mount "${esp_part}" /sysroot/boot/efi
+            mount_verbose "${esp_part}" /sysroot/boot/efi
             find "${saved_esp}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot/efi {} \;
         fi
         if [ -d "${saved_bios}" ]; then

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -90,22 +90,22 @@ case "${1:-}" in
     save)
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
-            mount_verbose "${root_part}" /sysroot
             echo "Moving rootfs to RAM..."
+            mount_verbose "${root_part}" /sysroot
             cp -aT /sysroot "${saved_root}"
             # also store the state of the partition
             lsblk "${root_part}" --nodeps --paths --json -b -o NAME,SIZE | jq -c . > "${partstate_root}"
         fi
         if [ -d "${saved_boot}" ]; then
+            echo "Moving bootfs to RAM..."
             mkdir -p /sysroot/boot
             mount_verbose "${boot_part}" /sysroot/boot
-            echo "Moving bootfs to RAM..."
             cp -aT /sysroot/boot "${saved_boot}"
         fi
         if [ -d "${saved_esp}" ]; then
+            echo "Moving EFI System Partition to RAM..."
             mkdir -p /sysroot/boot/efi
             mount_verbose "${esp_part}" /sysroot/boot/efi
-            echo "Moving EFI System Partition to RAM..."
             cp -aT /sysroot/boot/efi "${saved_esp}"
         fi
         if [ -d "${saved_bios}" ]; then
@@ -126,15 +126,15 @@ case "${1:-}" in
     restore)
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
-            mount_verbose "${root_part}" /sysroot
             echo "Restoring rootfs from RAM..."
+            mount_verbose "${root_part}" /sysroot
             find "${saved_root}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
             chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         fi
         if [ -d "${saved_boot}" ]; then
+            echo "Restoring bootfs from RAM..."
             mkdir -p /sysroot/boot
             mount_verbose "${boot_part}" /sysroot/boot
-            echo "Restoring bootfs from RAM..."
             find "${saved_boot}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot {} \;
         fi
         if [ -d "${saved_esp}" ]; then


### PR DESCRIPTION
We're sometimes hitting a flake in the RHCOS CI for LUKS-related tests:

    ignition-ostree-dracut-rootfs[909]: mount: /sysroot: unknown filesystem type 'crypto_LUKS'.
    systemd[1]: Failed to start Ignition OSTree: restore rootfs.

I think what may be happening here is that the `/dev/disk/by-label/root`
symlink is still pointing at the original partition which now hosts the
LUKS device and didn't actually get updated to point to the newly
created filesystem on top of it.

The `disks` stage does do a `udevadm trigger` on exit, though I'm not
sure how foolproof that is.

What we could do eventually to work around this is get the `device` from
the Ignition config and just mount that instead. Though to confirm first
this is what's happening, let's make the mount operations explicitly
call out what devices they're mounting.