### PR TITLE
image.yaml: split out image-base.yaml

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -1,0 +1,28 @@
+# Target disk size in GB.
+# Make it at least 10G because we want the rootfs to be at least 8G:
+# https://github.com/coreos/fedora-coreos-tracker/issues/586
+size: 10
+
+extra-kargs:
+    # Disable SMT on systems vulnerable to MDS or any similar future issue.
+    - mitigations=auto,nosmt
+    # https://github.com/coreos/fedora-coreos-tracker/issues/292
+    # https://fedoraproject.org/wiki/Changes/CGroupsV2
+    - systemd.unified_cgroup_hierarchy=0
+
+# Disable networking by default on firstboot. We can drop this once cosa stops
+# defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
+ignition-network-kcmdline: []
+
+# Optional remote by which to prefix the deployed OSTree ref
+ostree-remote: fedora
+
+# We want read-only /sysroot to protect from unintentional damage.
+# https://github.com/ostreedev/ostree/issues/1265
+sysroot-readonly: true
+
+# After this, we plan to add support for the Ignition
+# storage/filesystems sections.  (Although one can do
+# that on boot as well)
+
+

--- a/image.yaml
+++ b/image.yaml
@@ -1,28 +1,4 @@
-# Target disk size in GB.
-# Make it at least 10G because we want the rootfs to be at least 8G:
-# https://github.com/coreos/fedora-coreos-tracker/issues/586
-size: 10
-
-extra-kargs:
-    # Disable SMT on systems vulnerable to MDS or any similar future issue.
-    - mitigations=auto,nosmt
-    # https://github.com/coreos/fedora-coreos-tracker/issues/292
-    # https://fedoraproject.org/wiki/Changes/CGroupsV2
-    - systemd.unified_cgroup_hierarchy=0
-
-# Disable networking by default on firstboot. We can drop this once cosa stops
-# defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
-ignition-network-kcmdline: []
-
-# Optional remote by which to prefix the deployed OSTree ref
-ostree-remote: fedora
-
-# We want read-only /sysroot to protect from unintentional damage.
-# https://github.com/ostreedev/ostree/issues/1265
-sysroot-readonly: true
-
-# After this, we plan to add support for the Ignition
-# storage/filesystems sections.  (Although one can do
-# that on boot as well)
-
-
+# This file can optionally contain configuration specific to the stream,
+# similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
+# streams.
+include: image-base.yaml


### PR DESCRIPTION
The `image.yaml` file will be unique to each stream (like
`manifest.yaml`), while `image-base.yaml` will be shared by all streams
(like `manifests/fedora-coreos-base.yaml`).

Prep for dropping the `systemd.unified_cgroup_hierarchy=0` karg on the
next stream.