### PR TITLE
Revert "ci: run kola basic scenarios"

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -35,8 +35,7 @@ cosaPod {
     if (env.CHANGE_TARGET in mechanical_streams) {
         no_strict_build = true
     }
-    fcosBuild(skipInit: true, skipKola: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
-    fcosKola(basicScenarios: true)
+    fcosBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
 
     parallel metal: {
         shwrap("cd /srv/fcos && cosa buildextend-metal")


### PR DESCRIPTION
coreos-ci-lib does this by default as of https://github.com/coreos/coreos-ci-lib/pull/91.

This reverts commit 82859cbc47bdd0b13d61583431f82fb9456dfb49.