### PR TITLE
rework multipath fixes/tests

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -127,6 +127,35 @@ postprocess:
     ConditionVirtualization=!container
     EOF
 
+  # Put in the fix for multipathd.service in dracut on releases that haven't
+  # been fixed yet.
+  # https://github.com/dracutdevs/dracut/pull/1606
+  # https://github.com/coreos/fedora-coreos-config/pull/1233
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # This fix hasn't landed in rawhide (F36) yet, but hopefully will soon.
+    source /etc/os-release
+    [ ${VERSION_ID} -le 36 ] || exit 0
+    mkdir /usr/lib/dracut/modules.d/36coreos-multipath-fix
+    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf <<'EOF'
+    # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+    [Service]
+    ExecStop=
+    EOF
+    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh <<'EOF'
+    #!/bin/bash
+    # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+    # ex: ts=8 sw=4 sts=4 et filetype=sh
+    install() {
+        # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+        mkdir -p "$systemdsystemunitdir/multipathd.service.d"
+        inst_simple "$moddir/90-multipathd-remove-execstop.conf" \
+        "$systemdsystemunitdir/multipathd.service.d/90-multipathd-remove-execstop.conf"
+    }
+    EOF
+    chmod +x /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -107,6 +107,26 @@ postprocess:
       echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
     fi
 
+  # Put in the fix for multipathd.socket on releases that haven't been fixed yet.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2008098
+  # https://github.com/coreos/fedora-coreos-config/pull/1246
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # Only operate on releases before F36. The fix has landed in F36+ and there is no
+    # need for a workaround.
+    source /etc/os-release
+    [ ${VERSION_ID} -le 35 ] || exit 0
+    mkdir /usr/lib/systemd/system/multipathd.socket.d
+    cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'
+    # Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
+    [Unit]
+    ConditionKernelCommandLine=!multipath=off
+    ConditionKernelCommandLine=!nompath
+    ConditionPathExists=/etc/multipath.conf
+    ConditionVirtualization=!container
+    EOF
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -8,6 +8,7 @@ include:
   - networking-tools.yaml
   - system-configuration.yaml
   - user-experience.yaml
+  - shared-workarounds.yaml
 
 initramfs-args:
   - --no-hostonly
@@ -106,55 +107,6 @@ postprocess:
     if [ -z "${DEFAULT_HOSTNAME:-}" ]; then
       echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
     fi
-
-  # Put in the fix for multipathd.socket on releases that haven't been fixed yet.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2008098
-  # https://github.com/coreos/fedora-coreos-config/pull/1246
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    # Only operate on releases before F36. The fix has landed in F36+ and there is no
-    # need for a workaround.
-    source /etc/os-release
-    [ ${VERSION_ID} -le 35 ] || exit 0
-    mkdir /usr/lib/systemd/system/multipathd.socket.d
-    cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'
-    # Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
-    [Unit]
-    ConditionKernelCommandLine=!multipath=off
-    ConditionKernelCommandLine=!nompath
-    ConditionPathExists=/etc/multipath.conf
-    ConditionVirtualization=!container
-    EOF
-
-  # Put in the fix for multipathd.service in dracut on releases that haven't
-  # been fixed yet.
-  # https://github.com/dracutdevs/dracut/pull/1606
-  # https://github.com/coreos/fedora-coreos-config/pull/1233
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    # This fix hasn't landed in rawhide (F36) yet, but hopefully will soon.
-    source /etc/os-release
-    [ ${VERSION_ID} -le 36 ] || exit 0
-    mkdir /usr/lib/dracut/modules.d/36coreos-multipath-fix
-    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf <<'EOF'
-    # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
-    [Service]
-    ExecStop=
-    EOF
-    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh <<'EOF'
-    #!/bin/bash
-    # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
-    # ex: ts=8 sw=4 sts=4 et filetype=sh
-    install() {
-        # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
-        mkdir -p "$systemdsystemunitdir/multipathd.service.d"
-        inst_simple "$moddir/90-multipathd-remove-execstop.conf" \
-        "$systemdsystemunitdir/multipathd.service.d/90-multipathd-remove-execstop.conf"
-    }
-    EOF
-    chmod +x /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh
 
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go

--- a/manifests/shared-workarounds.yaml
+++ b/manifests/shared-workarounds.yaml
@@ -1,0 +1,64 @@
+# This manifest is a list of shared workarounds that are needed in both Fedora CoreOS
+# and downstreams (i.e. Red Hat CoreOS).
+
+postprocess:
+  # Put in the fix for multipathd.socket on releases that haven't been fixed yet.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2008098
+  # https://github.com/coreos/fedora-coreos-config/pull/1246
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # Operate on RHCOS and FCOS. 
+    source /etc/os-release
+    if [[ ${NAME} =~ "Fedora" ]]; then
+        # FCOS: Only operate on releases before F36. The fix has landed
+        # in F36+ and there is no need for a workaround.
+        [ ${VERSION_ID} -le 35 ] || exit 0
+    else 
+        # RHCOS: The fix hasn't landed in any version of RHEL yet
+        true
+    fi
+    mkdir /usr/lib/systemd/system/multipathd.socket.d
+    cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'
+    # Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
+    [Unit]
+    ConditionKernelCommandLine=!multipath=off
+    ConditionKernelCommandLine=!nompath
+    ConditionPathExists=/etc/multipath.conf
+    ConditionVirtualization=!container
+    EOF
+
+  # Put in the fix for multipathd.service in dracut on releases that haven't
+  # been fixed yet.
+  # https://github.com/dracutdevs/dracut/pull/1606
+  # https://github.com/coreos/fedora-coreos-config/pull/1233
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    source /etc/os-release
+    if [[ ${NAME} =~ "Fedora" ]]; then
+        # FCOS: This fix hasn't landed in rawhide (F36) yet,
+        # but hopefully will soon.
+        [ ${VERSION_ID} -le 36 ] || exit 0
+    else 
+        # RHCOS: The fix hasn't landed in any version of RHEL yet
+        true
+    fi
+    mkdir /usr/lib/dracut/modules.d/36coreos-multipath-fix
+    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf <<'EOF'
+    # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+    [Service]
+    ExecStop=
+    EOF
+    cat > /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh <<'EOF'
+    #!/bin/bash
+    # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+    # ex: ts=8 sw=4 sts=4 et filetype=sh
+    install() {
+        # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
+        mkdir -p "$systemdsystemunitdir/multipathd.service.d"
+        inst_simple "$moddir/90-multipathd-remove-execstop.conf" \
+        "$systemdsystemunitdir/multipathd.service.d/90-multipathd-remove-execstop.conf"
+    }
+    EOF
+    chmod +x /usr/lib/dracut/modules.d/36coreos-multipath-fix/module-setup.sh

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf
@@ -1,3 +1,0 @@
-# Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
-[Service]
-ExecStop=

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -12,11 +12,6 @@ install_ignition_unit() {
 }
 
 install() {
-    # Temporary workaround for https://github.com/dracutdevs/dracut/pull/1606.
-    mkdir -p "$systemdsystemunitdir/multipathd.service.d"
-    inst_simple "$moddir/90-multipathd-remove-execstop.conf" \
-        "$systemdsystemunitdir/multipathd.service.d/90-multipathd-remove-execstop.conf"
-
     inst_script "$moddir/coreos-propagate-multipath-conf.sh" \
         "/usr/sbin/coreos-propagate-multipath-conf"
 

--- a/overlay.d/05core/usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf
@@ -1,6 +1,0 @@
-# Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
-[Unit]
-ConditionKernelCommandLine=!multipath=off
-ConditionKernelCommandLine=!nompath
-ConditionPathExists=/etc/multipath.conf
-ConditionVirtualization=!container

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -219,7 +219,7 @@ ok "either dracut multipath module fixed or quickfix present"
 has_fixed_multipathd_socket=1
 grep -q 'ConditionPathExists=/etc/multipath.conf' /usr/lib/systemd/system/multipathd.socket || has_fixed_multipathd_socket=0
 has_overlay_multipathd_socket_quickfix=1
-test -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf || has_overlay_multipathd_socket_quickfix=0
+test -f /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf || has_overlay_multipathd_socket_quickfix=0
 if test "${has_fixed_multipathd_socket}" -eq "${has_overlay_multipathd_socket_quickfix}"; then
     if test "${has_fixed_multipathd_socket}" -eq 1; then
         fatal "Found fixed multipathd.socket but quickfix is present too"

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -204,7 +204,7 @@ ok "All initrd scripts are executable"
 has_fixed_dracut_multipathd_service=0
 grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service || has_fixed_dracut_multipathd_service=1
 has_overlay_multipathd_service_quickfix=1
-test -f /usr/lib/dracut/modules.d/35coreos-multipath/90-multipathd-remove-execstop.conf || has_overlay_multipathd_service_quickfix=0
+test -f /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf || has_overlay_multipathd_service_quickfix=0
 if test "${has_fixed_dracut_multipathd_service}" -eq "${has_overlay_multipathd_service_quickfix}"; then
     if test "${has_fixed_dracut_multipathd_service}" -eq 1; then
         fatal "Found fixed dracut multipath module but quickfix is present too"

--- a/tests/kola/misc-ro
+++ b/tests/kola/misc-ro
@@ -198,33 +198,3 @@ if find ${tmpd}/usr/{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-commo
 fi
 rm -r ${tmpd}
 ok "All initrd scripts are executable"
-
-# We need either a fixed dracut or temporary workaround, no need for both.
-# See https://github.com/coreos/fedora-coreos-tracker/issues/803.
-has_fixed_dracut_multipathd_service=0
-grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service || has_fixed_dracut_multipathd_service=1
-has_overlay_multipathd_service_quickfix=1
-test -f /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf || has_overlay_multipathd_service_quickfix=0
-if test "${has_fixed_dracut_multipathd_service}" -eq "${has_overlay_multipathd_service_quickfix}"; then
-    if test "${has_fixed_dracut_multipathd_service}" -eq 1; then
-        fatal "Found fixed dracut multipath module but quickfix is present too"
-    else
-        fatal "Found buggy dracut multipath module but quickfix is missing too"
-    fi
-fi
-ok "either dracut multipath module fixed or quickfix present"
-
-# We need either a fixed multipathd.socket or temporary workaround, no need for both.
-# See https://bugzilla.redhat.com/show_bug.cgi?id=2008098.
-has_fixed_multipathd_socket=1
-grep -q 'ConditionPathExists=/etc/multipath.conf' /usr/lib/systemd/system/multipathd.socket || has_fixed_multipathd_socket=0
-has_overlay_multipathd_socket_quickfix=1
-test -f /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf || has_overlay_multipathd_socket_quickfix=0
-if test "${has_fixed_multipathd_socket}" -eq "${has_overlay_multipathd_socket_quickfix}"; then
-    if test "${has_fixed_multipathd_socket}" -eq 1; then
-        fatal "Found fixed multipathd.socket but quickfix is present too"
-    else
-        fatal "Found buggy multipathd.socket but quickfix is missing too"
-    fi
-fi
-ok "either multipathd.socket fixed or quickfix present"

--- a/tests/kola/multipath/multipathd-service-fix
+++ b/tests/kola/multipath/multipathd-service-fix
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Just run on qemu since the answer is the same everywhere
+# kola: { "exclusive": false, "platforms": "qemu-unpriv" }
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# We need either a fixed dracut or temporary workaround, no need for both.
+# See https://github.com/coreos/fedora-coreos-tracker/issues/803.
+has_fixed_dracut_multipathd_service=0
+grep -q 'ExecStop=/sbin/multipathd shutdown' /usr/lib/dracut/modules.d/90multipath/multipathd.service || has_fixed_dracut_multipathd_service=1
+has_overlay_multipathd_service_quickfix=1
+test -f /usr/lib/dracut/modules.d/36coreos-multipath-fix/90-multipathd-remove-execstop.conf || has_overlay_multipathd_service_quickfix=0
+if test "${has_fixed_dracut_multipathd_service}" -eq "${has_overlay_multipathd_service_quickfix}"; then
+    if test "${has_fixed_dracut_multipathd_service}" -eq 1; then
+        fatal "Found fixed dracut multipath module but quickfix is present too"
+    else
+        fatal "Found buggy dracut multipath module but quickfix is missing too"
+    fi
+fi
+ok "either dracut multipath module fixed or quickfix present"

--- a/tests/kola/multipath/multipathd-socket-fix
+++ b/tests/kola/multipath/multipathd-socket-fix
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Just run on qemu since the answer is the same everywhere
+# kola: { "exclusive": false, "platforms": "qemu-unpriv" }
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# We need either a fixed multipathd.socket or temporary workaround, no need for both.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2008098.
+has_fixed_multipathd_socket=1
+grep -q 'ConditionPathExists=/etc/multipath.conf' /usr/lib/systemd/system/multipathd.socket || has_fixed_multipathd_socket=0
+has_overlay_multipathd_socket_quickfix=1
+test -f /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf || has_overlay_multipathd_socket_quickfix=0
+if test "${has_fixed_multipathd_socket}" -eq "${has_overlay_multipathd_socket_quickfix}"; then
+    if test "${has_fixed_multipathd_socket}" -eq 1; then
+        fatal "Found fixed multipathd.socket but quickfix is present too"
+    else
+        fatal "Found buggy multipathd.socket but quickfix is missing too"
+    fi
+fi
+ok "either multipathd.socket fixed or quickfix present"


### PR DESCRIPTION
This will enable us to apply the workarounds on specific fedora versions.

```
commit 3805d6943d3bca05ebe184cac1fd0af7708431ee
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 12 10:03:13 2021 -0400

    move multipathd.service workaround from overlay to manifest postprocess
    
    This will allow us to conditionalize it based on the major Fedora
    version when the fix starts landing in Fedora Linux (starting with
    Rawhide). This also moves the workaround into a new dracut module
    (36coreos-multipath-fix) and out of the old module (35coreos-multipath)
    to make it easier to add from postprocess.

commit 46d06effd5718ef50c9040674e8822b102ee4a0f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 12 09:55:40 2021 -0400

    move multipathd.socket workaround from overlay to manifest postprocess
    
    This will allow us to conditionalize it based on the major Fedora
    version. The fix has currently landed in rawhide but not F35 and
    we want to continue to execute the check everywhere.

commit 537bb8937686f0fc646b7551544e351cb4fa0525
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 12 09:36:21 2021 -0400

    tests: fix mulipathd.socket test
    
    I believe it should be testing for the existence of
    /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf.
    
    Fixup for 28d5409

```
