### PR TITLE
manifests: Move crun to fedora-coreos-base

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -115,6 +115,8 @@ postprocess:
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.
 packages:
+  # Container tooling
+  - crun
   # Security
   - polkit
   # System setup

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -28,7 +28,6 @@ packages:
   # Remote Access
   - openssh-clients openssh-server
   # Container tooling
-  - crun
   - podman
   - runc
   - skopeo


### PR DESCRIPTION
crun was explicitely included in [1] for Fedora CoreOS but we don't use it in RHCOS for now as we default to runc [2] so this moves it to the fedora-coreos-base manifest to make it FCOS only.

[1] https://github.com/coreos/fedora-coreos-config/commit/45b01675f9139aacf306830e5fda0a1c5d454b65
[2] https://github.com/openshift/os/commit/80aa676918965abd2c5f47415d70d8ceb55f2129