### PR TITLE
coreos-teardown-initramfs: don't propagate purely default network configs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/module-setup.sh
@@ -18,7 +18,9 @@ install_ignition_unit() {
 install() {
     inst_multiple \
         basename \
+        diff \
         lsblk \
+        sed \
         sgdisk
 
     inst_simple "$moddir/coreos-diskful-generator" \

--- a/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# With pure network defaults no networking should have been propagated
+# from the initramfs. This test tries to verify that is the case.
+# https://github.com/coreos/fedora-coreos-tracker/issues/696
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if ! journalctl -t coreos-teardown-initramfs | \
+       grep 'info: skipping propagation of default networking configs'; then
+    echo "no log message claiming to skip initramfs network propagation" >&2
+    fail=1
+fi
+
+if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
+    echo "configs exist in /etc/NetworkManager/system-connections/, but shouldn't" >&2
+    fail=1
+fi
+
+if [ -z "${fail:-}" ]; then
+    ok "success: no initramfs network propagation for default configuration"
+else
+    fatal "fail: no initramfs network propagation for default configuration"
+fi


### PR DESCRIPTION
If the config we are going to copy into the real root is just the
defaults let's just not copy any configuration in because
NetworkManager's "unconfigured" behavior is good enough.

This has side benefits of making the coreos-installer --copy-network
workflow slightly more intuitive.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/696