### PR TITLE
[next-devel] overrides: unpin kernel-5.14.13-300.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,22 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  kernel:
-    evr: 5.14.13-300.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-0f33f94e81
-      reason: https://github.com/coreos/fedora-coreos-config/pull/1305#issuecomment-951242424
-      type: pin
-  kernel-core:
-    evr: 5.14.13-300.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-0f33f94e81
-      reason: https://github.com/coreos/fedora-coreos-config/pull/1305#issuecomment-951242424
-      type: pin
-  kernel-modules:
-    evr: 5.14.13-300.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-0f33f94e81
-      reason: https://github.com/coreos/fedora-coreos-config/pull/1305#issuecomment-951242424
-      type: pin
+packages: {}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,8 +13,8 @@ repos:
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned. These repos are also used by the remove-graduated-overrides
   # GitHub Action.
-  - fedora-next
-  - fedora-next-updates
+  - fedora
+  - fedora-updates
 
 add-commit-metadata:
   fedora-coreos.stream: next-devel


### PR DESCRIPTION
This probably should have been classified as a fast-track so our
graduated overrides bot would have cleaned it up like the others.