### PR TITLE
tests/kdump: disable test

### DIFF
--- a/tests/kola/kdump/test.sh
+++ b/tests/kola/kdump/test.sh
@@ -3,6 +3,11 @@ set -xeuo pipefail
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
 # kola: {"minMemory": 4096, "tags": "skip-base-checks"}
 
+# ===== FIXME: Disabled due to broken CI
+echo "Test disabled"
+exit 0
+# =====
+
 fatal() {
     echo "$@" >&2
     exit 1


### PR DESCRIPTION
It's a new test, and is broken on three cloud platforms plus Ignition upstream CI.

https://github.com/coreos/fedora-coreos-config/pull/1043#issuecomment-859028582