### PR TITLE
overlay/growfs: handle broken lsblk in el8

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
@@ -7,6 +7,8 @@ ConditionKernelCommandLine=ostree
 ConditionPathExists=!/run/ostree-live
 Before=initrd-root-fs.target
 After=ignition-disks.service
+# If we've reprovisioned the rootfs, then there's no need to restamp
+ConditionPathExists=!/run/ignition-ostree-transposefs
 
 After=dev-disk-by\x2dlabel-root.device
 # Avoid racing with fsck

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -40,6 +40,7 @@ install() {
         touch      \
         xfs_admin  \
         xfs_growfs \
+        wc         \
         wipefs
 
     # growpart deps


### PR DESCRIPTION
Sometimes `lsblk` returns devices in the wrong order, so we can't rely
on it to iterate over the devices in hierarchical order. Instead, use
the `holders/` directory ourselves directly and use `--nodeps` when
calling `lsblk`.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1934174#c4
See: https://bugzilla.redhat.com/show_bug.cgi?id=1940607
See: https://github.com/coreos/coreos-installer/pull/453