### PR TITLE
rawhide: add iptables-legacy, pin containers-common

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,3 +29,8 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/978'
       type: pin
+  containers-common:
+    evra: 4:1-28.fc36.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/981
+      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,6 +27,9 @@ postprocess:
 packages:
   # resolved was broken out to its own package in rawhide/f35
   - systemd-resolved
+  # In F35+ need `iptables-legacy` package
+  # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
+  - iptables-legacy
 
 remove-from-packages:
   # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.


### PR DESCRIPTION
```
commit d820b2f9ef0b065814f6dffd4e38af6692dc3303
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Sep 28 16:44:00 2021 -0400

    overrides: pin to containers-common-1-28.fc36
    
    The update to containers-common-1-30.fc36 breaks creating toolbox
    containers.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/981

commit f643c59792a76873fc692cd6854a1367e2efe957
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 27 12:08:35 2021 -0400

    manifest: add iptables-legacy package
    
    In F35+ we need the `iptables-legacy` package to keep the status quo.
    See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
    
    (cherry picked from commit ff72c616808b009dbe66037934f42781ab67bf44)

```
