### PR TITLE
live/grub.cfg: update incorrect comment

### DIFF
--- a/live/EFI/fedora/grub.cfg
+++ b/live/EFI/fedora/grub.cfg
@@ -4,9 +4,11 @@
 #
 # One diff to note is we use linux and initrd instead of linuxefi and
 # initrdefi. We do this because it works and allows us to use this same
-# file on other architecutres. https://github.com/coreos/fedora-coreos-config/issues/63
+# file on other architectures. https://github.com/coreos/fedora-coreos-config/issues/63
 #
-# This file gets embedded into the efiboot.img on our Fedora CoreOS ISO.
+# This file is loaded directly when booting via El Torito, and indirectly
+# from a stub config in efiboot.img when booting via the hybrid ESP.
+
 set default="1"
 
 function load_video {


### PR DESCRIPTION
This file is shipped in the ISO itself, and `efiboot.img` contains a stub config that points to it.