### PR TITLE
[rhcos-4.8] overlay: initramfs teardown: add support for coreos.force_persist_ip karg

### DIFF
--- a/tests/manual/coreos-network-testing.sh
+++ b/tests/manual/coreos-network-testing.sh
@@ -607,6 +607,17 @@ EOF
     check_vm 'dhcp' 2 0 $ip $nic0 'n/a' $nameserverdhcp $sshkeyfile
     destroy_vm
 
+    # Do a `coreos.force_persist_ip` check. In this case we won't pass any networking
+    # configuration via Ignition either, so we'll just end up with DHCP and a
+    # static hostname that is unset (`n/a`).
+    echo -e "\n###### Testing coreos.force_persist_ip forces initramfs propagation\n"
+    create_ignition_file "$fcct_static_nic0" $ignitionfile
+    start_vm $qcow $ignitionfile $kernel $initramfs "${initramfs_static_bond0} coreos.force_persist_ip"
+    check_vm 'none' 1 3 $ip bond0 $ignitionhostname $nameserverstatic $sshkeyfile
+    reboot_vm
+    check_vm 'none' 1 3 $ip bond0 $ignitionhostname $nameserverstatic $sshkeyfile
+    destroy_vm
+
     # Do a check for the `nameserver=` initramfs arg. Need to test along with
     # the $initramfs_dhcp_nic0nic1 because that brings up more than one
     # interface and is one that doesn't specify the nameserver as part of the


### PR DESCRIPTION
This karg will override the check to see if Networking Configuration is
in the real root (i.e. written by Ignition most likely) and force
propagation of initramfs networking anyway. It should only be used in
cases where you know exactly what you are doing. For example, in the
problem described in https://bugzilla.redhat.com/show_bug.cgi?id=1958930
the networking configs didn't conflict at all, thus this could be used
safely. This option will help users who get stuck like they were in that
bug to get unstuck easily and then change their strategy later.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/853
(cherry picked from commit 0488b7aef824dc0feb1d4b494f8435a2619fc6bd)