### PR TITLE
overlay.d/35coreos-network: handle new nm-run.service in initramfs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.service
@@ -7,7 +7,8 @@ ConditionKernelCommandLine=!coreos.liveiso
 
 After=basic.target
 # Network is enabled here
-After=dracut-initqueue.service
+After=nm-run.service
+After=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
 
 # If we fail, the boot will fail.  Be explicit about it.
 OnFailure=emergency.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-nm-run-only-if-neednet.conf
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-nm-run-only-if-neednet.conf
@@ -1,0 +1,7 @@
+[Unit]
+# Workaround https://github.com/dracutdevs/dracut/pull/1347 until it lands.
+# Only run if network is needed. Right now we can detect this by seeing
+# if the /usr/lib/dracut/hooks/initqueue/finished/nm.sh file exists (written
+# out by nm_generate_connections() [1], which is called in the cmdline hook).
+# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-lib.sh#L16.
+ConditionPathExists=/usr/lib/dracut/hooks/initqueue/finished/nm.sh

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -8,30 +8,30 @@
 #     - i.e. after /dev/disk/by-label/boot is available
 #     - and after the ignition-dracut GPT generator (see below)
 # - Need to run before networking is brought up.
-#     - This is done in nm-run.sh [1] that runs as part of dracut-initqueue [2]
-#     - i.e. Before=dracut-initqueue.service
+#     - This is done in nm-run.service [1]
+#     - i.e. Before=nm-run.service
 # - Need to make sure karg networking configuration isn't applied
 #     - There are two ways to do this.
-#         - One is to run *before* the nm-config.sh [3] that runs as part of
-#           dracut-cmdline [4] and `ln -sf /bin/true /usr/libexec/nm-initrd-generator`.
+#         - One is to run *before* the nm-config.sh [2] that runs as part of
+#           dracut-cmdline [3] and `ln -sf /bin/true /usr/libexec/nm-initrd-generator`.
 #             - i.e. Before=dracut-cmdline.service
-#         - Another is to run *after* nm-config.sh [3] in dracut-cmdline [4]
+#         - Another is to run *after* nm-config.sh [2] in dracut-cmdline [3]
 #           and just delete all the files created by nm-initrd-generator.
-#             - i.e. After=dracut-cmdline.service, but Before=dracut-initqueue.service
+#             - i.e. After=dracut-cmdline.service, but Before=nm-run.service
 #     - We'll go with the second option here because the need for the /boot
 #       device (mentioned above) means we can't start before dracut-cmdline.service
 #
-# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.sh
-# [2] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/module-setup.sh#L37
-# [3] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-config.sh
-# [4] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/module-setup.sh#L36
+# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.service
+# [2] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-config.sh
+# [3] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/module-setup.sh#L34
 #
 [Unit]
 Description=Copy CoreOS Firstboot Networking Config
 ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
 Before=ignition-diskful.target
-Before=dracut-initqueue.service
+Before=nm-run.service
+Before=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
 After=dracut-cmdline.service
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
@@ -20,7 +20,8 @@ Before=ignition-fetch.service
 
 # See hack in coreos-enable-network, as well as coreos-copy-firstboot-network.service.
 After=dracut-cmdline.service
-Before=dracut-initqueue.service
+Before=nm-run.service
+Before=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
@@ -25,4 +25,8 @@ install() {
     inst_simple "$moddir/50-afterburn-network-kargs-default.conf" \
         "/usr/lib/systemd/system/afterburn-network-kargs.service.d/50-afterburn-network-kargs-default.conf"
 
+    # Workaround for https://github.com/dracutdevs/dracut/pull/1347 until it lands.
+    # Dropin to make NetworkManager systemd service only start if network is needed.
+    inst_simple "$moddir/50-nm-run-only-if-neednet.conf" \
+        "/usr/lib/systemd/system/nm-run.service.d/50-nm-run-only-if-neednet.conf"
 }

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -91,6 +91,23 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
 fi
 ok conditional initrd networking
 
+# In F34 network-manager in dracut started executing NM in
+# oneshot mode via a systemd unit. That needed some fixups.
+# https://github.com/dracutdevs/dracut/pull/1347
+# We're waiting on those changes to flow downstream.
+# When we get them we'll need to adjust some things so let's
+# complain when we detect they've come in.
+source /etc/os-release
+if [ "$VERSION_ID" -gt "33" ]; then
+    if [ ! -f /usr/lib/dracut/modules.d/35network-manager/nm-run.service ]; then
+        fatal "Did not find expected nm-run.service in dracut"
+    fi
+    if grep -q neednet /usr/lib/dracut/modules.d/35network-manager/nm-run.service; then
+        fatal "Upstream dracut fix landed. Please adjust the workaround."
+    fi
+fi
+ok dracut-networkmanager
+
 if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
     fatal missing LICENSE
 fi


### PR DESCRIPTION
```
commit 7d62b125bfd2660ce4364be1cee0293d11ac2fdf
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 13 16:44:42 2021 -0400

    overlay.d/35coreos-network: don't bring up NM if not needed
    
    In dracut 053+ dracut starting running NetworkManager from a systemd
    unit if systemd was used to start the system [1]. That systemd unit
    will always get started if there is any NM configuration. Let's make
    it only get started if we actually need the network. This is a
    simplified version of the more complicated proposed fix upstream [2].
    
    [1] https://github.com/dracutdevs/dracut/commit/c17c5b7
    [2] https://github.com/dracutdevs/dracut/pull/1347
    
    Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/782

commit 9f67c8f49c4eec31a9a957baf734fedce4593050
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 13 14:03:00 2021 -0400

    overlay.d/35coreos-network: handle new nm-run.service in initramfs
    
    In dracut 053+ dracut starting running NetworkManager from a systemd
    unit if systemd was used to start the system [1]. Let's adapt for that
    by ordering our units before `nm-run.service`. We'll also keep the
    ordering on dracut-initqueue.service for now for backwards compatibility
    and it's harmless to keep around.
    
    [1] https://github.com/dracutdevs/dracut/commit/c17c5b7
```