### PR TITLE
presets: disable systemd-oomd.service

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -22,3 +22,5 @@ enable bootupd.socket
 # The event for the attached device comes as a diag event.
 # Ideally it should have been added as part of base Fedora - but since it was arch specific, it was not added: https://bugzilla.redhat.com/show_bug.cgi?id=1433859
 enable rtas_errd.service
+# We don't have swap by default, and systemd-oomd hard requires it.
+disable systemd-oomd.service


### PR DESCRIPTION
It requires swap, which we don't turn on by default. (It also requires
cgroups v2, which we currently don't turn on by default but are aiming
to in the near future.)