### PR TITLE
[next] lockfiles: fast-track kernel and systemd

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -30,3 +30,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-0efb7aefc9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/889
       type: fast-track
+  kernel:
+    evr: 5.12.19-300.fc34
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  kernel-core:
+    evr: 5.12.19-300.fc34
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  kernel-modules:
+    evr: 5.12.19-300.fc34
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -45,3 +45,39 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
       type: fast-track
+  systemd:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-container:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-libs:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-pam:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-udev:
+    evr: 248.5-1.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track
+  systemd-rpm-macros:
+    evra: 248.5-1.fc34.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
+      type: fast-track


### PR DESCRIPTION
Fixes CVE-2021-33909 and CVE-2021-33910.

See https://github.com/coreos/fedora-coreos-tracker/issues/904.