### PR TITLE
overaly/preset: Enable Count Me by default

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -8,3 +8,6 @@ enable coreos-check-cgroups.service
 # Clean up injected Ignition config in /boot on upgrade
 # https://github.com/coreos/fedora-coreos-tracker/issues/889
 enable coreos-cleanup-ignition-config.service
+# Temporary fast track for rpm-ostree count me enablement
+# https://github.com/coreos/fedora-coreos-tracker/issues/717
+enable rpm-ostree-countme.timer

--- a/tests/kola/rpm-ostree-countme/config.fcc
+++ b/tests/kola/rpm-ostree-countme/config.fcc
@@ -1,7 +1,0 @@
-variant: fcos
-version: 1.3.0
-systemd:
-  units:
-    - name: rpm-ostree-countme.timer
-      mask: false
-      enabled: true


### PR DESCRIPTION
Enable rpm-ostree Count Me timer by default for existing and new
installs.

See: https://github.com/coreos/fedora-coreos-tracker/issues/717