### PR TITLE
[next-devel] overrides: freeze dracut on 051 in f34/next

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -13,3 +13,10 @@ packages:
     evra: 0.21.2-1.fc34.noarch
   console-login-helper-messages-profile:
     evra: 0.21.2-1.fc34.noarch
+  # Freeze dracut for now while we figure out the change in
+  # networking causing the CI test failure.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/782
+  dracut:
+    evr: 051-1.fc34.1
+  dracut-network:
+    evr: 051-1.fc34.1

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,18 +1,4 @@
 packages:
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-99a286473a
-  # New updates in console-login-helper-messages v0.21.2 fixes
-  # the console prompt being left solid white after displaying
-  # the OS release MOTD.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/750
-  console-login-helper-messages:
-    evra: 0.21.2-1.fc34.noarch
-  console-login-helper-messages-issuegen:
-    evra: 0.21.2-1.fc34.noarch
-  console-login-helper-messages-motdgen:
-    evra: 0.21.2-1.fc34.noarch
-  console-login-helper-messages-profile:
-    evra: 0.21.2-1.fc34.noarch
   # Freeze dracut for now while we figure out the change in
   # networking causing the CI test failure.
   # https://github.com/coreos/fedora-coreos-tracker/issues/782


### PR DESCRIPTION
Freeze dracut for now while we figure out the change in
networking causing the CI test failure.
https://github.com/coreos/fedora-coreos-tracker/issues/782