### PR TITLE
overlay.d: Add back CLHM presets

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -1,6 +1,8 @@
 # Presets here that eventually should live in the generic fedora presets
 
 # console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
+enable console-login-helper-messages-issuegen.service
+enable console-login-helper-messages-issuegen.path
 enable console-login-helper-messages-gensnippet-os-release.service
 enable console-login-helper-messages-gensnippet-ssh-keys.service
 # CA certs (probably to add to base fedora eventually)


### PR DESCRIPTION
CLHM v0.21+ used in FCOS no longer has `{issue,motd}gen`-related units, but the
`05core` overlay is shared and used as `01fcos` in RHCOS, and RHCOS is still on
older versions of CLHM that require these units. Keep presets for these units
until RHCOS catches up to CLHM v0.21+.

Note: CLHM does not have `motdgen`-related units in RHEL even in older versions,
so we only add back `issuegen.service` and `issuegen.path` here.