### PR TITLE
[branched] overrides: fast-track kexec-tools-2.0.22-6.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,7 +9,8 @@
 
 packages:
   kexec-tools:
-    evr: 2.0.22-3.fc35
+    evr: 2.0.22-6.fc35
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bb17734a90
+      type: fast-track


### PR DESCRIPTION
- reason: https://github.com/coreos/fedora-coreos-tracker/issues/913
- bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bb17734a90