### PR TITLE
Add remote ignition file which will be used to verify BZ1980679

### DIFF
--- a/tests/kola/ignition/remote/remote.ign
+++ b/tests/kola/ignition/remote/remote.ign
@@ -1,0 +1,21 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "kernelArguments": {
+    "shouldExist": [
+      "foobar"
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/testfile",
+        "contents": {
+          "source": "data:,test"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR is just the remote.ign file should be put on the github, which will be included in config.ign

Test to verify https://bugzilla.redhat.com/show_bug.cgi?id=1980679, steps:
1. remote.ign on github: inject kernel arguments and write something to /etc/testfile
2. config.ign to include remote kargsfile.ign
3. Verify kernel arg and exists /etc/testfile