### PR TITLE
[branched] overrides: fast-track kernel-5.14.0-60.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,17 +10,20 @@
 
 packages:
   kernel:
-    evr: 5.14.0-0.rc6.46.fc35
+    evr: 5.14.0-60.fc35
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bcb7602690
+      type: fast-track
   kernel-core:
-    evr: 5.14.0-0.rc6.46.fc35
+    evr: 5.14.0-60.fc35
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bcb7602690
+      type: fast-track
   kernel-modules:
-    evr: 5.14.0-0.rc6.46.fc35
+    evr: 5.14.0-60.fc35
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/937
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bcb7602690
+      type: fast-track


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/937
should be fixed now.