### PR TITLE
[rawhide] Switch to ostree-format: "oci"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,6 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# https://github.com/coreos/coreos-assembler/pull/2216
+ostree-format: "oci"


### PR DESCRIPTION
(Take 2, now that we have https://github.com/coreos/coreos-assembler/pull/2417 )

Part of https://github.com/coreos/fedora-coreos-tracker/issues/812

In this initial step, we're merely switching the internal
tarball to be a different format.

A future step will change the FCOS pipeline to automatically
push this container to quay.io.