### PR TITLE
overlay: always use prjquota for XFS rootfs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
@@ -3,14 +3,7 @@ set -euo pipefail
 
 rootpath=/dev/disk/by-label/root
 
-# If the rootfs was reprovisioned, then the user is free to define their own
-# rootflags.
-if [ -d /run/ignition-ostree-transposefs/root ]; then
-    exit 0
-fi
-
 eval $(blkid -o export ${rootpath})
-# this really should always be true, but let's be conservative
 if [ "${TYPE}" == "xfs" ]; then
     # We use prjquota on XFS by default to aid multi-tenant Kubernetes (and
     # other container) clusters.  See

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -144,3 +144,9 @@ if [ $(systemctl is-enabled systemd-repart.service) != 'masked' ]; then
     fatal "systemd-repart.service systemd unit should be masked"
 fi
 ok "systemd-repart.service systemd unit is masked"
+
+rootflags=$(findmnt /sysroot -no OPTIONS)
+if ! grep prjquota <<< "${rootflags}"; then
+    fatal "missing prjquota in root mount flags: ${rootflags}"
+fi
+ok "root mounted with prjquota"

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -2,15 +2,24 @@
 # kola: {"platforms": "qemu", "minMemory": 4096}
 set -xeuo pipefail
 
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
 fstype=$(findmnt -nvr / -o FSTYPE)
 [[ $fstype == ext4 ]]
+ok "source is ext4"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       # check that the partition was grown
       if [ ! -e /run/ignition-ostree-growfs.stamp ]; then
-          echo "ignition-ostree-growfs did not run"
-          exit 1
+          fatal "ignition-ostree-growfs did not run"
       fi
 
       # reboot once to sanity-check we can find root on second boot
@@ -19,6 +28,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
   rebooted)
       grep root=UUID= /proc/cmdline
+      ok "found root karg"
       ;;
-  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
 esac

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -21,6 +21,12 @@ fstype=$(findmnt -nvr / -o FSTYPE)
 [[ ${fstype} == xfs ]]
 ok "source is XFS on LUKS device"
 
+rootflags=$(findmnt /sysroot -no OPTIONS)
+if ! grep prjquota <<< "${rootflags}"; then
+    fatal "missing prjquota in root mount flags: ${rootflags}"
+fi
+ok "root mounted with prjquota"
+
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       # check that ignition-ostree-growfs ran

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -2,6 +2,15 @@
 # kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
 set -xeuo pipefail
 
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
 srcdev=$(findmnt -nvr / -o SOURCE)
 [[ ${srcdev} == $(realpath /dev/md/foobar) ]]
 
@@ -10,13 +19,13 @@ blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
 
 fstype=$(findmnt -nvr / -o FSTYPE)
 [[ ${fstype} == xfs ]]
+ok "source is XFS on RAID1 device"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       # check that ignition-ostree-growfs didn't run
       if [ -e /run/ignition-ostree-growfs.stamp ]; then
-          echo "ignition-ostree-growfs ran"
-          exit 1
+          fatal "ignition-ostree-growfs ran"
       fi
 
       # reboot once to sanity-check we can find root on second boot
@@ -26,6 +35,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   rebooted)
       grep root=UUID= /proc/cmdline
       grep rd.md.uuid= /proc/cmdline
+      ok "found root kargs"
       ;;
-  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
 esac

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -21,6 +21,12 @@ fstype=$(findmnt -nvr / -o FSTYPE)
 [[ ${fstype} == xfs ]]
 ok "source is XFS on RAID1 device"
 
+rootflags=$(findmnt /sysroot -no OPTIONS)
+if ! grep prjquota <<< "${rootflags}"; then
+    fatal "missing prjquota in root mount flags: ${rootflags}"
+fi
+ok "root mounted with prjquota"
+
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       # check that ignition-ostree-growfs didn't run


### PR DESCRIPTION
By default, we use `prjquota` for the rootfs for container orchestrators
to monitor and set drive space limits.

However, with the added support for rootfs reprovisioning, we made this
conditional on the rootfs not being reprovisioned, with the assumption
that you can just set whatever options you'd like instead. Though
actually doing that is really awkward right now, and it requires
surfacing prjquota in user documentations (see
https://bugzilla.redhat.com/show_bug.cgi?id=1940704#c2).

Since AFAICT `prjquota` doesn't actually have any significant overhead,
let's just simplify the messaging to: we *always* enable prjquota on XFS
root filesystems. Users who want to override this can fallback to
`rpm-ostree kargs` (and eventually once we have
https://github.com/coreos/fedora-coreos-config/issues/805, to
`mountOptions: []`).

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1940704
