### PR TITLE
tests/kola: provision swap before root and resize to fill

### DIFF
--- a/tests/kola/root-reprovision/swap-before-root/config.bu
+++ b/tests/kola/root-reprovision/swap-before-root/config.bu
@@ -1,0 +1,23 @@
+variant: fcos
+version: 1.4.0
+
+storage:
+  disks:
+    - device: /dev/vda
+      partitions:
+        - number: 4
+          label: swap
+          size_mib: 512
+          wipe_partition_entry: true
+        - number: 5
+          label: root
+  filesystems:
+    - device: /dev/disk/by-partlabel/swap
+      label: swap
+      format: swap
+      wipe_filesystem: true
+      with_mount_unit: true
+    - device: /dev/disk/by-partlabel/root
+      label: root
+      format: xfs
+      wipe_filesystem: true

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096}
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+swapstatus=$(systemctl is-active dev-disk-by\\x2dpartlabel-swap.swap)
+[[ ${swapstatus} == active ]]
+ok "swap is active"
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+ok "source is xfs"
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      ok "found root karg"
+      ;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac


### PR DESCRIPTION
This tests creating a defined sized partition before the root
filesystem, moving the default root partition from number 4 to 5
and allowing it to fill the rest of the device.  It also tests the
creation and mounting of swap.