### PR TITLE
Add extensions.yaml (subset of RHCOS)

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,0 +1,32 @@
+# RPMs as operating system extensions, distinct from the base ostree commit/image
+# https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
+# and https://github.com/coreos/fedora-coreos-tracker/issues/401
+
+# No additional repositories for Fedora
+repos: []
+
+extensions:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/326
+  usbguard:
+    packages:
+      - usbguard
+  # These are already in the base, so they're not OS extensions, but they're
+  # useful to have in RPM form to install in kmod build containers.
+  kernel:
+    kind: development
+    packages:
+      - kernel
+      - kernel-core
+      - kernel-modules
+      - kernel-modules-extra
+    match-base-evr: kernel
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+  # GRPA-3123
+  # - kata-containers (RHAOS)
+  #   - qemu-kiwi (advanced-virt)
+  sandboxed-containers:
+    architectures:
+      - x86_64
+    packages:
+      - kata-containers


### PR DESCRIPTION
This is a subset of the `extensions.yaml` from
https://github.com/openshift/os

My immediate motivation is that day to day I develop in
a Fedora toolbox targeting FCOS, and I wanted to test
`rpm-ostree compose extensions` as `cosa buildextend-extensions`
invokes it, and it's easier if we have a file here.

Since the FCOS pipeline doesn't invoke `cosa buildextend-extensions`,
this will be a no-op.

Or stated more strongly: We might just use this as part of e.g.
rpm-ostree's CI runs.

But...one could imagine that we actually share the list of extensions
between FCOS and RHCOS in the future.

Or more obviously, perhaps we actually do something with this FCOS
extensions list and don't actually offer "all Fedora packages"
as extensions.