### PR TITLE
misc-ign-ro: change message from kube-watch to be more unique

### DIFF
--- a/tests/kola/misc-ign-ro/config.fcc
+++ b/tests/kola/misc-ign-ro/config.fcc
@@ -44,11 +44,14 @@ systemd:
     - name: kube-watch.service
       # This is for verifying that `kubernetes_file_t` labeled files can be
       # watched by systemd
+      # NOTE: we've observed a race where the journal message shows up as
+      # coming from `echo` rather than `kube-watch`, so we're embedding
+      # a UUID in the message to make it easier to find.
       # See: https://github.com/coreos/fedora-coreos-tracker/issues/861
       # See: https://github.com/containers/container-selinux/issues/135
       contents: |
         [Service]
-        ExecStart=/usr/bin/echo "Found it"
+        ExecStart=/usr/bin/echo "This is the kube-watch unique id: 27a259a8-7f2d-4144-8b8f-23dd201b630c"
         RemainAfterExit=yes
         Type=oneshot
         [Install]

--- a/tests/kola/misc-ign-ro/test.sh
+++ b/tests/kola/misc-ign-ro/test.sh
@@ -54,7 +54,10 @@ if [ "$(systemctl is-active kube-watch.service)" != "active" ]; then
 fi
 ok "kube-watch.service activated successfully"
 
-if [ "$(journalctl -o cat -u kube-watch.service | sed -n 2p)" != "Found it" ]; then
+# NOTE: we've observed a race where the journal message shows up as
+# coming from `echo` rather than `kube-watch`, so we're embedding
+# a UUID in the message to make it easier to find.
+if ! journalctl -o cat -b | grep 27a259a8-7f2d-4144-8b8f-23dd201b630c; then
     fatal "kube-watch.service did not print message to journal"
 fi
 ok "Found message from kube-watch.service in journal"


### PR DESCRIPTION
We observed that the `kube-watch` test was occasionally failing
because the message from the service was being identified from `echo`
rather than the service name.  Change the service to emit a UUID that
we can check for instead of a generic log message.