### PR TITLE
overlay: Disable systemd-firstboot even if installed

### DIFF
--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -27,7 +27,8 @@ packages:
 
 remove-from-packages:
   # We don't want systemd-firstboot.service. It conceptually conflicts with
-  # Ignition.
+  # Ignition.  We also inject runtime bits to disable it in systemd-firstboot.service.d/fcos-disable.conf
+  # to make it easier to use systemd builds from git.
   - [systemd, /usr/bin/systemd-firstboot,
               /usr/lib/systemd/system/systemd-firstboot.service,
               /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]

--- a/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
@@ -1,0 +1,6 @@
+# Disable systemd-firstboot because it conflicts with Ignition.
+# In most cases this is handled via the remove-from-packages
+# bits in the manifest (ignition-and-ostree.yaml), but
+# we want to support overlaying builds of systemd from git.
+[Unit]
+ConditionPathExists=/run/nosuchfile


### PR DESCRIPTION
I'm trying to hack on systemd using `cosa build-fast`, which
doesn't run through the `remove-from-packages` path which we
use to disable systemd-firstboot.

Let's also add this cheap mechanism to disable it even if it's
installed.