### PR TITLE
tests/manual: minor updates to manual network testing scripts

### DIFF
--- a/tests/manual/coreos-docs-net-testing.sh
+++ b/tests/manual/coreos-docs-net-testing.sh
@@ -35,7 +35,7 @@ set -eu -o pipefail
 
 vmname="coreos-docs-nettest"
 
-fcct_common=\
+butane_common=\
 'variant: fcos
 version: 1.0.0
 passwd:
@@ -63,14 +63,14 @@ storage:
           # Raise console message logging level from DEBUG (7) to WARNING (4)
           kernel.printk=4'
 
-fcct_hostname='
+butane_hostname='
     - path: /etc/hostname
       mode: 0644
       contents:
         inline: |
           ${hostname}'
 
-fcct_disable_subnic2='
+butane_disable_subnic2='
     - path: /etc/NetworkManager/system-connections/${subnic2}.nmconnection
       mode: 0600
       contents:
@@ -84,7 +84,7 @@ fcct_disable_subnic2='
           [ipv6]
           method=disabled'
 
-fcct_staticip='
+butane_staticip='
     - path: /etc/NetworkManager/system-connections/${interface}.nmconnection
       mode: 0600
       contents:
@@ -101,7 +101,7 @@ fcct_staticip='
           may-fail=false
           method=manual'
 
-fcct_staticbond='
+butane_staticbond='
     - path: /etc/NetworkManager/system-connections/${bondname}.nmconnection
       mode: 0600
       contents:
@@ -141,7 +141,7 @@ fcct_staticbond='
           master=${bondname}
           slave-type=bond'
 
-fcct_dhcpbridge='
+butane_dhcpbridge='
     - path: /etc/NetworkManager/system-connections/${bridgename}.nmconnection
       mode: 0600
       contents:
@@ -178,7 +178,7 @@ fcct_dhcpbridge='
           slave-type=bridge
           [bridge-port]'
 
-fcct_dhcpteam='
+butane_dhcpteam='
     - path: /etc/NetworkManager/system-connections/${teamname}.nmconnection
       mode: 0600
       contents:
@@ -218,7 +218,7 @@ fcct_dhcpteam='
           [team-port]
           config={"prio": 100}'
 
-fcct_staticvlan='
+butane_staticvlan='
     - path: /etc/NetworkManager/system-connections/${interface}.${vlanid}.nmconnection
       mode: 0600
       contents:
@@ -256,7 +256,7 @@ fcct_staticvlan='
           dns-search=
           method=disabled'
 
-fcct_dhcpvlanbond='
+butane_dhcpvlanbond='
     - path: /etc/NetworkManager/system-connections/${bondname}.${vlanid}.nmconnection
       mode: 0600
       contents:
@@ -323,7 +323,7 @@ check_requirements() {
     reqs=(
         chcon
         envsubst
-        fcct
+        butane
         jq
         ssh
         ssh-keygen
@@ -361,11 +361,11 @@ destroy_vm() {
 }
 
 create_ignition_file() {
-    local fcctconfig=$1
+    local butaneconfig=$1
     local ignitionfile=$2
     # uncomment and use ign-converter instead if on rhcos less than 4.6
-    #echo "$fcctconfig" | fcct --strict | ign-converter -downtranslate -output $ignitionfile
-    echo "$fcctconfig" | fcct --strict --output $ignitionfile
+    #echo "$butaneconfig" | butane --strict | ign-converter -downtranslate -output $ignitionfile
+    echo "$butaneconfig" | butane --strict --output $ignitionfile
     chcon --verbose unconfined_u:object_r:svirt_home_t:s0 $ignitionfile &>/dev/null
 }
 
@@ -391,7 +391,7 @@ main() {
     local sshpubkeyfile="${PWD}/coreos-nettest-sshkey.pub"
     local ignitionfile="${PWD}/coreos-nettest-config.ign"
     local sshpubkey
-    local fcct
+    local butane
      
     check_requirements
 
@@ -446,23 +446,23 @@ EOF
     # in using the envsubst command
     export ip gateway netmask prefix interface nameserver bondname teamname bridgename subnic1 subnic2 vlanid
 
-    fcct_none=$(echo "${fcct_common}" | envsubst)
+    butane_none=$(echo "${butane_common}" | envsubst)
 
     export hostname="staticip"
     x="${common_args} rd.neednet=1"
     x+=" ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver}"
     x+=" ip=${subnic2}:off"
     initramfs_staticip=$x
-    fcct_initramfs_staticip="${fcct_none}"
-    fcct_staticip=$(echo "${fcct_common}${fcct_hostname}${fcct_staticip}${fcct_disable_subnic2}" | envsubst)
+    butane_initramfs_staticip="${butane_none}"
+    butane_staticip=$(echo "${butane_common}${butane_hostname}${butane_staticip}${butane_disable_subnic2}" | envsubst)
 
     export hostname="staticbond"
     x="${common_args} rd.neednet=1"
     x+=" ip=${ip}::${gateway}:${netmask}:${hostname}:${bondname}:none:${nameserver}"
     x+=" bond=${bondname}:${subnic1},${subnic2}:mode=active-backup,miimon=100"
     initramfs_staticbond=$x
-    fcct_initramfs_staticbond="${fcct_none}"
-    fcct_staticbond=$(echo "${fcct_common}${fcct_hostname}${fcct_staticbond}" | envsubst)
+    butane_initramfs_staticbond="${butane_none}"
+    butane_staticbond=$(echo "${butane_common}${butane_hostname}${butane_staticbond}" | envsubst)
 
     export hostname="dhcpbridge"
     x="${common_args} rd.neednet=1"
@@ -470,8 +470,8 @@ EOF
     x+=" bridge=${bridgename}:${subnic1},${subnic2}"
     x+=" nameserver=${nameserver}"
     initramfs_dhcpbridge=$x
-    fcct_initramfs_dhcpbridge=$(echo "${fcct_common}${fcct_hostname}" | envsubst)
-    fcct_dhcpbridge=$(echo "${fcct_common}${fcct_hostname}${fcct_dhcpbridge}" | envsubst)
+    butane_initramfs_dhcpbridge=$(echo "${butane_common}${butane_hostname}" | envsubst)
+    butane_dhcpbridge=$(echo "${butane_common}${butane_hostname}${butane_dhcpbridge}" | envsubst)
 
     export hostname="dhcpteam"
     x="${common_args} rd.neednet=1"
@@ -479,8 +479,8 @@ EOF
     x+=" team=${teamname}:${subnic1},${subnic2}"
     x+=" nameserver=${nameserver}"
     initramfs_dhcpteam=$x
-    fcct_initramfs_dhcpteam=$(echo "${fcct_common}${fcct_hostname}" | envsubst)
-    fcct_dhcpteam=$(echo "${fcct_common}${fcct_hostname}${fcct_dhcpteam}" | envsubst)
+    butane_initramfs_dhcpteam=$(echo "${butane_common}${butane_hostname}" | envsubst)
+    butane_dhcpteam=$(echo "${butane_common}${butane_hostname}${butane_dhcpteam}" | envsubst)
 
     export hostname="staticvlan"
     x="${common_args} rd.neednet=1"
@@ -488,8 +488,8 @@ EOF
     x+=" vlan=${interface}.${vlanid}:${interface}"
     x+=" ip=${subnic2}:off"
     initramfs_staticvlan=$x
-    fcct_initramfs_staticvlan="${fcct_none}"
-    fcct_staticvlan=$(echo "${fcct_common}${fcct_hostname}${fcct_staticvlan}${fcct_disable_subnic2}" | envsubst)
+    butane_initramfs_staticvlan="${butane_none}"
+    butane_staticvlan=$(echo "${butane_common}${butane_hostname}${butane_staticvlan}${butane_disable_subnic2}" | envsubst)
 
     export hostname="dhcpvlanbond"
     x="${common_args} rd.neednet=1"
@@ -497,8 +497,8 @@ EOF
     x+=" bond=${bondname}:${subnic1},${subnic2}:mode=active-backup,miimon=100"
     x+=" vlan=${bondname}.${vlanid}:${bondname}"
     initramfs_dhcpvlanbond=$x
-    fcct_initramfs_dhcpvlanbond=$(echo "${fcct_common}${fcct_hostname}" | envsubst)
-    fcct_dhcpvlanbond=$(echo "${fcct_common}${fcct_hostname}${fcct_dhcpvlanbond}" | envsubst)
+    butane_initramfs_dhcpvlanbond=$(echo "${butane_common}${butane_hostname}" | envsubst)
+    butane_dhcpvlanbond=$(echo "${butane_common}${butane_hostname}${butane_dhcpvlanbond}" | envsubst)
 
     destroy_vm || true
 
@@ -511,22 +511,22 @@ EOF
        #dhcpvlanbond  # Requires special setup, see top of file comment
     )
 
-    create_ignition_file "$fcct_none" $ignitionfile
+    create_ignition_file "$butane_none" $ignitionfile
     for net in ${loopitems[@]}; do
         var="initramfs_${net}"
         kernel_args=${!var}
-        var="fcct_initramfs_${net}"
-        fcctconfig=${!var}
-        create_ignition_file "$fcctconfig" $ignitionfile
+        var="butane_initramfs_${net}"
+        butaneconfig=${!var}
+        create_ignition_file "$butaneconfig" $ignitionfile
         start_vm $qcow $ignitionfile $kernel $initramfs "${kernel_args}"
         destroy_vm
     done
 
     for net in ${loopitems[@]}; do
-        var="fcct_${net}"
-        fcctconfig=${!var}
+        var="butane_${net}"
+        butaneconfig=${!var}
         kernel_args=${common_args}
-        create_ignition_file "$fcctconfig" $ignitionfile
+        create_ignition_file "$butaneconfig" $ignitionfile
         start_vm $qcow $ignitionfile $kernel $initramfs "${kernel_args}"
         destroy_vm
     done

--- a/tests/manual/coreos-docs-net-testing.sh
+++ b/tests/manual/coreos-docs-net-testing.sh
@@ -56,7 +56,12 @@ systemd:
           ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
           TTYVTDisallocate=no
 storage:
-  files:'
+  files:
+    - path: /etc/sysctl.d/20-silence-audit.conf
+      contents:
+        inline: |
+          # Raise console message logging level from DEBUG (7) to WARNING (4)
+          kernel.printk=4'
 
 fcct_hostname='
     - path: /etc/hostname

--- a/tests/manual/coreos-network-testing.sh
+++ b/tests/manual/coreos-network-testing.sh
@@ -13,7 +13,7 @@ set -eu -o pipefail
 
 vmname="coreos-nettest"
 
-fcct_common=\
+butane_common=\
 'variant: fcos
 version: 1.0.0
 passwd:
@@ -53,14 +53,14 @@ storage:
           kernel.printk=4'
 
 ignitionhostname='ignitionhost'
-fcct_hostname='
+butane_hostname='
     - path: /etc/hostname
       mode: 0644
       contents:
         inline: |
           ${ignitionhostname}'
 
-fcct_static_nic0_ifcfg='
+butane_static_nic0_ifcfg='
     - path: /etc/sysconfig/network-scripts/ifcfg-${nic0}
       mode: 0600
       contents:
@@ -86,7 +86,7 @@ fcct_static_nic0_ifcfg='
           DEVICE=${nic1}
           ONBOOT=no'
 
-fcct_static_nic0='
+butane_static_nic0='
     - path: /etc/NetworkManager/system-connections/${nic0}.nmconnection
       mode: 0600
       contents:
@@ -116,7 +116,7 @@ fcct_static_nic0='
           [ipv6]
           method=disabled'
 
-fcct_static_team0='
+butane_static_team0='
     - path: /etc/NetworkManager/system-connections/team0.nmconnection
       mode: 0600
       contents:
@@ -158,7 +158,7 @@ fcct_static_team0='
           [team-port]
           config={"prio": 100}'
 
-fcct_static_bond0='
+butane_static_bond0='
     - path: /etc/NetworkManager/system-connections/bond0.nmconnection
       mode: 0600
       contents:
@@ -197,7 +197,7 @@ fcct_static_bond0='
           master=bond0
           slave-type=bond'
 
-fcct_static_br0='
+butane_static_br0='
     - path: /etc/NetworkManager/system-connections/br0.nmconnection
       mode: 0600
       contents:
@@ -248,7 +248,7 @@ check_requirements() {
     reqs=(
         chcon
         envsubst
-        fcct
+        butane
         jq
         ssh
         ssh-keygen
@@ -448,11 +448,11 @@ destroy_vm() {
 }
 
 create_ignition_file() {
-    local fcctconfig=$1
+    local butaneconfig=$1
     local ignitionfile=$2
     # uncomment and use ign-converter instead if on rhcos less than 4.6
-    #echo "$fcctconfig" | fcct --strict | ign-converter -downtranslate -output $ignitionfile
-    echo "$fcctconfig" | fcct --strict --output $ignitionfile
+    #echo "$butaneconfig" | butane --strict | ign-converter -downtranslate -output $ignitionfile
+    echo "$butaneconfig" | butane --strict --output $ignitionfile
     chcon --verbose unconfined_u:object_r:svirt_home_t:s0 $ignitionfile &>/dev/null
 }
 
@@ -472,7 +472,7 @@ main() {
     local sshpubkeyfile="${PWD}/coreos-nettest-sshkey.pub"
     local ignitionfile="${PWD}/coreos-nettest-config.ign"
     local sshpubkey
-    local fcct
+    local butane
      
     check_requirements
 
@@ -578,12 +578,12 @@ EOF
     # in using the envsubst command
     export ip prefix nameserverstatic gateway sshpubkey ignitionhostname nic0 nic1
 
-    fcct_none=$(echo "${fcct_common}" | envsubst)
-    fcct_static_nic0=$(echo "${fcct_common}${fcct_hostname}${fcct_static_nic0}" | envsubst)
-    fcct_static_bond0=$(echo "${fcct_common}${fcct_hostname}${fcct_static_bond0}" | envsubst)
-    fcct_static_team0=$(echo "${fcct_common}${fcct_hostname}${fcct_static_team0}" | envsubst)
-    fcct_static_br0=$(echo "${fcct_common}${fcct_hostname}${fcct_static_br0}" | envsubst)
-    fcct_static_nic0_ifcfg=$(echo "${fcct_common}${fcct_hostname}${fcct_static_nic0_ifcfg}" | envsubst)
+    butane_none=$(echo "${butane_common}" | envsubst)
+    butane_static_nic0=$(echo "${butane_common}${butane_hostname}${butane_static_nic0}" | envsubst)
+    butane_static_bond0=$(echo "${butane_common}${butane_hostname}${butane_static_bond0}" | envsubst)
+    butane_static_team0=$(echo "${butane_common}${butane_hostname}${butane_static_team0}" | envsubst)
+    butane_static_br0=$(echo "${butane_common}${butane_hostname}${butane_static_br0}" | envsubst)
+    butane_static_nic0_ifcfg=$(echo "${butane_common}${butane_hostname}${butane_static_nic0_ifcfg}" | envsubst)
 
     # If the VM is still around for whatever reason, destroy it
     destroy_vm || true
@@ -593,7 +593,7 @@ EOF
     # networking. Do a ifcfg check to make sure.
     if [ "$rhcos" == 1 ]; then
         echo -e "\n###### Testing ifcfg file via Ignition disables initramfs propagation\n"
-        create_ignition_file "$fcct_static_nic0_ifcfg" $ignitionfile
+        create_ignition_file "$butane_static_nic0_ifcfg" $ignitionfile
         start_vm $qcow $ignitionfile $kernel $initramfs "$initramfs_static_bond0"
         check_vm 'none' 1 0 $ip $nic0 $ignitionhostname $nameserverstatic $sshkeyfile
         reboot_vm
@@ -605,7 +605,7 @@ EOF
     # configuration via Ignition either, so we'll just end up with DHCP and a
     # static hostname that is unset (`n/a`).
     echo -e "\n###### Testing coreos.no_persist_ip disables initramfs propagation\n"
-    create_ignition_file "$fcct_none" $ignitionfile
+    create_ignition_file "$butane_none" $ignitionfile
     start_vm $qcow $ignitionfile $kernel $initramfs "${initramfs_static_nic0} coreos.no_persist_ip"
     check_vm 'dhcp' 2 0 $ip $nic0 'n/a' $nameserverdhcp $sshkeyfile
     reboot_vm
@@ -616,7 +616,7 @@ EOF
     # configuration via Ignition either, so we'll just end up with DHCP and a
     # static hostname that is unset (`n/a`).
     echo -e "\n###### Testing coreos.force_persist_ip forces initramfs propagation\n"
-    create_ignition_file "$fcct_static_nic0" $ignitionfile
+    create_ignition_file "$butane_static_nic0" $ignitionfile
     start_vm $qcow $ignitionfile $kernel $initramfs "${initramfs_static_bond0} coreos.force_persist_ip"
     check_vm 'none' 1 3 $ip bond0 $ignitionhostname $nameserverstatic $sshkeyfile
     reboot_vm
@@ -642,7 +642,7 @@ EOF
     # 
     # [1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/issues/391
     echo -e "\n###### Testing initramfs nameserver= option\n"
-    create_ignition_file "$fcct_none" $ignitionfile
+    create_ignition_file "$butane_none" $ignitionfile
     start_vm $qcow $ignitionfile $kernel $initramfs "nameserver=${nameserverstatic} ${initramfs_dhcp_nic0nic1}"
     check_vm 'dhcp' 2 2 $ip $nic0 'n/a' $nameserverstatic $sshkeyfile
     reboot_vm
@@ -652,7 +652,7 @@ EOF
     # Do a `net.ifnames=0` check and make sure eth0 is the interface name.
     # We don't pass any hostname information so it will just be (`n/a`).
     echo -e "\n###### Testing net.ifnames=0 gives us legacy NIC naming\n"
-    create_ignition_file "$fcct_none" $ignitionfile
+    create_ignition_file "$butane_none" $ignitionfile
     start_vm $qcow $ignitionfile $kernel $initramfs "${initramfs_dhcp_eth0} net.ifnames=0"
     check_vm 'dhcp' 2 1 $ip 'eth0' 'n/a' $nameserverdhcp $sshkeyfile
     # Don't reboot and do another check because we didn't persist the net.ifnames=0 karg
@@ -667,7 +667,7 @@ EOF
         static_br0
     )
 
-    fcctloop=(
+    butaneloop=(
         none
         static_nic0
         static_bond0
@@ -676,11 +676,11 @@ EOF
     )
         
     for initramfsnet in ${initramfsloop[@]}; do
-        for fcctnet in ${fcctloop[@]}; do
+        for butanenet in ${butaneloop[@]}; do
             method='none'; interfaces=1;
             nameserver=${nameserverstatic}
             numkeyfiles=3
-            if [ "${fcctnet}" == 'none' ]; then
+            if [ "${butanenet}" == 'none' ]; then
                 # because we propagate initramfs networking if no real root networking 
                 devname=${initramfsnet##*_}
                 hostname=${initramfshostname}
@@ -700,24 +700,24 @@ EOF
                     numkeyfiles=2
                 fi
             else
-                devname=${fcctnet##*_}
+                devname=${butanenet##*_}
                 hostname=${ignitionhostname}
                 # If we're not using a virtual NIC (bond, bridge, team, etc)
                 # then only two keyfiles will be created.
-                if [ "${fcctnet}" == 'static_nic0' ]; then
+                if [ "${butanenet}" == 'static_nic0' ]; then
                     numkeyfiles=2
                 fi
             fi
             # If devname=nic0 then replace with ${nic0} variable
             [ $devname == "nic0" ] && devname=${nic0}
-            fcctvar="fcct_${fcctnet}"
-            fcctconfig=${!fcctvar}
+            butanevar="butane_${butanenet}"
+            butaneconfig=${!butanevar}
             initramfsvar="initramfs_${initramfsnet}"
             kernel_args=${!initramfsvar}
 
-            echo -e "\n###### Testing initramfs: ${initramfsnet} + ignition/fcct: ${fcctnet}\n"
+            echo -e "\n###### Testing initramfs: ${initramfsnet} + ignition/butane: ${butanenet}\n"
 
-            create_ignition_file "$fcctconfig" $ignitionfile
+            create_ignition_file "$butaneconfig" $ignitionfile
             start_vm $qcow $ignitionfile $kernel $initramfs "${kernel_args}"
             check_vm $method $interfaces $numkeyfiles $ip $devname $hostname $nameserver $sshkeyfile
             reboot_vm

--- a/tests/manual/coreos-network-testing.sh
+++ b/tests/manual/coreos-network-testing.sh
@@ -45,7 +45,12 @@ storage:
       contents:
         source: https://raw.githubusercontent.com/coreos/fedora-coreos-config/8b08bd030ef3968d00d4fea9a0fa3ca3fbabf852/COPYING
         verification:
-          hash: sha512-d904690e4fc5defb804c2151e397cbe2aeeea821639995610aa377bb2446214c3433616a8708163776941df585b657648f20955e50d4b011ea2a96e7d8e08c66'
+          hash: sha512-d904690e4fc5defb804c2151e397cbe2aeeea821639995610aa377bb2446214c3433616a8708163776941df585b657648f20955e50d4b011ea2a96e7d8e08c66
+    - path: /etc/sysctl.d/20-silence-audit.conf
+      contents:
+        inline: |
+          # Raise console message logging level from DEBUG (7) to WARNING (4)
+          kernel.printk=4'
 
 ignitionhostname='ignitionhost'
 fcct_hostname='


### PR DESCRIPTION
```
commit d3e7615258c6c0ec0925050bd1e1f35ab84e624d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Jul 15 15:39:18 2021 -0400

    tests/manual: fcct is now known as butane

commit 2aec80ae5929c17156820f4dd83dd05ccea178b4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Jul 15 15:36:23 2021 -0400

    tests/manual: silence audit messages to the console
    
    Makes poking around on the serial console easier.

```