### PR TITLE
manifest-lock: drop graduated overrides

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -22,20 +22,6 @@ packages:
     evr: 5.10.19-200.fc33
   kernel-modules:
     evr: 5.10.19-200.fc33
-  # Fast-track console-login-helper-messages release
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-cf005d6480
-  # New updates in console-login-helper-messages v0.21.2 fixes
-  # the console prompt being left solid white after displaying
-  # the OS release MOTD.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/750
-  console-login-helper-messages:
-    evra: 0.21.2-1.fc33.noarch
-  console-login-helper-messages-issuegen:
-    evra: 0.21.2-1.fc33.noarch
-  console-login-helper-messages-motdgen:
-    evra: 0.21.2-1.fc33.noarch
-  console-login-helper-messages-profile:
-    evra: 0.21.2-1.fc33.noarch
   # Fast-track new podman release to fix podman cp:
   # https://github.com/coreos/fedora-coreos-tracker/issues/771
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-e70b450680


### PR DESCRIPTION
Promoted to stable: https://bodhi.fedoraproject.org/updates/FEDORA-2021-cf005d6480