### PR TITLE
tests/misc-ign-ro: wait while kube-watch is activating

### DIFF
--- a/tests/kola/misc-ign-ro/test.sh
+++ b/tests/kola/misc-ign-ro/test.sh
@@ -49,6 +49,12 @@ ok "kube-watch.path successfully activated"
 touch /etc/kubernetes/kubeconfig
 ok "successfully created /etc/kubernetes/kubeconfig"
 
+# If we check the status too soon it could still be activating..
+# Sleep in a loop until it's done "activating"
+while [ "$(systemctl is-active kube-watch.service)" == "activating" ]; do
+    echo "kube-watch is activating. sleeping for 1 second"
+    sleep 1
+done
 if [ "$(systemctl is-active kube-watch.service)" != "active" ]; then
     fatal "kube-watch.service did not successfully activate"
 fi


### PR DESCRIPTION
We've hit a race a few times where:

```
kola-runext-test.sh[2023]: ++ systemctl is-active kube-watch.service
kola-runext-test.sh[2015]: + '[' activating '!=' active ']'
kola-runext-test.sh[2015]: + fatal 'kube-watch.service did not successfully activate'
kola-runext-test.sh[2015]: + echo 'kube-watch.service did not successfully activate'
kola-runext-test.sh[2015]: kube-watch.service did not successfully activate
```

Basically it's activating but not yet active. Let's loop while it
activates before we check the final state.