### PR TITLE
Buildroot: add golang

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -34,6 +34,9 @@ ostree
 # A super common tool
 jq
 
+# For golang projects like mantle and gangplank
+golang
+
 # Used by ostree/rpm-ostree CI (TODO: add to something like TestBuildRequires in spec files)
 attr
 rsync


### PR DESCRIPTION
Adding golang means that we can start using a common build root for
Prow, Jenkins and as the seed image for COSA.

