### PR TITLE
[next-devel] overrides: attempt to prevent f33->f34 downgrades

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -17,3 +17,45 @@ packages:
     evr: 2021.4-1.fc34
   rpm-ostree-libs:
     evr: 2021.4-1.fc34
+
+  #############################################
+  # updates to prevent downgrades from f33->f34
+  #############################################
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-ac9daea36e
+  container-selinux:
+    evra: 2:2.160.0-1.fc34.noarch
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-d56567bdab
+  kernel:
+    evr: 5.11.14-300.fc34
+  kernel-core:
+    evr: 5.11.14-300.fc34
+  kernel-modules:
+    evr: 5.11.14-300.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-83d3313ac6
+  zincati:
+    evr: 0.0.19-1.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-259ced3016
+  cups-libs:
+    evr: 1:2.3.3op2-4.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-4a3796dd99
+  libxcrypt:
+    evr: 4.4.19-1.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-e1ba164651
+  vim-minimal:
+    evr: 2:8.2.2735-1.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-39df52b880
+  fstrm:
+    evr: 0.6.1-2.fc34
+  # https://bodhi.fedoraproject.org/updates/FEDORA-2021-83b3740389
+  containers-common:
+    evra: 4:1-15.fc34.noarch
+  crun:
+    evr: 0.19-2.fc34
+  conmon:
+    evr: 2:2.0.27-2.fc34
+  podman:
+    evr: 2:3.1.1-2.fc34
+  podman-plugins:
+    evr: 2:3.1.1-2.fc34
+  runc:
+    evr: 2:1.0.0-376.dev.git12644e6.fc34


### PR DESCRIPTION
During this time f34 is frozen, but f33 is chugging along. Attempt
to override packages that would be perceived as a downgrade.

Attempts to remedy this as seen on testing-devel (33.20210419.20.0)
and next-devel (34.20210418.10.0):

```
ostree diff commit from: compose:fedora/x86_64/coreos/testing-devel (44185ba11838bac6978ecbcd075745d30ecad58a35d5daa743eb30feda46c76d)
ostree diff commit to:   compose:fedora/x86_64/coreos/next-devel (740c217efad716850314f72902a3ad6f87144ad3970f4b26415a7164fe2e9c42)
...
Downgraded:
  conmon 2:2.0.27-2.fc33 -> 2:2.0.27-1.fc34
  container-selinux 2:2.160.0-1.fc33 -> 2:2.158.0-1.gite78ac4f.fc34
  crun 0.19-1.fc33 -> 0.18-5.fc34
  cups-libs 1:2.3.3op2-4.fc33 -> 1:2.3.3op2-3.fc34
  fstrm 0.6.1-2.fc33 -> 0.6.0-4.fc34
  kernel 5.11.14-200.fc33 -> 5.11.12-300.fc34
  kernel-core 5.11.14-200.fc33 -> 5.11.12-300.fc34
  kernel-modules 5.11.14-200.fc33 -> 5.11.12-300.fc34
  libxcrypt 4.4.19-1.fc33 -> 4.4.18-1.fc34
  podman 2:3.1.0-3.fc33 -> 2:3.1.0-1.fc34
  podman-plugins 2:3.1.0-3.fc33 -> 2:3.1.0-1.fc34
  vim-minimal 2:8.2.2735-1.fc33 -> 2:8.2.2637-1.fc34
  zincati 0.0.19-1.fc33 -> 0.0.18-1.fc34
...