### PR TITLE
buildroot: Blow out quay.io cache

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.fedoraproject.org/fedora:33
 USER root
 WORKDIR /root/containerbuild
 COPY . tmp
-RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf
+RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf # nocache 20210406
 # match cosa's unprivileged default
 RUN useradd builder --uid 1000 -G wheel && \
         echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd && \


### PR DESCRIPTION
This is going to be problematic for the buildroot in
general.  Not finding docs on a mechanism to avoid
this on quay.