### PR TITLE
Move comments in systemd services to own line

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.service
@@ -8,7 +8,8 @@ ConditionKernelCommandLine=!coreos.liveiso
 After=basic.target
 # Network is enabled here
 After=nm-run.service
-After=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
+# compat: remove when everyone is on dracut 053+
+After=dracut-initqueue.service
 
 # If we fail, the boot will fail.  Be explicit about it.
 OnFailure=emergency.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -31,7 +31,8 @@ ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
 Before=ignition-diskful.target
 Before=nm-run.service
-Before=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
+# compat: remove when everyone is on dracut 053+
+Before=dracut-initqueue.service
 After=dracut-cmdline.service
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
@@ -21,7 +21,8 @@ Before=ignition-fetch.service
 # See hack in coreos-enable-network, as well as coreos-copy-firstboot-network.service.
 After=dracut-cmdline.service
 Before=nm-run.service
-Before=dracut-initqueue.service # compat: remove when everyone is on dracut 053+
+# compat: remove when everyone is on dracut 053+
+Before=dracut-initqueue.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Comments in systemd services at the end of lines cause unnecessary
warning messges:

Failed to add dependency on on, ignoring: Invalid argument
Failed to add dependency on dracut, ignoring: Invalid argument
Failed to add dependency on 053+, ignoring: Invalid argument

The services would still start so this is a cosmetic change only.