### PR TITLE
denylist: remove snooze on podman.base and rpmostree.install-uninstall

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,12 +5,6 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: podman.base
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/966
-  snooze: 2021-10-20
-  platforms:
-    - aws
-    - gce
 - pattern: ostree.hotfix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
   snooze: 2021-10-25

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,12 +11,6 @@
   platforms:
     - aws
     - gce
-- pattern: rpmostree.install-uninstall
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/996
-  snooze: 2021-10-17
-  streams:
-    - rawhide
-    - next-devel
 - pattern: ostree.hotfix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
   snooze: 2021-10-25


### PR DESCRIPTION
```
commit 5d1cadff1a146b290da8004285d6b304fa604a47
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 18 13:14:07 2021 -0400

    denylist: remove snooze on podman.base
    
    The fix landed in podman v3.4.0.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/966

commit 348281b0ccd1139a39a87fd22f8f6ab3fb25d56e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Oct 18 12:55:44 2021 -0400

    Revert "denylist: snooze rpmostree.install-uninstall for F35/F36 streams"
    
    This reverts commit 146b8d013b54e269464b82f80fe4997bfde7e1e3.
    The underlying issue is now fixed. See
    https://bugzilla.redhat.com/show_bug.cgi?id=2014514
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/996

```
