### PR TITLE
initramfs: ignore `udevadm settle` errors

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
@@ -39,4 +39,4 @@ fi
 
 echo "Randomizing disk GUID"
 sgdisk --disk-guid=R --move-second-header "$PKNAME"
-udevadm settle
+udevadm settle || :

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -61,7 +61,7 @@ if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
     xfs) xfs_admin -U generate "${target}" ;;
     *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
   esac
-  udevadm settle
+  udevadm settle || :
   echo "Regenerated UUID for ${target}"
 else
   echo "No changes required for ${target} TYPE=${TYPE} UUID=${UUID}"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.sh
@@ -72,7 +72,7 @@ while true; do
             if [ -n "${DM_MPATH:-}" ]; then
                 # Since growpart does not understand device mapper, we have to use sfdisk.
                 echo ", +" | sfdisk --no-reread --no-tell-kernel --force -N "${DM_PART}" "/dev/mapper/${DM_MPATH}"
-                udevadm settle # Wait for udev-triggered kpartx to update mappings
+                udevadm settle || : # Wait for udev-triggered kpartx to update mappings
             else
                 partnum=$(cat "/sys/dev/block/${MAJMIN}/partition")
                 # XXX: ideally this'd be idempotent and we wouldn't `|| :`


### PR DESCRIPTION
We do `udevadm settle` in a few places to e.g. wait for symlinks to
update based on whatever operation we just did. But if `udevadm settle`
fails, we shouldn't fail the boot for it. It could be failing on some
completely unrelated thing (since it waits for all events).

Ideally in those scripts, we'd wait only for the specific events that we
care about. But even so, we should just opportunistically keep booting.
As a plus, even if we end up failing further down, we'll get a clearer
error.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2009662