### PR TITLE
denylist: cleanup a few entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,8 +10,3 @@
   snooze: 2021-09-01
   platforms:
     - openstack
-- pattern: ext.config.toolbox
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/926
-  snooze: 2021-09-15
-  streams:
-    - rawhide

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,8 +5,3 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: podman.network-single
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/901
-  snooze: 2021-09-01
-  platforms:
-    - openstack


### PR DESCRIPTION
```
commit b62e1383931015f118462607b80c7858d983c4a3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Sep 15 10:09:57 2021 -0400

    denylist: remove snooze on podman.network-single for openstack
    
    It started running again on 2021-09-01 and is passing so let's remove
    it from the list.
    
    Resolves https://github.com/coreos/fedora-coreos-tracker/issues/901

commit bb935ecd1f3618bf0fa4be96a3cdb9ae7876e1ba
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Sep 15 10:07:41 2021 -0400

    denylist: remove ext.config.toolbox from denylist
    
    The toolbox containers for f35 and f36 are now in the registry.
    
    Resolves https://github.com/coreos/fedora-coreos-tracker/issues/926
```
