### PR TITLE
overlay: add warning if rootfs < 8G

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-check-rootfs-size
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-check-rootfs-size
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# See also ignition-ostree-check-rootfs-size.service
+# https://github.com/coreos/fedora-coreos-tracker/issues/586#issuecomment-777220000
+
+srcdev=$(findmnt -nvr -o SOURCE /sysroot | tail -n1)
+size=$(lsblk --nodeps --noheadings --bytes -o SIZE "${srcdev}")
+
+MINIMUM_GB=8
+MINIMUM_BYTES=$((1024 * 1024 * 1024 * MINIMUM_GB))
+
+MOTD_DROPIN=/etc/motd.d/60-coreos-rootfs-size.motd
+
+YELLOW=$(echo -e '\033[0;33m')
+RESET=$(echo -e '\033[0m')
+
+if [ "${size}" -lt "${MINIMUM_BYTES}" ]; then
+    mkdir -p "/sysroot/$(dirname "${MOTD_DROPIN}")"
+    cat > "/sysroot/${MOTD_DROPIN}" <<EOF
+${YELLOW}
+############################################################################
+WARNING: The root filesystem is too small. It is strongly recommended to
+allocate at least ${MINIMUM_GB} GiB of space to allow for upgrades. From June 2021, this
+condition will trigger a failure in some cases. For more information, see:
+https://docs.fedoraproject.org/en-US/fedora-coreos/storage/
+
+You may delete this warning using:
+sudo rm ${MOTD_DROPIN}
+############################################################################
+${RESET}
+EOF
+
+    # And also write it on stdout for the journal and console
+    cat "/sysroot/${MOTD_DROPIN}"
+    coreos-relabel "${MOTD_DROPIN}"
+fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Ignition OSTree: Check Root Filesystem Size
+Documentation=https://docs.fedoraproject.org/en-US/fedora-coreos/storage/
+DefaultDependencies=false
+ConditionKernelCommandLine=ostree
+ConditionPathExists=!/run/ostree-live
+After=ignition-ostree-growfs.service
+After=ostree-prepare-root.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-check-rootfs-size
+RemainAfterExit=yes

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -89,5 +89,9 @@ install() {
     install_ignition_unit ignition-ostree-growfs.service
     inst_script "$moddir/coreos-growpart" /usr/libexec/coreos-growpart
 
+    install_ignition_unit ignition-ostree-check-rootfs-size.service
+    inst_script "$moddir/coreos-check-rootfs-size" \
+        /usr/libexec/coreos-check-rootfs-size
+
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel
 }


### PR DESCRIPTION
We've recently had our first case of a "trapped" rootfs running out of
space for upgrades:

https://github.com/coreos/fedora-coreos-tracker/issues/731

Until we actually implement stronger behaviour for this, let's
explicitly check for this case and emit a warning if we detect it. In
the future, we'll look at making this a hard error by default (with an
escape hatch).

For more information, see:

https://github.com/coreos/fedora-coreos-tracker/issues/586#issuecomment-777220000