### PR TITLE
coreos-teardown-initramfs: propagate NM configs in /etc

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -89,11 +89,15 @@ propagate_initramfs_networking() {
         echo "info: will not attempt to propagate initramfs networking"
     else
         echo "info: no networking config is defined in the real root"
-        if [ -n "$(ls -A /run/NetworkManager/system-connections/)" ]; then
+        if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
+            echo "info: propagating /etc initramfs networking config to the real root"
+            cp -v /etc/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
+            selinux_relabel /etc/NetworkManager/system-connections/
+        elif [ -n "$(ls -A /run/NetworkManager/system-connections/)" ]; then
             if are_default_NM_configs; then
                 echo "info: skipping propagation of default networking configs"
             else
-                echo "info: propagating initramfs networking config to the real root"
+                echo "info: propagating /run initramfs networking config to the real root"
                 cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
                 selinux_relabel /etc/NetworkManager/system-connections/
             fi


### PR DESCRIPTION
In the case where a user is PXE booting (or booting a custom made ISO as
suggested in https://github.com/coreos/fedora-coreos-tracker/issues/661)
we want users to be able to specify their NM configurations using a
secondary initrd which overlays the config in `/etc/NetworkManager/` as
a better alternative to using networking kargs.

In that case, we do still want to propagate those configs into the real
root. This avoids users having to also specify the same config again via
Ignition.

Related: https://discussion.fedoraproject.org/t/25833
Related: https://github.com/coreos/fedora-coreos-tracker/issues/661