### PR TITLE
denylist: Add default-checks for chrony AVC

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,6 +1,8 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
+- pattern: default-checks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/751
 - pattern: fcos.internet
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow


### PR DESCRIPTION
Pairs with https://github.com/coreos/coreos-assembler/pull/2067
which will allow us to turn on SELinux AVC checks before/after
all tests.  But we can't do that until the chrony AVC is fixed.