### PR TITLE
tests: add distro tags to FCOS only tests

### DIFF
--- a/tests/kola/README.md
+++ b/tests/kola/README.md
@@ -1,0 +1,17 @@
+# Kola External Tests
+
+For more information about the `kola` external tests, see the [Integrating External Test Suites](https://coreos.github.io/coreos-assembler/kola/external-tests/#integrating-external-test-suites)
+topic in the `coreos-assembler` documentation.
+
+## Sharing tests between FCOS/RHCOS
+
+These tests are intended to be shared between FCOS and RHCOS. If you are adding
+a new test(s) to this collection, ensure that the test also run on RHCOS.
+Otherwise, use the `kola` JSON header to specify that it only runs on FCOS like
+so:
+
+```bash
+#!/bin/bash
+# kola: {"distros": "fcos"}
+...
+```

--- a/tests/kola/containers/cgroups-v2
+++ b/tests/kola/containers/cgroups-v2
@@ -1,5 +1,8 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS because RHCOS does not currently support cgroupsv2
+# by default.
+# TODO-RHCOS: drop "fcos" tag when cgroupsv2 lands in RHCOS
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/files/aleph-version
+++ b/tests/kola/files/aleph-version
@@ -12,5 +12,5 @@ fatal() {
 }
 
 # Defined in https://github.com/coreos/fedora-coreos-tracker/blob/master/internals/README-internals.md#aleph-version
-jq < /sysroot/.coreos-aleph-version.json >/dev/null
+jq . < /sysroot/.coreos-aleph-version.json >/dev/null
 ok aleph

--- a/tests/kola/files/file-directory-permissions
+++ b/tests/kola/files/file-directory-permissions
@@ -11,9 +11,9 @@ fatal() {
     exit 1
 }
 
-list="$(find /etc -type f,d -perm /022)"
+list="$(find /etc -type f -type d -perm /022)"
 if [[ -n "${list}" ]]; then
-    find /etc -type f,d -perm /022 -print0 | xargs -0 ls -al
+    find /etc -type f -type d -perm /022 -print0 | xargs -0 ls -al
     fatal "found files or directories with 'g+w' or 'o+w' permission"
 fi
 ok "no files with 'g+w' or 'o+w' permission found in /etc"

--- a/tests/kola/files/remove-manifest-files
+++ b/tests/kola/files/remove-manifest-files
@@ -1,5 +1,8 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS bceause RHCOS does ship `info` which is a
+# Requires on a number of RHCOS packages.
+# TODO-RHCOS: modify test to check for RHCOS-specific `remove-files` entry
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/files/rpmdb-sqlite
+++ b/tests/kola/files/rpmdb-sqlite
@@ -1,5 +1,7 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS as the RHCOS rpmdb has not migrated to sqlite yet.
+# TODO-RHCOS: drop the "fcos" tag when RHCOS migrates to using sqlite
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/firewall/iptables-legacy
+++ b/tests/kola/firewall/iptables-legacy
@@ -1,5 +1,9 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test is currently scoped to only FCOS because the RHCOS version of `iptables`
+# is using the `nf_tables` backend.
+# TODO: modify this test to check for `nf_tables` backend when FCOS switches.
+#       See https://github.com/coreos/fedora-coreos-config/pull/1324
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/ignition/systemd-unmasking/test.sh
+++ b/tests/kola/ignition/systemd-unmasking/test.sh
@@ -7,7 +7,10 @@ set -xeuo pipefail
 
 # We don't need to test this on every platform. If it passes in
 # one place it will pass everywhere.
-# kola: { "platforms": "qemu-unpriv" }
+# This test is currently scoped to FCOS because `dnsmasq` is not masked
+# on RHCOS.
+# TODO-RHCOS: determine if any services on RHCOS are masked and adapt test
+# kola: { "distros": "fcos", "platforms": "qemu-unpriv" }
 
 ok() {
     echo "ok" "$@"

--- a/tests/kola/migration/installer-cleanup
+++ b/tests/kola/migration/installer-cleanup
@@ -6,7 +6,9 @@
 
 # Just run on QEMU.  coreos-installer doesn't run in clouds, and rebooting
 # doesn't seem to work there currently.
-# kola: { "platforms": "qemu-unpriv" }
+# This test only runs on FCOS because the `coreos-cleanup-ignition-config` service
+# is not present on RHCOS.
+# kola: { "distros": "fcos", "platforms": "qemu-unpriv" }
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -136,7 +136,7 @@ fi
 
 # Execute nm-initrd-generator against our default kargs (defined by
 # afterburn drop in) to get the generated initrd network config.
-DEFAULT_KARGS_FILE=/usr/lib/dracut/modules.d/35coreos-network/50-afterburn-network-kargs-default.conf 
+DEFAULT_KARGS_FILE=/usr/lib/dracut/modules.d/35coreos-network/50-afterburn-network-kargs-default.conf
 source <(grep -o 'AFTERBURN_NETWORK_KARGS_DEFAULT=.*' $DEFAULT_KARGS_FILE)
 tmpdir=$(mktemp -d)
 /usr/libexec/nm-initrd-generator \

--- a/tests/kola/networking/dnsmasq-service
+++ b/tests/kola/networking/dnsmasq-service
@@ -1,5 +1,8 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS because the `dnsmasq` service on RHCOS is simply
+# disabled, not masked.
+# TODO-RHCOS: adapt test to check that `dnsmasq` is in the proper state on RHCOS
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/networking/resolv/systemd-resolved-service
+++ b/tests/kola/networking/resolv/systemd-resolved-service
@@ -1,5 +1,7 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS because `systemd-resolved` is not installed on
+# RHCOS
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/networking/stub-resolve.sh
+++ b/tests/kola/networking/stub-resolve.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS because `systemd-resolved` is not installed on
+# RHCOS
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -11,7 +11,11 @@ set -euxo pipefail
 
 # Just run on QEMU for now. If this test works in one place it should
 # work everywhere.
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
+# The test is scoped to only FCOS because the `--retry-all-errors` flag passed
+# to `curl` is not avaiable on the version in RHCOS.
+# TODO-RHCOS: adapt test to conditionally use the `-retry-all-errors` flag on
+# only FCOS
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv" }
 
 # Script to be executed as the `core` user to build and
 # run a rootless podman container that uses systemd inside.

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
-# kola: {"platforms": "qemu"}
+# This test is only run on FCOS because we are not mounting /boot by UUID on
+# RHCOS, yet.
+# TODO-RHCOS: drop 'fcos' tag when RHCOS starts mounting /boot by UUID
+# kola: {"distros": "fcos", "platforms": "qemu"}
 
 # These are read-only not-necessarily-related checks that verify default system
 # configuration both on first and subsequent boots.

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "architectures": "!s390x"}
+# This test is only running on FCOS because it is checking that /boot is
+# mounted by UUID and RHCOS is not doing that yet.
+# TODO-RHCOS: drop 'fcos' tag when RHCOS is mounting /boot by UUID
+#             See: https://github.com/openshift/os/issues/675
+# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x" }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096}
+# This test only runs on FCOS due to a problem enabling a swap partition on
+# RHCOS.  See: https://github.com/openshift/os/issues/665
+# kola: {"distros": "fcos", "platforms": "qemu", "minMemory": 4096}
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -2,7 +2,8 @@
 set -xeuo pipefail
 
 # No need to run on any other platform than QEMU.
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
+# This test only runs on FCOS because countme support is not available in RHCOS
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv" }
 
 ok() {
     echo "ok" "$@"

--- a/tests/kola/security/passwd/test.sh
+++ b/tests/kola/security/passwd/test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This test only runs on FCOS because RHCOS does not support `yescrypt`
+# TODO-RHCOS: adapt to use different `crypt` scheme for RHCOS
+# kola: { "distros": "fcos", "exclusive": false }
+
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/swap/zram-default
+++ b/tests/kola/swap/zram-default
@@ -1,4 +1,6 @@
 #!/bin/bash
+# We can run this on both FCOS and RHCOS as neither should have a zram device
+# enabled by default. (In RHCOS, there is no zram support at all)
 # kola: { "exclusive": false }
 set -xeuo pipefail
 

--- a/tests/kola/swap/zram-generator/test.sh
+++ b/tests/kola/swap/zram-generator/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This test conflicts with swap/zram-default so we cannot set this to non-exclusive
-# kola: { "exclusive": true}
+# This test only runs on FCOS because RHCOS does not have zram support.
+# kola: { "distros": "fcos", "exclusive": true}
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -13,7 +13,11 @@
 
 # Only run on QEMU to reduce CI costs as nothing is platform specific here.
 # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "architectures": "x86_64 aarch64" }
+# This test only runs on FCOS because RHCOS is missing the `machinectl` command.
+# Additionally, there are some distro specific choices made for this test that
+# should/could be adpated for RHCOS.
+# TODO-RHCOS: adapt test for RHCOS specifics or create separate RHCOS toolbox test
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "architectures": "x86_64 aarch64" }
 
 set -xeuo pipefail
 


### PR DESCRIPTION
This is a first pass at categorizing the existing external tests using
the `distros` tag to indicate that the tests are only supported on
FCOS.  This should allow better sharing of tests with RHCOS.

Note: some of these tests may be able to be adapted for RHCOS; will
investigate in a follow-up PR.

See: openshift/os#661
See: coreos/coreos-assembler#2521