### PR TITLE
coreos-kargs-reboot: make flag file a triggering condition

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=CoreOS Kernel Arguments Reboot
 ConditionPathExists=/etc/initrd-release
-ConditionPathExists=/run/ignition-modified-kargs
+# Other Dracut modules may add additional triggers via drop-ins
+ConditionPathExists=|/run/ignition-modified-kargs
 DefaultDependencies=false
 Before=ignition-complete.target
  


### PR DESCRIPTION
RHCOS FIPS support wants to add an additional trigger.  See https://github.com/openshift/os/pull/574#discussion_r675688876.