### PR TITLE
[next-devel] manifest.yaml: drop lockfile-repos

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,12 +16,6 @@ repos:
   - fedora-next
   - fedora-next-updates
 
-# All Fedora CoreOS streams share the same pool for locked files.
-# This will be in fedora-coreos.yaml in the future so it can be more easily be
-# shared between all the streams
-lockfile-repos:
-  - fedora-coreos-pool
-
 add-commit-metadata:
   fedora-coreos.stream: next-devel
 


### PR DESCRIPTION
This is part of the common `fedora-coreos.yaml` manifest now.