### PR TITLE
[rawhide] overrides: pin kernel, tpm2-tss

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.15.0-0.rc1.12.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
+      type: pin
+  kernel-core:
+    evr: 5.15.0-0.rc1.12.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
+      type: pin
+  kernel-modules:
+    evr: 5.15.0-0.rc1.12.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,8 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
       type: pin
+  tpm2-tss:
+    evr: 3.1.0-3.fc35
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
+      type: pin


### PR DESCRIPTION
```
commit cbc7c944b3655442bd16f9a76042cac115033634
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 20 12:16:12 2021 -0400

    overrides: pin tpm2-tss-3.1.0-3.fc35
    
    The new tpm2-tss-3.1.0-4.fc36 is causing our luks tests to fail.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/968

commit f12dcfe88b526f3cf08a1d7265b16f90530e094b
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 20 10:53:31 2021 -0400

    overrides: pin kernel 5.15.0-0.rc1.12.fc36
    
    There is a new circular locking dependency introduced in
    5.15.0-0.rc1.20210915git3ca706c189db.13.fc36 that we want
    to avoid.
```
