### PR TITLE
manifests: Move afterburn-dracut to shared system-configuration manifest

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -116,8 +116,6 @@ packages:
   - crun
   # Security
   - polkit
-  # System setup
-  - afterburn-dracut
   # SSH
   - ssh-key-dir
   # Containers

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -5,6 +5,7 @@
 packages:
   # Configuring SSH keys, cloud provider check-in, etc
   - afterburn
+  - afterburn-dracut
   # NTP support
   - chrony
   # Installing CoreOS itself


### PR DESCRIPTION
This sub package split will also be reflected in RHCOS.