### PR TITLE
overlay.d/05core: Remove CLHM-{issuegen,motdgen} units

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -1,10 +1,6 @@
 # Presets here that eventually should live in the generic fedora presets
 enable coreos-growpart.service
 # console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
-enable console-login-helper-messages-issuegen.service
-enable console-login-helper-messages-motdgen.service
-enable console-login-helper-messages-issuegen.path
-enable console-login-helper-messages-motdgen.path
 enable console-login-helper-messages-gensnippet-os-release.service
 enable console-login-helper-messages-gensnippet-ssh-keys.service
 # CA certs (probably to add to base fedora eventually)


### PR DESCRIPTION
These units no longer exist after CLHM v0.21.

Lockfiles already bumped to v0.21.1. https://github.com/coreos/fedora-coreos-config/commit/8a4b1fdb1a4b769008afb97ccabd1e900b6c88cd