### PR TITLE
lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,24 +8,12 @@
 # omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
 
 packages:
-  dracut:
-    evr: 055-3.fc34
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842#issuecomment-867900969
-      type: fast-track
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d1b72b267
-  dracut-network:
-    evr: 055-3.fc34
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842#issuecomment-867900969
-      type: fast-track
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d1b72b267
   fedora-coreos-pinger:
     evr: 0.0.4-11.fc34
     metadata:
-      type: fast-track
-      reason: https://github.com/coreos/fedora-coreos-config/pull/1088
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9d4c3ddc8a
+      reason: https://github.com/coreos/fedora-coreos-config/pull/1088
+      type: fast-track
   ignition:
     evr: 2.11.0-2.fc34
     metadata:


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.