### PR TITLE
tests/kola/rpm-ostree-countme: Update for pre-release repo count

### DIFF
--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -29,7 +29,8 @@ if [[ $(systemctl show -p ActiveState rpm-ostree-countme.service) != "ActiveStat
 fi
 
 # Check rpm-ostree count me output
-if [[ $(journalctl --output=json --boot --unit=rpm-ostree-countme.service --grep "Successful requests:" | jq --raw-output '.MESSAGE') != "Successful requests: 2/2" ]]; then
+output="$(journalctl --output=json --boot --unit=rpm-ostree-countme.service --grep "Successful requests:" | jq --raw-output '.MESSAGE')"
+if [[ "${output}" != "Successful requests: 2/2" ]] && [[ "${output}" != "Successful requests: 3/3" ]]; then
 	fatal "rpm-ostree-countme service ouput does not match expected sucess output"
 fi
 


### PR DESCRIPTION
In production, we allow counting to silently fail when partially
reporting count me status to avoid unnecessary unit failures as this not
critical. In CI however, we want to make sure this test is properly
working so we need to manually validate the output.

FCOS versions based on pre-release Fedora (branched/beta/rc) will have
an additionnal repo enabled, so this updates the check to take that into
account.

For: https://github.com/coreos/fedora-coreos-tracker/issues/790