### PR TITLE
overlay.d & tests/misc-ro: Fix and test for 664 mode for some files in /etc

### DIFF
--- a/overlay.d/09misc/usr/lib/tmpfiles.d/coreos-fix-etc-ownership.conf
+++ b/overlay.d/09misc/usr/lib/tmpfiles.d/coreos-fix-etc-ownership.conf
@@ -1,0 +1,11 @@
+# Workaround for https://github.com/coreos/fedora-coreos-tracker/issues/829
+# Fix mode (chmod g-w) for existing files on the system during boot
+z /etc/crypto-policies/state/current               644 root root
+z /etc/group                                       644 root root
+z /etc/group-                                      644 root root
+z /etc/iscsi/initiatorname.iscsi                   644 root root
+z /etc/passwd                                      644 root root
+z /etc/passwd-                                     644 root root
+z /etc/selinux/config                              644 root root
+z /etc/ssh/sshd_config.d/40-disable-passwords.conf 644 root root
+z /etc/systemd/dont-synthesize-nobody              644 root root

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -15,7 +15,8 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1700056
 09misc
 ------
 
-Warning about `/etc/sysconfig`.
+* Warning about `/etc/sysconfig`.
+* Temporary systemd-tpmfiles.d config to fix ownership and permissions in /etc
 
 14NetworkManager-plugins
 ------------------------

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -22,14 +22,6 @@ Warning about `/etc/sysconfig`.
 
 Disables the Red Hat Linux legacy `ifcfg` format.
 
-20platform-chrony
------------------
-
-Add static chrony configuration for NTP servers provided on platforms
-such as `azure`, `aws`, `gcp`. The chrony config for these NTP servers
-should override other chrony configuration (e.g. DHCP-provided)
-configuration.
-
 15fcos
 ------
 
@@ -45,4 +37,7 @@ Things that are more closely "Fedora CoreOS":
 20platform-chrony
 -----------------
 
-Platform aware timeserver setup for chrony daemon.
+Add static chrony configuration for NTP servers provided on platforms
+such as `azure`, `aws`, `gcp`. The chrony config for these NTP servers
+should override other chrony configuration (e.g. DHCP-provided)
+configuration.

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -155,3 +155,18 @@ fi
 if [[ $sys_fs_cgroup_source != cgroup2 ]]; then
     fatal "/sys/fs/cgroup is not cgroup2"
 fi
+
+for perms in 'o+w' 'g+w'; do
+	list="$(find /etc -type f -perm /${perms})"
+	if [[ -n "${list}" ]]; then
+		fatal "found files with ${perms}:\n${list}"
+	fi
+done
+ok "no files with o+w or g+w found in /etc"
+
+for f in '/etc/passwd' '/etc/group'; do
+	if [[ $(stat --format="%a %u %g" "${f}") != "644 0 0" ]]; then
+		fatal "found incorrect permissions for ${f}"
+	fi
+done
+ok "correct ownership and mode on /etc/passwd & /etc/group"


### PR DESCRIPTION
overlay.d/09misc: Add workaround for /etc/passwd & group mod issue

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/829

---

tests/misc-ro: Check mode for files in /etc

- Do not allow others or group writable files in /etc
- Extended ownership (root:root) & mode (644) checks for
  /etc/{passwd,group}

Test for https://github.com/coreos/fedora-coreos-tracker/issues/829