### PR TITLE
multipathd.socket: add start conditions via dropin

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf
@@ -1,0 +1,6 @@
+# Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
+[Unit]
+ConditionKernelCommandLine=!multipath=off
+ConditionKernelCommandLine=!nompath
+ConditionPathExists=/etc/multipath.conf
+ConditionVirtualization=!container

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -201,10 +201,12 @@ ok "All initrd scripts are executable"
 
 # We need either a fixed dracut or temporary workaround, no need for both.
 # See https://github.com/coreos/fedora-coreos-tracker/issues/803.
-has_fixed_dracut=$(grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service; echo $?)
-has_overlay_quickfix=$(test ! -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf; echo $?)
-if test "${has_fixed_dracut}" -eq "${has_overlay_quickfix}"; then
-    if test "${has_fixed_dracut}" -eq 1; then
+has_fixed_dracut_multipathd_service=0
+grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service || has_fixed_dracut_multipathd_service=1
+has_overlay_multipathd_service_quickfix=1
+test -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf || has_overlay_multipathd_service_quickfix=0
+if test "${has_fixed_dracut_multipathd_service}" -eq "${has_overlay_multipathd_service_quickfix}"; then
+    if test "${has_fixed_dracut_multipathd_service}" -eq 1; then
         fatal "Found fixed dracut multipath module but quickfix is present too"
     else
         fatal "Found buggy dracut multipath module but quickfix is missing too"

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -213,3 +213,18 @@ if test "${has_fixed_dracut_multipathd_service}" -eq "${has_overlay_multipathd_s
     fi
 fi
 ok "either dracut multipath module fixed or quickfix present"
+
+# We need either a fixed multipathd.socket or temporary workaround, no need for both.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2008098.
+has_fixed_multipathd_socket=1
+grep -q 'ConditionPathExists=/etc/multipath.conf' /usr/lib/systemd/system/multipathd.socket || has_fixed_multipathd_socket=0
+has_overlay_multipathd_socket_quickfix=1
+test -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf || has_overlay_multipathd_socket_quickfix=0
+if test "${has_fixed_multipathd_socket}" -eq "${has_overlay_multipathd_socket_quickfix}"; then
+    if test "${has_fixed_multipathd_socket}" -eq 1; then
+        fatal "Found fixed multipathd.socket but quickfix is present too"
+    else
+        fatal "Found buggy multipathd.socket but quickfix is missing too"
+    fi
+fi
+ok "either multipathd.socket fixed or quickfix present"


### PR DESCRIPTION
This adds a dropin for 'multipathd.socket' adding the same start
conditions that are present on the service unit. It is a temporary
workaround that can be removed once the packaged one is fixed.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2008098