### PR TITLE
manifests/fedora-coreos-base: stop disabling modular repos

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -49,16 +49,6 @@ rpmdb: sqlite
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:
-  # This will be dropped once rpm-ostree because module-aware.
-  # https://github.com/projectatomic/rpm-ostree/issues/1542#issuecomment-419684977
-  # https://github.com/projectatomic/rpm-ostree/issues/1435
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    for x in /etc/yum.repos.d/*modular.repo; do
-      sed -i -e 's,enabled=[01],enabled=0,' ${x}
-    done
-
   # Enable SELinux booleans used by OpenShift
   # https://github.com/coreos/fedora-coreos-tracker/issues/284
   - |

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -198,3 +198,6 @@ if find ${tmpd}/usr/{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-commo
 fi
 rm -r ${tmpd}
 ok "All initrd scripts are executable"
+
+rpm-ostree ex module install cri-o:1.20/default --dry-run
+ok "basic modularity support"

--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -56,7 +56,8 @@ for i in $(seq 1 5); do
 	# Depending on the stream, we expect different numbers of countme-enabled repos
 	if [[ "${output}" != "Successful requests: 1/1" ]] && \
 	   [[ "${output}" != "Successful requests: 2/2" ]] && \
-	   [[ "${output}" != "Successful requests: 3/3" ]]; then
+	   [[ "${output}" != "Successful requests: 3/3" ]] && \
+	   [[ "${output}" != "Successful requests: 4/4" ]]; then
 		echo "rpm-ostree-countme service ouput does not match expected sucess output (try: $i):"
 		echo "${output}"
 		sleep 10


### PR DESCRIPTION
The latest rpm-ostree release now has proper support for modules. It
will not layer modular packages unless explicitly enabled. So let's stop
disabling the repos so e.g. `rpm-ostree ex module install cri-o:1.20`
alone just works.