### PR TITLE
unfreeze dracut, adapt for NM via systemd in initrd

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,16 +8,6 @@
 # omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
 
 packages:
-  dracut:
-    evr: 053-5.fc34
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
-      type: pin
-  dracut-network:
-    evr: 053-5.fc34
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
-      type: pin
   fedora-coreos-pinger:
     evr: 0.0.4-11.fc34
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,6 +8,18 @@
 # omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
 
 packages:
+  dracut:
+    evr: 055-3.fc34
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842#issuecomment-867900969
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d1b72b267
+  dracut-network:
+    evr: 055-3.fc34
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842#issuecomment-867900969
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d1b72b267
   fedora-coreos-pinger:
     evr: 0.0.4-11.fc34
     metadata:

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
@@ -5,6 +5,11 @@ Before=initrd.target
 # we write to the rootfs, so run after it's ready
 After=initrd-root-fs.target
 
+# That service starts initrd-cleanup.service which will race with us completing
+# before we get nuked. Need to get to the bottom of it, but for now we need
+# this (XXX: add link to systemd issue here).
+Before=initrd-parse-etc.service
+
 ConditionKernelCommandLine=rd.multipath=default
 
 OnFailure=emergency.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -47,6 +47,10 @@ After=coreos-multipath-wait.target
 # hook which will generate NM configs from the network kargs, but we want to
 # have precedence.
 After=coreos-enable-network.service
+# We've seen races with ignition-kargs.service, which accesses /boot rw.
+# Let's introduce some ordering here. Need to use `Before` because otherwise
+# we get a systemd ordering cycle. https://github.com/coreos/fedora-coreos-tracker/issues/883
+Before=ignition-kargs.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -8,8 +8,8 @@
 #     - i.e. after /dev/disk/by-label/boot is available
 #     - and after the ignition-dracut GPT generator (see below)
 # - Need to run before networking is brought up.
-#     - This is done in nm-run.service [1]
-#     - i.e. Before=nm-run.service
+#     - This is done in nm-initrd.service [1]
+#     - i.e. Before=nm-initrd.service
 # - Need to make sure karg networking configuration isn't applied
 #     - There are two ways to do this.
 #         - One is to run *before* the nm-config.sh [2] that runs as part of
@@ -17,11 +17,11 @@
 #             - i.e. Before=dracut-cmdline.service
 #         - Another is to run *after* nm-config.sh [2] in dracut-cmdline [3]
 #           and just delete all the files created by nm-initrd-generator.
-#             - i.e. After=dracut-cmdline.service, but Before=nm-run.service
+#             - i.e. After=dracut-cmdline.service, but Before=nm-initrd.service
 #     - We'll go with the second option here because the need for the /boot
 #       device (mentioned above) means we can't start before dracut-cmdline.service
 #
-# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-run.service
+# [1] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-initrd.service
 # [2] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/nm-config.sh
 # [3] https://github.com/dracutdevs/dracut/blob/master/modules.d/35network-manager/module-setup.sh#L34
 #
@@ -30,8 +30,8 @@ Description=Copy CoreOS Firstboot Networking Config
 ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
 Before=ignition-diskful.target
-Before=nm-run.service
-# compat: remove when everyone is on dracut 053+
+Before=nm-initrd.service
+# compat: remove when everyone is on dracut 054+
 Before=dracut-initqueue.service
 After=dracut-cmdline.service
 # Any services looking at mounts need to order after this

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-enable-network.service
@@ -20,8 +20,8 @@ Before=ignition-fetch.service
 
 # See hack in coreos-enable-network, as well as coreos-copy-firstboot-network.service.
 After=dracut-cmdline.service
-Before=nm-run.service
-# compat: remove when everyone is on dracut 053+
+Before=nm-initrd.service
+# compat: remove when everyone is on dracut 054+
 Before=dracut-initqueue.service
 
 [Service]


### PR DESCRIPTION
Upstream dracut updated NM to run as a systemd service
(with full dbus support) in the initrd in [1]. Adapt our
systemd units to handle this case.

This should still work fine for RHCOS because we still have
`Before=dracut-initqueue.service`, which can be dropped when
everyone is on dracut 0.54+.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/842