### PR TITLE
[stable] overrides: pin sudo to 1.9.5p2-1.fc33 for CVE-2021-3156

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -23,3 +23,7 @@ packages:
     evra: 5.10.12-200.fc33.aarch64
   kernel-modules:
     evra: 5.10.12-200.fc33.aarch64
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -23,3 +23,7 @@ packages:
     evra: 5.10.12-200.fc33.ppc64le
   kernel-modules:
     evra: 5.10.12-200.fc33.ppc64le
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -23,3 +23,7 @@ packages:
     evra: 5.10.12-200.fc33.s390x
   kernel-modules:
     evra: 5.10.12-200.fc33.s390x
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -23,3 +23,7 @@ packages:
     evra: 5.10.12-200.fc33.x86_64
   kernel-modules:
     evra: 5.10.12-200.fc33.x86_64
+  # CVE-2021-3156
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-2cb63d912a
+  sudo:
+    evra: 1.9.5p2-1.fc33.x86_64


### PR DESCRIPTION
(cherry picked from commit e86ffdd9e8512514478e48f7f07385d538e9933d)

(This was mistakenly un-cherry-picked as part of
https://github.com/coreos/fedora-coreos-config/pull/834.)