### PR TITLE
tests/kola: handle possible rootless-systemd flake

### DIFF
--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -53,10 +53,8 @@ main() {
     chmod +x /tmp/runascoreuserscript
     runascoreuser /tmp/runascoreuserscript
 
-    # Let it come up
-    sleep 5
-
-    if ! curl http://localhost:8080 1>/dev/null; then
+    # Try to grab the web page. Retry as it might not be up fully yet.
+    if ! curl --silent --show-error --retry 4 --retry-all-errors http://localhost:8080 >/dev/null; then
         echo TEST FAILED 1>&2
         runascoreuser podman logs httpd
         return 1


### PR DESCRIPTION
The sleep 5 might not be long enough if CI is loaded. Let's make curl
itself do the retry, which contains logic for exponential backoff.