### PR TITLE
manifests: use /usr/sbin/zipl instead of s390utils-core

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -17,7 +17,9 @@ packages-aarch64:
 packages-ppc64le:
   - grub2 ostree-grub2
 packages-s390x:
-  - s390utils-core
+  # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
+  # provided by s390utils-base, but soon will be -core too.
+  - /usr/sbin/zipl
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl


### PR DESCRIPTION
As discussed in this thread:

https://github.com/coreos/fedora-coreos-config/pull/756#issuecomment-743221406

The `-core` package doesn't yet exist in RHEL. Let's request by path
instead for now.