### PR TITLE
12kdump: Remount /boot rw before `kdump.service`

### DIFF
--- a/overlay.d/12kdump/usr/lib/systemd/system/kdump.service.d/remount-boot.conf
+++ b/overlay.d/12kdump/usr/lib/systemd/system/kdump.service.d/remount-boot.conf
@@ -1,0 +1,9 @@
+# https://bugzilla.redhat.com/show_bug.cgi?id=1918493
+# `/boot` is read-only, but `kdump.service` wants to 
+# places its generated initramfs alongside the default
+# initramfs under `/boot/ostree`.
+# Until `kdump` gains the ability to place its initramfs
+# elsewhere, temporarily remount `/boot` read-write before
+# the `kdump` initramfs is generated.
+[Service]
+ExecStartPre=/usr/bin/mount -o remount,rw /boot


### PR DESCRIPTION
Right now, `kdump` fails to generate its initramfs because
it cannot place it next to our default initramfs in
`/boot/ostree`, which is read-only.
This is a workaround to get `kdump` working again until
it gains the ability to place its generated initramfs
in a different location (e.g. `/var/lib/kdump`).

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1918493