### PR TITLE
overlay: use Ignition `result.json`

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -85,9 +85,7 @@ fi
 # If the user supplied an Ignition config, they have the ability to enable
 # autologin themselves.  Don't automatically render them insecure, since
 # they might be running in production and booting via e.g. IPMI.
-# See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
-ign_usercfg_msg=$(journalctl -q MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb IGNITION_CONFIG_TYPE=user)
-if [ -n "${ign_usercfg_msg}" ]; then
+if jq -e .userConfigProvided /var/lib/ignition/result.json &>/dev/null; then
     exit 0
 fi
 

--- a/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# We put this in /run and it's then moved by
-# coreos-check-ignition-config.service into /var/lib/coreos. The reason is that
-# I don't want to use RequiresMountsFor=/var/lib on this service to keep it less
-# fallible. Once we move this service to the initramfs, then we can directly
-# write there since /var mounts are in place and we can safely trigger
-# emergency.target if we fail.
-IGNITION_INFO=/run/ignition.info.json
-
 mount -o remount,rw /boot
 
 if [[ $(uname -m) = s390x ]]; then
@@ -24,25 +16,3 @@ rm -rf /boot/ignition
 # this file. Fail if we are unable to remove it, rather than risking rerunning
 # Ignition at next boot.
 rm /boot/ignition.firstboot
-
-# See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.
-nusercfgs=$(journalctl -o json-pretty MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb \
-                | jq -s '.[] | select(.IGNITION_CONFIG_TYPE == "user")'| wc -l)
-if [ "${nusercfgs}" -gt 0 ]; then
-    usercfg=true
-else
-    usercfg=false
-fi
-
-mkdir -p "$(dirname "${IGNITION_INFO}")"
-
-# This is hardly sooper seekret stuff, but let's be conservative in light of
-# https://github.com/coreos/fedora-coreos-tracker/issues/889.
-touch "${IGNITION_INFO}"
-chmod 600 "${IGNITION_INFO}"
-cat >> "${IGNITION_INFO}" <<EOF
-{
-    "date": $(date +%s),
-    "usercfg": ${usercfg}
-}
-EOF

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -2,12 +2,9 @@
 # no Ignition config is provided.
 [Unit]
 Description=Check if Ignition config is provided
-After=coreos-ignition-firstboot-complete.service
 Before=systemd-user-sessions.service
-RequiresMountsFor=/var/lib/coreos
-ConditionPathExists=|/var/lib/coreos/ignition.info.json
-# See coreos-ignition-firstboot-complete
-ConditionPathExists=|/run/ignition.info.json
+RequiresMountsFor=/var/lib/ignition
+ConditionPathExists=/var/lib/ignition/result.json
 
 [Service]
 Type=oneshot

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
@@ -1,25 +1,17 @@
 #!/usr/bin/bash
 set -euo pipefail
 
-IGNITION_INFO=/var/lib/coreos/ignition.info.json
-IGNITION_FIRSTBOOT_INFO=/run/ignition.info.json
+IGNITION_RESULT=/var/lib/ignition/result.json
 
 WARN='\033[0;33m' # yellow
 RESET='\033[0m' # reset
 
-# See coreos-ignition-firstboot-complete
-is_firstboot=0
-if [ -e "${IGNITION_FIRSTBOOT_INFO}" ]; then
-    is_firstboot=1
-    mkdir -p "$(dirname "${IGNITION_INFO}")"
-    mv "${IGNITION_FIRSTBOOT_INFO}" "${IGNITION_INFO}"
-fi
-
 mkdir -p /run/issue.d
 touch /run/issue.d/30_coreos_ignition_provisioning.issue
 
-d=$(date --date "@$(jq .date "${IGNITION_INFO}")" +"%Y/%m/%d %H:%M:%S %Z")
-if [ "${is_firstboot}" == 1 ]; then
+d=$(date --date "$(jq -r .provisioningDate "${IGNITION_RESULT}")" +"%Y/%m/%d %H:%M:%S %Z")
+ignitionBoot=$(jq -r .provisioningBootID "${IGNITION_RESULT}")
+if [ $(cat /proc/sys/kernel/random/boot_id) = "${ignitionBoot}" ]; then
     echo "Ignition: ran on ${d} (this boot)" \
         > /run/issue.d/30_coreos_ignition_provisioning.issue
 else
@@ -29,7 +21,7 @@ else
         > /run/issue.d/30_coreos_ignition_provisioning.issue
 fi
 
-if jq -e .usercfg "${IGNITION_INFO}" &>/dev/null; then
+if jq -e .userConfigProvided "${IGNITION_RESULT}" &>/dev/null; then
     echo "Ignition: user-provided config was applied" \
         >> /run/issue.d/30_coreos_ignition_provisioning.issue
 else


### PR DESCRIPTION
As of https://github.com/coreos/ignition/pull/1250, Ignition produces its own report similar to `ignition.info.json`, so use that instead of making our own.

Hold until https://github.com/coreos/ignition/pull/1250 lands in a release.