### PR TITLE
15fcos: change the location of Ignition report

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -85,7 +85,7 @@ fi
 # If the user supplied an Ignition config, they have the ability to enable
 # autologin themselves.  Don't automatically render them insecure, since
 # they might be running in production and booting via e.g. IPMI.
-if jq -e .userConfigProvided /var/lib/ignition/result.json &>/dev/null; then
+if jq -e .userConfigProvided /etc/.ignition-result.json &>/dev/null; then
     exit 0
 fi
 

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ignition-config.service
@@ -3,8 +3,7 @@
 [Unit]
 Description=Check if Ignition config is provided
 Before=systemd-user-sessions.service
-RequiresMountsFor=/var/lib/ignition
-ConditionPathExists=/var/lib/ignition/result.json
+ConditionPathExists=/etc/.ignition-result.json
 
 [Service]
 Type=oneshot

--- a/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ignition-config
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 set -euo pipefail
 
-IGNITION_RESULT=/var/lib/ignition/result.json
+IGNITION_RESULT=/etc/.ignition-result.json
 
 WARN='\033[0;33m' # yellow
 RESET='\033[0m' # reset


### PR DESCRIPTION
Fixes coreos/fedora-coreos-tracker#977

This change helps to address the problem of displaying a warning about running Ignition twice while reprovisioning a bare metal
CoreOS instance with a persistent /var partition.

Needs: https://github.com/coreos/ignition/pull/1267