### PR TITLE
35coreos-ignition: use cp instead of mv

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -43,7 +43,7 @@ install() {
     # dracut inst_script doesn't allow overwrites and we are replacing
     # the default script placed by Ignition
     binpath="/usr/sbin/ignition-kargs-helper"
-    mv "$moddir/coreos-kargs.sh" "$initdir$binpath"
+    cp "$moddir/coreos-kargs.sh" "$initdir$binpath"
     install_ignition_unit coreos-kargs-reboot.service
 
     inst_script "$moddir/coreos-boot-edit.sh" \


### PR DESCRIPTION
We can't `mv` out of the module directory since `/usr` is mounted
read-only in the dracut container when rpm-ostree runs it.

Reported-by: Luca BRUNO <luca.bruno@coreos.com>