### PR TITLE
35coreos-ignition: allow setting kargs in live system if it's a no-op, via rdcore

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-kargs.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-/usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/coreos-kargs-reboot "$@"
+if is-live-image; then
+    /usr/bin/rdcore kargs --current --create-if-changed /run/coreos-kargs-changed "$@"
+    if [ -e /run/coreos-kargs-changed ]; then
+        echo "Need to modify kernel arguments, but cannot affect live system." >&2
+        exit 1
+    fi
+else
+    /usr/bin/rdcore kargs --boot-device /dev/disk/by-label/boot --create-if-changed /run/coreos-kargs-reboot "$@"
+fi


### PR DESCRIPTION
In a live system, we can't set kargs in an Ignition config because we don't control the bootloader settings.  If the config specifies kargs anyway, we currently fail with `/dev/disk/by-label/boot: not a block device`, which isn't very clear.

In the live case, use the new `rdcore kargs --current` option to perform a dry run on `/proc/cmdline`, and if it doesn't create the stamp file, we don't need to do anything and can succeed anyway.  Otherwise, fail with a clearer error message.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/917.