### PR TITLE
lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -11,28 +11,10 @@ packages:
   dracut:
     evr: 053-5.fc34
     metadata:
-      type: pin
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+      type: pin
   dracut-network:
     evr: 053-5.fc34
     metadata:
-      type: pin
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
-  ignition:
-    evr: 2.10.1-3.fc34
-    metadata:
-      type: fast-track
-      reason: https://github.com/coreos/fedora-coreos-config/pull/1011
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
-  selinux-policy:
-    evra: 34.11-1.fc34.noarch
-    metadata:
-      type: fast-track
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/850
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-d8e34dbd6e
-  selinux-policy-targeted:
-    evra: 34.11-1.fc34.noarch
-    metadata:
-      type: fast-track
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/850
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-d8e34dbd6e
+      type: pin


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.