### PR TITLE
ci/buildroot: default to builder user

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -11,3 +11,8 @@ WORKDIR /root/containerbuild
 COPY . tmp
 RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf
 WORKDIR /root
+# match cosa's unprivileged default
+RUN useradd builder --uid 1000 -G wheel && \
+        echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd && \
+        chmod 600 /etc/sudoers.d/wheel-nopasswd
+USER builder


### PR DESCRIPTION
Let's match cosa's default of using an unprivileged builder user for
builds. Projects which really want to can request uid 0 via
`runAsUser:`.

Add `wheel` access to make it nicer for local development.