### PR TITLE
overrides: pin clevis to 15-2.fc33

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,3 +15,13 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.aarch64
+  # Pin to previous version until we have
+  # https://github.com/latchset/clevis/pull/295
+  clevis:
+    evra: 15-2.fc33.aarch64
+  clevis-dracut:
+    evra: 15-2.fc33.aarch64
+  clevis-luks:
+    evra: 15-2.fc33.aarch64
+  clevis-systemd:
+    evra: 15-2.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -15,3 +15,13 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.ppc64le
+  # Pin to previous version until we have
+  # https://github.com/latchset/clevis/pull/295
+  clevis:
+    evra: 15-2.fc33.ppc64le
+  clevis-dracut:
+    evra: 15-2.fc33.ppc64le
+  clevis-luks:
+    evra: 15-2.fc33.ppc64le
+  clevis-systemd:
+    evra: 15-2.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -15,3 +15,13 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.s390x
+  # Pin to previous version until we have
+  # https://github.com/latchset/clevis/pull/295
+  clevis:
+    evra: 15-2.fc33.s390x
+  clevis-dracut:
+    evra: 15-2.fc33.s390x
+  clevis-luks:
+    evra: 15-2.fc33.s390x
+  clevis-systemd:
+    evra: 15-2.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,3 +15,13 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.x86_64
+  # Pin to previous version until we have
+  # https://github.com/latchset/clevis/pull/295
+  clevis:
+    evra: 15-2.fc33.x86_64
+  clevis-dracut:
+    evra: 15-2.fc33.x86_64
+  clevis-luks:
+    evra: 15-2.fc33.x86_64
+  clevis-systemd:
+    evra: 15-2.fc33.x86_64


### PR DESCRIPTION
The dracut module from the latest Clevis v16 release has an undeclared
dependency on `seq`. There's a patch to fix that upstream:

https://github.com/latchset/clevis/pull/295

But for now, let's just pin to the previous release. This will unblock
lockfile bumps.