### PR TITLE
overlay.d: add zipl

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -24,6 +24,12 @@ install() {
         sed \
         sgdisk
 
+    # ignition can update kargs
+    if [[ "$_arch" == "s390x" ]]; then
+        inst_multiple zipl
+        inst /lib/s390-tools/stage3.bin
+    fi
+
     inst_simple "$moddir/coreos-diskful-generator" \
         "$systemdutildir/system-generators/coreos-diskful-generator"
 


### PR DESCRIPTION
We require zipl in ramdisk (only on s390x) for ignition/rdcore kargs modification feature.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>