### PR TITLE
tests/misc-ro: check initrd for non-executable scripts

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -189,3 +189,12 @@ if ! systemctl show -p ActiveState network-online.target | grep -q ActiveState=i
     fatal "Unit network-online.target shouldn't be active"
 fi
 ok "unit network-online.target inactive"
+
+# It's easy for dracut modules to accidentally ship scripts without +x set
+tmpd=$(mktemp -d)
+( cd ${tmpd} && lsinitrd --unpack /boot/ostree/*/init* )
+if find ${tmpd}/usr/{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-common-functions; then
+    fatal "Found non-executable scripts in initrd"
+fi
+rm -r ${tmpd}
+ok "All initrd scripts are executable"


### PR DESCRIPTION
If a script is committed to Git without `+x`, Dracut will happily install it into the initrd without `+x`.  Add a simple check for this.