### PR TITLE
tests: add test for watching files labeled kubernetes_file_t

### DIFF
--- a/tests/kola/misc-ign-ro/config.fcc
+++ b/tests/kola/misc-ign-ro/config.fcc
@@ -1,6 +1,12 @@
 variant: fcos
-version: 1.1.0
+version: 1.2.0
 storage:
+  directories:
+    # This is for verifying that `kubernetes_file_t` labeled files can be
+    # watched by systemd
+    # See: https://github.com/coreos/fedora-coreos-tracker/issues/861
+    # See: https://github.com/containers/container-selinux/issues/135
+    - path: /etc/kubernetes
   files:
     - path: /etc/systemd/zram-generator.conf
       mode: 0644
@@ -33,3 +39,28 @@ storage:
           AKbyaAqbChEy9CvDgyv6qxTYU+eeBImLKS3PH2uW5etc/69V/sDojqpH3hEffsOt
           9g==
           -----END CERTIFICATE-----
+systemd:
+  units:
+    - name: kube-watch.service
+      # This is for verifying that `kubernetes_file_t` labeled files can be
+      # watched by systemd
+      # See: https://github.com/coreos/fedora-coreos-tracker/issues/861
+      # See: https://github.com/containers/container-selinux/issues/135
+      contents: |
+        [Service]
+        ExecStart=/usr/bin/echo "Found it"
+        RemainAfterExit=yes
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target
+    - name: kube-watch.path
+      # This is for verifying that `kubernetes_file_t` labeled files can be
+      # watched by systemd
+      # See: https://github.com/coreos/fedora-coreos-tracker/issues/861
+      # See: https://github.com/containers/container-selinux/issues/135
+      enabled: true
+      contents: |
+        [Path]
+        PathExists=/etc/kubernetes/kubeconfig
+        [Install]
+        WantedBy=multi-user.target

--- a/tests/kola/misc-ign-ro/test.sh
+++ b/tests/kola/misc-ign-ro/test.sh
@@ -36,3 +36,25 @@ if [ "$context" != "system_u:object_r:net_conf_t:s0" ]; then
     fatal "SELinux context on stub-resolv.conf is wrong"
 fi
 ok "SELinux context on stub-resolv.conf is correct"
+
+# This is for verifying that `kubernetes_file_t` labeled files can be
+# watched by systemd
+# See: https://github.com/coreos/fedora-coreos-tracker/issues/861
+# See: https://github.com/containers/container-selinux/issues/135
+if [ "$(systemctl is-active kube-watch.path)" != "active" ]; then
+    fatal "kube-watch.path did not activate successfully"
+fi
+ok "kube-watch.path successfully activated"
+
+touch /etc/kubernetes/kubeconfig
+ok "successfully created /etc/kubernetes/kubeconfig"
+
+if [ "$(systemctl is-active kube-watch.service)" != "active" ]; then
+    fatal "kube-watch.service did not successfully activate"
+fi
+ok "kube-watch.service activated successfully"
+
+if [ "$(journalctl -o cat -u kube-watch.service | sed -n 2p)" != "Found it" ]; then
+    fatal "kube-watch.service did not print message to journal"
+fi
+ok "Found message from kube-watch.service in journal"


### PR DESCRIPTION
Adds a test for the ability of `systemd` to watch files                                                                                                    
labeled with `kubernetes_file_t`.                                                                                                                          
                                                                                                                                                               
See: https://github.com/coreos/fedora-coreos-tracker/issues/861                                                                                            
See: https://github.com/containers/container-selinux/issues/135    