### PR TITLE
[next-devel] overrides: freeze on dracut-053-5.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,4 +1,10 @@
 packages:
+    # Freeze dracut on 053. We need to investigate NetworkManager systemd changes.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/842
+    dracut:
+        evr: 053-5.fc34
+    dracut-network:
+        evr: 053-5.fc34
     # Fast-track crun-0.19.1-3.fc34 It was erroneously downgraded in Fedora.
     # https://bodhi.fedoraproject.org/updates/FEDORA-2021-316efff8f2
     crun:


### PR DESCRIPTION
There are some NetworkManager related changes and possibly others
that are causing failures in our bump-lockfile process. We need
to investigate these issues before promoting dracut-054.

https://github.com/coreos/fedora-coreos-tracker/issues/842
(cherry picked from commit f6dab79d48ef4d82dacf04f44285a3c7eb2adfec)