### PR TITLE
overrides: fast-track selinux-policy-34.10-1.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -5,13 +5,13 @@ packages:
         evr: 053-5.fc34
     dracut-network:
         evr: 053-5.fc34
-    # Freeze selinux-policy so we can unblock bumping lockfiles
-    # https://github.com/coreos/fedora-coreos-tracker/issues/850
-    selinux-policy:
-        evra: 34.8-1.fc34.noarch
-    selinux-policy-targeted:
-        evra: 34.8-1.fc34.noarch
-    # For firstboot multipath
+    # Fast-track for firstboot multipath
     # https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
     ignition:
         evr: 2.10.1-3.fc34
+    # Fast-track for https://github.com/coreos/fedora-coreos-tracker/issues/850
+    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-f014ca8326
+    selinux-policy:
+        evra: 34.10-1.fc34.noarch
+    selinux-policy-targeted:
+        evra: 34.10-1.fc34.noarch


### PR DESCRIPTION
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/850