### PR TITLE
manifests: f34: Delete coreos-reset-stub-resolv-selinux-context.{path,service}.

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -99,6 +99,18 @@ postprocess:
     DNSStubListener=no
     EOF
 
+  # Disable and delete the coreos-reset-stub-resolv-selinux-context.{path,service}.
+  # Not needed in Fedora 34 since https://github.com/systemd/systemd/pull/17976 has landed.
+  # Can remove this and the files in the overlay once we've migrated everything to F34.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    source /etc/os-release
+    if [ ${VERSION_ID} -ge 34 ]; then
+    rm -fv /etc/systemd/system/multi-user.target.wants/coreos-reset-stub-resolv-selinux-context.{path,service} \
+           /usr/lib/systemd/system/coreos-reset-stub-resolv-selinux-context.{path,service}
+    fi
+
   # Set the fallback hostname to `localhost`. This piggybacks on the
   # postprocess script above which neuters systemd-resolved, because
   # currently, a fallback hostname of `localhost` + systemd-resolved breaks


### PR DESCRIPTION
Not needed in Fedora 34 since https://github.com/systemd/systemd/pull/17976 has landed.