### PR TITLE
[rawhide] manifest: empty out cracklib-dicts

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,3 +27,9 @@ postprocess:
 packages:
   # resolved was broken out to its own package in rawhide/f35
   - systemd-resolved
+
+remove-from-packages:
+  # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.
+  # This keeps the size down and ensures nothing tries to use it, preventing us
+  # from shedding the dep eventually.
+  - [cracklib-dicts, .*]


### PR DESCRIPTION
We already ship a dropin to make libpwquality not use it. It became a
hard dep recently. We're hoping to revert that but for now, just empty
it out.

See thread at
https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.

Cherry-picked from part of 8ef41080bc2156f3f25ef9b0491539e5280f24ad.