### PR TITLE
denylist: snooze podman.base test on aws/gcp

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,3 +5,9 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
+- pattern: podman.base
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/966
+  snooze: 2021-10-20
+  platforms:
+    - aws
+    - gcp


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/966

There is a fix upstream but we need to wait for it to propagate
down into FCOS.