### PR TITLE
effectively revert use of systemd-resolved

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,4 +1,20 @@
 packages:
+  # Fast-track systemd update that reverts fallback hostname change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
+  # This is a one-off build, please don't remove it without talking
+  # to dustymabe or jlebon.
+  systemd:
+    evra: 246.7-1.fc33.aarch64
+  systemd-container:
+    evra: 246.7-1.fc33.aarch64
+  systemd-libs:
+    evra: 246.7-1.fc33.aarch64
+  systemd-pam:
+    evra: 246.7-1.fc33.aarch64
+  systemd-rpm-macros:
+    evra: 246.7-1.fc33.noarch
+  systemd-udev:
+    evra: 246.7-1.fc33.aarch64
   # Fast-track Afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-94fd991213
   afterburn:

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -21,3 +21,10 @@ packages:
     evra: 4.6.0-2.fc33.aarch64
   afterburn-dracut:
     evra: 4.6.0-2.fc33.aarch64
+  # Fast-track SELinux policy for
+  # https://github.com/coreos/fedora-coreos-tracker/issues/679
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f33aa1146d
+  selinux-policy:
+    evra: 3.14.6-33.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-33.fc33.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -21,3 +21,10 @@ packages:
     evra: 4.6.0-2.fc33.ppc64le
   afterburn-dracut:
     evra: 4.6.0-2.fc33.ppc64le
+  # Fast-track SELinux policy for
+  # https://github.com/coreos/fedora-coreos-tracker/issues/679
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f33aa1146d
+  selinux-policy:
+    evra: 3.14.6-33.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-33.fc33.noarch

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,4 +1,20 @@
 packages:
+  # Fast-track systemd update that reverts fallback hostname change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
+  # This is a one-off build, please don't remove it without talking
+  # to dustymabe or jlebon.
+  systemd:
+    evra: 246.7-1.fc33.ppc64le
+  systemd-container:
+    evra: 246.7-1.fc33.ppc64le
+  systemd-libs:
+    evra: 246.7-1.fc33.ppc64le
+  systemd-pam:
+    evra: 246.7-1.fc33.ppc64le
+  systemd-rpm-macros:
+    evra: 246.7-1.fc33.noarch
+  systemd-udev:
+    evra: 246.7-1.fc33.ppc64le
   # Fast-track Afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-94fd991213
   afterburn:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,4 +1,20 @@
 packages:
+  # Fast-track systemd update that reverts fallback hostname change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
+  # This is a one-off build, please don't remove it without talking
+  # to dustymabe or jlebon.
+  systemd:
+    evra: 246.7-1.fc33.s390x
+  systemd-container:
+    evra: 246.7-1.fc33.s390x
+  systemd-libs:
+    evra: 246.7-1.fc33.s390x
+  systemd-pam:
+    evra: 246.7-1.fc33.s390x
+  systemd-rpm-macros:
+    evra: 246.7-1.fc33.noarch
+  systemd-udev:
+    evra: 246.7-1.fc33.s390x
   # Fast-track Afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-94fd991213
   afterburn:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -21,3 +21,10 @@ packages:
     evra: 4.6.0-2.fc33.s390x
   afterburn-dracut:
     evra: 4.6.0-2.fc33.s390x
+  # Fast-track SELinux policy for
+  # https://github.com/coreos/fedora-coreos-tracker/issues/679
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f33aa1146d
+  selinux-policy:
+    evra: 3.14.6-33.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-33.fc33.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -21,3 +21,10 @@ packages:
     evra: 4.6.0-2.fc33.x86_64
   afterburn-dracut:
     evra: 4.6.0-2.fc33.x86_64
+  # Fast-track SELinux policy for
+  # https://github.com/coreos/fedora-coreos-tracker/issues/679
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2020-f33aa1146d
+  selinux-policy:
+    evra: 3.14.6-33.fc33.noarch
+  selinux-policy-targeted:
+    evra: 3.14.6-33.fc33.noarch

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,4 +1,20 @@
 packages:
+  # Fast-track systemd update that reverts fallback hostname change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
+  # This is a one-off build, please don't remove it without talking
+  # to dustymabe or jlebon.
+  systemd:
+    evra: 246.7-1.fc33.x86_64
+  systemd-container:
+    evra: 246.7-1.fc33.x86_64
+  systemd-libs:
+    evra: 246.7-1.fc33.x86_64
+  systemd-pam:
+    evra: 246.7-1.fc33.x86_64
+  systemd-rpm-macros:
+    evra: 246.7-1.fc33.noarch
+  systemd-udev:
+    evra: 246.7-1.fc33.x86_64
   # Fast-track Afterburn release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2020-94fd991213
   afterburn:

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -71,6 +71,8 @@ postprocess:
 
   # Neuter systemd-resolved for now.
   # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-743219353
+  # Note: When removing this, we likely also want to remove
+  # coreos-reset-stub-resolv-selinux-context.{path,service} and their presets.
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -69,6 +69,22 @@ postprocess:
     #!/usr/bin/env bash
     systemctl mask dnsmasq.service
 
+  # Neuter systemd-resolved for now.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-743219353
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # Get us back to Fedora 32's nsswitch.conf settings
+    sed -i 's/^hosts:.*/hosts:      files dns myhostname/' /etc/nsswitch.conf
+    mkdir /usr/lib/systemd/resolved.conf.d/
+    cat > /usr/lib/systemd/resolved.conf.d/fedora-coreos-stub-listener.conf <<'EOF'
+    # Fedora CoreOS is electing to not use systemd-resolved's internal
+    # logic for now because of issues with setting hostnames via reverse DNS.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-736104003
+    [Resolve]
+    DNSStubListener=no
+    EOF
+
 packages:
   # Security
   - selinux-policy-targeted

--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -5,3 +5,6 @@ enable coreos-check-ignition-config.service
 enable coreos-check-ssh-keys.service
 # Monitor the stub-resolv.conf SELinux context
 enable coreos-reset-stub-resolv-selinux-context.path
+# Run once on startup to prevent some race conditions with
+# NetworkManager and systemd-resolved starting up.
+enable coreos-reset-stub-resolv-selinux-context.service

--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -3,3 +3,5 @@ enable fedora-coreos-pinger.service
 # Provide information if no ignition is provided
 enable coreos-check-ignition-config.service
 enable coreos-check-ssh-keys.service
+# Monitor the stub-resolv.conf SELinux context
+enable coreos-reset-stub-resolv-selinux-context.path

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.path
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.path
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor /run/systemd/resolve/stub-resolv.conf to fixup SELinux context.
+Documentation=https://github.com/systemd/systemd/pull/17976
+Before=systemd-resolved.service
+
+[Path]
+PathModified=/run/systemd/resolve/stub-resolv.conf
+Unit=coreos-reset-stub-resolv-selinux-context.service
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.service
@@ -2,9 +2,17 @@
 Description=Fixup SELinux context on /run/systemd/resolve/stub-resolv.conf
 Documentation=https://github.com/systemd/systemd/pull/17976
 ConditionPathExists=/run/systemd/resolve/stub-resolv.conf
+# Run once on startup in addition to the path unit invocations
+# so that we can order ourselves before NetworkManager to prevent
+# at least a few race condition denials.
+After=systemd-resolved.service
+Before=NetworkManager.service
 
 [Service]
 Type=oneshot
 # This service can be started more than once. If the file changes.
 RemainAfterExit=no
 ExecStart=restorecon -v /run/systemd/resolve/stub-resolv.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Fixup SELinux context on /run/systemd/resolve/stub-resolv.conf
+Documentation=https://github.com/systemd/systemd/pull/17976
+ConditionPathExists=/run/systemd/resolve/stub-resolv.conf
+
+[Service]
+Type=oneshot
+# This service can be started more than once. If the file changes.
+RemainAfterExit=no
+ExecStart=restorecon -v /run/systemd/resolve/stub-resolv.conf

--- a/tests/kola/misc-ign-ro/test.sh
+++ b/tests/kola/misc-ign-ro/test.sh
@@ -27,3 +27,12 @@ if ! grep '^# coreos.com$' /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.c
     fatal "expected coreos.com in ca-bundle"
 fi
 ok "coreos-update-ca-trust.service"
+
+# Make sure that the stub-resolv.conf file has the correct selinux context.
+# https://github.com/fedora-selinux/selinux-policy/pull/509#issuecomment-744540382
+# https://github.com/systemd/systemd/pull/17976
+context=$(stat --format "%C" /run/systemd/resolve/stub-resolv.conf)
+if [ "$context" != "system_u:object_r:net_conf_t:s0" ]; then
+    fatal "SELinux context on stub-resolv.conf is wrong"
+fi
+ok "SELinux context on stub-resolv.conf is correct"


### PR DESCRIPTION
This one is complicated, we need to revert the systemd change
in f33 that makes it fallback to `fedora` rather than `localhost`
for the hostname and we also need to essentially render systemd-resolved
ineffective because it's internal fallbacks for reverse DNS make
it really hard to set the hostname via reverse DNS, which is
something we don't want to break and needs upstream work to
get more appropriate fixes in.

More context in https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-736104003
