### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,10 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  conmon:
-    evr: 2:2.0.30-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-87e84e3404
-      reason: https://github.com/coreos/fedora-coreos-streams/issues/377#issuecomment-926302173
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.