### PR TITLE
[rawhide] Revert "overrides: pin to containers-common-1-28.fc36"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,8 +14,3 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
-  containers-common:
-    evra: 4:1-28.fc36.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/981
-      type: pin


### PR DESCRIPTION
The new podman major release (`podman-3:3.4.0-3.fc36`) seems to
make the issues with toolbox go away.

This reverts commit e3113918724d190cb047f4fb7271f14bf13205fc.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/981