### PR TITLE
ci: don't do a strict build for mechanical streams

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -4,6 +4,7 @@ cosaPod {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")
+    def mechanical_streams = ['rawhide']
 
     shwrap("cd config && ci/validate")
 
@@ -27,7 +28,14 @@ cosaPod {
         parent_commit = meta["ostree-commit"]
     }
 
-    fcosBuild(skipInit: true, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
+    // do a build. If we are operating on a mechanical stream then we
+    // can pin packages in lockfiles but we don't maintain a full set
+    // so we can't do a strict build.
+    def no_strict_build = false
+    if (env.CHANGE_TARGET in mechanical_streams) {
+        no_strict_build = true
+    }
+    fcosBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
 
     parallel metal: {
         shwrap("cd /srv/fcos && cosa buildextend-metal")


### PR DESCRIPTION
If we are operating on a mechanical stream then we can pin packages in
lockfiles but we don't maintain a full set so we can't do a strict build.