### PR TITLE
35coreos-ignition: allow setting kargs in live system if it's a no-op

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
@@ -1,4 +1,40 @@
 #!/bin/bash
 set -euo pipefail
 
-/usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/coreos-kargs-reboot "$@"
+fail_live() {
+    echo "Need to $1, but cannot change kernel arguments in live system." >&2
+    exit 1
+}
+
+if is-live-image; then
+    # In the live case, we can't actually change anything.  Check the
+    # arguments and succeed anyway if there's nothing we need to do.
+
+    # add leading and trailing whitespace to allow for easy matching
+    kernelopts=" $(cat /proc/cmdline) "
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --should-exist)
+            arg="$2"
+            if [[ ! "${kernelopts}" =~ " ${arg} " ]]; then
+                fail_live "add kernel argument '${arg}'"
+            fi
+            shift 2
+            ;;
+        --should-not-exist)
+            arg="$2"
+            if [[ "${kernelopts}" =~ " ${arg} " ]]; then
+                fail_live "remove kernel argument '${arg}'"
+            fi
+            shift 2
+            ;;
+        *)
+            echo "Unknown option" >&2
+            exit 1
+            ;;
+        esac
+    done
+else
+    /usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/coreos-kargs-reboot "$@"
+fi


### PR DESCRIPTION
In a live system, we can't set kargs in an Ignition config because we don't control the bootloader settings.  If the config specifies kargs anyway, we currently fail with `/dev/disk/by-label/boot: not a block device`, which isn't very clear.

In the live case, notice if the `shouldExist` kargs exist and the `shouldNotExist` kargs do not, because then we don't need to do anything and can succeed anyway.  Otherwise, fail with a clearer error message.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/917.