### PR TITLE
overlay: create 40-coreos-systemd.preset

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -1,0 +1,4 @@
+# This file contains overrides for systemd services that are
+# enabled by default, but conflict with things we ship
+# We don't have swap by default, and systemd-oomd hard requires it.
+disable systemd-oomd.service

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -1,7 +1,15 @@
 # This file contains overrides for systemd services that are
-# enabled by default, but conflict with things we ship
+# enabled by default, but conflict with things we ship.
+
 # We don't have swap by default, and systemd-oomd hard requires it.
 disable systemd-oomd.service
+
+# Disable systemd-firstboot because it conflicts with Ignition.
+# In most cases this is handled via the remove-from-packages
+# bits in the manifest (ignition-and-ostree.yaml), but
+# we want to support overlaying builds of systemd from git.
+disable systemd-firstboot.service
+
 # This hasn't been tested with ostree/rpm-ostree and heavily overlaps
 # with the latter.  Preemptively disable the service; it will hopefully
 # be subpackaged though for Fedora.

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -2,3 +2,7 @@
 # enabled by default, but conflict with things we ship
 # We don't have swap by default, and systemd-oomd hard requires it.
 disable systemd-oomd.service
+# This hasn't been tested with ostree/rpm-ostree and heavily overlaps
+# with the latter.  Preemptively disable the service; it will hopefully
+# be subpackaged though for Fedora.
+disable systemd-sysext.service

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -22,5 +22,3 @@ enable bootupd.socket
 # The event for the attached device comes as a diag event.
 # Ideally it should have been added as part of base Fedora - but since it was arch specific, it was not added: https://bugzilla.redhat.com/show_bug.cgi?id=1433859
 enable rtas_errd.service
-# We don't have swap by default, and systemd-oomd hard requires it.
-disable systemd-oomd.service

--- a/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
@@ -1,6 +1,5 @@
-# Disable systemd-firstboot because it conflicts with Ignition.
-# In most cases this is handled via the remove-from-packages
-# bits in the manifest (ignition-and-ostree.yaml), but
-# we want to support overlaying builds of systemd from git.
+# See the comment in 40-coreos-systemd.preset; we're
+# keeping this even stronger disable override for now,
+# but it may not really be necessary.
 [Unit]
 ConditionPathExists=/run/nosuchfile


### PR DESCRIPTION
overlay: create 40-coreos-systemd.preset

Let's keep 40-coreos.preset to be only `enable` stanzas for
"our stuff" overall.

Create a separate `40-coreos-systemd.preset` which only
relates to systemd things because it really is a distinct
problem domain.

---

40-coreos-systemd.preset: Disable systemd-sysext.service

I was just reading the pre-release notes: https://lists.freedesktop.org/archives/systemd-devel/2021-February/046147.html

This hasn't been tested with ostree/rpm-ostree and heavily overlaps
with the latter.  Preemptively disable the service; it will hopefully
be subpackaged though for Fedora.

---

overlay/40-coreos-systemd:: Add systemd-firstboot disablement here too

This way we're moving closer to having our systemd overrides in one place.

---

