### PR TITLE
overlay.d: Use `systemctl {add-wants, add-requires}`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/module-setup.sh
@@ -2,8 +2,7 @@ install_and_enable_unit() {
     unit="$1"; shift
     target="$1"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$unit"
+    systemctl -q --root="$initdir" add-requires "$target" "$unit"
 }
 
 install() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/module-setup.sh
@@ -7,8 +7,7 @@ install_and_enable_unit() {
     unit="$1"; shift
     target="$1"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$unit"
+    systemctl -q --root="$initdir" add-requires "$target" "$unit"
 }
 
 install() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/30ignition-coreos/module-setup.sh
@@ -11,8 +11,7 @@ install_ignition_unit() {
     local target="${1:-ignition-complete.target}"; shift
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$instantiated"
+    systemctl -q --root="$initdir" add-requires "$target" "$instantiated"
 }
 
 install() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -10,9 +10,7 @@ install_ignition_unit() {
     local unit=$1; shift
     local target=${1:-complete}
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    local targetpath="$systemdsystemunitdir/ignition-${target}.target.requires/"
-    mkdir -p "${initdir}/${targetpath}"
-    ln_r "../$unit" "${targetpath}/${unit}"
+    systemctl -q --root="$initdir" add-requires "ignition-${target}.target" "$unit"
 }
 
 install() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/50coreos-kernel/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/50coreos-kernel/module-setup.sh
@@ -2,8 +2,7 @@ install_unit() {
     unit="$1"; shift
     target="$1"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$unit"
+    systemctl -q --root="$initdir" add-requires "$target" "$unit"
 }
 
 install() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/module-setup.sh
@@ -7,8 +7,7 @@ install_unit_wants() {
     local target="$1"; shift
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.wants"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.wants/$instantiated"
+    systemctl -q --root="$initdir" add-wants "$target" "$instantiated"
 }
 
 install() {


### PR DESCRIPTION
Use `systemctl`'s built-in way of adding `Wants=` and `Requires=`
dependencies, since this is the recommended way of adding dependencies
and we can do so with a single command.