### PR TITLE
[next-devel] manifest.yaml: stop using -next repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,11 +9,12 @@ rojig:
   summary: Fedora CoreOS next-devel
 
 repos:
-  # these repos are there to make it easier to add new packages to the OS and to
+  # These repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
-  # still pinned
-  - fedora-next
-  - fedora-next-updates
+  # still pinned. These repos are also used by the remove-graduated-overrides
+  # GitHub Action.
+  - fedora
+  - fedora-updates
 
 # All Fedora CoreOS streams share the same pool for locked files.
 # This will be in fedora-coreos.yaml in the future so it can be more easily be


### PR DESCRIPTION
Both testing and next are on the same release now, so we can go back to
the stable repos for next-devel.

That stream isn't being built right now, but remove-graduated-overrides
still wants to try to check it, and I'd rather let it than disable it
for next-devel to be consistent and reduce churn whenever we flip the
switch. It's currently failing because those repos are no longer valid
for f34.

Also, it's possible we re-enable the stream anyway for rolling out some
of the systemd-oomd and swap suggestions.