### PR TITLE
fedora-coreos-base: skip the script to disable module repos if no files match

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -55,6 +55,7 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
+    shopt -s nullglob
     for x in /etc/yum.repos.d/*modular.repo; do
       sed -i -e 's,enabled=[01],enabled=0,' ${x}
     done


### PR DESCRIPTION
Setting nullglob makes the repos skip passing "/etc/yum.repos.d/*modular.repo" to sed if no matching files found.

See error message in https://cirrus-ci.com/task/6296878716289024 - bash passes `/etc/yum.repos.d/*modular.repo` as is if no files match