### PR TITLE
05core: add coreos-ignition-firstboot-complete.service

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -5,8 +5,8 @@ enable console-login-helper-messages-gensnippet-os-release.service
 enable console-login-helper-messages-gensnippet-ssh-keys.service
 # CA certs (probably to add to base fedora eventually)
 enable coreos-update-ca-trust.service
-# This one is from https://github.com/coreos/ignition-dracut
-enable ignition-firstboot-complete.service
+# https://github.com/coreos/ignition/issues/1125
+enable coreos-ignition-firstboot-complete.service
 # Boot checkin services for cloud providers.
 enable afterburn-checkin.service
 enable afterburn-firstboot-checkin.service

--- a/overlay.d/05core/usr/lib/systemd/system/coreos-ignition-firstboot-complete.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-ignition-firstboot-complete.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=CoreOS Mark Ignition Boot Complete
+Documentation=https://docs.fedoraproject.org/en-US/fedora-coreos/
+ConditionKernelCommandLine=ignition.firstboot
+ConditionPathExists=!/run/ostree-live
+RequiresMountsFor=/boot
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# The MountFlags=slave is so we remount /boot temporarily writable;
+# see https://github.com/ostreedev/ostree/issues/1265 for the bigger picture.
+# This option creates a new mount namespace; from the point of view of
+# everything else, /boot stays readonly. We only have a transient writable mount
+# for the lifetime of the unit.
+#
+# Also regarding the lack of `-f` for rm ; we should have only run if GRUB
+# detected this file. Fail if we are unable to remove it, rather than risking
+# rerunning Ignition at next boot.
+MountFlags=slave
+# It is better to have a separate script to do this but it might be polluting
+# the target system with some script in i.e. /usr/sbin/firstboot-complete
+# The retval code is still respected with having this if-else block.
+ExecStart=/bin/sh -c \
+	'mount -o remount,rw /boot && \
+	if [[ $(uname -m) = s390x ]]; then zipl; fi && \
+	rm /boot/ignition.firstboot'
+
+[Install]
+# Part of basic.target so this happens early on in firstboot
+WantedBy=basic.target


### PR DESCRIPTION
This is mostly a mechanical move of ignition-firstboot-complete.service
to this repo. The only differences are tweaking the service unit name
and the Description and Documentation keys.

Prompted by tweaks we'd like to do here, and possibly eventually moving
it to the initramfs fully (merging it with coreos-boot-edit.service).

The renaming also allows us to loosen the order of operation in which
this is done, so that we can get this in to enable the new unit, while
keeping the old unit disabled, without necessarily waiting for the
original unit file itself to drop out of the `ignition` package.

For background, see: https://github.com/coreos/ignition/issues/1125