### PR TITLE
manifests: require crun

### DIFF
--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -28,6 +28,7 @@ packages:
   # Remote Access
   - openssh-clients openssh-server
   # Container tooling
+  - crun
   - podman
   - runc
   - skopeo


### PR DESCRIPTION
Recently `runc` started providing `oci-runtime` as well, which caused
`crun` to fall out of the required dependencies. Let's explicitly
require `crun` as well so we get `crun` too.