### PR TITLE
tests/misc-ro: drop `rpm-ostree ex module install` test

### DIFF
--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -198,6 +198,3 @@ if find ${tmpd}/usr/{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-commo
 fi
 rm -r ${tmpd}
 ok "All initrd scripts are executable"
-
-rpm-ostree ex module install cri-o:1.20/default --dry-run
-ok "basic modularity support"


### PR DESCRIPTION
Thought this was cool to have here, but first it needs Internet, which
the rest of `misc-ro` doesn't so far which is nice. And second each
Fedora version has different stream versions so the matrix is slightly
trickier.

I think I'll put it in the rpm-ostree testsuite instead. Anyway if we
really go the modularity route for cri-o, ideally we'd have some k8s
testing going on in CI here on top of OKD or Typhoon, and then this will
implicitly be tested.