### PR TITLE
Revert "kola-denylist.yaml: add ext.config.podman.rootless-systemd"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,8 +5,3 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: ext.config.podman.rootless-systemd
-  tracker: https://github.com/containers/buildah/issues/3071
-  streams:
-    - branched
-    - rawhide


### PR DESCRIPTION
Kernel 5.11+ seems to fix this based on the comments in
https://github.com/containers/buildah/issues/3071#issuecomment-806072194

Indeed, when I run the test against a rawhide build it passes.

This reverts commit f12a5132ebe169ad643dab5b7fe028889c77a386.