### PR TITLE
overrides: fast-track rpm-ostree-2021.1-3.fc33

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -23,3 +23,9 @@ packages:
     evra: 5.10.12-200.fc33.aarch64
   kernel-modules:
     evra: 5.10.12-200.fc33.aarch64
+  # Fast-track rpm-ostree for libsolv fix
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-937b45bf55
+  rpm-ostree:
+    evra: 2021.1-3.fc33.aarch64
+  rpm-ostree-libs:
+    evra: 2021.1-3.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -23,3 +23,9 @@ packages:
     evra: 5.10.12-200.fc33.ppc64le
   kernel-modules:
     evra: 5.10.12-200.fc33.ppc64le
+  # Fast-track rpm-ostree for libsolv fix
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-937b45bf55
+  rpm-ostree:
+    evra: 2021.1-3.fc33.ppc64le
+  rpm-ostree-libs:
+    evra: 2021.1-3.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -23,3 +23,9 @@ packages:
     evra: 5.10.12-200.fc33.s390x
   kernel-modules:
     evra: 5.10.12-200.fc33.s390x
+  # Fast-track rpm-ostree for libsolv fix
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-937b45bf55
+  rpm-ostree:
+    evra: 2021.1-3.fc33.s390x
+  rpm-ostree-libs:
+    evra: 2021.1-3.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -23,3 +23,9 @@ packages:
     evra: 5.10.12-200.fc33.x86_64
   kernel-modules:
     evra: 5.10.12-200.fc33.x86_64
+  # Fast-track rpm-ostree for libsolv fix
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-937b45bf55
+  rpm-ostree:
+    evra: 2021.1-3.fc33.x86_64
+  rpm-ostree-libs:
+    evra: 2021.1-3.fc33.x86_64


### PR DESCRIPTION
To unblock lockfile bumps which try to pull in new libsolv and hit
against https://github.com/coreos/rpm-ostree/pull/2490.