### PR TITLE
ci/buildroot: bump nocache hack to defeat Quay.io caching

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -7,4 +7,4 @@
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
 FROM registry.fedoraproject.org/fedora:34
 COPY . /src
-RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf  # nocache 20210426
+RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf  # nocache 20210706


### PR DESCRIPTION
The images are being built, but the contents at this point are almost a
month out of date. If there's no sustainable way to work around this, we
should probably just move it to e.g. openshift/release and have it push
to Quay.io.

See: https://github.com/coreos/fedora-coreos-tracker/issues/890