### PR TITLE
buildroot: Drop USER creation, add createrepo_c+ostree

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -6,13 +6,5 @@
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
 FROM registry.fedoraproject.org/fedora:33
-USER root
-WORKDIR /root/containerbuild
-COPY . tmp
-RUN ./tmp/install-buildroot.sh && yum clean all && rm tmp -rf # nocache 20210406
-# match cosa's unprivileged default
-RUN useradd builder --uid 1000 -G wheel && \
-        echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd && \
-        chmod 600 /etc/sudoers.d/wheel-nopasswd
-USER builder
-WORKDIR /home/builder
+COPY . /src
+RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf  # nocache 20210406

--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -28,6 +28,9 @@ xz
 # For rust projects like rpm-ostree
 rustfmt
 
+# For unit tests at least.
+ostree
+
 # A super common tool
 jq
 
@@ -36,6 +39,7 @@ attr
 rsync
 python3-pyyaml
 parallel gjs
+createrepo_c
 
 # Also, add clang since it's useful at least in CI for C/C++ projects
 clang lld


### PR DESCRIPTION
The USER bit breaks the ability to use this in Github actions.
Further, it's not useful for OpenShift because the platform
allocates a dynamic UID today (Eventually Kube user namespaces
will augment this).

We added this for the Jenkins/CCI, but previously we
were running the buildroot as uid 0 (i.e. Docker default) anyways.
If we want to enhance the flow to run as non-root, I think the
right thing is to do it in the platform and not the container.