### PR TITLE
35coreos-live: add requirement on loop kmod

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
@@ -12,6 +12,11 @@ install_and_enable_unit() {
     systemctl -q --root="$initdir" add-requires "$target" "$unit" || exit 1
 }
 
+installkernel() {
+    # we do loopmounts
+    instmods -c loop
+}
+
 install() {
     inst_multiple \
         bsdtar \


### PR DESCRIPTION
For some reason in rawhide this is no longer getting pulled in to the
initramfs. Since we require the use of it here then let's be explicit
and pull it in.