### PR TITLE
Add temporary workaround for `agetty --reload` SELinux denial

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/coreos-touch-run-agetty.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/coreos-touch-run-agetty.service
@@ -1,0 +1,12 @@
+# Temporary hack to work around agetty SELinux denials.
+# https://github.com/coreos/fedora-coreos-config/pull/859#issuecomment-783713383
+# https://bugzilla.redhat.com/show_bug.cgi?id=1932053
+[Unit]
+Description=CoreOS: Touch /run/agetty.reload
+Documentation=https://bugzilla.redhat.com/show_bug.cgi?id=1932053
+DefaultDependencies=false
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/touch /run/agetty.reload

--- a/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/module-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+# Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1932053.
+
+install_unit() {
+    local unit=$1; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires initrd.target "$unit" || exit 1
+}
+
+install() {
+    inst_multiple \
+        touch
+
+    # TODO f34: check if we can drop this whole module
+    install_unit coreos-touch-run-agetty.service
+}


### PR DESCRIPTION
In f34+, we're hitting an SELinux denial from c-l-h-m trying to do
`agetty --reload` and causing `/run/agetty.reload` to be created with
the wrong label. This then prevents agetty from adding an inotify watch
to know when to reload the prompt to display new information. For more
details, see:

https://github.com/coreos/fedora-coreos-config/pull/859#issuecomment-783713383

This is tracked at https://bugzilla.redhat.com/show_bug.cgi?id=1932053.

With this workaround, we create the file up front in the initrd so that
it gets relabeled by systemd on switchroot and thus will already exists
with the right label well before c-l-h-m or anything else tries to
`agetty --reload`.