### PR TITLE
[WIP] dracut/ignition-ostree: avoid double /sysroot/var mounts

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-var.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-var.sh
@@ -40,13 +40,26 @@ do_mount() {
         fatal "${stateroot_var_path} is not a directory"
     fi
 
-    echo "Mounting $stateroot_var_path"
-    mount --bind "$stateroot_var_path" /sysroot/var
+    rm -f /tmp/ignition-ostree-mount-var-mounted
+    findmnt_exitcode="0"
+    findmnt /sysroot/var || findmnt_exitcode="1"
+    if [ "${findmnt_exitcode}" -eq 0 ]; then
+        echo "/sysroot/var already mounted"
+    else
+        echo "Mounting $stateroot_var_path"
+        mount --bind "$stateroot_var_path" /sysroot/var
+        touch /tmp/ignition-ostree-mount-var-mounted
+    fi
+
 }
 
 do_umount() {
-    echo "Unmounting /sysroot/var"
-    umount /sysroot/var
+     if [ -f /tmp/ignition-ostree-mount-var-mounted ]; then
+         echo "Unmounting /sysroot/var"
+         umount /sysroot/var
+     else
+         echo "Leaving /sysroot/var intact"
+     fi
 }
 
 "do_$1"


### PR DESCRIPTION
This tweaks `ignition-ostree-mount-var.service` in order to avoid
mounting `/sysroot/var` (and unmounting it, on stop) if it is already
mounted.

Part of https://github.com/ostreedev/ostree/pull/2187