### PR TITLE
[rawhide] manifest.yaml: remove now common manifest.yaml entries

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,18 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
+  kernel:
+    evr: 5.15.0-60.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
+      type: pin
+  kernel-core:
+    evr: 5.15.0-60.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
+      type: pin
+  kernel-modules:
+    evr: 5.15.0-60.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
+      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -23,16 +23,3 @@ postprocess:
     mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
-
-packages:
-  # resolved was broken out to its own package in rawhide/f35
-  - systemd-resolved
-  # In F35+ need `iptables-legacy` package
-  # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
-  - iptables-legacy
-
-remove-from-packages:
-  # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.
-  # This keeps the size down and ensures nothing tries to use it, preventing us
-  # from shedding the dep eventually.
-  - [cracklib-dicts, .*]


### PR DESCRIPTION
These are now in the shared `fedora-coreos-base.yaml` so we
can remove them from the toplevel manifest.yaml.