### PR TITLE
manifest: use `mkdir -p` for resolved.conf.d/ dir

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -90,7 +90,7 @@ postprocess:
     set -xeuo pipefail
     # Get us back to Fedora 32's nsswitch.conf settings
     sed -i 's/^hosts:.*/hosts:      files dns myhostname/' /etc/nsswitch.conf
-    mkdir /usr/lib/systemd/resolved.conf.d/
+    mkdir -p /usr/lib/systemd/resolved.conf.d/
     cat > /usr/lib/systemd/resolved.conf.d/fedora-coreos-stub-listener.conf <<'EOF'
     # Fedora CoreOS is electing to not use systemd-resolved's internal
     # logic for now because of issues with setting hostnames via reverse DNS.


### PR DESCRIPTION
This directory already exists in the latest f34 builds, so we need
`mkdir -p` here.