### PR TITLE
core/dracut/ignition-ostree: add ignition-ostree-sysusers service 

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Needed to work around the initrd `rootfs` / filesystem not being a valid
+# mount to pivot out of. For reference, see:
+#  - https://github.com/torvalds/linux/blob/26bc672134241a080a83b2ab9aa8abede8d30e1c/fs/namespace.c#L3605
+#  - https://gist.github.com/jlebon/fb6e7c6dcc3ce17d3e2a86f5938ec033
+set -euo pipefail
+
+TMP_CHROOT_DIR=""
+
+main() {
+    setup_chroot_tmpdir
+    run_chrooted_bwrap "$@"
+}
+
+setup_chroot_tmpdir() {
+    TMP_CHROOT_DIR=$(mktemp --directory --tmpdir=/mnt '.coreos-sysroot-bwrap.tmp.XXXXXXXXXX')
+    mount --bind / "${TMP_CHROOT_DIR}"
+    mount --make-private "${TMP_CHROOT_DIR}"
+    mount --bind "${TMP_CHROOT_DIR}" "${TMP_CHROOT_DIR}"
+    for mnt in proc sys dev; do
+      mount --bind /$mnt "${TMP_CHROOT_DIR}"/$mnt
+    done
+    touch "${TMP_CHROOT_DIR}"/run/ostree-booted
+    mount --bind /sysroot "${TMP_CHROOT_DIR}"/sysroot
+}
+
+run_chrooted_bwrap() {
+    chroot "${TMP_CHROOT_DIR}" \
+        /usr/bin/env --chdir /sysroot \
+            bwrap \
+            --unshare-pid --unshare-uts --unshare-ipc --unshare-net \
+            --unshare-cgroup-try --dev /dev --proc /proc --chdir / \
+            --ro-bind usr /usr --bind etc /etc --dir /tmp --tmpfs /var/tmp \
+            --tmpfs /run --ro-bind /run/ostree-booted /run/ostree-booted \
+            --symlink usr/lib /lib \
+            --symlink usr/lib64 /lib64 \
+            --symlink usr/bin /bin \
+            --symlink usr/sbin /sbin -- "$@"
+}
+
+cleanup() {
+  if test -z "${TMP_CHROOT_DIR}"; then
+    return
+  fi
+
+  umount --lazy --recursive "${TMP_CHROOT_DIR}"
+  umount --recursive "${TMP_CHROOT_DIR}"
+  rmdir "${TMP_CHROOT_DIR}"
+}
+
+trap cleanup EXIT
+main "$@"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run systemd-sysusers for the target OSTree sysroot.
+
+set -euo pipefail
+
+main() {
+    coreos-sysroot-bwrap systemd-sysusers
+    coreos-relabel \
+        /etc/group \
+        /etc/group- \
+        /etc/gshadow \
+        /etc/gshadow- \
+        /etc/passwd \
+        /etc/passwd- \
+        /etc/shadow \
+        /etc/shadow-
+}
+
+main "$@"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Populate OSTree sysusers
+DefaultDependencies=false
+ConditionKernelCommandLine=|ostree
+
+# Need to do this with all mount points active
+After=ignition-mount.service
+
+# But *before* we start dumping files in there
+Before=ignition-files.service
+Before=ignition-ostree-populate-var.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+ExecStart=/usr/sbin/ignition-ostree-sysusers

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -15,7 +15,9 @@ install_ignition_unit() {
 
 install() {
     inst_multiple \
+        bwrap \
         realpath \
+        rmdir \
         setfiles \
         systemd-sysusers \
         systemd-tmpfiles \
@@ -87,4 +89,5 @@ install() {
     inst_script "$moddir/coreos-growpart" /usr/libexec/coreos-growpart
 
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel
+    inst_script "$moddir/coreos-sysroot-bwrap" /usr/bin/coreos-sysroot-bwrap
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -58,6 +58,10 @@ install() {
         sgdisk    \
         find
 
+    inst_script "$moddir/ignition-ostree-sysusers" \
+        "/usr/sbin/ignition-ostree-sysusers"
+    install_ignition_unit ignition-ostree-sysusers.service
+
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service
         inst_script "$moddir/ignition-ostree-${x}-var.sh" "/usr/sbin/ignition-ostree-${x}-var"

--- a/tests/kola/ignition/sysusers/config.fcc
+++ b/tests/kola/ignition/sysusers/config.fcc
@@ -1,0 +1,12 @@
+---
+variant: fcos
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/zincati/config.d/00-dummy-placeholder.toml
+      mode: 0644
+      user:
+        name: "zincati"
+      contents:
+        inline: |
+          # Dummy placeholder

--- a/tests/kola/ignition/sysusers/test.sh
+++ b/tests/kola/ignition/sysusers/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+TARGET="/etc/zincati/config.d/00-dummy-placeholder.toml"
+OWNER=$(stat -c '%U' "${TARGET}")
+
+# make sure the placeholder file is owned by the proper system user.
+if test "${OWNER}" != 'zincati' ; then
+    fatal "unexpected owner of ${TARGET}: ${OWNER}"
+fi
+ok "placeholder file correctly owned by zincati user"


### PR DESCRIPTION
This introduces a new `ignition-ostree-sysusers.service`, which takes
care of poulating users and groups on the target sysroot before the
Ignition `files` stage.