### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,15 +21,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-5945df5d64
       reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
       type: fast-track
-  ethtool:
-    evr: 2:5.14-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-2bbeaf7176
-      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
-      type: fast-track
-  libuv:
-    evr: 1:1.42.0-2.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-4dd44521bf
-      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
-      type: fast-track


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.