### PR TITLE
manifest: Add back `dracut-squash` and `squashfs-tools`

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -237,6 +237,9 @@
     "dracut-network": {
       "evra": "050-64.git20200529.fc33.x86_64"
     },
+    "dracut-squash": {
+      "evra": "050-64.git20200529.fc33.x86_64"
+    },
     "e2fsprogs": {
       "evra": "1.45.6-4.fc33.x86_64"
     },
@@ -1100,6 +1103,9 @@
     },
     "sqlite-libs": {
       "evra": "3.34.1-1.fc33.x86_64"
+    },
+    "squashfs-tools": {
+      "evra": "4.4-2.20200513gitc570c61.fc33.x86_64"
     },
     "ssh-key-dir": {
       "evra": "0.1.2-5.fc33.x86_64"

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -24,7 +24,10 @@ packages:
   - console-login-helper-messages-profile
   # kdump support
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
+  ## dracut-squash - weak dependency of kexec-tools
+  ## https://github.com/coreos/fedora-coreos-tracker/issues/798
   - kexec-tools
+  - dracut-squash
   # Remote Access
   - openssh-clients openssh-server
   # Container tooling


### PR DESCRIPTION
`dracut-squash` and `squashfs-tools` were made weak dependencies
by `kexec-tools` in version `2.0.21-4.fc33.x86_64`. However,
without these two packages, kdump's generated initramfs will be
unable to boot.
https://bugzilla.redhat.com/show_bug.cgi?id=1925585

Add back these packages for now so kdump functionality is not
broken.