### PR TITLE
denylist: snooze podman.network-single on openstack

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,3 +5,8 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
+- pattern: podman.network-single
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/901
+  snooze: 2021-09-01
+  platforms:
+    - openstack


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/901

The problem comes and goes in the vexxhost environment. Let's wait
a month and see if it's better then.
