### PR TITLE
denylist: snooze ostree.hotfix in rawhide on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,3 +17,10 @@
   streams:
     - rawhide
     - next-devel
+- pattern: ostree.hotfix
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
+  snooze: 2021-10-25
+  streams:
+    - rawhide
+  arches:
+    - aarch64


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/942
We need someone to dig into why.