### PR TITLE
manifest: use DEFAULT_HOSTNAME=localhost

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,8 +1,7 @@
 packages:
-  # Fast-track systemd update that reverts fallback hostname change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
-  # This is a one-off build, please don't remove it without talking
-  # to dustymabe or jlebon.
+  # Keep this until we move to Fedora 34.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
   systemd:
     evra: 246.7-1.fc33.aarch64
   systemd-container:

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,8 +1,7 @@
 packages:
-  # Fast-track systemd update that reverts fallback hostname change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
-  # This is a one-off build, please don't remove it without talking
-  # to dustymabe or jlebon.
+  # Keep this until we move to Fedora 34.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
   systemd:
     evra: 246.7-1.fc33.ppc64le
   systemd-container:

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,8 +1,7 @@
 packages:
-  # Fast-track systemd update that reverts fallback hostname change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
-  # This is a one-off build, please don't remove it without talking
-  # to dustymabe or jlebon.
+  # Keep this until we move to Fedora 34.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
   systemd:
     evra: 246.7-1.fc33.s390x
   systemd-container:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,8 +1,7 @@
 packages:
-  # Fast-track systemd update that reverts fallback hostname change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-739956843
-  # This is a one-off build, please don't remove it without talking
-  # to dustymabe or jlebon.
+  # Keep this until we move to Fedora 34.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/649
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
   systemd:
     evra: 246.7-1.fc33.x86_64
   systemd-container:

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -97,6 +97,18 @@ postprocess:
     DNSStubListener=no
     EOF
 
+  # Set the fallback hostname to `localhost`. This piggybacks on the
+  # postprocess script above which neuters systemd-resolved, because
+  # currently, a fallback hostname of `localhost` + systemd-resolved breaks
+  # rDNS. Eventually, we should be able to drop this at the same time as we drop
+  # the above. See: https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
+  - |
+    #!/usr/bin/env bash
+    source /etc/os-release
+    if [ ${VERSION_ID} -ge 34 ] && [ -z "${DEFAULT_HOSTNAME:-}" ]; then
+      echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
+    fi
+
   # Edit `login.defs` to configure `login(1)` to read from `/run/motd.d` for
   # displaying the MOTD. This is required for newer versions of
   # `console-login-helper-messages` to function properly.


### PR DESCRIPTION
systemd in f34 learned to read the default hostname from a
`DEFAULT_HOSTNAME` key in `/etc/os-release`.

Use that to set the hostname back to `localhost` on f34 so that once we
move over we can unpin the systemd build which had this same effect at
compilation time.

Ideally, this would be part of `fedora-release`, but I'm trying to aim
for a better fix where the compiled-in default hostname in Fedora is
back to `localhost` and only on the variants where we really want
`fedora` would we set `DEFAULT_HOSTNAME=fedora` in `fedora-release`.

So for now, let's just do this here.

Closes: coreos/fedora-coreos-tracker#649