### PR TITLE
denylist: snooze rpmostree.install-uninstall for F35/F36 streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,3 +11,9 @@
   platforms:
     - aws
     - gce
+- pattern: rpmostree.install-uninstall
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/996
+  snooze: 2021-10-17
+  streams:
+    - rawhide
+    - next-devel


### PR DESCRIPTION
One of the remote yum repositories has an infra issue and is causing
the test to fail.

See https://github.com/coreos/fedora-coreos-tracker/issues/996