### PR TITLE
[RFC] systemd-generators: perform ostree-remount early on

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-ostree-remount
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-ostree-remount
@@ -1,0 +1,31 @@
+#!/bin/bash
+export PATH="/usr/bin:/usr/sbin:${PATH}"
+set -euo pipefail
+
+. /usr/lib/coreos/generator-lib.sh
+
+/usr/lib/ostree/ostree-remount
+echo "done: ostree-remount"
+
+touch /run/ostree-sysroot-ro.stamp
+echo "done: /run/ostree-sysroot-ro.stamp"
+
+if test -f /run/ostree-live; then
+  echo "skip: /var on live loopback"
+  exit 0
+fi
+
+# NOTE(lucab): native libostree knows how to locate the booted stateroot.
+STATEROOT="fedora-coreos"
+# NOTE(lucab): native libostree knows how to locate the booted deployment.
+VARMOUNT=$(realpath /ostree/deploy/${STATEROOT}/deploy/*/etc/systemd/system/var.mount || echo /etc/systemd/system/var.mount)
+
+if test -s "${VARMOUNT}"; then
+  echo "skip: external var.mount"
+  exit 0
+fi
+
+mkdir -p /var
+mount --bind /ostree/deploy/${STATEROOT}/var /var
+mount -o remount,rw /var
+echo "done: bind + rw /var"


### PR DESCRIPTION
**DO NOT MERGE**: this is a crude hack to experiment around performing ostree-remount
logic early on. If working, it can live directly within ostree.