### PR TITLE
[rawhide] Revert "Switch to ostree-format: "oci""

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,6 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# https://github.com/coreos/coreos-assembler/pull/2216
-ostree-format: "oci"


### PR DESCRIPTION
This reverts commit e7ef64d938dd47b23cc2d785815d63039f6466d7.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/909