### PR TITLE
manifest: Enable cliwrap

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -43,6 +43,9 @@ default-target: multi-user.target
 # we can drop this when it's the rpm-ostree default
 rpmdb: sqlite
 
+# See the treefile docs
+cliwrap: true
+
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -123,6 +123,12 @@ if [ ! -f /usr/share/rpm/rpmdb.sqlite ]; then
 fi
 ok rpmdb is sqlite
 
+if dracut 2>err.txt; then
+    fatal "ran dracut"
+    grep -q 'rpm-ostree initramfs' err.txt
+fi
+echo "ok rpm-ostree cliwrap"
+
 # make sure we don't default to having swap on zram
 # https://github.com/coreos/fedora-coreos-tracker/issues/509
 # https://github.com/coreos/fedora-coreos-config/pull/687


### PR DESCRIPTION
This functionality has been around for quite a while in rpm-ostree
but I'm not aware of anyone using it.  I'd like to turn it
on here so we can gain the benefits, which right now are
better protection against non-ostree-aware commands run as
root (`rpm` and `dracut` namely).

A bit more in https://github.com/coreos/rpm-ostree/pull/1789

Closes https://github.com/coreos/fedora-coreos-tracker/issues/730.