### PR TITLE
lockfiles: fast-track systemd-248.5-1.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,39 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f5ae883a27
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/746
       type: fast-track
+  systemd:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-container:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-libs:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-pam:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-udev:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-rpm-macros:
+    evra: 248.5-1.fc34.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track


### PR DESCRIPTION
Contains a fix for CVE-2021-33910.

See https://github.com/coreos/fedora-coreos-tracker/issues/904