### PR TITLE
manifest: Block plymouth

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -96,6 +96,9 @@ exclude-packages:
   # Let's make sure initscripts doesn't get pulled back in
   # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
   - initscripts
+  # For (datacenter/cloud oriented) servers, we want to see the details by default.
+  # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
+  - plymouth
 
 # And remove some cruft from grub2
 arch-include:


### PR DESCRIPTION
For (datacenter/cloud oriented) servers, we want to see the details by default.
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/