### PR TITLE
buildroot: add dumb-init

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -41,3 +41,6 @@ clang lld
 libubsan libasan libtsan
 # And all C/C++ projects should use clang-analyzer
 clang-analyzer
+
+# We don't want zombies in our pods
+dumb-init


### PR DESCRIPTION
We want this, just like we had for the cosa buildroot image. At least
until this becomes built into k8s and we can just request it via the pod
manifest.