### PR TITLE
manifest: ship specific sssd subpackages instead

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -159,7 +159,9 @@ packages:
   # https://github.com/coreos/fedora-coreos-tracker/issues/445
   - libsss_sudo
   # Extra runtime
-  - sssd shadow-utils
+  - shadow-utils
+  # SSSD; we only ship a subset of the backends
+  - sssd-client sssd-ad sssd-ipa sssd-krb5 sssd-ldap
   # There are things that write outside of the journal still (such as the classic wtmp, etc.)
   # (auditd also writes outside the journal but it has its own log rotation.)
   # Anything package layered will also tend to expect files dropped in


### PR DESCRIPTION
The `sssd` subpackage is a meta-package which just pulls in the default
set of packages. This default set changed in Fedora 34, which started
pulling in `python3-sssdconfig`:

https://bugzilla.redhat.com/show_bug.cgi?id=1927907

From the maintainer feedback there, it seems like it'd be better anyway
to be more explicit about the specific backends we want to ship. So
let's do that here: break out `sssd` into the client and the backends
for AD, IPA, KRB5, and LDAP.