### PR TITLE
README: add blurb about interacting with CI jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,16 @@ done
 # After verifying the list looks good:
 #   - koji untag-build coreos-pool $untaglist
 ```
+
+## Interacting with CI jobs on PRs
+
+Pull requests submitted to this repo will run through a CI job that builds
+and tests Fedora CoreOS with your change.  The CI jobs are run via Jenkins
+in the [CentOS CI cluster](https://jenkins-coreos-ci.apps.ocp.ci.centos.org/) and
+can be retried in case of a failure.
+
+In order to retry the failed job, click through to the details of the failed job
+and use the retry "loopy icon" at the top right of the job page.  You will need
+to be logged into the CentOS CI cluster for this ability.  See the instructions
+on the [fedora-coreos-pipeline](https://github.com/coreos/fedora-coreos-pipeline)
+repo on how to request access to the CentOS CI cluster.


### PR DESCRIPTION
I keep forgetting how to interact with failed CI jobs, so I documented
now to do so.