### PR TITLE
tests/misc-ro: Simplify permission checks for files in /etc

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -174,16 +174,16 @@ if [[ $sys_fs_cgroup_source != cgroup2 ]]; then
     fatal "/sys/fs/cgroup is not cgroup2"
 fi
 
-for perms in 'o+w' 'g+w'; do
-	list="$(find /etc -type f -perm /${perms})"
-	if [[ -n "${list}" ]]; then
-		fatal "found files with ${perms}:\n${list}"
-	fi
-done
-ok "no files with o+w or g+w found in /etc"
+list="$(find /etc -type f,d -perm /022)"
+if [[ -n "${list}" ]]; then
+	find /etc -type f,d -perm /022 -print0 | xargs -0 ls -al
+	fatal "found files or directories with 'g+w' or 'o+w' permission"
+fi
+ok "no files with 'g+w' or 'o+w' permission found in /etc"
 
 for f in '/etc/passwd' '/etc/group'; do
 	if [[ $(stat --format="%a %u %g" "${f}") != "644 0 0" ]]; then
+		ls -al "${f}"
 		fatal "found incorrect permissions for ${f}"
 	fi
 done


### PR DESCRIPTION
Make use of some GNU find extensions to make the check simpler.