### PR TITLE
40ignition-ostree: fix possible transposefs-restore race

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -34,6 +34,7 @@ if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
     xfs) xfs_admin -U generate "${target}" ;;
     *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
   esac
+  udevadm settle
   echo "Regenerated UUID for ${target}"
 else
   echo "No changes required for ${target} TYPE=${TYPE} UUID=${UUID}"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -5,8 +5,6 @@ set -euo pipefail
 # or booted directly in the cloud.
 # Generate new UUID on firstboot; this is general best practice, but in the future
 # we may use this for mounting by e.g. adding a boot=<uuid> and root=<uuid> kernel args.
-# Note this code should be changed when we land https://github.com/coreos/fedora-coreos-tracker/issues/94
-# so that we only generate a new UUID if we're using the default one.
 
 label=$1
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
@@ -2,6 +2,8 @@
 Description=Ignition OSTree: Restore Partitions
 DefaultDependencies=false
 After=ignition-disks.service
+# Avoid racing with UUID regeneration
+After=ignition-ostree-uuid-root.service
 Before=ignition-ostree-growfs.service
 Before=ignition-ostree-mount-firstboot-sysroot.service
 


### PR DESCRIPTION
Serialize `transposefs-restore` and `firstboot-uuid`, since they both want to mutate the root filesystem.  Also have `firstboot-uuid` wait for udev to settle, since closing a device node for write can cause udevd to recreate `/dev/disk` links.

Alternative to https://github.com/coreos/fedora-coreos-config/pull/770.  Untested.