### PR TITLE
[rhcos-4.6] backport updates for pxe rootfs fetch retry

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/20live/coreos-livepxe-rootfs.sh
@@ -34,7 +34,7 @@ elif [[ -n "${rootfs_url}" ]]; then
     # image hash.
     # bsdtar can read cpio archives and we already depend on it for
     # coreos-liveiso-persist-osmet.service, so use it instead of cpio.
-    if ! curl --silent --insecure --location --retry 5 "${rootfs_url}" | \
+    if ! curl --silent --show-error --insecure --location --retry 5 "${rootfs_url}" | \
             rdcore stream-hash /etc/coreos-live-want-rootfs | \
             bsdtar -xf - -C / ; then
         echo "Couldn't fetch, verify, and unpack image specified by coreos.live.rootfs_url=" >&2


### PR DESCRIPTION
```
commit 42298433aa9e077c9b0fe171c50f18794897d99a 
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Apr 15 13:34:13 2021 -0400

    35coreos-live/coreos-livepxe-rootfs: retry fetching rootfs forever
    
    We don't know how long it will take for networking to come up, so let's
    match Ignition's semantic of retrying to fetch remote resources forever.
    
    `curl` doesn't natively have support for this, so wrap it in a `while`
    loop. This also works around the fact that el8's `curl` doesn't support
    `--retry-all-errors`.
    
    This was previously added in #929.
    
    (cherry picked from commit d2776ed618d7d72fc0b226b7f08e45d3182406e7)

commit ca46a43fe4c1745be8aff12e4c43ca066b95a87e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Apr 6 11:11:55 2021 -0400

    35coreos-live/coreos-livepxe-rootfs: add in connectivity check before downloading
    
    This should help us get around some race conditions on startup
    where we've seen curl exit with "No route to host" errors. This
    most likely happens because the Networking in the kernel is still
    being brought up (seen more in complex networking scenarios) and
    curl hits that error the first time it tries. Since "No route to
    host" isn't considered retryable, curl exits.
    
    Instead let's just verify we can get to the remote at all in an
    initial `curl --head` call. In this one we'll use --retry-all-errors
    so that we will retry all errors. Once the connectivity to the remote
    is verified then it should be safe to start downloading.
    
    (cherry picked from commit b4a65864ef3b7d05b1452ee92384266c875196df)

commit 412fdc983be2d74b0f0725e11cdddb5bc6cf3300
Author: Benjamin Gilbert <bgilbert@redhat.com>
Date:   Thu Dec 3 00:04:00 2020 -0500

    20live: log rootfs fetch errors
    
    When rootfs fetch fails, ensure we have some useful logging for tracking
    down the problem.
    
    (cherry picked from commit 0e432bd7ea4839bf80304233337def06f6d7fd3d)
```