### PR TITLE
overrides: fast-track rpm-ostree-2021.11-2.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  rpm-ostree:
+    evr: 2021.11-2.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-03a5539124
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2021.11-2.fc34
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-03a5539124
+      type: fast-track


### PR DESCRIPTION
It's just sitting there in Bodhi.

We want it for its own sake, but also for
https://github.com/coreos/rpm-ostree/pull/3103 because of
https://github.com/fedora-silverblue/issue-tracker/issues/210 which can
also apply to FCOS, even if having it as a layer is likely rarer here.