### PR TITLE
kola-denylist: extend snooze for the toolbox test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,6 +12,6 @@
     - openstack
 - pattern: ext.config.toolbox
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/926
-  snooze: 2021-09-01
+  snooze: 2021-09-15
   streams:
     - rawhide


### PR DESCRIPTION
registry.fedoraproject.org/fedora-toolbox:36 still doesn't exist.
See https://github.com/coreos/fedora-coreos-tracker/issues/926