### PR TITLE
Add Kubernetes e2e node tests

### DIFF
--- a/tests/kola/k8s/node-e2e/config.bu
+++ b/tests/kola/k8s/node-e2e/config.bu
@@ -1,0 +1,14 @@
+variant: fcos
+version: 1.3.0
+ignition:
+  config:
+    merge:
+      # XXX: what this config does should probably be folded into the test
+      # directly instead so that the release-specific cri-o is used
+      - source: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/crio/crio_cgrpv2.ign
+storage:
+  filesystems:
+    - device: /dev/disk/by-id/virtio-disk1
+      format: xfs
+      path: /var
+      with_mount_unit: true

--- a/tests/kola/k8s/node-e2e/data/node-e2e
+++ b/tests/kola/k8s/node-e2e/data/node-e2e
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -xeuo pipefail
+
+SELF=$(realpath "$0")
+IMAGE=quay.io/projectquay/golang:1.17
+
+branch=$1; shift
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ -z "${container:-}" ]; then
+    mkdir -m 0600 ~/.ssh
+    ssh-keygen -N "" -t ed25519 -f /srv/kube
+    cat /srv/kube.pub >> ~/.ssh/authorized_keys
+    chmod 0600 ~/.ssh/*
+    exec podman run --net=host --rm -v /srv/kube:/srv/kube:z \
+        -v "${KOLA_EXT_DATA}:/srv/kola_ext_data:z" \
+        -v "${SELF}:/srv/self:z" "${IMAGE}" /srv/self "${branch}"
+    fatal "unreachable"
+fi
+
+# in container now
+dnf install -y rsync diffutils hostname
+git clone -b "${branch}" --depth 1 https://github.com/kubernetes/kubernetes
+make -C kubernetes test-e2e-node REMOTE=true REMOTE_MODE=ssh SSH_USER=root \
+    RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT="unix:///var/run/crio/crio.sock" \
+    SSH_KEY=/srv/kube HOSTS=localhost FOCUS="\[NodeConformance\]" \
+    SSH_OPTIONS='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' \
+    TEST_ARGS='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true
+                                --cgroup-root=/ --non-masquerade-cidr=0.0.0.0/0
+                                --runtime-cgroups=/system.slice/crio.service
+                                --kubelet-cgroups=/system.slice/kubelet.service"'

--- a/tests/kola/k8s/node-e2e/master
+++ b/tests/kola/k8s/node-e2e/master
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -xeuo pipefail
+# Just run on x86_64 for now. We'd need multi-arch images with go 1.17. We
+# could run on any platform, though need to replace `additionalDisks` by e.g.
+# `minDiskSpace` or something similar.
+# kola: {"minMemory": 4096, "timeoutMin": 45, "additionalDisks": ["15G"], "platforms": "qemu", "architectures": "x86_64", "requiredTag": "k8s", "tags": "needs-internet"}
+exec "${KOLA_EXT_DATA}/node-e2e" "${KOLA_TEST_EXE}"


### PR DESCRIPTION
This patch adds new external tests which run the Kubernetes e2e node
tests. This will ensure that we don't inadvertedly break Kubernetes,
which is now itself tested on Fedora CoreOS.

The approach taken here is to model it as an external test. This makes
it easy for anyone to run it locally, which is important for
maintenance.

Note that these tests do *not* run by default: for now, I don't think we
should run these tests on every PR. They take a lot of resources and
time and it's not clear yet how flaky they'll be. Instead, we'll start
off by running them in the pipeline as a follow-on job. But as a next
step, I'd like to enable opt-in PR testing as well as testing as part of
the lockfile bumper.

One thing worth noting that makes it very different from a regular
external test is that the test binaries are built in the VM itself. This
is because (1) we may need newer golang than we have available in cosa,
and (2) cloning and building Kubernetes multiple times (per tested
release) is heavy and takes enough space that it's nicer to have it be
lifecycled to the VM itself, where it can be resource-constrained and
e.g. parallelized easily. For faster iteration, one can always just do
the same thing the test script does to build on the host and point the
k8s test harness at a pre-provisioned host.

Requires: https://github.com/coreos/coreos-assembler/pull/2505
Requires: https://github.com/kubernetes/kubernetes/pull/105764