### PR TITLE
pipeline.yaml: New file which configures the pipeline

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,0 +1,8 @@
+# This file configures the pipeline, which is currently
+# https://github.com/coreos/fedora-coreos-pipeline
+
+# S3 bucket used for builds
+s3_bucket: fcos-builds
+
+# Location of the oscontainer (temporary value)
+oscontainer: quay.io/cgwalters/fcos


### PR DESCRIPTION
The idea is to keep the pipeline as more the mechanics/implementation,
and the config git repo is the declarative state.

One goal here is that e.g. `cosa upload-oscontainer` defaults to this value.

I also added `s3_bucket`.  Right now the pipeline writes this
as an annotation, but I think it will be easier to deal with if
e.g. `cosa buildupload` defaults to this.