### PR TITLE
tests/kola/authentication/passwd: Added tests for password authentication

### DIFF
--- a/tests/kola/authentication/passwd/config.fcc
+++ b/tests/kola/authentication/passwd/config.fcc
@@ -1,0 +1,7 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: tester 
+      # encrypted version of 'foobar'. generated with `mkpasswd --method=yescrypt`
+      password_hash: $y$j9T$0HA8ReLTqRTccLKT0gzVY.$/e.OCrjePrh2tOm8CAoLqCMlZWS9q/WSAPBaZuopRs4

--- a/tests/kola/authentication/passwd/test.sh
+++ b/tests/kola/authentication/passwd/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+#Testing that a user password provisioned by ignition works
+OUTPUT=$(echo 'foobar' | setsid su - tester -c id)
+
+if [[ $OUTPUT != "uid=1001(tester) gid=1001(tester) groups=1001(tester) context=system_u:system_r:unconfined_service_t:s0" ]]; then
+    fatal "Failure when checking command output running with specified username and password"
+fi
+# yescrypt was changed to the default in Fedora 35
+# https://fedoraproject.org/wiki/Changes/yescrypt_as_default_hashing_method_for_shadow
+# Testing that passwd command creates a yescrypt password hash(starting with '$y$')
+source /etc/os-release 
+if [ "$VERSION_ID" -ge "35" ]; then
+    sudo useradd tester2
+    echo "42abcdef" | sudo passwd tester2 --stdin
+    PASSWD_CONFIRMATION=$(sudo grep tester2 /etc/shadow)
+    if [[ ${PASSWD_CONFIRMATION:0:11} != 'tester2:$y$' ]]; then
+        fatal "passwd did not create a yescrypt password hash"
+    fi
+fi
+ok "User-password provisioned and passwd command successfully tested"


### PR DESCRIPTION
Tested user password provisioned by ignition works and tested that passwd created yescrypt(pwd starting with $y$) password hash