### PR TITLE
buildroot: Add rsync

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -33,6 +33,7 @@ jq
 
 # Used by ostree/rpm-ostree CI (TODO: add to something like TestBuildRequires in spec files)
 attr
+rsync
 python3-pyyaml
 parallel gjs
 


### PR DESCRIPTION
It's a convenient way to *merge* local filesystem trees, see
https://github.com/ostreedev/ostree/blob/47bf29fed3b99d72c153d3c1581bf9a19c7a9b6d/.cci.jenkinsfile#L73
(Tempting to have this functionality in ostree too but)