### PR TITLE
35coreos-ignition: run `coreos-boot-edit` after `ignition-cleanup-boot`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
@@ -12,8 +12,8 @@ OnFailureJobMode=isolate
 # necessary since we run late, but on principle let's make clear the dependency.
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
-# Start after Ignition has finished
-After=ignition-files.service
+# Start after Ignition has finished and cleaned up /boot
+After=ignition-files.service ignition-cleanup-boot.service
 # As above, this isn't strictly necessary, but on principle.
 After=coreos-multipath-wait.target
 


### PR DESCRIPTION
In https://github.com/coreos/ignition/pull/1246, Ignition adds a new service after `ignition-files.service`.  Sequence after both to aid ratcheting.