### PR TITLE
overlay/dracut/multipath: remove problematic stop command

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf
@@ -1,0 +1,3 @@
+# Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+[Service]
+ExecStop=

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -12,6 +12,11 @@ install_ignition_unit() {
 }
 
 install() {
+    # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+    mkdir -p "$systemdsystemunitdir/multipathd.service.d"
+    inst_simple "$moddir/90-multipathd-remove-execstop.conf" \
+        "$systemdsystemunitdir/multipathd.service.d/90-multipathd-remove-execstop.conf"
+
     inst_script "$moddir/coreos-propagate-multipath-conf.sh" \
         "/usr/sbin/coreos-propagate-multipath-conf"
 

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -198,3 +198,16 @@ if find ${tmpd}/usr/{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-commo
 fi
 rm -r ${tmpd}
 ok "All initrd scripts are executable"
+
+# We need either a fixed dracut or temporary workaround, no need for both.
+# See https://github.com/coreos/fedora-coreos-tracker/issues/803.
+has_fixed_dracut=$(grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service; echo $?)
+has_overlay_quickfix=$(test ! -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf; echo $?)
+if test "${has_fixed_dracut}" -eq "${has_overlay_quickfix}"; then
+    if test "${has_fixed_dracut}" -eq 1; then
+        fatal "Found fixed dracut multipath module but quickfix is present too"
+    else
+        fatal "Found buggy dracut multipath module but quickfix is missing too"
+    fi
+fi
+ok "either dracut multipath module fixed or quickfix present"


### PR DESCRIPTION
This is a temporary workaround to remove a problematic stop command
from `multipathd.service`, until the already-merged proper fix gets
released in dracut.

Ref: https://github.com/dracutdevs/dracut/pull/1606
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/803