### PR TITLE
35coreos-ignition: perform kargs reboot with `--force`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
@@ -18,4 +18,6 @@ OnFailureJobMode=isolate
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/systemctl reboot
+# --force causes a rapid reboot.  Without it, systemd continues running
+# Ignition stages in parallel with shutting down.
+ExecStart=/usr/bin/systemctl reboot --force


### PR DESCRIPTION
Without `--force`, the boot process races with service shutdown, leaving enough time for the disks stage to start.  With `--force`, systemd immediately kills processes, unmounts filesystems, and reboots.

xref https://github.com/coreos/ignition/pull/1252 upstream.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/896.