### PR TITLE
manifests: explicitly add fwupd

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -10,6 +10,8 @@ packages:
  - kernel kernel-core kernel-modules systemd
  # rpm-ostree
  - rpm-ostree nss-altfiles
+ # firmware updates
+ - fwupd
 
 # bootloader
 packages-aarch64:


### PR DESCRIPTION
This was pulled in transitively when we moved to f33, and we knowingly
allowed it because we wanted it. But in f34, it looks like it gets
dropped out again, so explicitly list it now to make sure we keep
shipping it.