### PR TITLE
coreos-kargs-reboot: rename flag file

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs-reboot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=CoreOS Kernel Arguments Reboot
 ConditionPathExists=/etc/initrd-release
-ConditionPathExists=/run/ignition-modified-kargs
+ConditionPathExists=/run/coreos-kargs-reboot
 DefaultDependencies=false
 Before=ignition-complete.target
  

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-/usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/ignition-modified-kargs "$@"
+/usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/coreos-kargs-reboot "$@"


### PR DESCRIPTION
The RHCOS FIPS code is going to create the same flag file, so let's name it something more generic.