### PR TITLE
[next-devel] manifest: add iptables-legacy package

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -417,6 +417,9 @@
     "iproute-tc": {
       "evra": "5.13.0-2.fc35.x86_64"
     },
+    "iptables-legacy": {
+      "evra": "1.8.7-13.fc35.x86_64"
+    },
     "iptables-legacy-libs": {
       "evra": "1.8.7-13.fc35.x86_64"
     },

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,6 +32,9 @@ postprocess:
 packages:
   # resolved was broken out to its own package in rawhide/f35
   - systemd-resolved
+  # In F35+ need `iptables-legacy` package
+  # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
+  - iptables-legacy
 
 remove-from-packages:
   # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.


### PR DESCRIPTION
In F35+ we need the `iptables-legacy` package to keep the status quo.
See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451