### PR TITLE
live-generator: don't call `man bootup`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -90,7 +90,7 @@ EOF
 DefaultDependencies=false
 # HACK for https://github.com/coreos/fedora-coreos-config/issues/437
 Wants=systemd-udev-settle.service
-# Note that `man bootup` implies that initrd-root-device is After=basic.target
+# Note that bootup(7) implies that initrd-root-device is After=basic.target
 # but that appears to not be the case.  We explicitly order after sysinit.target
 After=sysinit.target
 After=initrd-root-device.target


### PR DESCRIPTION
Even though it's on a comment line, because it's in a heredoc, bash does
try to execute this. This fails on FCOS thankfully because there is no
`man` on FCOS, but it still logs an error message. (And... any derived
system which does ship `man`, I think this actually would dump the
manpage into the unit.)