### PR TITLE
s390x: add keyfile for LUKS encrypted root into initramfs

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -22,6 +22,7 @@ packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
   - /usr/sbin/zipl
+  - /usr/bin/genprotimg
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl

--- a/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
@@ -4,6 +4,9 @@ set -euo pipefail
 mount -o remount,rw /boot
 
 if [[ $(uname -m) = s390x ]]; then
+    if [[ -f /etc/luks/root && -f /etc/crypttab ]]; then
+        rpm-ostree initramfs --enable --arg="-I" --arg="/etc/crypttab /etc/luks/root"
+    fi
     zipl
 fi
 


### PR DESCRIPTION
IBM s390x doesn't use/support TPM. Setting up a separate VM for Tang (or allowing local zKVM guests to access remote Tang) could be undesirable. In this case it's easier to inject `/etc/crypttab` and `/etc/luks/root` into `ramdisk`.