### PR TITLE
denylist: switch podman.base snooze to gce

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,4 +10,4 @@
   snooze: 2021-10-20
   platforms:
     - aws
-    - gcp
+    - gce


### PR DESCRIPTION
`gce` is the proper platform name, though we should consider
renaming it.