### PR TITLE
tests: Split up misc-ro and mark tests as non-exclusive

### DIFF
--- a/tests/kola/misc-ign-ro/config.fcc
+++ b/tests/kola/misc-ign-ro/config.fcc
@@ -8,12 +8,6 @@ storage:
     # See: https://github.com/containers/container-selinux/issues/135
     - path: /etc/kubernetes
   files:
-    - path: /etc/systemd/zram-generator.conf
-      mode: 0644
-      contents:
-        inline: |
-          # This config file enables a /dev/zram0 device with the default settings
-          [zram0]
     - path: /etc/pki/ca-trust/source/anchors/coreos.crt
       mode: 0644
       contents:

--- a/tests/kola/misc-ign-ro/test.sh
+++ b/tests/kola/misc-ign-ro/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# kola: { "exclusive": false }
 set -xeuo pipefail
 
 ok() {
@@ -9,15 +10,6 @@ fatal() {
         echo "$@" >&2
             exit 1
         }
-
-# This test makes sure that swap on zram devices can be set up
-# using the zram-generator as defined in the docs at
-# https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-configure-swaponzram/
-
-if ! grep -q 'zram0' /proc/swaps; then
-    fatal "expected zram0 to be set up"
-fi
-ok "swap on zram was set up correctly"
 
 # Make sure that coreos-update-ca-trust kicked in and observe the result.
 if ! systemctl show coreos-update-ca-trust.service -p ActiveState | grep ActiveState=active; then

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -1,4 +1,5 @@
 #!/bin/bash
+# kola: { "exclusive": false }
 # This is a place to put random quick read-only tests.
 set -xeuo pipefail
 
@@ -133,14 +134,6 @@ if [ ! -f /usr/share/rpm/rpmdb.sqlite ]; then
     fatal "Didn't find file /usr/share/rpm/rpmdb.sqlite"
 fi
 ok rpmdb is sqlite
-
-# make sure we don't default to having swap on zram
-# https://github.com/coreos/fedora-coreos-tracker/issues/509
-# https://github.com/coreos/fedora-coreos-config/pull/687
-if [ -e /dev/zram0 ]; then
-    fatal "zram0 swap device set up on default install"
-fi
-ok no zram swap by default
 
 # make sure dnsmasq is masked
 # https://github.com/coreos/fedora-coreos-tracker/issues/519#issuecomment-705140528

--- a/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# kola: { "exclusive": false }
 set -xeuo pipefail
 
 # With pure network defaults no networking should have been propagated

--- a/tests/kola/swap/zram-default
+++ b/tests/kola/swap/zram-default
@@ -1,0 +1,20 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# make sure we don't default to having swap on zram
+# https://github.com/coreos/fedora-coreos-tracker/issues/509
+# https://github.com/coreos/fedora-coreos-config/pull/687
+if [ -e /dev/zram0 ]; then
+    fatal "zram0 swap device set up on default install"
+fi
+ok no zram swap by default

--- a/tests/kola/swap/zram-generator/config.fcc
+++ b/tests/kola/swap/zram-generator/config.fcc
@@ -1,0 +1,10 @@
+variant: fcos
+version: 1.2.0
+storage:
+  files:
+    - path: /etc/systemd/zram-generator.conf
+      mode: 0644
+      contents:
+        inline: |
+          # This config file enables a /dev/zram0 device with the default settings
+          [zram0]

--- a/tests/kola/swap/zram-generator/test.sh
+++ b/tests/kola/swap/zram-generator/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This test conflicts with swap/zram-default so we cannot set this to non-exclusive
+# kola: { "exclusive": true}
+set -xeuo pipefail
+
+ok() {
+        echo "ok" "$@"
+    }
+
+fatal() {
+        echo "$@" >&2
+            exit 1
+        }
+
+# This test makes sure that swap on zram devices can be set up
+# using the zram-generator as defined in the docs at
+# https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-configure-swaponzram/
+
+if ! grep -q 'zram0' /proc/swaps; then
+    fatal "expected zram0 to be set up"
+fi
+ok "swap on zram was set up correctly"


### PR DESCRIPTION
Moved 'z-ram is off by default' test from misc-ro and 'setup swap on zram device'
from misc-ign-ro into new files under kola/swap. Now misc-ro and misc-ign-ro
do not conflict and can be run in one VM after
coreos/coreos-assembler#2356 lands.