### PR TITLE
[next-devel] overrides: fast-track frozen packages to avoid downgrades

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,153 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-cf95715f80
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/767
       type: fast-track
+  bind-libs:
+    evr: 32:9.16.21-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3215da7cce
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  bind-license:
+    evra: 32:9.16.21-1.fc35.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3215da7cce
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  bind-utils:
+    evr: 32:9.16.21-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3215da7cce
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  bsdtar:
+    evr: 3.5.2-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-44be6b8144
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  btrfs-progs:
+    evr: 5.14.1-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2225202282
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  conmon:
+    evr: 2:2.0.30-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-87e84e3404
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  container-selinux:
+    evra: 2:2.168.0-1.fc35.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3759db1fb2
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  cracklib:
+    evr: 2.9.6-27.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f579afbe46
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  cracklib-dicts:
+    evr: 2.9.6-27.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-f579afbe46
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  crun:
+    evr: 1.0-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9ecb573669
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  dnsmasq:
+    evr: 2.86-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-5945df5d64
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  efi-filesystem:
+    evra: 5-4.fc35.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-1130e4dd89
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  ethtool:
+    evr: 2:5.14-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2bbeaf7176
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  fuse-overlayfs:
+    evr: 1.7.1-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-fa163d36fc
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  libarchive:
+    evr: 3.5.2-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-44be6b8144
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  libuv:
+    evr: 1:1.42.0-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-5ca1a838f5
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  openssl:
+    evr: 1:1.1.1l-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-50c9be197d
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  openssl-libs:
+    evr: 1:1.1.1l-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-50c9be197d
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  ostree:
+    evr: 2021.4-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9289771bc7
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  ostree-libs:
+    evr: 2021.4-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9289771bc7
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  podman:
+    evr: 3:3.3.1-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bee0f9562c
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  podman-plugins:
+    evr: 3:3.3.1-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-bee0f9562c
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  skopeo:
+    evr: 1:1.4.1-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-9859e3e68c
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  slirp4netns:
+    evr: 1.1.12-2.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-ae387f6b66
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track
+  vim-minimal:
+    evr: 2:8.2.3404-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-e982f972f2
+      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
+      type: fast-track


### PR DESCRIPTION
We want to ship with the packages that would be in the stable repo if
updates weren't currently frozen. This avoids having downgrades during
the f34 -> f35 rebase.