### PR TITLE
denylist: don't run tracker #997 workaround test on rawhide/next/next-devel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,3 +12,9 @@
     - rawhide
   arches:
     - aarch64
+- pattern: ext.config.storage.tracker-997-workaround
+  tracker: https://github.com/coreos/fedora-coreos-config/pull/1289#issuecomment-947052725
+  streams:
+    - rawhide
+    - next-devel
+    - next


### PR DESCRIPTION
The fix has already made it to rawhide. Instead of shuffling the
denylist every time it hits a new stream deny them all until it reaches
`testing-devel` at which point we can just remove the test entirely.