### PR TITLE
repos: drop `failovermethod` key

### DIFF
--- a/fedora-next.repo
+++ b/fedora-next.repo
@@ -3,7 +3,6 @@
 
 [fedora-next]
 name=Fedora $releasever - $basearch
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/Everything/$basearch/os/
         https://dl.fedoraproject.org/pub/fedora-secondary/development/$releasever/Everything/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
@@ -17,7 +16,6 @@ skip_if_unavailable=False
 
 [fedora-next-updates]
 name=Fedora $releasever - $basearch - Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Everything/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
@@ -31,7 +29,6 @@ skip_if_unavailable=False
 
 [fedora-next-updates-testing]
 name=Fedora $releasever - $basearch - Test Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Everything/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
@@ -56,7 +53,6 @@ skip_if_unavailable=False
 
 [fedora-next-updates-modular]
 name=Fedora Modular $releasever - $basearch - Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Modular/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
@@ -70,7 +66,6 @@ skip_if_unavailable=False
 
 [fedora-next-updates-testing-modular]
 name=Fedora Modular $releasever - $basearch - Test Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Modular/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Modular/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch

--- a/fedora.repo
+++ b/fedora.repo
@@ -3,7 +3,6 @@
 
 [fedora]
 name=Fedora $releasever - $basearch
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
         https://dl.fedoraproject.org/pub/fedora-secondary/releases/$releasever/Everything/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
@@ -17,7 +16,6 @@ skip_if_unavailable=False
 
 [fedora-updates]
 name=Fedora $releasever - $basearch - Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Everything/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
@@ -31,7 +29,6 @@ skip_if_unavailable=False
 
 [fedora-updates-testing]
 name=Fedora $releasever - $basearch - Test Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Everything/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Everything/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
@@ -56,7 +53,6 @@ skip_if_unavailable=False
 
 [fedora-updates-modular]
 name=Fedora Modular $releasever - $basearch - Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Modular/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Modular/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
@@ -70,7 +66,6 @@ skip_if_unavailable=False
 
 [fedora-updates-testing-modular]
 name=Fedora Modular $releasever - $basearch - Test Updates
-failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releasever/Modular/$basearch/
         https://dl.fedoraproject.org/pub/fedora-secondary/updates/testing/$releasever/Modular/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch


### PR DESCRIPTION
This isn't supported by `dnf`. `libdnf` will parse it but it's not
actually hooked up to anything. Recent repo files no longer use this
key. So just nuke it.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1653831