### PR TITLE
tests: Enable TPM test for all arches except s390x

### DIFF
--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "architectures": "x86_64"}
+# kola: {"platforms": "qemu", "minMemory": 4096, "architectures": "!s390x"}
 set -xeuo pipefail
 
 srcdev=$(findmnt -nvr / -o SOURCE)


### PR DESCRIPTION
With TPM support landing in Fedora-33, enable TPM test for all arches except s390x. A TPM
backend device is not available on s390x to suport TPM