### PR TITLE
Revert "Switch to sqlite rpmdb backend"

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -40,9 +40,6 @@ check-groups:
 
 default-target: multi-user.target
 
-# we can drop this when it's the rpm-ostree default
-rpmdb: sqlite
-
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -116,12 +116,12 @@ if [ -n "${unlabeled}" ]; then
 fi
 ok no files with unlabeled_t SELinux label
 
-# make sure we're using the sqlite rpmdb backend
+# make sure we stick with bdb until we're ready to move to sqlite
 # https://github.com/coreos/fedora-coreos-tracker/issues/623
-if [ ! -f /usr/share/rpm/rpmdb.sqlite ]; then
-    fatal "Didn't find file /usr/share/rpm/rpmdb.sqlite"
+if [ ! -f /usr/share/rpm/Packages ]; then
+    fatal "Didn't find bdb file /usr/share/rpm/Packages"
 fi
-ok rpmdb is sqlite
+ok rpmdb is bdb
 
 # make sure we don't default to having swap on zram
 # https://github.com/coreos/fedora-coreos-tracker/issues/509


### PR DESCRIPTION
This reverts commit 51cd4932c7346e9f266ce6940044c7c7e8f80195.

It seems like it breaks some rpm-ostree pkglayering tests, which means
it might be subtly changing layering semantics. Let's revert for now
while we investigate to make sure it doesn't somehow get into a release.

See: https://github.com/coreos/rpm-ostree/issues/2435