### PR TITLE
ci/remove-graduated-overrides: don't fail-fast in matrix job

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -16,6 +16,7 @@ jobs:
         branch:
           - testing-devel
           - next-devel
+      fail-fast: false
     steps:
       - run: dnf install -y rpm-ostree # see related TODO above
       - name: Checkout


### PR DESCRIPTION
If e.g. the `next-devel` branch of the job failed, don't stop the
`testing-devel` branch.