### PR TITLE
Revert "overlay.d/35coreos-network: don't bring up NM if not needed"

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-nm-run-only-if-neednet.conf
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-nm-run-only-if-neednet.conf
@@ -1,7 +1,0 @@
-[Unit]
-# Workaround https://github.com/dracutdevs/dracut/pull/1347 until it lands.
-# Only run if network is needed. Right now we can detect this by seeing
-# if the /usr/lib/dracut/hooks/initqueue/finished/nm.sh file exists (written
-# out by nm_generate_connections() [1], which is called in the cmdline hook).
-# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-lib.sh#L16.
-ConditionPathExists=/usr/lib/dracut/hooks/initqueue/finished/nm.sh

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
@@ -25,8 +25,4 @@ install() {
     inst_simple "$moddir/50-afterburn-network-kargs-default.conf" \
         "/usr/lib/systemd/system/afterburn-network-kargs.service.d/50-afterburn-network-kargs-default.conf"
 
-    # Workaround for https://github.com/dracutdevs/dracut/pull/1347 until it lands.
-    # Dropin to make NetworkManager systemd service only start if network is needed.
-    inst_simple "$moddir/50-nm-run-only-if-neednet.conf" \
-        "/usr/lib/systemd/system/nm-run.service.d/50-nm-run-only-if-neednet.conf"
 }

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -91,23 +91,6 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
 fi
 ok conditional initrd networking
 
-# In F34 network-manager in dracut started executing NM in
-# oneshot mode via a systemd unit. That needed some fixups.
-# https://github.com/dracutdevs/dracut/pull/1347
-# We're waiting on those changes to flow downstream.
-# When we get them we'll need to adjust some things so let's
-# complain when we detect they've come in.
-source /etc/os-release
-if [ "$VERSION_ID" -gt "33" ]; then
-    if [ ! -f /usr/lib/dracut/modules.d/35network-manager/nm-run.service ]; then
-        fatal "Did not find expected nm-run.service in dracut"
-    fi
-    if grep -q neednet /usr/lib/dracut/modules.d/35network-manager/nm-run.service; then
-        fatal "Upstream dracut fix landed. Please adjust the workaround."
-    fi
-fi
-ok dracut-networkmanager
-
 if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
     fatal missing LICENSE
 fi


### PR DESCRIPTION
This reverts commit 2747e11aa0798a5b04e3230c2ba2f7014698391b.
Now that we have a dracut build in f34 with the fixes, we don't
need these workarounds any longer.