### PR TITLE
40ignition-ostree: copy ESP contents as independent filesystems

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -39,6 +39,7 @@ mount_verbose() {
     local srcdev=$1; shift
     local destdir=$1; shift
     echo "Mounting ${srcdev} ($(realpath "$srcdev")) to $destdir"
+    mkdir -p "${destdir}"
     mount "${srcdev}" "${destdir}"
 }
 
@@ -70,7 +71,6 @@ mount_and_restore_filesystem_by_label() {
     local new_dev
     new_dev=$(jq -r "$(query_fslabel "${label}") | .[0].device" "${ignition_cfg}")
     udev_trigger_on_label_mismatch "${label}" "${new_dev}"
-    mkdir -p "${mountpoint}"
     mount_verbose "/dev/disk/by-label/${label}" "${mountpoint}"
     find "${saved_fs}" -mindepth 1 -maxdepth 1 -exec mv -t "${mountpoint}" {} \;
 }
@@ -135,13 +135,11 @@ case "${1:-}" in
         fi
         if [ -d "${saved_boot}" ]; then
             echo "Moving bootfs to RAM..."
-            mkdir -p /sysroot/boot
             mount_verbose "${boot_part}" /sysroot/boot
             cp -aT /sysroot/boot "${saved_boot}"
         fi
         if [ -d "${saved_esp}" ]; then
             echo "Moving EFI System Partition to RAM..."
-            mkdir -p /sysroot/boot/efi
             mount_verbose "${esp_part}" /sysroot/boot/efi
             cp -aT /sysroot/boot/efi "${saved_esp}"
         fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -102,7 +102,7 @@ case "${1:-}" in
         # boot breaks anyway, but we still want to leave room for everything
         # else so it hits ENOSPC and doesn't invoke the OOM killer
         echo $(( $(grep MemAvailable /proc/meminfo | awk '{print $2}') * 90 / 100 ))K > /sys/block/zram"${dev}"/mem_limit
-        mkfs.xfs /dev/zram"${dev}"
+        mkfs.xfs -q /dev/zram"${dev}"
         mkdir "${saved_data}"
         mount /dev/zram"${dev}" "${saved_data}"
         # save the zram device number created for when called to cleanup

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -72,18 +72,4 @@ EOF
 # the dependency on the underlying device unit.
 if [ ! -f /run/ostree-live ]; then
     mk_mount /boot boot
-
-    # Only mount the EFI System Partition on machines where it exists,
-    # which are 1) machines actually booted through EFI, and 2) x86_64
-    # when booted through BIOS.
-    if [ "$(uname -m)" = "x86_64" -o -d /sys/firmware/efi ]; then
-        mk_mount /boot/efi EFI-SYSTEM
-        # In the general case the ESP might have per-machine or private
-        # data on it.  Let's not make it world readable on general
-        # principle.
-        # https://github.com/coreos/fedora-coreos-tracker/issues/640
-        cat >>${UNIT_DIR}/boot-efi.mount << EOF
-Options=umask=0077
-EOF
-    fi
 fi

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -93,9 +93,6 @@ ok LICENSE
 
 case "$(arch)" in
     x86_64|aarch64)
-        if runuser -u core -- ls /boot/efi &>/dev/null; then
-            fatal "Was able to access /boot/efi as non-root"
-        fi
         # This is just a basic sanity check; at some point we
         # will implement "project-owned tests run in the pipeline"
         # and be able to run the existing bootupd tests:


### PR DESCRIPTION
If the firmware writes to an individual ESP replica, the RAID will desynchronize.  Linux `md` will return reads from either replica, and then any dependent writes could corrupt the filesystem.  To prevent this, FCCT will no longer put the ESP on a RAID (https://github.com/coreos/fcct/pull/178); instead we create multiple independent filesystems and copy the contents to each.  This is okay because bootupd and fwupd should be the only things that care about the contents of the ESP.

Drop the mount unit for `/boot/efi`, since there's no longer going to be a "canonical ESP" to mount.

Don't worry too much about backward compatibility because we're making this change soon after the functionality landed, and before it was documented.  For the record, old configs will fail on new systems (because the partitions will be RAID members) but new configs will skip copying `/boot` on old systems (because there's no filesystem labeled `EFI-SYSTEM`).

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/694 and [RHBZ 1909453](https://bugzilla.redhat.com/show_bug.cgi?id=1909453).  Closes https://github.com/coreos/fedora-coreos-tracker/issues/581.  Obsoletes https://github.com/coreos/fedora-coreos-config/pull/407.  Discussion in https://github.com/coreos/fedora-coreos-config/pull/718 and design doc update in https://github.com/coreos/enhancements/pull/4.