### PR TITLE
40ignition-ostree: make transposefs-related errors hard

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-detect.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-detect.service
@@ -6,6 +6,8 @@ Before=ignition-disks.service
 Before=initrd-root-fs.target
 Before=sysroot.mount
 ConditionKernelCommandLine=ostree
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # This stage requires udevd to detect disks
 Requires=systemd-udevd.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
@@ -6,6 +6,8 @@ After=ignition-disks.service
 After=ignition-ostree-uuid-root.service
 Before=ignition-ostree-growfs.service
 Before=ignition-ostree-mount-firstboot-sysroot.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 ConditionKernelCommandLine=ostree
 ConditionPathIsDirectory=/run/ignition-ostree-transposefs

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
@@ -8,6 +8,8 @@ ConditionPathIsDirectory=/run/ignition-ostree-transposefs
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
 After=coreos-gpt-setup.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Noticed that `ignition-ostree-transposefs-save.service` didn't break the
boot immediately after an error while debugging logs with @mike-nguyen.
Let's cargo-cult the `OnFailure` bits into those services too.

I think we may still be suffering from
https://github.com/systemd/systemd/issues/14142 in RHEL systemd.