### PR TITLE
ci/remove-graduated-overrides: enable for branched and rawhide

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -19,6 +19,8 @@ jobs:
         branch:
           - testing-devel
           - next-devel
+          - branched
+          - rawhide
       fail-fast: false
     steps:
       - run: dnf install -y rpm-ostree # see related TODO above


### PR DESCRIPTION
In rare situations, we sometimes need to fast-track packages to these
mechanical streams, e.g. if pungi composes are failing and not updating
the repos. It's trivial to check those branches too for when the repos
are finally updated using the same GitHub Action, so let's do that.

Closes: #1170