### PR TITLE
misc-ro: Validate aleph version is present and is valid JSON

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -89,6 +89,10 @@ if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
 fi
 ok LICENSE
 
+# Defined in https://github.com/coreos/fedora-coreos-tracker/blob/master/internals/README-internals.md#aleph-version
+jq < /sysroot/.coreos-aleph-version.json >/dev/null
+ok aleph
+
 case "$(arch)" in
     x86_64|aarch64)
         # This is just a basic sanity check; at some point we


### PR DESCRIPTION
I was idly thinking about deduplication between cosa and osbuild,
and this is a good example of a detail we should keep.  Let's
test it's present.