### PR TITLE
[rawhide]: overrides: fast-track kexec-tools-2.0.22-6.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,8 @@
 
 packages:
   kexec-tools:
-    evr: 2.0.22-3.fc35
+    evr: 2.0.22-6.fc36
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-06f2aaa5bb
+      type: fast-track


### PR DESCRIPTION
- reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
- bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-06f2aaa5bb