### PR TITLE
move to cgroups v2 everywhere

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,8 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-extra-kargs:
-    # https://github.com/coreos/fedora-coreos-tracker/issues/292
-    # https://fedoraproject.org/wiki/Changes/CGroupsV2
-    - systemd.unified_cgroup_hierarchy=0

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -144,25 +144,14 @@ if ! grep prjquota <<< "${rootflags}"; then
 fi
 ok "root mounted with prjquota"
 
+# make sure the system is on cgroups v2
 has_cgroup_karg=1
 grep -q systemd.unified_cgroup_hierarchy /proc/cmdline || has_cgroup_karg=0
 sys_fs_cgroup_source=$(findmnt -no SOURCE /sys/fs/cgroup)
 stream=$(rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]')
-case "$stream" in
-    "testing-devel" | "testing" | "stable")
-        if [ $has_cgroup_karg == 0 ]; then
-            fatal "missing systemd.unified_cgroup_hierarchy=0"
-        fi
-        if [[ $sys_fs_cgroup_source != tmpfs ]]; then
-            fatal "/sys/fs/cgroup is not tmpfs"
-        fi
-        ;;
-    *)
-        if [ $has_cgroup_karg == 1 ]; then
-            fatal "found systemd.unified_cgroup_hierarchy=0"
-        fi
-        if [[ $sys_fs_cgroup_source != cgroup2 ]]; then
-            fatal "/sys/fs/cgroup is not cgroup2"
-        fi
-        ;;
-esac
+if [ $has_cgroup_karg == 1 ]; then
+    fatal "found systemd.unified_cgroup_hierarchy=0"
+fi
+if [[ $sys_fs_cgroup_source != cgroup2 ]]; then
+    fatal "/sys/fs/cgroup is not cgroup2"
+fi


### PR DESCRIPTION
Adjust the kernel arguments so that we're now using cgroups v2
in our testing-devel (and subsequently, testing and stable) stream(s).

Context: https://github.com/coreos/fedora-coreos-tracker/issues/292