### PR TITLE
[rawhide] lockfiles: pin to kexec-tools-2.0.22-3.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -7,4 +7,9 @@
 # *should* include a URL in the `metadata.reason` key, though it's acceptable to
 # omit one for FCOS-specific packages (e.g. ignition, afterburn, etc...).
 
-packages: {}
+packages:
+  kexec-tools:
+    evr: 2.0.22-3.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
+      type: pin


### PR DESCRIPTION
It now requires grubby and we have a rule against that.

https://github.com/coreos/fedora-coreos-tracker/issues/913