### PR TITLE
manifests: move fedora-coreos-pool to fedora-coreos.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,12 +16,6 @@ repos:
   - fedora
   - fedora-updates
 
-# All Fedora CoreOS streams share the same pool for locked files.
-# This will be in fedora-coreos.yaml in the future so it can be more easily be
-# shared between all the streams
-lockfile-repos:
-  - fedora-coreos-pool
-
 add-commit-metadata:
   fedora-coreos.stream: testing-devel
 

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -7,6 +7,10 @@ include: fedora-coreos-base.yaml
 automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
 mutate-os-release: "${releasever}"
 
+# All Fedora CoreOS streams share the same pool for locked files.
+lockfile-repos:
+  - fedora-coreos-pool
+
 packages:
   - fedora-release-coreos
   - fedora-repos-ostree


### PR DESCRIPTION
This is common to all streams, so we can move it here. I had initially
kept it in `manifest.yaml` because of:

https://github.com/coreos/fedora-coreos-config/pull/355#issuecomment-620860762