### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,9 +15,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-87e84e3404
       reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
       type: fast-track
-  dnsmasq:
-    evr: 2.86-2.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-5945df5d64
-      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
-      type: fast-track


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.