### PR TITLE
tests/installer-cleanup: only run on QEMU

### DIFF
--- a/tests/kola/migration/installer-cleanup
+++ b/tests/kola/migration/installer-cleanup
@@ -4,6 +4,10 @@
 # cleaned up.
 # https://github.com/coreos/fedora-coreos-tracker/issues/889
 
+# Just run on QEMU.  coreos-installer doesn't run in clouds, and rebooting
+# doesn't seem to work there currently.
+# kola: { "platforms": "qemu-unpriv" }
+
 set -xeuo pipefail
 
 ok() {


### PR DESCRIPTION
coreos-installer doesn't usually run on clouds and there's nothing cloud-specific about the cleanup code.  Also, rebooting from external tests doesn't seem to work outside of QEMU right now.