### PR TITLE
 overlay.d: add udev rule for creating stable symlink to boot disk

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-fs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-fs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# checks whether `disk` contains filesystem labeled `label`
+set -euo pipefail
+
+disk=$1
+label=$2
+
+# during execution of udev rules on disks 'lsblk' returns empty fields
+for pt in /sys/block/$disk/*; do
+    name=$(basename $pt)
+    if [[ "$name" =~ ${disk}p?[[:digit:]] ]] && [[ -e "/sys/block/$disk/$name/start" ]];
+    then
+        eval $(udevadm info --query=property -n /dev/$name | grep -e ID_FS_LABEL -e PARTNAME)
+        if [[ "${ID_FS_LABEL:-}" == "$label" ]] || [[ "${PARTNAME:-}" == "$label" ]]; then
+            exit 0
+        fi
+    fi
+done
+
+exit 1

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -211,6 +211,8 @@ main() {
     # clean it up so that no information from outside of the
     # real root is passed on to NetworkManager in the real root
     rm -rf /run/NetworkManager/
+
+    rm -rf /dev/disk/by-id/coreos-boot-disk
 }
 
 main

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -22,6 +22,7 @@ install() {
         diff \
         lsblk \
         sed \
+        grep \
         sgdisk
 
     inst_simple "$moddir/coreos-diskful-generator" \
@@ -29,6 +30,11 @@ install() {
 
     inst_script "$moddir/coreos-gpt-setup.sh" \
         "/usr/sbin/coreos-gpt-setup"
+
+    inst_simple "/usr/lib/udev/rules.d/80-coreos-boot-disk.rules"
+
+    inst_script "$moddir/coreos-disk-contains-fs.sh" \
+        "/usr/lib/udev/coreos-disk-contains-fs"
 
     inst_script "$moddir/coreos-ignition-setup-user.sh" \
         "/usr/sbin/coreos-ignition-setup-user"

--- a/overlay.d/05core/usr/lib/udev/rules.d/80-coreos-boot-disk.rules
+++ b/overlay.d/05core/usr/lib/udev/rules.d/80-coreos-boot-disk.rules
@@ -1,0 +1,10 @@
+# CoreOS-specific symlink for boot disk
+
+ACTION!="add|change", GOTO="stable_boot_end"
+SUBSYSTEM!="block", GOTO="stable_boot_end"
+
+ENV{DEVTYPE}=="disk" \
+  , PROGRAM=="coreos-disk-contains-fs $name boot" \
+  , SYMLINK+="disk/by-id/coreos-boot-disk"
+
+LABEL="stable_boot_end"

--- a/tests/kola/ignition/stable-boot/config.bu
+++ b/tests/kola/ignition/stable-boot/config.bu
@@ -1,0 +1,15 @@
+variant: fcos
+version: 1.3.0
+storage:
+  disks:
+  - device: /dev/disk/by-id/coreos-boot-disk
+    wipe_table: false
+    partitions:
+    - number: 5
+      size_mib: 1024
+      label: toor
+  filesystems:
+    - path: /var/lib/toor
+      device: /dev/disk/by-partlabel/toor
+      format: ext4
+      with_mount_unit: true

--- a/tests/kola/ignition/stable-boot/test.sh
+++ b/tests/kola/ignition/stable-boot/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This test makes sure that ignition is able to use `coreos-boot-disk` symlink
+
+# We don't need to test this on every platform. If it passes in
+# one place it will pass everywhere.
+# kola: { "platforms": "qemu-unpriv" }
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# symlink shouldn't be propogated to real-root
+link="/dev/disk/by-id/coreos-boot-disk"
+if [[ -h "${link}" ]]; then
+    fatal "${link} still exists"
+fi
+
+# sanity-check that the root disk has all required partitions
+findmnt -nvr -o SOURCE /boot
+findmnt -nvr -o SOURCE /sysroot
+toor=$(findmnt -nvr -o SOURCE /var/lib/toor)
+if [[ ! "$toor" =~ ^/dev/[a-z0-9]+p?5$ ]]; then
+    fatal "${toor} is not 5th partition"
+fi


### PR DESCRIPTION
Creates '/dev/disk/coreos-root-disk' symlink to boot disk for
use by Ignition config, therefore 'storage.disks' section
could be defined without hardcoding /dev/sda, /dev/vda, etc.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/759
