### PR TITLE
overrides: pin to kernel-5.10.19-200.fc33 for rootless podman

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -14,3 +14,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.aarch64
+  # There's a regression in 5.10.20+ which breaks rootless podman
+  # https://github.com/containers/buildah/issues/3071
+  kernel:
+    evra: 5.10.19-200.fc33.aarch64
+  kernel-core:
+    evra: 5.10.19-200.fc33.aarch64
+  kernel-modules:
+    evra: 5.10.19-200.fc33.aarch64

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -14,3 +14,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.ppc64le
+  # There's a regression in 5.10.20+ which breaks rootless podman
+  # https://github.com/containers/buildah/issues/3071
+  kernel:
+    evra: 5.10.19-200.fc33.ppc64le
+  kernel-core:
+    evra: 5.10.19-200.fc33.ppc64le
+  kernel-modules:
+    evra: 5.10.19-200.fc33.ppc64le

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -14,3 +14,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.s390x
+  # There's a regression in 5.10.20+ which breaks rootless podman
+  # https://github.com/containers/buildah/issues/3071
+  kernel:
+    evra: 5.10.19-200.fc33.s390x
+  kernel-core:
+    evra: 5.10.19-200.fc33.s390x
+  kernel-modules:
+    evra: 5.10.19-200.fc33.s390x

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -14,3 +14,11 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evra: 246.7-1.fc33.x86_64
+  # There's a regression in 5.10.20+ which breaks rootless podman
+  # https://github.com/containers/buildah/issues/3071
+  kernel:
+    evra: 5.10.19-200.fc33.x86_64
+  kernel-core:
+    evra: 5.10.19-200.fc33.x86_64
+  kernel-modules:
+    evra: 5.10.19-200.fc33.x86_64


### PR DESCRIPTION
There's a regression in 5.10.20+ which breaks rootless podman:
https://github.com/containers/buildah/issues/3071

(This is the same regression which prompted
https://github.com/coreos/fedora-coreos-config/pull/883 but for the
production streams, let's try to avoid exposing the regression to users
for now while it gets sorted out.)