### PR TITLE
[next] lockfiles: add iptables-legacy to aarch64 lockfile.

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -411,6 +411,9 @@
     "iproute-tc": {
       "evra": "5.13.0-2.fc35.aarch64"
     },
+    "iptables-legacy": {
+      "evra": "1.8.7-13.fc35.aarch64"
+    },
     "iptables-legacy-libs": {
       "evra": "1.8.7-13.fc35.aarch64"
     },


### PR DESCRIPTION
Should have done this over in 6405a05 but missed it.

(cherry picked from commit f735bb28f5698469f991ad9de899297d68e6fcf2)