### PR TITLE
coreos-boot-mount-generator: Always use mpath for /boot if for root

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -41,20 +41,11 @@ add_wants() {
 # is backed by a device-mapper target the dev-mapper.*.device is used.
 mk_mount() {
     local mount_pt="${1}"; shift
-    local label="${1}"; shift
+    local path="${1}"; shift
     local options="${1}"; shift
 
-    local path="/dev/disk/by-label/${label}"
+    local devservice=$(systemd-escape -p ${path} --suffix=service)
     local unit_name=$(systemd-escape -p ${mount_pt} --suffix=mount)
-
-    eval $(udevadm info --query property --export "${path}")
-    device="$(systemd-escape ${path})"
-    if [ "${DM_NAME:-x}" != "x" ]; then
-        path="/dev/mapper/${DM_NAME}"
-        device="$(systemd-escape dev/mapper/${DM_NAME})"
-    fi
-    device="${device//-dev/dev}"
-    echo "coreos-boot-mount-generator: using ${device} for ${label} mount to ${mount_pt}"
 
     cat > "${UNIT_DIR}/${unit_name}" <<EOF
 # Automatically created by coreos-boot-mount-generator
@@ -63,21 +54,31 @@ Description=CoreOS Dynamic Mount for ${mount_pt}
 Documentation=https://github.com/coreos/fedora-coreos-config
 
 Before=local-fs.target
-Requires=systemd-fsck@${device}.service
-After=systemd-fsck@${device}.service
+Requires=systemd-fsck@${devservice}
+After=systemd-fsck@${devservice}
 
 [Mount]
 What=${path}
 Where=${mount_pt}
 Options=${options}
 EOF
-
     add_wants "${unit_name}"
 }
+
+# If the root device is multipath, hook up /boot to use that too,
+# based on our custom udev rules in 90-coreos-device-mapper.rules
+# that creates "label found on mpath" links.
+# Otherwise, use the usual by-label symlink.
+# See discussion in https://github.com/coreos/fedora-coreos-config/pull/1022
+bootdev=/dev/disk/by-label/boot
+# Yes this isn't a real karg parser but we're trapped in this shell script
+if grep -q rd.multipath /proc/cmdline; then
+    bootdev=/dev/disk/by-label/dm-mpath-boot
+fi
 
 # We mount read-only by default mostly to protect
 # against accidental damage.  Only a few things
 # owned by CoreOS should be touching /boot or the ESP.
 # Use nodev,nosuid because some hardening guides want
 # that even though it's of minimal value.
-mk_mount /boot boot ro,nodev,nosuid
+mk_mount /boot "${bootdev}" ro,nodev,nosuid

--- a/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/90-coreos-device-mapper.rules
@@ -1,24 +1,27 @@
+# CoreOS-specific symlinks for dm-multipath filesystem labels,
+# used for `label=boot` and `label=root`.
+
 ACTION=="remove", GOTO="dm_label_end"
 SUBSYSTEM!="block", GOTO="dm_label_end"
 KERNEL!="dm-*", GOTO="dm_label_end"
 
 # Ensure that the device mapper target is active
-# And the required attributes exist.
 ENV{DM_ACTIVATION}!="1", GOTO="dm_label_end"
-ENV{ID_FS_LABEL_ENC}!="?*", GOTO="dm_label_end"
-ENV{ID_FS_UUID_ENC}!="?*", GOTO="dm_label_end"
+ENV{DM_SUSPENDED}=="1", GOTO="dm_label_end"
 
 # Only act on filesystems. This should prevent layered devices
 # such as Raid on Multipath devices from appearing.
 ENV{ID_FS_USAGE}!="filesystem", GOTO="dm_label_end"
+
+# And if the filesystem doesn't have a label+uuid, we're done.
+ENV{ID_FS_LABEL_ENC}!="?*", GOTO="dm_label_end"
+ENV{ID_FS_UUID_ENC}!="?*", GOTO="dm_label_end"
 
 # Setup up Multipath labels and UUID's. Match on DM_UUID which
 # is stable regardless of whether friendly names are used or not.
 # 66-kpartx.rules use DM_UUID to match for linear mappings on multipath
 # targets.
 ENV{DM_UUID}=="*mpath*" \
-  , ENV{DM_SUSPENDED}=="Active" \
-  , ENV{DM_TABLES_LOADED}=="Live" \
   , SYMLINK+="disk/by-label/dm-mpath-$env{ID_FS_LABEL_ENC}" \
   , SYMLINK+="disk/by-uuid/dm-mpath-$env{ID_FS_UUID_ENC}"
 


### PR DESCRIPTION
udev/90-coreos-device-mapper: Create label links in real root too

We're currently gating on `ENV{DM_SUSPENDED}=="Active"` but
`10-dm.rules` does:

```
ENV{DM_SUSPENDED}=="Active", ENV{DM_SUSPENDED}="0"
ENV{DM_SUSPENDED}=="Suspended", ENV{DM_SUSPENDED}="1"
```

So what I think is happening here is that our rule happens to
run before that kicks in, so we make the links once, but not
thereafter.

Change the condition to match what `13-dm-disk.rules` from
LVM is doing.

Also slightly reorder the code and add some comments for extra clarity.

---

coreos-boot-mount-generator: Always use mpath for /boot if for root

If root is on multipath, then we *know* we must use it for `/boot`.
The current code is I believe racy because at the time the generator
runs, we're querying the current properties of the device at
`/dev/disk/by-label/boot`.  But multipathd could still be in
the process of setting up and replacing what that symlink
points to.

https://bugzilla.redhat.com/show_bug.cgi?id=1944660

---

