### PR TITLE
[next-devel] overrides: freeze podman to 3.1.2-1

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,1 +1,8 @@
-packages: {}
+packages:
+    # Freeze due to regression in 3.2.0 rc
+    # https://github.com/containers/podman/issues/10274
+    # https://github.com/containers/podman/pull/10288
+    podman:
+        evr: 2:3.1.2-1.fc34
+    podman-plugins:
+        evr: 2:3.1.2-1.fc34


### PR DESCRIPTION
There is a regression in the latest 3.2.0 RC in stable:
- https://github.com/containers/podman/issues/10274
- https://github.com/containers/podman/pull/10288

No Bodhi updates yet with the fix.

Also hit that bug myself locally on FSB.

(cherry picked from commit b72844c5c801e7bf899ac65b4040aaecb743a7ec)