### PR TITLE
overlay: chmod 600 /etc/sudoers.d/coreos-sudo-group

### DIFF
--- a/overlay.d/05core/statoverride
+++ b/overlay.d/05core/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/05core/statoverride
+++ b/overlay.d/05core/statoverride
@@ -1,2 +1,6 @@
 # Config file for overriding permission bits on overlay files/dirs
 # Format: =<file mode in decimal> <absolute path to a file or directory>
+
+# Some security scanners complain if /etc/sudoers.d files have 0044 mode bits
+# https://bugzilla.redhat.com/show_bug.cgi?id=1981979
+=384 /etc/sudoers.d/coreos-sudo-group

--- a/overlay.d/08nouveau/statoverride
+++ b/overlay.d/08nouveau/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/09misc/statoverride
+++ b/overlay.d/09misc/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/12kdump/statoverride
+++ b/overlay.d/12kdump/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/14NetworkManager-plugins/statoverride
+++ b/overlay.d/14NetworkManager-plugins/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15fcos/statoverride
+++ b/overlay.d/15fcos/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/20platform-chrony/statoverride
+++ b/overlay.d/20platform-chrony/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -64,6 +64,14 @@ if test -d /usr/share/info; then
     fatal "found /usr/share/info"
 fi
 
+# Security scanners complain about world-readable files in /etc/sudoers.d.
+# Check that there aren't any.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1981979
+sudoers_files="$(find /etc/sudoers.d -type f ! -perm 600 2>&1)"
+if [ -n "$sudoers_files" ]; then
+    fatal "Found files in /etc/sudoers.d with unexpected permissions: $sudoers_files"
+fi
+
 # See https://github.com/coreos/coreos-assembler/pull/1786
 path=/usr/lib/systemd/system-generators/coreos-platform-chrony
 mode=$(stat -c '%a' ${path})


### PR DESCRIPTION
Apparently there are security scanners that object to mode 644.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1981979.  Requires coreos/coreos-assembler#2293.