### PR TITLE
35coreos-network: enable initrd networking on azurestack

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
@@ -7,10 +7,11 @@ After=basic.target
 # Triggering conditions for cases where we need network:
 #  * when Ignition signals that it is required for provisioning.
 #  * on live systems fetching the remote rootfs in initramfs.
-#  * on Azure, for hostname fetching (metadata endpoint) and boot check-in (wireserver).
+#  * on Azure and Azure Stack Hub, for hostname fetching (metadata endpoint) and boot check-in (wireserver).
 ConditionPathExists=|/run/ignition/neednet
 ConditionKernelCommandLine=|coreos.live.rootfs_url
 ConditionKernelCommandLine=|ignition.platform.id=azure
+ConditionKernelCommandLine=|ignition.platform.id=azurestack
 
 # Creates /run/ignition/neednet
 After=ignition-fetch-offline.service


### PR DESCRIPTION
Just like on Azure, Afterburn needs networking for hostname fetching and
boot check-in. Ideally, Afterburn would request it itself but this is
where that logic lives for now (see [1]).

[1] https://github.com/coreos/fedora-coreos-tracker/blob/master/internals/README-initramfs.md#networking