### PR TITLE
overlay: propagate rootfs mountOptions to rootflags karg

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/config.ign
+++ b/tests/kola/root-reprovision/filesystem-only/config.ign
@@ -1,6 +1,6 @@
 {
     "ignition": {
-        "version": "3.0.0"
+        "version": "3.2.0"
     },
     "storage": {
         "filesystems": [
@@ -8,7 +8,8 @@
                 "device": "/dev/disk/by-label/root",
                 "wipeFilesystem": true,
                 "format": "ext4",
-                "label": "root"
+                "label": "root",
+                "mountOptions": ["debug"]
             }
         ]
     }

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -15,6 +15,12 @@ fstype=$(findmnt -nvr / -o FSTYPE)
 [[ $fstype == ext4 ]]
 ok "source is ext4"
 
+rootflags=$(findmnt /sysroot -no OPTIONS)
+if ! grep debug <<< "${rootflags}"; then
+    fatal "missing debug in root mount flags: ${rootflags}"
+fi
+ok "root mounted with debug"
+
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       # check that the partition was grown


### PR DESCRIPTION
Right now, specifying `mountOptions` for the rootfs in the Ignition
config is ignored. To fix that, we simply need to have
`coreos-rootflags` inspect the Ignition config if the rootfs was
reprovisioned and extract the field.

This then takes effect on first boot (via
`ignition-ostree-mount-sysroot.sh` calling out to it) and subsequent
boots (via `rdcore rootmap` calling out to `coreos-rootflags`).

Closes: https://github.com/coreos/fedora-coreos-config/issues/805