### PR TITLE
overlay.d/15fcos: Stop utilizing c-l-h-m private dir

### DIFF
--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config.sh
@@ -16,7 +16,11 @@ nc='\033[0m'
 output=$(journalctl -o json-pretty MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb | jq -s '.[] | select(.IGNITION_CONFIG_TYPE == "user")'| wc -l)
 
 if [[ $output -gt  0 ]];then
-   echo "Ignition: user provided config was applied" > /run/console-login-helper-messages/issue.d/30_ignition_config_info.issue
+    echo "Ignition: user provided config was applied" > /etc/issue.d/30_ignition_config_info.issue
 else
-  echo -e "${warn}Ignition: no config provided by user${nc}" > /run/console-login-helper-messages/issue.d/30_ignition_config_info.issue
+    echo -e "${warn}Ignition: no config provided by user${nc}" > /etc/issue.d/30_ignition_config_info.issue
 fi
+
+# Ask all running agetty instances to reload and update their
+# displayed prompts in case this script was run before agetty.
+/usr/sbin/agetty --reload

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys.sh
@@ -36,11 +36,15 @@ main() {
     fi
 
     if [ -n "$output" ]; then
-        echo "$output" > /run/console-login-helper-messages/issue.d/30_ssh_authorized_keys.issue
+        echo "$output" > /etc/issue.d/30_ssh_authorized_keys.issue
     else
         echo -e "${warn}No ssh authorized keys provided by Ignition or Afterburn${nc}" \
-             > /run/console-login-helper-messages/issue.d/30_ssh_authorized_keys.issue
+            > /etc/issue.d/30_ssh_authorized_keys.issue
     fi
+
+    # Ask all running agetty instances to reload and update their
+    # displayed prompts in case this script was run before agetty.
+    /usr/sbin/agetty --reload
 }
 
 main


### PR DESCRIPTION
Drop issue file snippets directly into `/etc/issue.d`, which
is read by `agetty`.

Following https://github.com/coreos/console-login-helper-messages/pull/91,
new versions of console-login-helper-messages will no longer
support users dropping files into its private directories
(e.g. `/run/console-login-helper-messages/issue.d`).