### PR TITLE
switch default networking config to ip=auto

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -11,7 +11,7 @@ extra-kargs:
     - mitigations=auto,nosmt
 
 # Disable networking by default on firstboot. We can drop this once cosa stops
-# defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
+# defaulting to `ip=auto rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
 # Optional remote by which to prefix the deployed OSTree ref

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -30,6 +30,9 @@ dracut_func() {
 # If it matches then it was the default, if not then the user provided
 # something extra.
 are_default_NM_configs() {
+    # pick up our CoreOS default networking kargs from the afterburn dropin
+    DEFAULT_KARGS_FILE=/usr/lib/systemd/system/afterburn-network-kargs.service.d/50-afterburn-network-kargs-default.conf
+    source <(grep -o 'AFTERBURN_NETWORK_KARGS_DEFAULT=.*' $DEFAULT_KARGS_FILE)
     # Make two dirs for storing files to use in the comparison
     mkdir -p /run/coreos-teardown-initramfs/connections-compare-{1,2}
     # Make another that's just a throwaway for the initrd-data-dir
@@ -40,7 +43,7 @@ are_default_NM_configs() {
     # Do a new run with the default input
     /usr/libexec/nm-initrd-generator \
         -c /run/coreos-teardown-initramfs/connections-compare-2 \
-        -i /run/coreos-teardown-initramfs/initrd-data-dir -- ip=auto
+        -i /run/coreos-teardown-initramfs/initrd-data-dir -- $AFTERBURN_NETWORK_KARGS_DEFAULT
     # remove unique identifiers from the files (so our diff can work)
     sed -i '/^uuid=/d' /run/coreos-teardown-initramfs/connections-compare-{1,2}/*
     # currently the output will differ based on whether rd.neednet=1

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -40,7 +40,7 @@ are_default_NM_configs() {
     # Do a new run with the default input
     /usr/libexec/nm-initrd-generator \
         -c /run/coreos-teardown-initramfs/connections-compare-2 \
-        -i /run/coreos-teardown-initramfs/initrd-data-dir -- ip=dhcp,dhcp6
+        -i /run/coreos-teardown-initramfs/initrd-data-dir -- ip=auto
     # remove unique identifiers from the files (so our diff can work)
     sed -i '/^uuid=/d' /run/coreos-teardown-initramfs/connections-compare-{1,2}/*
     # currently the output will differ based on whether rd.neednet=1

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-afterburn-network-kargs-default.conf
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/50-afterburn-network-kargs-default.conf
@@ -4,4 +4,4 @@
 # https://github.com/coreos/fedora-coreos-tracker/issues/460
 
 [Service]
-Environment=AFTERBURN_NETWORK_KARGS_DEFAULT='ip=dhcp,dhcp6'
+Environment=AFTERBURN_NETWORK_KARGS_DEFAULT='ip=auto'

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# No need to run on any other platform than QEMU.
+# kola: { "exclusive": false, "platforms": "qemu-unpriv" }
+set -xeuo pipefail
+
+# Since we depend so much on the default networking configurations let's
+# alert ourselves when any default networking configuration changes in
+# NetworkManager. This allows us to react and adjust to the changes
+# (if needed) instead of finding out later that problems were introduced.
+# some context in: https://github.com/coreos/fedora-coreos-tracker/issues/1000
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# EXPECTED_INITRD_NETWORK_CFG1
+#   - used on FCOS 35+ releases
+EXPECTED_INITRD_NETWORK_CFG1="[connection]
+id=Wired Connection
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-retries=1
+multi-connect=3
+permissions=
+
+[ethernet]
+mac-address-blacklist=
+
+[ipv4]
+dhcp-timeout=90
+dns-search=
+method=auto
+required-timeout=20000
+
+[ipv6]
+addr-gen-mode=eui64
+dhcp-timeout=90
+dns-search=
+method=auto
+
+[proxy]
+
+[user]
+org.freedesktop.NetworkManager.origin=nm-initrd-generator"
+# EXPECTED_INITRD_NETWORK_CFG2
+#   - used on all RHCOS releases
+#   - used on FCOS F34
+EXPECTED_INITRD_NETWORK_CFG2="[connection]
+id=Wired Connection
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-retries=1
+multi-connect=3
+permissions=
+
+[ethernet]
+mac-address-blacklist=
+
+[ipv4]
+dhcp-timeout=90
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=eui64
+dhcp-timeout=90
+dns-search=
+method=auto
+
+[proxy]"
+
+# EXPECTED_REALROOT_NETWORK_CFG1:
+#   - used on all FCOS/RHCOS releases
+EXPECTED_REALROOT_NETWORK_CFG1="[connection]
+id=Wired connection 1
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-priority=-999
+interface-name=xxxx
+permissions=
+timestamp=xxxxxxxxxx
+
+[ethernet]
+mac-address-blacklist=
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]
+
+[.nmmeta]
+nm-generated=true"
+
+# Function that will remove unique (per-run) data from a connection file
+normalize_connection_file() {
+    sed -e s/^uuid=.*$/uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/ \
+        -e s/^timestamp=.*$/timestamp=xxxxxxxxxx/                 \
+        -e s/^interface-name=.*$/interface-name=xxxx/             \
+        $1
+}
+
+source /etc/os-release
+# All current FCOS releases use the same config
+if [ "$ID" == "fedora" ]; then
+    if [ "$VERSION_ID" -eq "34" ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG2
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
+    elif [ "$VERSION_ID" -ge "35" ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG1
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
+    else
+        fatal "fail: not operating on expected OS version"
+    fi
+elif [ "$ID" == "rhcos" ]; then
+    # For the version comparison use string substitution to remove the
+    # '.` from the version so we can use integer comparison
+    RHCOS_MINIMUM_VERSION="4.9"
+    if [ "${VERSION_ID/\./}" -ge "${RHCOS_MINIMUM_VERSION/\./}" ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG2
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
+    else
+        fatal "fail: not operating on expected OS version"
+    fi
+else
+    fatal "fail: not operating on expected OS"
+fi
+
+
+# Execute nm-initrd-generator against our default kargs (defined by
+# afterburn drop in) to get the generated initrd network config.
+DEFAULT_KARGS_FILE=/usr/lib/dracut/modules.d/35coreos-network/50-afterburn-network-kargs-default.conf 
+source <(grep -o 'AFTERBURN_NETWORK_KARGS_DEFAULT=.*' $DEFAULT_KARGS_FILE)
+tmpdir=$(mktemp -d)
+/usr/libexec/nm-initrd-generator \
+    -c "${tmpdir}/connections" \
+    -i "${tmpdir}/initrd-data-dir" \
+    -r "${tmpdir}/conf.d" \
+    -- $AFTERBURN_NETWORK_KARGS_DEFAULT
+GENERATED_INITRD_NETWORK_CFG=$(normalize_connection_file \
+                               "${tmpdir}/connections/default_connection.nmconnection")
+
+# Diff the outputs and fail if the expected doesn't match the generated.
+if ! diff -u <(echo "$EXPECTED_INITRD_NETWORK_CFG") <(echo "$GENERATED_INITRD_NETWORK_CFG"); then
+    fatal "fail: the expected initrd network config is not given by the kargs"
+fi
+
+# Check the default NetworkManager runtime generated connection profile in
+# the real root to make sure it matches what we expect.
+GENERATED_REALROOT_NETWORK_CFG=$(normalize_connection_file \
+                                 <(sudo cat "/run/NetworkManager/system-connections/Wired connection 1.nmconnection"))
+if ! diff -u <(echo "$EXPECTED_REALROOT_NETWORK_CFG") <(echo "$GENERATED_REALROOT_NETWORK_CFG"); then
+    fatal "fail: the expected realroot network config is not given by the kargs"
+fi
+
+ok "success: expected network configs were generated"


### PR DESCRIPTION

```
commit 0411655054315530aa6587a0fdea182db08b76eb
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Nov 4 14:46:15 2021 -0400

    coreos-teardown-initramfs: pick up default net cfg from afterburn dropin
    
    This way we can only define it in one place.

commit ba49263d64b0834b904c6ec8ea59c6e3a66c47b7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 2 14:51:36 2021 -0400

    switch default networking config to ip=auto
    
    Upstream NM changed the behavior of `ip=dhcp,dhcp6` to also wait
    20 seconds for DHCPv6. We don't want to require all users by default
    to wait for DHCPv6 especially when it's doubtful most users even have
    a ipv6 DHCP server. We can stick with our current behavior by utilizing
    `ip=auto` instead.
    
    Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1000

commit d8555698bc3398fb017d0a098651bec909dca4e3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 2 14:31:40 2021 -0400

    tests: add test for default networking configuration
    
    Since we depend so much on the default networking configurations let's
    alert ourselves when any default networking configuration changes in
    NetworkManager. This allows us to react and adjust to the changes
    (if needed) instead of finding out later that problems were introduced.
    some context in: https://github.com/coreos/fedora-coreos-tracker/issues/1000
```
