### PR TITLE
coreos-boot-edit: run `rdcore bind-boot`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
@@ -34,18 +34,12 @@ if [ -z "${root}" ]; then
     rdcore rootmap /sysroot --boot-mount ${bootmnt}
 fi
 
-# And similarly, only inject boot= if it's not already present.
-boot=$(karg boot)
-if [ -z "${boot}" ]; then
-    # XXX: `rdcore rootmap --inject-boot-karg` or maybe `rdcore bootmap`
-    eval $(blkid -o export "${bootdev}")
-    if [ -z "${UUID}" ]; then
-        # This should never happen
-        echo "Boot filesystem ${bootdev} has no UUID" >&2
-        exit 1
-    fi
-    rdcore kargs --boot-mount ${bootmnt} --append boot=UUID=${UUID}
-    # but also put it in /run for the first boot real root mount
-    mkdir -p /run/coreos
-    echo "${UUID}" > /run/coreos/bootfs_uuid
-fi
+# This does a few things:
+# 1. it puts the boot UUID in /run/coreos/bootfs_uuid which is used by the real
+#    root for mounting the bootfs in this boot
+# 2. it adds a boot=UUID= karg which is used by the real root for mounting the
+#    bootfs in subsequent boots
+# 3. it create a .root_uuid stamp file on the bootfs or fails if one exists
+# 4. it adds GRUB bootuuid.cfg dropins so that GRUB selects the boot filesystem
+#    by UUID
+rdcore bind-boot /sysroot ${bootmnt}


### PR DESCRIPTION
This binds the bootloader to the bootfs and the bootfs to the rootfs.

Part of https://github.com/coreos/fedora-coreos-tracker/issues/976.