### PR TITLE
40ignition-ostree/transposefs: load zram with num_devices=0

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -82,7 +82,7 @@ case "${1:-}" in
             echo "Found duplicate or missing BIOS-BOOT or PReP labels in config" >&2
             exit 1
         fi
-        modprobe zram
+        modprobe zram num_devices=0
         read dev < /sys/class/zram-control/hot_add
         # disksize is set arbitrarily large, as zram is capped by mem_limit
         echo 10G > /sys/block/zram"${dev}"/disksize


### PR DESCRIPTION
By default, upon inserting the zram module, it'll automatically create
one zram device. Because we don't know if we're the first ones or not,
it's not safe to make use of that device.

Instead, tell it to not do that so that if we *are* the first ones to
load the module, we don't end up with an extra zram device. If we
aren't, it's a no-op.