### PR TITLE
Move next-devel to cgroupsv2 for new nodes

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -1,3 +1,6 @@
+# This file is shared by all streams. For a stream-specific change, use
+# image.yaml instead.
+
 # Target disk size in GB.
 # Make it at least 10G because we want the rootfs to be at least 8G:
 # https://github.com/coreos/fedora-coreos-tracker/issues/586
@@ -6,9 +9,6 @@ size: 10
 extra-kargs:
     # Disable SMT on systems vulnerable to MDS or any similar future issue.
     - mitigations=auto,nosmt
-    # https://github.com/coreos/fedora-coreos-tracker/issues/292
-    # https://fedoraproject.org/wiki/Changes/CGroupsV2
-    - systemd.unified_cgroup_hierarchy=0
 
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.

--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,8 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+extra-kargs:
+    # https://github.com/coreos/fedora-coreos-tracker/issues/292
+    # https://fedoraproject.org/wiki/Changes/CGroupsV2
+    - systemd.unified_cgroup_hierarchy=0

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -150,3 +150,26 @@ if ! grep prjquota <<< "${rootflags}"; then
     fatal "missing prjquota in root mount flags: ${rootflags}"
 fi
 ok "root mounted with prjquota"
+
+has_cgroup_karg=1
+grep -q systemd.unified_cgroup_hierarchy /proc/cmdline || has_cgroup_karg=0
+sys_fs_cgroup_source=$(findmnt -no SOURCE /sys/fs/cgroup)
+stream=$(rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]')
+case "$stream" in
+    "testing-devel" | "testing" | "stable")
+        if [ $has_cgroup_karg == 0 ]; then
+            fatal "missing systemd.unified_cgroup_hierarchy=0"
+        fi
+        if [[ $sys_fs_cgroup_source != tmpfs ]]; then
+            fatal "/sys/fs/cgroup is not tmpfs"
+        fi
+        ;;
+    *)
+        if [ $has_cgroup_karg == 1 ]; then
+            fatal "found systemd.unified_cgroup_hierarchy=0"
+        fi
+        if [[ $sys_fs_cgroup_source != cgroup2 ]]; then
+            fatal "/sys/fs/cgroup is not cgroup2"
+        fi
+        ;;
+esac


### PR DESCRIPTION
All we need to do is to make the associated karg be specific to
`testing-devel` by uplisting it to `image.yaml`. Then `next-devel` will
naturally shed it when `image-base.yaml` gets synced over.

See: https://github.com/coreos/fedora-coreos-tracker/issues/292