### PR TITLE
ci: add `branched` to list of mechanical streams

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -4,7 +4,7 @@ cosaPod {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")
-    def mechanical_streams = ['rawhide']
+    def mechanical_streams = ['branched', 'rawhide']
 
     shwrap("cd config && ci/validate")
 


### PR DESCRIPTION
We might as well enable overrides support on all mechanical streams
while we're at it.

Eventually, we should move our stream definitions into coreos-ci-lib to
have it in one canonical place.