### PR TITLE
overrides: freeze on selinux-policy-34.8-1.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -5,6 +5,12 @@ packages:
         evr: 053-5.fc34
     dracut-network:
         evr: 053-5.fc34
+    # Freeze selinux-policy so we can unblock bumping lockfiles
+    # https://github.com/coreos/fedora-coreos-tracker/issues/850
+    selinux-policy:
+        evra: 34.8-1.fc34.noarch
+    selinux-policy-targeted:
+        evra: 34.8-1.fc34.noarch
     # For firstboot multipath
     # https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
     ignition:

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -127,7 +127,7 @@
       "evra": "0.21.2-1.fc34.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.162.1-3.fc34.noarch"
+      "evra": "2:2.162.2-1.fc34.noarch"
     },
     "containerd": {
       "evra": "1.5.0~rc.1-1.fc34.x86_64"
@@ -169,10 +169,10 @@
       "evra": "20210213-1.git5c710c0.fc34.noarch"
     },
     "cryptsetup": {
-      "evra": "2.3.5-2.fc34.x86_64"
+      "evra": "2.3.6-1.fc34.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.3.5-2.fc34.x86_64"
+      "evra": "2.3.6-1.fc34.x86_64"
     },
     "cups-libs": {
       "evra": "1:2.3.3op2-7.fc34.x86_64"
@@ -250,13 +250,13 @@
       "evra": "37-15.fc34.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.183-1.fc34.noarch"
+      "evra": "0.185-2.fc34.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.183-1.fc34.x86_64"
+      "evra": "0.185-2.fc34.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.183-1.fc34.x86_64"
+      "evra": "0.185-2.fc34.x86_64"
     },
     "ethtool": {
       "evra": "2:5.12-1.fc34.x86_64"
@@ -304,7 +304,7 @@
       "evra": "1:4.8.0-2.fc34.x86_64"
     },
     "firewalld-filesystem": {
-      "evra": "0.9.3-2.fc34.noarch"
+      "evra": "0.9.3-3.fc34.noarch"
     },
     "flatpak-session-helper": {
       "evra": "1.10.2-3.fc34.x86_64"
@@ -355,13 +355,13 @@
       "evra": "2.68.2-1.fc34.x86_64"
     },
     "glibc": {
-      "evra": "2.33-8.fc34.x86_64"
+      "evra": "2.33-14.fc34.x86_64"
     },
     "glibc-common": {
-      "evra": "2.33-8.fc34.x86_64"
+      "evra": "2.33-14.fc34.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.33-8.fc34.x86_64"
+      "evra": "2.33-14.fc34.x86_64"
     },
     "gmp": {
       "evra": "1:6.2.0-6.fc34.x86_64"
@@ -370,7 +370,7 @@
       "evra": "2.2.27-4.fc34.x86_64"
     },
     "gnutls": {
-      "evra": "3.7.1-2.fc34.x86_64"
+      "evra": "3.7.2-1.fc34.x86_64"
     },
     "gpgme": {
       "evra": "1.15.1-2.fc34.x86_64"
@@ -463,13 +463,13 @@
       "evra": "2.4.0-2.fc34.noarch"
     },
     "kernel": {
-      "evra": "5.12.7-300.fc34.x86_64"
+      "evra": "5.12.8-300.fc34.x86_64"
     },
     "kernel-core": {
-      "evra": "5.12.7-300.fc34.x86_64"
+      "evra": "5.12.8-300.fc34.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.12.7-300.fc34.x86_64"
+      "evra": "5.12.8-300.fc34.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.21-5.fc34.x86_64"
@@ -574,13 +574,13 @@
       "evra": "1.4-4.fc34.x86_64"
     },
     "libgcc": {
-      "evra": "11.1.1-1.fc34.x86_64"
+      "evra": "11.1.1-3.fc34.x86_64"
     },
     "libgcrypt": {
       "evra": "1.9.3-2.fc34.x86_64"
     },
     "libgomp": {
-      "evra": "11.1.1-1.fc34.x86_64"
+      "evra": "11.1.1-3.fc34.x86_64"
     },
     "libgpg-error": {
       "evra": "1.42-1.fc34.x86_64"
@@ -751,7 +751,7 @@
       "evra": "2.5.0-2.fc34.x86_64"
     },
     "libstdc++": {
-      "evra": "11.1.1-1.fc34.x86_64"
+      "evra": "11.1.1-3.fc34.x86_64"
     },
     "libtalloc": {
       "evra": "2.3.2-2.fc34.x86_64"
@@ -805,7 +805,7 @@
       "evra": "4.4.20-2.fc34.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.12-2.fc34.x86_64"
+      "evra": "2.9.12-4.fc34.x86_64"
     },
     "libxmlb": {
       "evra": "0.3.2-1.fc34.x86_64"
@@ -913,13 +913,13 @@
       "evra": "2.4.57-3.fc34.x86_64"
     },
     "openssh": {
-      "evra": "8.5p1-2.fc34.x86_64"
+      "evra": "8.6p1-3.fc34.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.5p1-2.fc34.x86_64"
+      "evra": "8.6p1-3.fc34.x86_64"
     },
     "openssh-server": {
-      "evra": "8.5p1-2.fc34.x86_64"
+      "evra": "8.6p1-3.fc34.x86_64"
     },
     "openssl": {
       "evra": "1:1.1.1k-1.fc34.x86_64"
@@ -1066,7 +1066,7 @@
       "evra": "15.4-4.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.2.3-1.fc34.x86_64"
+      "evra": "1:1.3.0-1.fc34.x86_64"
     },
     "slang": {
       "evra": "2.3.2-9.fc34.x86_64"
@@ -1144,7 +1144,7 @@
       "evra": "0.0.99.1-1.fc34.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.0-2.fc34.x86_64"
+      "evra": "5.1-1.fc34.x86_64"
     },
     "tpm2-tss": {
       "evra": "3.1.0-1.fc34.x86_64"
@@ -1159,7 +1159,7 @@
       "evra": "2.36.2-1.fc34.x86_64"
     },
     "vim-minimal": {
-      "evra": "2:8.2.2879-1.fc34.x86_64"
+      "evra": "2:8.2.2932-1.fc34.x86_64"
     },
     "which": {
       "evra": "2.21-26.fc34.x86_64"
@@ -1193,16 +1193,16 @@
     }
   },
   "metadata": {
-    "generated": "2021-05-29T20:53:20Z",
+    "generated": "2021-06-06T18:29:13Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-04-23T10:47:57Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2021-05-28T21:27:46Z"
+        "generated": "2021-05-29T21:25:40Z"
       },
       "fedora-updates": {
-        "generated": "2021-05-29T00:50:08Z"
+        "generated": "2021-06-06T00:48:39Z"
       }
     }
   }


### PR DESCRIPTION
The new one causes issues and has taken too long to get a fix.
https://github.com/coreos/fedora-coreos-tracker/issues/850

Let's unblock the lockfile bumper.
