### PR TITLE
lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,33 +15,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-463a2721ec
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/881
       type: fast-track
-  ostree:
-    evr: 2021.3-1.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f5ae883a27
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/746
-      type: fast-track
-  ostree-libs:
-    evr: 2021.3-1.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f5ae883a27
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/746
-      type: fast-track
-  systemd:
-    evr: 248.5-1.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
-      type: fast-track
-  systemd-container:
-    evr: 248.5-1.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
-      type: fast-track
-  systemd-libs:
-    evr: 248.5-1.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2a6ba64260
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/904
-      type: fast-track


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.