### PR TITLE
buildroot: Add jq

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -28,6 +28,9 @@ xz
 # For rust projects like rpm-ostree
 rustfmt
 
+# A super common tool
+jq
+
 # Used by ostree/rpm-ostree CI
 parallel gjs
 


### PR DESCRIPTION
This is used by rpm-ostree's CI; add it to the buildroot for
the same reason we ship it in FCOS.