### PR TITLE
[branched] overrides: pin kernel-5.14.0-0.rc6.46.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.14.0-0.rc6.46.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
+      type: pin
+  kernel-core:
+    evr: 5.14.0-0.rc6.46.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
+      type: pin
+  kernel-modules:
+    evr: 5.14.0-0.rc6.46.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
+      type: pin


### PR DESCRIPTION
The newer kernel-5.14.0-0.rc7.54.fc35 breaks secure boot.
See https://github.com/coreos/fedora-coreos-tracker/issues/937