### PR TITLE
kola/var-mount: change to use by-partuuid to accomodate s390x

### DIFF
--- a/tests/kola/var-mount/simple/config.bu
+++ b/tests/kola/var-mount/simple/config.bu
@@ -5,16 +5,18 @@ storage:
     - device: /dev/vda
       partitions:
         - label: var
+          guid: 63194b49-e4b7-43f9-9a8b-df0fd8279bb7
           size_mib: 1000
           start_mib: 5000
         - label: varlog
+          guid: 6385b84e-2c7b-4488-a870-667c565e01a8
       wipe_table: false
   filesystems:
-    - device: /dev/disk/by-partlabel/var
+    - device: /dev/disk/by-partuuid/63194b49-e4b7-43f9-9a8b-df0fd8279bb7
       format: xfs
       path: /var
       with_mount_unit: true
-    - device: /dev/disk/by-partlabel/varlog
+    - device: /dev/disk/by-partuuid/6385b84e-2c7b-4488-a870-667c565e01a8
       format: ext4
       path: /var/log
       with_mount_unit: true

--- a/tests/kola/var-mount/simple/test.sh
+++ b/tests/kola/var-mount/simple/test.sh
@@ -16,7 +16,7 @@ fatal() {
 # /var
 
 src=$(findmnt -nvr /var -o SOURCE)
-[[ $(realpath "$src") == $(realpath /dev/disk/by-partlabel/var) ]]
+[[ $(realpath "$src") == $(realpath /dev/disk/by-partuuid/63194b49-e4b7-43f9-9a8b-df0fd8279bb7) ]]
 
 fstype=$(findmnt -nvr /var -o FSTYPE)
 [[ $fstype == xfs ]]
@@ -24,7 +24,7 @@ fstype=$(findmnt -nvr /var -o FSTYPE)
 # /var/log
 
 src=$(findmnt -nvr /var/log -o SOURCE)
-[[ $(realpath "$src") == $(realpath /dev/disk/by-partlabel/varlog) ]]
+[[ $(realpath "$src") == $(realpath /dev/disk/by-partuuid/6385b84e-2c7b-4488-a870-667c565e01a8) ]]
 
 fstype=$(findmnt -nvr /var/log -o FSTYPE)
 [[ $fstype == ext4 ]]


### PR DESCRIPTION
by-partlabel doesn't work for s390x because of https://bugzilla.redhat.com/show_bug.cgi?id=1899990.This addresses https://github.com/openshift/os/issues/648