### PR TITLE
overrides: fast-track ignition-2.10.1-3.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,3 +19,7 @@ packages:
     # https://bodhi.fedoraproject.org/updates/FEDORA-2021-0440f235a0
     runc:
         evr: 2:1.0.0-378.rc95.fc34
+    # For firstboot multipath
+    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
+    ignition:
+        evr: 2.10.1-3.fc34


### PR DESCRIPTION
For firstboot multipath support:
https://github.com/coreos/fedora-coreos-config/pull/1011