### PR TITLE
tests/kola/rootless-systemd: add back sleep

### DIFF
--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -53,8 +53,10 @@ main() {
     chmod +x /tmp/runascoreuserscript
     runascoreuser /tmp/runascoreuserscript
 
+    sleep 5
+
     # Try to grab the web page. Retry as it might not be up fully yet.
-    if ! curl --silent --show-error --retry 4 --retry-all-errors http://localhost:8080 >/dev/null; then
+    if ! curl --silent --show-error --retry 5 --retry-all-errors http://localhost:8080 >/dev/null; then
         echo TEST FAILED 1>&2
         runascoreuser podman logs httpd
         return 1


### PR DESCRIPTION
Let's both sleep upfront and have `curl` do its exponential retry.
Follow-up to #937 since I saw this test failing still in #946.