### PR TITLE
35coreos-ignition: randomize partition GUIDs on first boot

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
@@ -38,5 +38,5 @@ if [ "${PTUUID:-}" != "$UNINITIALIZED_GUID" ]; then
 fi
 
 echo "Randomizing disk GUID"
-sgdisk --disk-guid=R --move-second-header "$PKNAME"
+sgdisk --randomize-guids --move-second-header "$PKNAME"
 udevadm settle || :


### PR DESCRIPTION
We've been randomizing the disk GUID but not the partition GUIDs, contrary to the GPT spec.  Partition GUIDs are already not stable identifiers, since new ones are generated by `create_disk.sh` on every image build, so ensure they're globally unique as well.

Randomizing the ESP GUID will break any existing UEFI boot variable created by `fallback.efi`, so it's important that we only do this on the first boot (to not break existing systems) and only after our bootloader setup has been taught not to create boot variables (to not break new systems).

Requires https://github.com/coreos/coreos-assembler/pull/2421 or equivalent.