### PR TITLE
[rawhide] overrides: unpin shadow-utils

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -13,3 +13,38 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
       type: pin
+  fedora-gpg-keys:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos-archive:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos-modular:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos-ostree:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos-rawhide:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track
+  fedora-repos-rawhide-modular:
+    evra: 36-0.3.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -48,3 +48,13 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/925
       type: fast-track
+  coreos-installer:
+    evr: 0.10.0-2.fc36
+    metadata:
+      reason: https://github.com/coreos/coreos-installer/pull/599
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.10.0-2.fc36
+    metadata:
+      reason: https://github.com/coreos/coreos-installer/pull/599
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -13,8 +13,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
       type: pin
-  shadow-utils:
-    evr: 2:4.8.1-20.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/916
-      type: pin


### PR DESCRIPTION
The issue should now be fixed in `shadow-utils-4.9-2.fc36`.

See https://src.fedoraproject.org/rpms/shadow-utils/c/3a328328567ec0e4ec8f6e3dacdba36022b121a2?branch=rawhide

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/916