### PR TITLE
manifests: Move stalld to shared 'system-configuration' manifest

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -179,9 +179,6 @@ packages:
   # zram-generator (but not zram-generator-defaults) for F33 change
   # https://github.com/coreos/fedora-coreos-tracker/issues/509
   - zram-generator
-  # Boost starving threads
-  # https://github.com/coreos/fedora-coreos-tracker/issues/753
-  - stalld
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened
 # yet.  Also we may want to add to rpm-ostree something like arch negation;

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -33,3 +33,6 @@ packages:
   # /etc/logrotate.d to work. Really, this is a legacy thing, but if we don't
   # have it then people's disks will slowly fill up with logs.
   - logrotate
+  # Boost starving threads
+  # https://github.com/coreos/fedora-coreos-tracker/issues/753
+  - stalld


### PR DESCRIPTION
This manifest is shared with RHCOS which will have stalld with the move to 8.4 content.