### PR TITLE
40ignition-ostree: explicitly add zram kmod in initrd

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -15,6 +15,11 @@ install_ignition_unit() {
     systemctl -q --root="$initdir" add-requires "ignition-${target}.target" "$unit" || exit 1
 }
 
+installkernel() {
+    # Used by ignition-ostree-transposefs
+    instmods -c zram
+}
+
 install() {
     inst_multiple \
         realpath \


### PR DESCRIPTION
We were relying on the zram kmod already being in the initramfs so far,
though that assumption for whatever reason is now incorrect in rawhide,
causing rootfs reprovisioning related tests to fail.

Anyway, we should be more explicit here about what our requirements are.