### PR TITLE
Add a udevadm settle invocations in transposefs and uuid

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -10,6 +10,8 @@ set -euo pipefail
 
 label=$1
 
+udevadm settle
+
 # Keep this in sync with https://github.com/coreos/coreos-assembler/blob/e3905fd2e138de04184c1cd86b99b0fd83cbe5cf/src/create_disk.sh#L17
 bootfs_uuid="96d15588-3596-4b3c-adca-a2ff7279ea63"
 rootfs_uuid="910678ff-f77e-4a7d-8d53-86f2ac47a823"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -124,6 +124,8 @@ case "${1:-}" in
         fi
         ;;
     restore)
+        # Ensure that if there's an updated /dev/disk/by-partlabel/root, we see the symlink.
+        udevadm settle
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
             echo "Restoring rootfs from RAM..."


### PR DESCRIPTION
I think this will fix a race I saw in an rpm-ostree PR that looks like
this:

```
...
Ignition finished successfully
Missed 21 kernel messages
audit: type=1130 audit(1607446019.771:30): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=ignition-disks comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=ignition-disks comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Finished Ignition (disks).
Reached target Initrd Root Device.
Restoring rootfs from RAM...
Mounting /dev/disk/by-label/root (/dev/disk/by-label/root) to /sysroot
Missed 3 kernel messages
audit: type=1130 audit(1607446019.805:31): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=ignition-ostree-uuid-root comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=failed'
Missed 1 kernel messages
audit: type=1131 audit(1607446019.816:32): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=dracut-pre-mount comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=ignition-ostree-uuid-root comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=failed'
SERVICE_STOP pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=dracut-pre-mount comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Starting Ignition OSTree: Restore Partitions...
mount: /sysroot: special device /dev/disk/by-label/root does not exist.
Missed 2 kernel messages
audit: type=1131 audit(1607446019.821:33): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=dracut-initqueue comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
SERVICE_STOP pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=dracut-initqueue comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Starting Ignition OSTree: Regenerate filesystem UUID (root)...
/usr/sbin/ignition-ostree-firstboot-uuid: Failed to find block device /dev/disk/by-label/root
Missed 2 kernel messages
```