### PR TITLE
image.yaml: bump virtual disk images to 10G

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,6 +1,7 @@
-# This replaces image.ks
-# size is the target disk size in GB.
-size: 8
+# Target disk size in GB.
+# Make it at least 10G because we want the rootfs to be at least 8G:
+# https://github.com/coreos/fedora-coreos-tracker/issues/586
+size: 10
 
 extra-kargs:
     # Disable SMT on systems vulnerable to MDS or any similar future issue.


### PR DESCRIPTION
Right now, our images are triggering the new 8G warning because the disk
size itself is 8G, so the rootfs is less than that. Let's go to 10G so
we meet our own standard.