### PR TITLE
coreos-growpart: drop support for growing multipathed disks

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.service
@@ -3,7 +3,7 @@
 # https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
 
 [Unit]
-Description=CoreOS Tear down initramfs
+Description=CoreOS Tear Down Initramfs
 DefaultDependencies=false
 
 # We want to run the teardown after all other Ignition stages

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-growpart
@@ -45,43 +45,23 @@ case "${TYPE:-}" in
     *) echo "error: Unsupported filesystem for ${path}: '${TYPE:-}'" 1>&2; exit 1 ;;
 esac
 
-if [[ "${src}" =~ "/dev/mapper" ]]; then
-    eval $(udevadm info --query property --export "${src}")
-    # get the partition, if any, and the name for the device mapper
-    partition="${ID_PART_ENTRY_NUMBER:-}"
-    dm_name="${DM_NAME//$partition/}"
-    # identify the type of device mapper.
-    subsystem=$(dmsetup info ${dm_name} -C -o subsystem --noheadings)
-
-    # for now, we only support multipath devices
-    if [ "${subsystem}" == "mpath" ] && [ -n "${partition}" ]; then
-        # growpart does not understand device mapper, instead of having sfdisk inform the kernel,
-        # use kpartx to inform the kernel and the device mapper linear maps.
-        echo ", +" | sfdisk --no-reread --no-tell-kernel --force -N "${ID_PART_ENTRY_NUMBER}" "/dev/mapper/${dm_name}"
-        kpartx -fu /dev/mapper/${dm_name}
-    else
-        echo "coreos-growpart: unsupported device-mapper target: ${dm_name}"
-        exit 0
-    fi
+if test "${TYPE:-}" = "btrfs"; then
+    # Theoretically btrfs can have multiple devices, but when
+    # we start we will always have exactly one.
+    devpath=$(btrfs device usage /sysroot | grep /dev | cut -f 1 -d ,)
+    devpath=$(realpath /sys/class/block/${devpath#/dev/})
 else
-    if test "${TYPE:-}" = "btrfs"; then
-        # Theoretically btrfs can have multiple devices, but when
-        # we start we will always have exactly one.
-        devpath=$(btrfs device usage /sysroot | grep /dev | cut -f 1 -d ,)
-        devpath=$(realpath /sys/class/block/${devpath#/dev/})
-    else
-        # Handle traditional disk/partitions
-        majmin=$(findmnt -nvr -o MAJ:MIN "$path" | tail -n1)
-        devpath=$(realpath "/sys/dev/block/$majmin")
-    fi
-    partition="${partition:-$(cat "$devpath/partition")}"
-    parent_path=$(dirname "$devpath")
-    parent_device=/dev/$(basename "${parent_path}")
-
-    # TODO: make this idempotent, and don't error out if
-    # we can't resize.
-    growpart "${parent_device}" "${partition}" || true
+    # Handle traditional disk/partitions
+    majmin=$(findmnt -nvr -o MAJ:MIN "$path" | tail -n1)
+    devpath=$(realpath "/sys/dev/block/$majmin")
 fi
+partition="${partition:-$(cat "$devpath/partition")}"
+parent_path=$(dirname "$devpath")
+parent_device=/dev/$(basename "${parent_path}")
+
+# TODO: make this idempotent, and don't error out if
+# we can't resize.
+growpart "${parent_device}" "${partition}" || true
 
 # Wipe any filesystem signatures from the extended partition that don't
 # correspond to the FS type we detected earlier.


### PR DESCRIPTION
The model we're moving towards is one where multipath enablement is
configured via Ignition and so only takes effect on the next boot:

https://github.com/openshift/os/pull/484#issuecomment-760454177

Therefore, we don't need to worry here about support for growing a
multipathed root partition. This simplifies a big chunk of the script.