### PR TITLE
Add python3-libs to exclude list

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -85,7 +85,9 @@ remove-files:
 exclude-packages:
   - python
   - python2
+  - python2-libs
   - python3
+  - python3-libs
   - perl
   - nodejs
   - dnf


### PR DESCRIPTION
This was in rawhide due to sudo but will drop out now with
https://src.fedoraproject.org/rpms/sudo/pull-request/21. Let's exclude
it here to make sure we catch it more easily in the future.