### PR TITLE
ci: add GitHub Action to automatically graduate overrides

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -1,0 +1,45 @@
+name: remove-graduated-overrides
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  remove-graduated-overrides:
+    name: Remove graduated overrides
+    runs-on: ubuntu-latest
+    # TODO: use cosa directly here
+    # https://github.com/coreos/coreos-assembler/issues/2223
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    strategy:
+      matrix:
+        branch:
+          - testing-devel
+          - next-devel
+    steps:
+      - run: dnf install -y rpm-ostree # see related TODO above
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Remove graduated overrides
+        run: |
+          git config user.name 'CoreOS Bot'
+          git config user.email coreosbot@fedoraproject.org
+          ci/remove-graduated-overrides.py
+      - name: Open pull request
+        run: |
+          if ! git diff --quiet --exit-code; then
+              git commit -am "lockfiles: drop graduated overrides 🎓" \
+                -m "Triggered by remove-graduated-overrides GitHub Action."
+          fi
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          branch: ${{ matrix.branch }}-graduation
+          push-to-fork: coreosbot-releng/fedora-coreos-config
+          title: "lockfiles: drop graduated overrides 🎓"
+          body: "Triggered by remove-graduated-overrides GitHub Action."
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"

--- a/README.md
+++ b/README.md
@@ -50,19 +50,63 @@ By default, all packages for FCOS come from the stable
 Fedora repos. However, it is sometimes necessary to either
 hold back some packages, or pull in fixes ahead of Bodhi. To
 add such overrides, one needs to add the packages to
-`manifest-lock.overrides.$basearch.yaml`. E.g.:
+`manifest-lock.overrides.yaml` (there are also arch-specific
+variants of these files for the rare occasions the override
+should only apply to a specific arch).
+
+Note that comments are not preserved in these files. The
+lockfile supports arbitrary keys under the `metadata` key to
+carry information. Some keys are semantically meaningful to
+humans or other tools.
+
+### Fast-tracking
+
+Example:
 
 ```yaml
 packages:
-  # document reason here and link to any Bodhi update
-  foobar:
-    evra: 1.2.3-1.fc31.x86_64
+  selinux-policy:
+    evra: 34.10-1.fc34.noarch
+    metadata:
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f014ca8326
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/850
+  selinux-policy-targeted:
+    evra: 34.10-1.fc34.noarch
+    metadata:
+      type: fast-track
+      # you don't have to repeat the other keys for related packages
 ```
 
-Whenever possible, in the case of pulling in a newer
-package, it is important that the package be submitted as an
-update to Bodhi so that we don't have to carry the override
-forever.
+Whenever possible, it is important that the package be
+submitted as an update to Bodhi so that we don't have to
+carry the override for a long time.
+
+Fast-tracked packages will automatically be removed by the
+`remove-graduated-overrides` GitHub Action in this repo once
+they reach the stable Fedora repos (or newer versions). They
+are detected by the `type: fast-track` key.
+
+### Pinning
+
+Example:
+
+```
+packages:
+  dracut:
+      evr: 053-5.fc34
+      metadata:
+        type: pin
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+  dracut-network:
+      evr: 053-5.fc34
+      metadata:
+        type: pin
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+```
+
+All pinned packages *must* have a `reason` key containing
+more information about why the pin is necessary.
 
 Once an override PR is merged,
 [`coreos-koji-tagger`](https://github.com/coreos/fedora-coreos-releng-automation/tree/main/coreos-koji-tagger)

--- a/ci/remove-graduated-overrides.py
+++ b/ci/remove-graduated-overrides.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import json
+import yaml
+import subprocess
+
+import dnf
+import hawkey
+
+ARCHES = ['s390x', 'x86_64', 'ppc64le', 'aarch64']
+
+OVERRIDES_HEADER = """
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a URL in the `metadata.reason` key, though it's acceptable to
+# omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
+"""
+
+
+def main():
+    treefile = get_treefile()
+    base = get_dnf_base(treefile)
+    setup_repos(base, treefile)
+
+    for fn in get_lockfiles():
+        update_lockfile(base, fn)
+
+
+def get_treefile():
+    treefile = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
+                                        '--print-only', 'manifest.yaml'])
+    return json.loads(treefile)
+
+
+def get_dnf_base(treefile):
+    base = dnf.Base()
+    base.conf.reposdir = "."
+    base.conf.releasever = treefile['releasever']
+    base.read_all_repos()
+    return base
+
+
+def setup_repos(base, treefile):
+    for repo in base.repos.values():
+        repo.disable()
+
+    print("Enabled repos:")
+    for repo in treefile['repos']:
+        base.repos[repo].enable()
+        print(f"- {repo}")
+
+    print("Downloading metadata")
+    base.fill_sack(load_system_repo=False)
+
+
+def get_lockfiles():
+    lockfiles = ['manifest-lock.overrides.yaml']
+    # TODO: for now, we only support the archless variant; supporting
+    # arch-specific lockfiles will require making dnf fetch metadata not just
+    # for the basearch on which we're running
+    # lockfiles += [f'manifest-lock.overrides.{arch}.yaml' for arch in ARCHES]
+    return lockfiles
+
+
+def update_lockfile(base, fn):
+    if not os.path.exists(fn):
+        return
+
+    with open(fn) as f:
+        lockfile = yaml.load(f)
+    if 'packages' not in lockfile:
+        return
+
+    new_packages = {}
+    for name, lock in lockfile['packages'].items():
+        if ('metadata' not in lock or
+                lock['metadata'].get('type') != "fast-track"):
+            new_packages[name] = lock
+            continue
+
+        if 'evra' in lock:
+            nevra = f"{name}-{lock['evra']}"
+        else:
+            # it applies to all arches, so we can just check our arch (see
+            # related TODO above)
+            nevra = f"{name}-{lock['evr']}.{base.conf.basearch}"
+        graduated = sack_has_nevra_greater_or_equal(base, nevra)
+        if not graduated:
+            new_packages[name] = lock
+        else:
+            print(f"{fn}: {nevra} has graduated")
+
+    if lockfile['packages'] != new_packages:
+        lockfile['packages'] = new_packages
+        with open(fn, 'w') as f:
+            f.write(OVERRIDES_HEADER.strip())
+            f.write('\n\n')
+            yaml.dump(lockfile, f)
+    else:
+        print(f"{fn}: no packages graduated")
+
+
+def sack_has_nevra_greater_or_equal(base, nevra):
+    nevra = hawkey.split_nevra(nevra)
+    pkgs = base.sack.query().filterm(name=nevra.name).latest().run()
+
+    if len(pkgs) == 0:
+        # Odd... the only way I can imagine this happen is if we fast-track a
+        # brand new package from Koji which hasn't hit the updates repo yet.
+        # Corner-case, but let's be nice.
+        print(f"couldn't find package {nevra.name}; assuming not graduated")
+        return False
+
+    nevra_latest = hawkey.split_nevra(str(pkgs[0]))
+    return nevra_latest >= nevra
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,17 +1,38 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a URL in the `metadata.reason` key, though it's acceptable to
+# omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
+
 packages:
-    # Freeze dracut on 053. We need to investigate NetworkManager systemd changes.
-    # https://github.com/coreos/fedora-coreos-tracker/issues/842
-    dracut:
-        evr: 053-5.fc34
-    dracut-network:
-        evr: 053-5.fc34
-    # Fast-track for firstboot multipath
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
-    ignition:
-        evr: 2.10.1-3.fc34
-    # Fast-track for https://github.com/coreos/fedora-coreos-tracker/issues/850
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-d8e34dbd6e
-    selinux-policy:
-        evra: 34.11-1.fc34.noarch
-    selinux-policy-targeted:
-        evra: 34.11-1.fc34.noarch
+  dracut:
+    evr: 053-5.fc34
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+  dracut-network:
+    evr: 053-5.fc34
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+  ignition:
+    evr: 2.10.1-3.fc34
+    metadata:
+      type: fast-track
+      reason: https://github.com/coreos/fedora-coreos-config/pull/1011
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
+  selinux-policy:
+    evra: 34.11-1.fc34.noarch
+    metadata:
+      type: fast-track
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/850
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-d8e34dbd6e
+  selinux-policy-targeted:
+    evra: 34.11-1.fc34.noarch
+    metadata:
+      type: fast-track
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/850
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-d8e34dbd6e

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,9 +9,10 @@ rojig:
   summary: Fedora CoreOS testing-devel
 
 repos:
-  # these repos are there to make it easier to add new packages to the OS and to
+  # These repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
-  # still pinned
+  # still pinned. These repos are also used by the remove-graduated-overrides
+  # GitHub Action.
   - fedora
   - fedora-updates
 


### PR DESCRIPTION
Currently, we have to manually check if fast-tracked packages have made
it into the Fedora repos and drop them. This GitHub Action automates
this process.

It also formalizes the process of pinning packages a bit by adding
guidelines for metadata keys overrides should use to be more explicit.