### PR TITLE
#975: bootup: ostree-remount may race with systemd-backlight and fail

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/systemd-backlight@.service.d/45-after-ostree-remount.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/systemd-backlight@.service.d/45-after-ostree-remount.conf
@@ -1,0 +1,4 @@
+# Temporary fix for https://github.com/coreos/fedora-coreos-tracker/issues/975
+# until https://github.com/ostreedev/ostree/issues/2115 is fixed.
+[Unit]
+After=ostree-remount.service


### PR DESCRIPTION
Adding a temporary fragment until ostreedev/ostree#2115 is complete.