### PR TITLE
overrides: drop graduated overrides

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,18 +15,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.aarch64
-  # Fast-track kernel fix for CVE-2021-3347
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
-  kernel:
-    evra: 5.10.12-200.fc33.aarch64
-  kernel-core:
-    evra: 5.10.12-200.fc33.aarch64
-  kernel-modules:
-    evra: 5.10.12-200.fc33.aarch64
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1925717
-  libsolv:
-    evra: 0.7.15-1.fc33.aarch64
-  # Fast-track Ignition cleanups and IMDSv2 fix
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-9e7c4ba680
-  ignition:
-    evra: 2.9.0-4.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,18 +15,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.ppc64le
-  # Fast-track kernel fix for CVE-2021-3347
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
-  kernel:
-    evra: 5.10.12-200.fc33.ppc64le
-  kernel-core:
-    evra: 5.10.12-200.fc33.ppc64le
-  kernel-modules:
-    evra: 5.10.12-200.fc33.ppc64le
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1925717
-  libsolv:
-    evra: 0.7.15-1.fc33.ppc64le
-  # Fast-track Ignition cleanups and IMDSv2 fix
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-9e7c4ba680
-  ignition:
-    evra: 2.9.0-4.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,18 +15,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.s390x
-  # Fast-track kernel fix for CVE-2021-3347
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
-  kernel:
-    evra: 5.10.12-200.fc33.s390x
-  kernel-core:
-    evra: 5.10.12-200.fc33.s390x
-  kernel-modules:
-    evra: 5.10.12-200.fc33.s390x
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1925717
-  libsolv:
-    evra: 0.7.15-1.fc33.s390x
-  # Fast-track Ignition cleanups and IMDSv2 fix
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-9e7c4ba680
-  ignition:
-    evra: 2.9.0-4.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,18 +15,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.x86_64
-  # Fast-track kernel fix for CVE-2021-3347
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-6e805a5051
-  kernel:
-    evra: 5.10.12-200.fc33.x86_64
-  kernel-core:
-    evra: 5.10.12-200.fc33.x86_64
-  kernel-modules:
-    evra: 5.10.12-200.fc33.x86_64
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1925717
-  libsolv:
-    evra: 0.7.15-1.fc33.x86_64
-  # Fast-track Ignition cleanups and IMDSv2 fix
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-9e7c4ba680
-  ignition:
-    evra: 2.9.0-4.fc33.x86_64


### PR DESCRIPTION
And also drop the libsolv override now that we're shipping with the
patched rpm-ostree.