### PR TITLE
tests: add tests for systemd reading files labeled kubernetes_file_t

### DIFF
--- a/tests/kola/kubernetes/systemd-env-read/config.bu
+++ b/tests/kola/kubernetes/systemd-env-read/config.bu
@@ -1,0 +1,27 @@
+variant: fcos
+version: 1.2.0
+storage:
+  files:
+    - path: /etc/kubernetes/envfile
+      # This is for verifying that `kubernetes_file_t` labeled files can be
+      # read by systemd
+      # See: https://bugzilla.redhat.com/show_bug.cgi?id=1973418
+      mode: 0644
+      contents:
+        inline: |
+          KUBE="FCOS"
+systemd:
+  units:
+    - name: kube-env.service
+      # This is for verifying that `kubernetes_file_t` labeled files can be
+      # read by systemd
+      # See: https://bugzilla.redhat.com/show_bug.cgi?id=1973418
+      enabled: true
+      contents: |
+        [Service]
+        EnvironmentFile=/etc/kubernetes/envfile
+        ExecStart=/usr/bin/echo ${KUBE}
+        RemainAfterExit=yes
+        Type=oneshot
+        [Install]
+        WantedBy=multi-user.target

--- a/tests/kola/kubernetes/systemd-env-read/test.sh
+++ b/tests/kola/kubernetes/systemd-env-read/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# In order to verify that `kubernetes_file_t` labeled files can be read by
+# systemd, we check to see if the `kube-env` service started successfully
+# and that the service wrote to the journal successfully.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1973418
+if [ "$( stat -c %C /etc/kubernetes/envfile)" != "system_u:object_r:kubernetes_file_t:s0" ]; then
+    fatal "/etc/kubernetes/envfile is labeled incorrectly"
+fi
+ok "/etc/kubernetes/envfile is labeled correctly"
+
+if [ "$(systemctl is-failed kube-env.service)" != "active" ]; then
+    fatal "kube-env.service failed unexpectedly"
+fi
+ok "kube-env.service successfully started"
+
+# Verify that 'FCOS' was wrtitten to the journal
+if [ "$(journalctl -o cat -u kube-env.service | sed -n 2p)" != "FCOS" ]; then
+    fatal "kube-env.service did not write 'FCOS' to journal"
+fi
+ok "kube-env.service ran and wrote 'FCOS' to the journal"


### PR DESCRIPTION
Adds a test for the ability of `systemd` to read files
labeled with `kubernetes_file_t`.
    
See: https://bugzilla.redhat.com/show_bug.cgi?id=1973418