### PR TITLE
lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -18,7 +18,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
       type: pin
-  ignition:
-    evr: 2.11.0-1.fc34
-    metadata:
-      type: fast-track


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.