### PR TITLE
[next-devel] overrides: fast-track kernel for CVE-2021-3347 ("Use after free via P…

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,3 +15,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.aarch64
+  # Fast-track kernel fix for CVE-2021-3347
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
+  kernel:
+    evra: 5.10.12-200.fc33.aarch64
+  kernel-core:
+    evra: 5.10.12-200.fc33.aarch64
+  kernel-modules:
+    evra: 5.10.12-200.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,3 +15,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.ppc64le
+  # Fast-track kernel fix for CVE-2021-3347
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
+  kernel:
+    evra: 5.10.12-200.fc33.ppc64le
+  kernel-core:
+    evra: 5.10.12-200.fc33.ppc64le
+  kernel-modules:
+    evra: 5.10.12-200.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,3 +15,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.s390x
+  # Fast-track kernel fix for CVE-2021-3347
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
+  kernel:
+    evra: 5.10.12-200.fc33.s390x
+  kernel-core:
+    evra: 5.10.12-200.fc33.s390x
+  kernel-modules:
+    evra: 5.10.12-200.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,3 +15,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.x86_64
+  # Fast-track kernel fix for CVE-2021-3347
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
+  kernel:
+    evra: 5.10.12-200.fc33.x86_64
+  kernel-core:
+    evra: 5.10.12-200.fc33.x86_64
+  kernel-modules:
+    evra: 5.10.12-200.fc33.x86_64


### PR DESCRIPTION
…I futex state")

A flaw was found in the Linux kernel. A use after free issue in PI futex
may lead to code execution.

Tracker bug: https://bugzilla.redhat.com/show_bug.cgi?id=1922249
Bodhi update: https://bodhi.fedoraproject.org/updates/FEDORA-2021-879c756377