### PR TITLE
workaround failures in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,3 +13,7 @@
 - pattern: ext.config.yum-repos
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/925
   snooze: 2021-09-01
+- pattern: ext.config.toolbox
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/926
+  stream: rawhide
+  snooze: 2021-09-01

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,3 +10,6 @@
   snooze: 2021-09-01
   platforms:
     - openstack
+- pattern: ext.config.yum-repos
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/925
+  snooze: 2021-09-01

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -117,6 +117,17 @@ postprocess:
       echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
     fi
 
+
+  # Workaround issue in rawhide parsing the F37 GPG key
+  # by removing it from the list of gpgkeys to load.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/925
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    source /etc/os-release
+    [ ${VERSION_ID} -eq 36 ] || exit 0
+    sed -i 's|gpgkey=.*$|gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-rawhide-$basearch|' /etc/yum.repos.d/fedora-rawhide.repo
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.

--- a/tests/kola/yum-repos/test.sh
+++ b/tests/kola/yum-repos/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# No need to run an other platforms than QEMU.
+# kola: { "platforms": "qemu-unpriv" }
+
+# We can delete this test when the following issue is resolved:
+# https://github.com/coreos/fedora-coreos-tracker/issues/925
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+source /etc/os-release
+if [ "$VERSION_ID" -eq "36" ]; then
+    if ! grep 'RPM-GPG-KEY-fedora-37' /etc/yum.repos.d/fedora-rawhide.repo; then
+        fatal "Fedora 37 gpg key should be in rawhide repo"
+    fi
+fi
+ok rawhiderepo


### PR DESCRIPTION
```
commit c9ccb6c377b430e595a9fb55970619123f76f714
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 16 16:40:51 2021 -0400

    kola-denylist: snooze the toolbox test
    
    There is currently no registry.fedoraproject.org/fedora-toolbox:36
    container. Let's snooze for a few weeks in the rawhide stream and
    hopefully it will be in the registry by then.
    
    https://github.com/coreos/fedora-coreos-tracker/issues/926

commit c6f9e475bb64f703859d2f0b861763f23c2bf2c3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 16 16:36:30 2021 -0400

    manifests: workaround F37 GPG key issue for rawhide
    
    We'll workaround the issue by removing the F37 key from the list of
    gpgkeys to load. We'll also add a test that fails if the f37 entry
    isn't put back in place and we'll snooze that test. This gives us
    a reminder to followup on this issue if we don't get it resolved
    in upstream libdnf/rpm in the immediate future.
    
    https://github.com/coreos/fedora-coreos-tracker/issues/925
```
