### PR TITLE
manifests: make the systemd-resolved neutering F34 only

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -83,8 +83,6 @@ postprocess:
 
   # Neuter systemd-resolved for now.
   # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-743219353
-  # Note: When removing this, we likely also want to remove
-  # coreos-reset-stub-resolv-selinux-context.{path,service} and their presets.
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -83,9 +83,16 @@ postprocess:
 
   # Neuter systemd-resolved for now.
   # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-743219353
+  # Remove when on F35+ as NM now handles rdns + resolved better
+  # https://github.com/coreos/fedora-coreos-tracker/issues/834
+  # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/601
+  # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/877
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
+    # Only operate on F34 since F35+ has been fixed
+    source /etc/os-release
+    [ ${VERSION_ID} -eq 34 ] || exit 0
     # Get us back to Fedora 32's nsswitch.conf settings
     sed -i 's/^hosts:.*/hosts:      files dns myhostname/' /etc/nsswitch.conf
     mkdir -p /usr/lib/systemd/resolved.conf.d/
@@ -97,11 +104,12 @@ postprocess:
     DNSStubListener=no
     EOF
 
-  # Set the fallback hostname to `localhost`. This piggybacks on the
-  # postprocess script above which neuters systemd-resolved, because
-  # currently, a fallback hostname of `localhost` + systemd-resolved breaks
-  # rDNS. Eventually, we should be able to drop this at the same time as we drop
-  # the above. See: https://bugzilla.redhat.com/show_bug.cgi?id=1892235#c25
+  # Set the fallback hostname to `localhost`. This was needed in F33/F34
+  # because a fallback hostname of `fedora` + systemd-resolved broke
+  # rDNS. It's now fixed in F35+ NetworkManager to handle the corner cases
+  # around synthetized hostnames and systemd-resolved, but the question
+  # remains on what is a more appropriate default hostname for a server like
+  # host. https://github.com/coreos/fedora-coreos-tracker/issues/902
   - |
     #!/usr/bin/env bash
     source /etc/os-release

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -32,9 +32,15 @@ if ! systemctl show -p ActiveState kdump.service | grep -q ActiveState=inactive;
     fatal "Unit kdump.service shouldn't be active"
 fi
 # systemd-resolved should be enabled
-source /etc/os-release
 if ! systemctl is-enabled systemd-resolved 1>/dev/null; then
     fatal "Unit systemd-resolved should be enabled"
+fi
+# systemd-resolved should be fully functional on f35+
+source /etc/os-release
+if [ "$VERSION_ID" -ge "35" ]; then
+    if ! grep 'nameserver 127.0.0.53' /etc/resolv.conf; then
+        fatal "systemd-resolved stub listener isn't enabled"
+    fi
 fi
 ok services
 


### PR DESCRIPTION
The underlying issues are resolved in the latest NetworkManager in
Fedora 35+ so let's conditionalize it on Fedora 34.

Was fixed upstream by https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/877

Will fix https://github.com/coreos/fedora-coreos-tracker/issues/834
