### PR TITLE
Switch to sqlite rpmdb backend

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -40,6 +40,9 @@ check-groups:
 
 default-target: multi-user.target
 
+# we can drop this when it's the rpm-ostree default
+rpmdb: sqlite
+
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -114,12 +114,12 @@ if [ -n "${unlabeled}" ]; then
 fi
 ok no files with unlabeled_t SELinux label
 
-# make sure we stick with bdb until we're ready to move to sqlite
+# make sure we're using the sqlite rpmdb backend
 # https://github.com/coreos/fedora-coreos-tracker/issues/623
-if [ ! -f /usr/share/rpm/Packages ]; then
-    fatal "Didn't find bdb file /usr/share/rpm/Packages"
+if [ ! -f /usr/share/rpm/rpmdb.sqlite ]; then
+    fatal "Didn't find file /usr/share/rpm/rpmdb.sqlite"
 fi
-ok rpmdb is bdb
+ok rpmdb is sqlite
 
 # make sure we don't default to having swap on zram
 # https://github.com/coreos/fedora-coreos-tracker/issues/509


### PR DESCRIPTION
There won't be any support for writing to the bdb backend in f34, so
e.g. pkglayering won't work (and obviously even composes wouldn't work
once we move cosa to f34).

All the production streams now have an f33 barrier release (as part of
the resolved workarounds), so it should be safe to switch to sqlite now.

For the other rpm-ostree-based variants, we'll probably just flip the
default in rpm-ostree to sqlite in f34. But at least in FCOS, we can do
this now so that we flush out any issues earlier and squash the ugly
warnings when querying the rpmdb.

Closes: #623