### PR TITLE
[WIP] overlay: generate and propagate udev rules for s390x znet devices

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/ibm-znet-rules.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/ibm-znet-rules.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=IBM znet udev-rules generator
+ConditionArchitecture=s390x
+ConditionPathExists=/etc/initrd-release
+DefaultDependencies=false
+Before=ignition-complete.target
+
+After=ostree-prepare-root.service
+Before=ignition-files.service
+
+ConditionKernelCommandLine=rd.znet
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ibm-znet-rules
+RemainAfterExit=yes

--- a/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/ibm-znet-rules.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/ibm-znet-rules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1818033
+
+znet=$(lszdev qeth -c ID --no-headings | awk -F ":" '{print $1}')
+for dev in ${znet}; do
+    # chzdev creates udev rules to store the persistent configuration of devices in this directory. File names start with "41-".
+    rule="/sysroot/etc/udev/rules.d/41-qeth-${dev}.rules"
+    if [[ ! -f ${rule} ]]; then
+	echo "${dev}: generating ${rule}"
+	chzdev qeth -e ${dev} --no-root-update --base /etc=/sysroot/etc
+    fi
+done

--- a/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99ibm-znet-rules/module-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+       echo systemd
+}
+
+install_and_enable_unit() {
+       local unit="$1"; shift
+       local target="$1"; shift
+       inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+       # note we `|| exit 1` here so we error out if e.g. the units are missing
+       # see https://github.com/coreos/fedora-coreos-config/issues/799
+       systemctl -q --root="$initdir" add-requires "$target" "$unit" || exit 1
+}
+
+install() {
+    inst_multiple chzdev lszdev awk
+
+    install_and_enable_unit "ibm-znet-rules.service" \
+                            "ignition-complete.target"
+
+    inst_script "$moddir/ibm-znet-rules.sh" \
+                "/usr/sbin/ibm-znet-rules"
+}


### PR DESCRIPTION
Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1818033

When varying off and on the chpid to simulate an outage, the network does not come up automatically afterwards.
The guest has to be restarted. Adding missing udev rules so device could be added back withot system restart.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>