### PR TITLE
ci: print human-readable RPM diff and error out if downgrade detected

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,6 +3,8 @@
 cosaPod {
     checkoutToDir(scm, 'config')
 
+    def basearch = shwrapCapture("cosa basearch")
+
     shwrap("cd config && ci/validate")
 
     shwrap("""
@@ -17,8 +19,8 @@ cosaPod {
     // use a --parent-build arg so we can diff later and it matches prod
     def parent_arg = ""
     def parent_commit = ""
-    if (shwrapRc("test -e /srv/fcos/builds/latest/x86_64/meta.json") == 0) {
-        shwrap("cp /srv/fcos/builds/latest/x86_64/meta.json .") // readJSON wants it in the WORKSPACE
+    if (shwrapRc("test -e /srv/fcos/builds/latest/${basearch}/meta.json") == 0) {
+        shwrap("cp /srv/fcos/builds/latest/${basearch}/meta.json .") // readJSON wants it in the WORKSPACE
         def meta = readJSON file: "meta.json"
         def version = meta["buildid"]
         parent_arg = "--parent-build ${version}"
@@ -48,7 +50,7 @@ cosaPod {
         stage("RPM Diff") {
             shwrap("""
                 cd /srv/fcos
-                new_commit=\$(jq -r '.["ostree-commit"]' builds/latest/x86_64/meta.json)
+                new_commit=\$(jq -r '.["ostree-commit"]' builds/latest/${basearch}/meta.json)
                 rpm-ostree db diff --repo tmp/repo ${parent_commit} \${new_commit} | tee tmp/diff.txt
                 if grep -q Downgraded tmp/diff.txt; then
                     echo "Downgrade detected. This is likely unintentional. If not, you may safely ignore this error."

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -14,7 +14,18 @@ cosaPod {
         cosa buildprep https://builds.coreos.fedoraproject.org/prod/streams/${env.CHANGE_TARGET}/builds
     """)
 
-    fcosBuild(skipInit: true, extraFetchArgs: '--with-cosa-overrides')
+    // use a --parent-build arg so we can diff later and it matches prod
+    def parent_arg = ""
+    def parent_commit = ""
+    if (shwrapRc("test -e /srv/fcos/builds/latest/x86_64/meta.json") == 0) {
+        shwrap("cp /srv/fcos/builds/latest/x86_64/meta.json .") // readJSON wants it in the WORKSPACE
+        def meta = readJSON file: "meta.json"
+        def version = meta["buildid"]
+        parent_arg = "--parent-build ${version}"
+        parent_commit = meta["ostree-commit"]
+    }
+
+    fcosBuild(skipInit: true, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
 
     parallel metal: {
         shwrap("cd /srv/fcos && cosa buildextend-metal")

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -44,7 +44,13 @@ cosaPod {
     }
 
     // also print the pkgdiff as a separate stage to make it more visible
-    stage("RPM Diff") {
-        shwrap("jq .pkgdiff /srv/fcos/builds/latest/x86_64/meta.json")
+    if (parent_arg != "") {
+        stage("RPM Diff") {
+            shwrap("""
+                cd /srv/fcos
+                new_commit=\$(jq -r '.["ostree-commit"]' builds/latest/x86_64/meta.json)
+                rpm-ostree db diff --repo tmp/repo ${parent_commit} \${new_commit} | tee tmp/diff.txt
+            """)
+        }
     }
 }

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -50,6 +50,10 @@ cosaPod {
                 cd /srv/fcos
                 new_commit=\$(jq -r '.["ostree-commit"]' builds/latest/x86_64/meta.json)
                 rpm-ostree db diff --repo tmp/repo ${parent_commit} \${new_commit} | tee tmp/diff.txt
+                if grep -q Downgraded tmp/diff.txt; then
+                    echo "Downgrade detected. This is likely unintentional. If not, you may safely ignore this error."
+                    exit 1
+                fi
             """)
         }
     }


### PR DESCRIPTION
commit cbe1253b8cfb741ebf0d647e4cd06bf0da12697c
Date:   Fri Mar 12 16:27:23 2021 -0500

    ci: print human-readable RPM diff

    The `.pkgdiff` element from the build metadata isn't very useful to
    humans. Let's just re-invoke `rpm-ostree db diff` to get a nice legible
    diff.

commit 0b0a10e41a3d906b0975050b93fe1bfd420a7f5e
Date:   Fri Mar 12 16:28:27 2021 -0500

    ci: error out if downgrade detected

    In the majority of cases, we don't expect new builds to downgrade RPMs.
    Let's default to erroring out and contributors can consciously override
    CI if was really expected.
