### PR TITLE
overlay: remove `/boot/ignition` on upgrade if present

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -5,3 +5,6 @@ enable coreos-check-ignition-config.service
 enable coreos-check-ssh-keys.service
 # Check if cgroupsv1 is still being used
 enable coreos-check-cgroups.service
+# Clean up injected Ignition config in /boot on upgrade
+# https://github.com/coreos/fedora-coreos-tracker/issues/889
+enable coreos-cleanup-ignition-config.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-cleanup-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-cleanup-ignition-config.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Clean Up Injected Ignition Config in /boot
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/889
+# Newer Ignition will handle this on first boot; we only want to clean up
+# leftover configs on upgrade.  Disambiguate those two code paths for tests.
+ConditionKernelCommandLine=!ignition.firstboot
+RequiresMountsFor=/boot
+ConditionPathExists=/boot/ignition
+# We ship a kdump.service dropin that remounts /boot rw; avoid conflicts
+Before=kdump.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-cleanup-ignition-config
+RemainAfterExit=yes
+# MountFlags=slave ensures the rw mount of /boot is private to the unit
+MountFlags=slave
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-cleanup-ignition-config
+++ b/overlay.d/15fcos/usr/libexec/coreos-cleanup-ignition-config
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+#
+# Clean up existing nodes that have a world-readable /boot/ignition/config.ign.
+# Remove this after the next barrier release on all streams.
+# https://github.com/coreos/fedora-coreos-tracker/issues/889
+
+set -euo pipefail
+
+mount -o remount,rw /boot
+rm -rf /boot/ignition

--- a/tests/kola/migration/installer-cleanup
+++ b/tests/kola/migration/installer-cleanup
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Old instances might have a leftover Ignition config in /boot/ignition on
+# upgrade.  Manually create one, reboot, and ensure that it's correctly
+# cleaned up.
+# https://github.com/coreos/fedora-coreos-tracker/issues/889
+
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+    sudo mount -o remount,rw /boot
+    sudo mkdir -p /boot/ignition
+    sudo touch /boot/ignition/config.ign
+    /tmp/autopkgtest-reboot rebooted
+    ;;
+rebooted)
+    [[ ! -e /boot/ignition ]]
+    ok "/boot/ignition was removed"
+    ;;
+*)
+    fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"
+    ;;
+esac


### PR DESCRIPTION
On subsequent boots, if `/boot/ignition` is present, remove it.  This fixes up old nodes with a world-readable Ignition config in `/boot`.

For https://github.com/coreos/fedora-coreos-tracker/issues/889.