### PR TITLE
[testing] manifests/fedora-coreos-base: explicitly add `xen-blkfront` to initrd

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -21,6 +21,10 @@ initramfs-args:
   # Omit these since we don't use them
   - --omit=lvm
   - --omit=iscsi
+  # Dracut currently fails to add xen-blkfront driver on 5.14 kernels
+  # https://github.com/coreos/fedora-coreos-tracker/issues/997
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2010058
+  - --add-drivers=xen-blkfront
 
 # Be minimal
 recommends: false

--- a/tests/kola/storage/tracker-997-workaround
+++ b/tests/kola/storage/tracker-997-workaround
@@ -1,0 +1,18 @@
+#!/bin/bash
+# kola: { "exclusive": false, "architectures": "x86_64" }
+
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if grep -q blk_mq_alloc_disk /usr/lib/dracut/modules.d/90kernel-modules/module-setup.sh; then
+    fatal "BZ 2010058 fixed; revert coreos/fedora-coreos-config#1289"
+fi
+ok "BZ 2010058 unfixed"


### PR DESCRIPTION
Dracut currently fails to do this for 5.14 kernels, breaking boot on Xen-based EC2 instances.

Addresses https://github.com/coreos/fedora-coreos-tracker/issues/997.  Backports https://github.com/coreos/fedora-coreos-config/pull/1289.