### PR TITLE
15fcos: remember when Ignition ran and print on console

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# We put this in /run and it's then moved by
+# coreos-check-ignition-config.service into /var/lib/coreos. The reason is that
+# I don't want to use RequiresMountsFor=/var/lib on this service to keep it less
+# fallible. Once we move this service to the initramfs, then we can directly
+# write there since /var mounts are in place and we can safely trigger
+# emergency.target if we fail.
+IGNITION_INFO=/run/ignition.info.json
+
 mount -o remount,rw /boot
 
 if [[ $(uname -m) = s390x ]]; then
@@ -16,3 +24,25 @@ rm -rf /boot/ignition
 # this file. Fail if we are unable to remove it, rather than risking rerunning
 # Ignition at next boot.
 rm /boot/ignition.firstboot
+
+# See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
+nusercfgs=$(journalctl -o json-pretty MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb \
+                | jq -s '.[] | select(.IGNITION_CONFIG_TYPE == "user")'| wc -l)
+if [ "${nusercfgs}" -gt 0 ]; then
+    usercfg=true
+else
+    usercfg=false
+fi
+
+mkdir -p "$(dirname "${IGNITION_INFO}")"
+
+# This is hardly sooper seekret stuff, but let's be conservative in light of
+# https://github.com/coreos/fedora-coreos-tracker/issues/889.
+touch "${IGNITION_INFO}"
+chmod 600 "${IGNITION_INFO}"
+cat >> "${IGNITION_INFO}" <<EOF
+{
+    "date": $(date +%s),
+    "usercfg": ${usercfg}
+}
+EOF

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -2,16 +2,17 @@
 # no Ignition config is provided.
 [Unit]
 Description=Check if Ignition config is provided
-# Only perform checks on the first (Ignition) boot as they are
-# mostly useful only on that boot. This ensures systems started
-# before Ignition/Afterburn started logging structured data don't
-# get misleading messages. Also handles the case where the journal
-# gets rotated and no longer has the structured log messages.
-ConditionKernelCommandLine=ignition.firstboot
+After=coreos-ignition-firstboot-complete.service
 Before=systemd-user-sessions.service
+RequiresMountsFor=/var/lib/coreos
+ConditionPathExists=|/var/lib/coreos/ignition.info.json
+# See coreos-ignition-firstboot-complete
+ConditionPathExists=|/run/ignition.info.json
+
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/coreos-check-ignition-config
 RemainAfterExit=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -8,6 +8,7 @@ Description=Check if Ignition config is provided
 # get misleading messages. Also handles the case where the journal
 # gets rotated and no longer has the structured log messages.
 ConditionKernelCommandLine=ignition.firstboot
+Before=systemd-user-sessions.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/coreos-check-ignition-config

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
@@ -1,23 +1,42 @@
 #!/usr/bin/bash
-# The logic for the message_id is handled in 
-# https://github.com/coreos/ignition/pull/958
-# In this script, we need to capture the journald 
-# log with the particular message_id and query using 
-#`jq` utility to check if a user config is provided.
+set -euo pipefail
 
-# Change the output color to yellow
-warn='\033[0;33m'
-# No color
-nc='\033[0m'
+IGNITION_INFO=/var/lib/coreos/ignition.info.json
+IGNITION_FIRSTBOOT_INFO=/run/ignition.info.json
 
-# See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
-# It will track the journal messages related to an Ignition config provided 
-# by the user.
-output=$(journalctl -o json-pretty MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb | jq -s '.[] | select(.IGNITION_CONFIG_TYPE == "user")'| wc -l)
+WARN='\033[0;33m' # yellow
+RESET='\033[0m' # reset
 
-if [[ $output -gt  0 ]];then
-    echo "Ignition: user-provided config was applied" > /etc/issue.d/30_ignition_config_info.issue
-else
-    echo -e "${warn}Ignition: no config provided by user${nc}" > /etc/issue.d/30_ignition_config_info.issue
+# See coreos-ignition-firstboot-complete
+is_firstboot=0
+if [ -e "${IGNITION_FIRSTBOOT_INFO}" ]; then
+    is_firstboot=1
+    mkdir -p "$(dirname "${IGNITION_INFO}")"
+    mv "${IGNITION_FIRSTBOOT_INFO}" "${IGNITION_INFO}"
 fi
 
+mkdir -p /run/issue.d
+touch /run/issue.d/30_coreos_ignition_provisioning.issue
+
+d=$(date --date "@$(jq .date "${IGNITION_INFO}")" +"%Y/%m/%d %H:%M:%S %Z")
+if [ "${is_firstboot}" == 1 ]; then
+    echo "Ignition: ran on ${d} (this boot)" \
+        > /run/issue.d/30_coreos_ignition_provisioning.issue
+else
+    nreboots=$(($(journalctl --list-boots | wc -l) - 1))
+    [ "${nreboots}" -eq 1 ] && boot="boot" || boot="boots"
+    echo "Ignition: ran on ${d} (at least $nreboots $boot ago)" \
+        > /run/issue.d/30_coreos_ignition_provisioning.issue
+fi
+
+if jq -e .usercfg "${IGNITION_INFO}" &>/dev/null; then
+    echo "Ignition: user-provided config was applied" \
+        >> /run/issue.d/30_coreos_ignition_provisioning.issue
+else
+    echo -e "${WARN}Ignition: no config provided by user${RESET}" \
+        >> /run/issue.d/30_coreos_ignition_provisioning.issue
+fi
+
+# Our makeshift way of getting /run/issue.d semantics. See:
+# https://github.com/coreos/console-login-helper-messages/blob/e06fc88ae8fbcc3a422bc8c686f70c15aebb9d9a/usr/lib/console-login-helper-messages/issue.defs#L8-L17
+ln -sf /run/issue.d/30_coreos_ignition_provisioning.issue /etc/issue.d/

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
@@ -21,6 +21,3 @@ else
     echo -e "${warn}Ignition: no config provided by user${nc}" > /etc/issue.d/30_ignition_config_info.issue
 fi
 
-# Ask all running agetty instances to reload and update their
-# displayed prompts in case this script was run before agetty.
-/usr/sbin/agetty --reload


### PR DESCRIPTION
Some users sometimes may not realize that they're using a pre-booted
version of a CoreOS image. This makes things confusing because they then
don't understand why the Ignition config wasn't applied.

There's no way to consistently detect this, but at least we can print an
informational message about (1) when Ignition ran, and (2) how many
boots ago that was.

This enhances the Ignition issue we already write for whether a
user config was provided rather than creating a separate one.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1977949
Related: https://github.com/coreos/ignition/issues/1214