### PR TITLE
rootless-systemd: update packages before installing httpd

### DIFF
--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -26,7 +26,8 @@ set -euxo pipefail
 cd $(mktemp -d)
 cat <<EOF > Containerfile
 FROM registry.fedoraproject.org/fedora:33
-RUN dnf -y install systemd httpd \
+RUN dnf -y update \
+&& dnf -y install systemd httpd \
 && dnf clean all \
 && systemctl enable httpd
 ENTRYPOINT [ "/sbin/init" ]


### PR DESCRIPTION
Fedora container may be outdated and in order to install httpd existing packages may require an update.

Test in https://jenkins-fedora-coreos.apps.ocp.ci.centos.org/job/fedora-coreos/job/fedora-coreos-fedora-coreos-pipeline/1168/ fails with
```
Mar 10 05:15:52 qemu0 kola-runext-rootless-systemd[1997]:   systemd-pam-246.10-1.fc33.x86_64
Mar 10 05:15:52 qemu0 kola-runext-rootless-systemd[1997]:   systemd-rpm-macros-246.10-1.fc33.noarch
Mar 10 05:15:52 qemu0 kola-runext-rootless-systemd[1997]:   xkeyboard-config-2.30-3.fc33.noarch
Mar 10 05:15:52 qemu0 kola-runext-rootless-systemd[1997]: Failed:
Mar 10 05:15:52 qemu0 kola-runext-rootless-systemd[1997]:   httpd-2.4.46-9.fc33.x86_64
Mar 10 05:15:52 qemu0 systemd[1]: kola-runext.service: Main process exited, code=exited, status=125/n/a
```