### PR TITLE
overlay: Remove /boot RW workaround for kdump

### DIFF
--- a/overlay.d/12kdump/statoverride
+++ b/overlay.d/12kdump/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/12kdump/usr/lib/systemd/system/kdump.service.d/remount-boot.conf
+++ b/overlay.d/12kdump/usr/lib/systemd/system/kdump.service.d/remount-boot.conf
@@ -1,9 +1,0 @@
-# https://bugzilla.redhat.com/show_bug.cgi?id=1918493
-# `/boot` is read-only, but `kdump.service` wants to 
-# places its generated initramfs alongside the default
-# initramfs under `/boot/ostree`.
-# Until `kdump` gains the ability to place its initramfs
-# elsewhere, temporarily remount `/boot` read-write before
-# the `kdump` initramfs is generated.
-[Service]
-ExecStartPre=/usr/bin/mount -o remount,rw /boot

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-cleanup-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-cleanup-ignition-config.service
@@ -6,8 +6,6 @@ Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/889
 ConditionKernelCommandLine=!ignition.firstboot
 RequiresMountsFor=/boot
 ConditionPathExists=/boot/ignition
-# We ship a kdump.service dropin that remounts /boot rw; avoid conflicts
-Before=kdump.service
 
 [Service]
 Type=oneshot

--- a/tests/kola/kdump/test.sh
+++ b/tests/kola/kdump/test.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
-# kola: {"minMemory": 4096, "tags": "skip-base-checks"}
-
-# ===== FIXME: Disabled due to broken CI
-echo "Test disabled"
-exit 0
-# =====
+# Only run on QEMU and x86_64 & aarch64 for now:
+# https://github.com/coreos/fedora-coreos-tracker/issues/860
+# kola: {"platforms": "qemu-unpriv", "minMemory": 4096, "tags": "skip-base-checks", "architectures": "x86_64 aarch64"}
 
 fatal() {
     echo "$@" >&2


### PR DESCRIPTION
Remove workaround keeping `/boot` read only when kdump support was
requested now that kdump writes the temporary initrd in
`/var/lib/kdump`.

This reverts 3167d83 12kdump: Remount /boot rw before `kdump.service`.