### PR TITLE
[rawhide] overrides: Unpin kernel 5.15.0-0.rc2.18.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,21 +14,6 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
-  kernel:
-    evr: 5.15.0-0.rc2.18.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/978'
-      type: pin
-  kernel-core:
-    evr: 5.15.0-0.rc2.18.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/978'
-      type: pin
-  kernel-modules:
-    evr: 5.15.0-0.rc2.18.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/978'
-      type: pin
   containers-common:
     evra: 4:1-28.fc36.noarch
     metadata:


### PR DESCRIPTION
Circular dep loop warnings seem to be gone now with the new kernel builds. Let's unpin
the kernel.