### PR TITLE
tests/kola/chrony: hardcode NTP server address for now

### DIFF
--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -30,7 +30,10 @@ test_setup() {
 
     # run podman commands to set up dnsmasq server
     pushd $(mktemp -d)
-    NTPHOSTIP=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
+    # XXX: hardcode IP for now until can resolve in CentOS CI again
+    #      https://pagure.io/centos-infra/issue/356
+    #NTPHOSTIP=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
+    NTPHOSTIP='129.6.15.30'
     cat <<EOF >Dockerfile
 FROM registry.fedoraproject.org/fedora:34
 RUN dnf -y install systemd dnsmasq iproute iputils \

--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -32,7 +32,7 @@ test_setup() {
     pushd $(mktemp -d)
     NTPHOSTIP=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
     cat <<EOF >Dockerfile
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:34
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq


### PR DESCRIPTION
DNS for time-c-g.nist.gov is not resolving right now in CentOS CI
and this test is failing in CI as a result:

```
Jun 12 21:00:52 qemu0 kola-runext-dhcp-propagation[1293]: ++ getent hosts time-c-g.nist.gov  
Jun 12 21:01:11 qemu0 kola-runext-dhcp-propagation[1280]: + NTPHOSTIP=
Jun 12 21:01:11 qemu0 systemd[1]: kola-runext.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

Opened an issue for the DNS issue over at https://pagure.io/centos-infra/issue/356
