### PR TITLE
lockfiles: fast-track ostree-2021.3-1.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -42,3 +42,15 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-119c2c9b63
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/861
       type: fast-track
+  ostree:
+    evr: 2021.3-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f5ae883a27
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/746
+      type: fast-track
+  ostree-libs:
+    evr: 2021.3-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f5ae883a27
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/746
+      type: fast-track


### PR DESCRIPTION
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/746