### PR TITLE
[testing-devel] override gardening

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,14 +14,6 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evr: 246.7-1.fc33
-  # There's a regression in 5.10.20+ which breaks rootless podman
-  # https://github.com/containers/buildah/issues/3071
-  kernel:
-    evr: 5.10.19-200.fc33
-  kernel-core:
-    evr: 5.10.19-200.fc33
-  kernel-modules:
-    evr: 5.10.19-200.fc33
   # Fast-track new podman release to fix podman cp:
   # https://github.com/coreos/fedora-coreos-tracker/issues/771
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-e70b450680

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,13 +14,6 @@ packages:
     evra: 246.7-1.fc33.noarch
   systemd-udev:
     evr: 246.7-1.fc33
-  # Fast-track new podman release to fix podman cp:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/771
-  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-e70b450680
-  podman:
-    evr: 2:3.1.0-2.fc33
-  podman-plugins:
-    evr: 2:3.1.0-2.fc33
   # Fast-track new coreos-installer release
   # https://bodhi.fedoraproject.org/updates/FEDORA-2021-c67cfeca62
   coreos-installer:


### PR DESCRIPTION
```
commit 6be03d5a80246434b4ee65062dcc402bee8bebed
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Apr 14 15:01:36 2021 -0400

    overrides: drop graduated podman override
    
    This actually got replaced in the updated with podman-3.1.0-3, but that
    has now made it to stable so we can just drop the override altogether.

commit 31e33f2d0d100765ca7a4fd50900a1d620e4a7bc
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Apr 14 14:19:52 2021 -0400

    overrides: drop kernel 5.10.19 freeze
    
    The linked issue is resolved in kernel 5.11.

```