### PR TITLE
overrides: fast-track Ignition 2.11.0-2.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,7 @@ packages:
       type: fast-track
       reason: https://github.com/coreos/fedora-coreos-config/pull/1088
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d4c3ddc8a
+  ignition:
+    evr: 2.11.0-2.fc34
+    metadata:
+      type: fast-track


### PR DESCRIPTION
Move `ignition-firstboot-complete` and `ignition-setup-user` services to fedora-coreos-config.