### PR TITLE
overlay: helper service for warning about cgroupsv1

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -3,3 +3,5 @@ enable fedora-coreos-pinger.service
 # Provide information if no ignition is provided
 enable coreos-check-ignition-config.service
 enable coreos-check-ssh-keys.service
+# Check if cgroupsv1 is still being used
+enable coreos-check-cgroups.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-cgroups.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-cgroups.service
@@ -1,0 +1,11 @@
+# This service is used for printing a message if
+# cgroups v1 is still being used
+[Unit]
+Description=Check if cgroupsv1 is still being used
+ConditionControlGroupController=v1
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-check-cgroups.sh
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-check-cgroups.sh
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-cgroups.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/bash
+# This script checks if the system is still using cgroups v1
+# and prints a message to the serial console.
+
+# Change the output color to yellow
+warn=$(echo -e '\033[0;33m')
+# No color
+nc=$(echo -e '\033[0m')
+
+motd_path=/run/motd.d/30_cgroupsv1_warning.motd
+
+cat << EOF > "${motd_path}"
+${warn}
+############################################################################
+WARNING: This system is using cgroups v1. For increased reliability
+it is strongly recommended to migrate this system and your workloads
+to use cgroups v2. For instructions on how to adjust kernel arguments
+to use cgroups v2, see:
+https://docs.fedoraproject.org/en-US/fedora-coreos/kernel-args/
+
+To disable this warning, use:
+sudo systemctl disable coreos-check-cgroups.service
+############################################################################
+${nc}
+EOF


### PR DESCRIPTION
This will check if a system is still using cgroupsv1 and generate a
message to be printed as part of CLHM.