### PR TITLE
[rawhide] overrides: unpin kernel-5.15.0-0.rc1.12.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,21 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 5.15.0-0.rc1.12.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
-      type: pin
-  kernel-core:
-    evr: 5.15.0-0.rc1.12.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
-      type: pin
-  kernel-modules:
-    evr: 5.15.0-0.rc1.12.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/967'
-      type: pin
   tpm2-tss:
     evr: 3.1.0-3.fc35
     metadata:


### PR DESCRIPTION
Now that https://github.com/coreos/coreos-assembler/pull/2451 has landed
any circular dep loops will fail CI thus the PR for this to merge won't
pass CI (and won't be merged) until a good kernel exists.

Resolves https://github.com/coreos/fedora-coreos-tracker/issues/967