### PR TITLE
manifests: Fix split to enable sharing with RHCOS

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -125,6 +125,9 @@ postprocess:
       echo 'MOTD_FILE=/usr/share/misc/motd:/run/motd:/run/motd.d:/etc/motd:/etc/motd.d' >> /etc/login.defs
     fi
 
+# Packages listed here should be specific to Fedore CoreOS (as in not yet
+# available in RHCOS or not desired in RHCOS). All other packages should go
+# into one of the sub-manifests listed at the top.
 packages:
   # Security
   - polkit
@@ -167,7 +170,7 @@ packages:
   # file-transfer: note fuse-sshfs is not in RHEL
   # so we can't put it in file-transfer.yaml
   - fuse-sshfs
-  # User experience
+  # Improved MOTD experience
   - console-login-helper-messages-motdgen
   # i18n
   - kbd

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -137,7 +137,7 @@ packages:
   - fuse-overlayfs slirp4netns
   # name resolution for podman containers
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
-  - podman-plugins
+  - podman-plugins dnsmasq
   # Remote IPC for podman
   - libvarlink-util
   # Minimal NFS client
@@ -176,6 +176,9 @@ packages:
   # zram-generator (but not zram-generator-defaults) for F33 change
   # https://github.com/coreos/fedora-coreos-tracker/issues/509
   - zram-generator
+  # Boost starving threads
+  # https://github.com/coreos/fedora-coreos-tracker/issues/753
+  - stalld
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -32,6 +32,3 @@ packages:
   # /etc/logrotate.d to work.  Really, this is a legacy thing, but if we don't
   # have it then people's disks will slowly fill up with logs.
   - logrotate
-  # Boost starving threads
-  # https://github.com/coreos/fedora-coreos-tracker/issues/753
-  - stalld

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -10,9 +10,10 @@ packages:
   # Installing CoreOS itself
   - coreos-installer coreos-installer-bootinfra
   # Storage configuration/management
+  ## cloud-utils-growpart - For growing root partition
   - cifs-utils
   - cloud-utils-growpart
-  - cryptsetup 
+  - cryptsetup
   - device-mapper-multipath
   - e2fsprogs
   - iscsi-initiator-utils
@@ -25,10 +26,10 @@ packages:
   - shadow-utils
   # SELinux policy
   - selinux-policy-targeted
-  # There are things that write outside of the journal still (such as the 
-  # classic wtmp, etc.)
-  #(auditd also writes outside the journal but it has its own log rotation.)
+  # There are things that write outside of the journal still (such as the
+  # classic wtmp, etc.). auditd also writes outside the journal but it has its
+  # own log rotation.
   # Anything package layered will also tend to expect files dropped in
-  # /etc/logrotate.d to work.  Really, this is a legacy thing, but if we don't
+  # /etc/logrotate.d to work. Really, this is a legacy thing, but if we don't
   # have it then people's disks will slowly fill up with logs.
   - logrotate

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -22,8 +22,6 @@ packages:
   # Improved MOTD experience
   - console-login-helper-messages-issuegen
   - console-login-helper-messages-profile
-  # DNS/DHCP server
-  - dnsmasq
   # kdump support
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
   - kexec-tools

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -13,7 +13,7 @@ packages:
   - sudo
   - vim-minimal
   # File compression/decompression
-  ## (bsdtar - dependency of 35coreos-live dracut module)
+  ## bsdtar - dependency of 35coreos-live dracut module
   - bsdtar
   - bzip2
   - gzip


### PR DESCRIPTION
- Move stalld back to fedora-coreos-base until it is released in RHEL
- Keep dnsmasq alongside podman-plugins as explicit dependency