### PR TITLE
[stable] overrides: fast-track rpm-ostree-2021.4

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -44,3 +44,9 @@ packages:
     evr: 1:1.1.1k-1.fc33
   openssl-libs:
     evr: 1:1.1.1k-1.fc33
+  # Fast-track rpm-ostree for CVE-2021-3445
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-eadfc56b95
+  rpm-ostree:
+    evr: 2021.4-1.fc33
+  rpm-ostree-libs:
+    evr: 2021.4-1.fc33


### PR DESCRIPTION
For CVE-2021-3445 (https://bugzilla.redhat.com/show_bug.cgi?id=1932079).