### PR TITLE
[rawhide] Revert "Switch to ostree-format: "oci""

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,6 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# https://github.com/coreos/coreos-assembler/pull/2216
-ostree-format: "oci"


### PR DESCRIPTION
This reverts commit d6ae23d96c2241b46bf2b58c70e10fbfbe4c26a6.

We need a newer rpm-ostree in cosa with https://github.com/coreos/rpm-ostree/pull/3129
So this blocks on a new release of rpm-ostree.