### PR TITLE
Revert "overaly/preset: Enable Count Me by default"

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -8,6 +8,3 @@ enable coreos-check-cgroups.service
 # Clean up injected Ignition config in /boot on upgrade
 # https://github.com/coreos/fedora-coreos-tracker/issues/889
 enable coreos-cleanup-ignition-config.service
-# Temporary fast track for rpm-ostree count me enablement
-# https://github.com/coreos/fedora-coreos-tracker/issues/717
-enable rpm-ostree-countme.timer


### PR DESCRIPTION
This is now enabled via the `90-default.preset` from fedora-release
(included since commit 83f5e120101b125ad399acfc87fbf9d2744108c3).

See:
  - https://src.fedoraproject.org/rpms/fedora-release/pull-request/203
  - https://bugzilla.redhat.com/show_bug.cgi?id=1995495

This reverts commit 12ba5c2922d59fb2451ff3fbbb033913538b9460.