### PR TITLE
[next] overrides: pin sudo to 1.9.5p2-1.fc33 for CVE-2021-3156

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -19,3 +19,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2c1659799a
   ignition:
     evra: 2.9.0-2.git1d56dc8.fc33.aarch64
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -19,3 +19,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2c1659799a
   ignition:
     evra: 2.9.0-2.git1d56dc8.fc33.ppc64le
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -19,3 +19,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2c1659799a
   ignition:
     evra: 2.9.0-2.git1d56dc8.fc33.s390x
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -19,3 +19,7 @@ packages:
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2c1659799a
   ignition:
     evra: 2.9.0-2.git1d56dc8.fc33.x86_64
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.x86_64


### PR DESCRIPTION
(cherry picked from commit 5ebd114cc9cc7922839b9541694f519b9c896aaa)