### PR TITLE
ci: enable kola basic scenarios and many more ISO tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -45,13 +45,7 @@ cosaPod {
 
     stage("Test ISO") {
         shwrap("cd /srv/fcos && cosa buildextend-live")
-        try {
-            shwrap("cd /srv/fcos && kola testiso -S --scenarios pxe-install,pxe-offline-install,iso-install --output-dir tmp/kola-testiso")
-            shwrap("cd /srv/fcos && kola testiso -S --scenarios iso-offline-install --qemu-multipath --output-dir tmp/kola-testiso-mpath")
-        } finally {
-            shwrap("cd /srv/fcos && tar -cf - tmp/kola-testiso/ tmp/kola-testiso-mpath/ | xz -c9 > ${env.WORKSPACE}/kola-testiso.tar.xz")
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso.tar.xz'
-        }
+        fcosKolaTestIso(cosaDir: "/srv/fcos", extraArgs4k: "--no-pxe")
     }
 
     // also print the pkgdiff as a separate stage to make it more visible

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -35,7 +35,8 @@ cosaPod {
     if (env.CHANGE_TARGET in mechanical_streams) {
         no_strict_build = true
     }
-    fcosBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
+    fcosBuild(skipInit: true, skipKola: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
+    fcosKola(basicScenarios: true)
 
     parallel metal: {
         shwrap("cd /srv/fcos && cosa buildextend-metal")


### PR DESCRIPTION
Basic scenarios get us UEFI boot testing with the bare-metal image, plus an NVMe boot test.  Switching to the coreos-ci-lib `kola testiso` wrapper adds `iso-live-login` and `iso-as-disk` scenarios, plus tests on metal4k, multipath, and UEFI.  It also drops the `iso-install` scenario, which isn't a typical use case for FCOS.