### PR TITLE
overlay: propagate multipath config post-firstboot

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -22,17 +22,6 @@ dracut_func() {
     return $rc
 }
 
-selinux_relabel() {
-    # If we have access to coreos-relabel then let's use that because
-    # it allows us to set labels on things before switching root
-    # If not, fallback to tmpfiles.
-    if command -v coreos-relabel; then
-        coreos-relabel $1
-    else
-        echo "Z $1 - - -" >> "/run/tmpfiles.d/$(basename $0)-relabel.conf"
-    fi
-}
-
 # Determine if the generated NM connection profiles match the default
 # that would be given to us if the user had provided no additional
 # configuration. i.e. did the user give us any network configuration
@@ -95,7 +84,7 @@ propagate_initramfs_networking() {
             else
                 echo "info: propagating initramfs networking config to the real root"
                 cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
-                selinux_relabel /etc/NetworkManager/system-connections/
+                coreos-relabel /etc/NetworkManager/system-connections/
             fi
         else
             echo "info: no initramfs networking information to propagate"
@@ -147,7 +136,7 @@ propagate_initramfs_hostname() {
         if [ -n "$hostname" ]; then
             echo "info: propagating initramfs hostname (${hostname}) to the real root"
             echo $hostname > /sysroot/etc/hostname
-            selinux_relabel /etc/hostname
+            coreos-relabel /etc/hostname
         else
             echo "info: no initramfs hostname information to propagate"
         fi
@@ -161,7 +150,7 @@ propagate_initramfs_hostname() {
         hostname=$(</run/NetworkManager/initrd/hostname)
         echo "info: propagating initramfs hostname (${hostname}) to the real root"
         echo $hostname > /sysroot/etc/hostname
-        selinux_relabel /etc/hostname
+        coreos-relabel /etc/hostname
     else
         echo "info: no initramfs hostname information to propagate"
     fi
@@ -176,8 +165,8 @@ propagate_initramfs_multipath() {
         echo "info: propagating automatic multipath configuration"
         cp -v /etc/multipath.conf /sysroot/etc/
         mkdir -p /sysroot/etc/multipath/multipath.conf.d
-        selinux_relabel /etc/multipath.conf
-        selinux_relabel /etc/multipath/multipath.conf.d
+        coreos-relabel /etc/multipath.conf
+        coreos-relabel /etc/multipath/multipath.conf.d
     else
         echo "info: no initramfs automatic multipath configuration to propagate"
     fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -156,22 +156,6 @@ propagate_initramfs_hostname() {
     fi
 }
 
-# Persist automatic multipath configuration, if any.
-# When booting with `rd.multipath=default`, the default multipath
-# configuration is written. We need to ensure that the mutlipath configuration
-# is persisted to the final target.
-propagate_initramfs_multipath() {
-    if [ ! -f /sysroot/etc/multipath.conf ] && [ -f /etc/multipath.conf ]; then
-        echo "info: propagating automatic multipath configuration"
-        cp -v /etc/multipath.conf /sysroot/etc/
-        mkdir -p /sysroot/etc/multipath/multipath.conf.d
-        coreos-relabel /etc/multipath.conf
-        coreos-relabel /etc/multipath/multipath.conf.d
-    else
-        echo "info: no initramfs automatic multipath configuration to propagate"
-    fi
-}
-
 down_interface() {
     echo "info: taking down network device: $1"
     # On recommendation from the NM team let's try to delete the device
@@ -242,10 +226,6 @@ main() {
     # clean it up so that no information from outside of the
     # real root is passed on to NetworkManager in the real root
     rm -rf /run/NetworkManager/
-
-    # If automated multipath configuration has been enabled, ensure
-    # that its propagated to the real rootfs.
-    propagate_initramfs_multipath
 }
 
 main

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CoreOS Propagate Multipath Configuration
+After=ostree-prepare-root.service
+Before=initrd.target
+
+ConditionKernelCommandLine=rd.multipath=default
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/coreos-propagate-multipath-conf
+RemainAfterExit=yes

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Persist automatic multipath configuration, if any.
+# When booting with `rd.multipath=default`, the default multipath
+# configuration is written. We need to ensure that the multipath configuration
+# is persisted to the final target.
+
+if [ ! -f /sysroot/etc/multipath.conf ] && [ -f /etc/multipath.conf ]; then
+    echo "info: propagating automatic multipath configuration"
+    cp -v /etc/multipath.conf /sysroot/etc/
+    mkdir -p /sysroot/etc/multipath/multipath.conf.d
+    coreos-relabel /etc/multipath.conf
+    coreos-relabel /etc/multipath/multipath.conf.d
+else
+    echo "info: no initramfs automatic multipath configuration to propagate"
+fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install_ignition_unit() {
+    local unit=$1; shift
+    local target=${1:-complete}
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires "ignition-${target}.target" "$unit" || exit 1
+}
+
+install() {
+    inst_script "$moddir/coreos-propagate-multipath-conf.sh" \
+        "/usr/sbin/coreos-propagate-multipath-conf"
+
+    install_ignition_unit coreos-propagate-multipath-conf.service subsequent
+}


### PR DESCRIPTION
Because multipath support now works on the second boot, the propagation
code in `coreos-teardown-network.service` didn't work. Split that code
out into a separate dracut module and have it run on subsequent boots.

Resolves: bugzilla.redhat.com/show_bug.cgi?id=1920571