### PR TITLE
ci/buildroot: set WORKDIR to /home/builder

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -10,9 +10,9 @@ USER root
 WORKDIR /root/containerbuild
 COPY . tmp
 RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf
-WORKDIR /root
 # match cosa's unprivileged default
 RUN useradd builder --uid 1000 -G wheel && \
         echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd && \
         chmod 600 /etc/sudoers.d/wheel-nopasswd
 USER builder
+WORKDIR /home/builder


### PR DESCRIPTION
The `builder` user doesn't have permissions to access `/root`.
Should've been part of #917.