### PR TITLE
40ignition-ostree/transposefs: trigger udev for by-label symlink mismatch for ESP too, and fix a labeling issue

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -168,11 +168,13 @@ case "${1:-}" in
         if [ -d "${saved_root}" ]; then
             echo "Restoring rootfs from RAM..."
             mount_and_restore_filesystem root /sysroot "${saved_root}"
+            chcon -v --reference "${saved_root}" /sysroot  # the root of the fs itself
             chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         fi
         if [ -d "${saved_boot}" ]; then
             echo "Restoring bootfs from RAM..."
             mount_and_restore_filesystem boot /sysroot/boot "${saved_boot}"
+            chcon -v --reference "${saved_boot}" /sysroot/boot  # the root of the fs itself
         fi
         if [ -d "${saved_esp}" ]; then
             echo "Restoring EFI System Partition from RAM..."

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -63,6 +63,18 @@ get_partition_offset() {
     cat "/sys${devpath}/start"
 }
 
+mount_and_restore_filesystem() {
+    local label=$1; shift
+    local mountpoint=$1; shift
+    local saved_fs=$1; shift
+    local new_dev
+    new_dev=$(jq -r "$(query_fslabel "${label}") | .[0].device" "${ignition_cfg}")
+    udev_trigger_on_label_mismatch "${label}" "${new_dev}"
+    mkdir -p "${mountpoint}"
+    mount_verbose "/dev/disk/by-label/${label}" "${mountpoint}"
+    find "${saved_fs}" -mindepth 1 -maxdepth 1 -exec mv -t "${mountpoint}" {} \;
+}
+
 case "${1:-}" in
     detect)
         # Mounts are not in a private namespace so we can mount ${saved_data}
@@ -155,27 +167,16 @@ case "${1:-}" in
         # Mounts happen in a private mount namespace since we're not "offically" mounting
         if [ -d "${saved_root}" ]; then
             echo "Restoring rootfs from RAM..."
-            new_root_dev=$(jq -r "$(query_fslabel root) | .[0].device" "${ignition_cfg}")
-            udev_trigger_on_label_mismatch root "${new_root_dev}"
-            mount_verbose "${root_part}" /sysroot
-            find "${saved_root}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot {} \;
+            mount_and_restore_filesystem root /sysroot "${saved_root}"
             chattr +i $(ls -d /sysroot/ostree/deploy/*/deploy/*/)
         fi
         if [ -d "${saved_boot}" ]; then
             echo "Restoring bootfs from RAM..."
-            new_boot_dev=$(jq -r "$(query_fslabel boot) | .[0].device" "${ignition_cfg}")
-            udev_trigger_on_label_mismatch boot "${new_boot_dev}"
-            mkdir -p /sysroot/boot
-            mount_verbose "${boot_part}" /sysroot/boot
-            find "${saved_boot}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot {} \;
+            mount_and_restore_filesystem boot /sysroot/boot "${saved_boot}"
         fi
         if [ -d "${saved_esp}" ]; then
             echo "Restoring EFI System Partition from RAM..."
-            new_efi_dev=$(jq -r "$(query_fslabel EFI-SYSTEM) | .[0].device" "${ignition_cfg}")
-            udev_trigger_on_label_mismatch EFI-SYSTEM "${new_efi_dev}"
-            mkdir -p /sysroot/boot/efi
-            mount_verbose "${esp_part}" /sysroot/boot/efi
-            find "${saved_esp}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot/efi {} \;
+            mount_and_restore_filesystem EFI-SYSTEM /sysroot/boot/efi "${saved_esp}"
         fi
         if [ -d "${saved_bios}" ]; then
             echo "Restoring BIOS Boot partition and boot sector from RAM..."

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -171,6 +171,8 @@ case "${1:-}" in
         fi
         if [ -d "${saved_esp}" ]; then
             echo "Restoring EFI System Partition from RAM..."
+            new_efi_dev=$(jq -r "$(query_fslabel EFI-SYSTEM) | .[0].device" "${ignition_cfg}")
+            udev_trigger_on_label_mismatch EFI-SYSTEM "${new_efi_dev}"
             mkdir -p /sysroot/boot/efi
             mount_verbose "${esp_part}" /sysroot/boot/efi
             find "${saved_esp}" -mindepth 1 -maxdepth 1 -exec mv -t /sysroot/boot/efi {} \;

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -17,6 +17,7 @@ install() {
     inst_multiple \
         realpath \
         setfiles \
+        chcon \
         systemd-sysusers \
         systemd-tmpfiles \
         sort \


### PR DESCRIPTION
```
commit 7bed856c3b030187916ae47ac1baf5fec801a4b1
Date:   Thu Dec 17 17:07:47 2020 -0500

    40ignition-ostree/transposefs: also trigger udev on by-label link mismatch for ESP

    Just saw the same issue described in 6c9f15c88 happen for
    `/dev/disk/by-label/EFI-SYSTEM` locally.

commit e0184d5a879a139d00ebb033fd368875960cbadf
Date:   Thu Dec 17 17:27:08 2020 -0500

    40ignition-ostree/transposefs: factor out function to restore fs

    We're doing this three times now; let's just factor it out. That way
    it's obvious that we're following the exact same pattern each time.

commit 767a2444b5dae76a6aa447134a04ba2f7b8c421f
Date:   Thu Dec 17 17:33:24 2020 -0500

    40ignition-ostree/transposefs: relabel the root of reprovisioned filesystems

    When we do `mv -t $mountpoint`, everything we move *into* the
    mountpoints gets its SELinux label preserved, but the root of the
    filesystem itself (i.e. `$mountpoint`) doesn't get relabeled.

    This is something that `rsync` would've done for us if we had used that
    instead of `mv`. (Though I recall using `rsync` was also slower than
    `mv` in my tests.) Anyway, I think eventually we want to rewrite some of
    this stuff into rdcore.
```

The last commit is independent of the others. I can break it out into a separate PR if preferred.