### PR TITLE
manifest: Add stalld

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1128,6 +1128,9 @@
     "sssd-ldap": {
       "evra": "2.4.1-1.fc33.x86_64"
     },
+    "stalld": {
+      "evra": "1.8-1.fc33.x86_64"
+    },
     "sudo": {
       "evra": "1.9.5p2-1.fc33.x86_64"
     },
@@ -1208,7 +1211,7 @@
     }
   },
   "metadata": {
-    "generated": "2021-02-17T01:46:18Z",
+    "generated": "2021-02-24T18:41:46Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2020-10-19T23:27:19Z"

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -198,6 +198,8 @@ packages:
   - zram-generator
   # kdump (https://github.com/coreos/fedora-coreos-tracker/issues/622)
   - kexec-tools
+  # Similar to irqbalance: https://github.com/coreos/fedora-coreos-tracker/issues/753
+  - stalld
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;


### PR DESCRIPTION
The immediate desire is to use this in OpenShift, but it's
quite similar to irqbalance, albeit disabled by default.
It's very small, off by default but the people who want it
really want it.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/753