### PR TITLE
[next-devel] lockfiles: add iptables-legacy to aarch64 lockfile.

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -411,6 +411,9 @@
     "iproute-tc": {
       "evra": "5.13.0-2.fc35.aarch64"
     },
+    "iptables-legacy": {
+      "evra": "1.8.7-13.fc35.aarch64"
+    },
     "iptables-legacy-libs": {
       "evra": "1.8.7-13.fc35.aarch64"
     },


### PR DESCRIPTION
Should have done this over in ff72c61 but missed it.