### PR TITLE
tests/kola/toolbox: Run only on x86_64 and aarch64

### DIFF
--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -12,7 +12,8 @@
 # ensure that previous commands were successful.
 
 # Only run on QEMU to reduce CI costs as nothing is platform specific here.
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
+# Toolbox container is currently available only for x86_64 and aarch64 in Fedora
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "architectures": "x86_64 aarch64" }
 
 set -xeuo pipefail
 


### PR DESCRIPTION
Toolbox container is currently missing on ppc64le and s390x in Fedora.