### PR TITLE
overlay: temporarily ship `seq` in initrd

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -14,13 +14,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.aarch64
-  # Pin to previous version until we have
-  # https://github.com/latchset/clevis/pull/295
-  clevis:
-    evra: 15-2.fc33.aarch64
-  clevis-dracut:
-    evra: 15-2.fc33.aarch64
-  clevis-luks:
-    evra: 15-2.fc33.aarch64
-  clevis-systemd:
-    evra: 15-2.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -14,13 +14,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.ppc64le
-  # Pin to previous version until we have
-  # https://github.com/latchset/clevis/pull/295
-  clevis:
-    evra: 15-2.fc33.ppc64le
-  clevis-dracut:
-    evra: 15-2.fc33.ppc64le
-  clevis-luks:
-    evra: 15-2.fc33.ppc64le
-  clevis-systemd:
-    evra: 15-2.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -14,13 +14,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.s390x
-  # Pin to previous version until we have
-  # https://github.com/latchset/clevis/pull/295
-  clevis:
-    evra: 15-2.fc33.s390x
-  clevis-dracut:
-    evra: 15-2.fc33.s390x
-  clevis-luks:
-    evra: 15-2.fc33.s390x
-  clevis-systemd:
-    evra: 15-2.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -14,13 +14,3 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.x86_64
-  # Pin to previous version until we have
-  # https://github.com/latchset/clevis/pull/295
-  clevis:
-    evra: 15-2.fc33.x86_64
-  clevis-dracut:
-    evra: 15-2.fc33.x86_64
-  clevis-luks:
-    evra: 15-2.fc33.x86_64
-  clevis-systemd:
-    evra: 15-2.fc33.x86_64

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -59,6 +59,9 @@ install() {
         sgdisk    \
         find
 
+    # TODO f34: check if we can drop this temporary workaround for https://github.com/latchset/clevis/pull/295
+    inst_multiple seq
+
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service
         inst_script "$moddir/ignition-ostree-${x}-var.sh" "/usr/sbin/ignition-ostree-${x}-var"


### PR DESCRIPTION
Previously we pinned clevis to v15 in order to work around
https://github.com/latchset/clevis/pull/295.

But overrides are not set up in the tagger for mechanical streams, so we
can't easily pin in `branched` and `rawhide`. Let's just unpin and
temporarily ship `seq` ourselves to work around this. Put that temporary
hack in `40ignition-ostree` since that's the closest module conceptually
to clevis.