### PR TITLE
15fcos: Order coreos-check-ssh-keys before systemd-user-sessions

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -12,6 +12,8 @@ After=afterburn-sshkeys.target
 # get misleading messages. Also handles the case where the journal
 # gets rotated and no longer has the structured log messages.
 ConditionKernelCommandLine=ignition.firstboot
+# Run before user sessions to avoid reloading agetty
+Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys
@@ -41,10 +41,6 @@ main() {
         echo -e "${warn}No SSH authorized keys provided by Ignition or Afterburn${nc}" \
             > /etc/issue.d/30_ssh_authorized_keys.issue
     fi
-
-    # Ask all running agetty instances to reload and update their
-    # displayed prompts in case this script was run before agetty.
-    /usr/sbin/agetty --reload
 }
 
 main


### PR DESCRIPTION
Run before user sessions to avoid reloading agetty.

See also: https://github.com/coreos/fedora-coreos-config/commit/386b6fedfdee105e35b75381e48cc46c28806fad