### PR TITLE
ci/remove-graduated-overrides: query by arch too

### DIFF
--- a/ci/remove-graduated-overrides.py
+++ b/ci/remove-graduated-overrides.py
@@ -109,7 +109,8 @@ def update_lockfile(base, fn):
 
 def sack_has_nevra_greater_or_equal(base, nevra):
     nevra = hawkey.split_nevra(nevra)
-    pkgs = base.sack.query().filterm(name=nevra.name).latest().run()
+    pkgs = base.sack.query().filterm(name=nevra.name,
+                                     arch=nevra.arch).latest().run()
 
     if len(pkgs) == 0:
         # Odd... the only way I can imagine this happen is if we fast-track a


### PR DESCRIPTION
The x86_64 repo also includes i686 packages so we need to filter on the
arch too when querying to make sure we're comparing packages of the same
arch.