### PR TITLE
updates for the default-network-behavior-change test

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -72,29 +72,6 @@ postprocess:
     #!/usr/bin/env bash
     systemctl mask systemd-repart.service
 
-  # Neuter systemd-resolved for now.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-743219353
-  # Remove when on F35+ as NM now handles rdns + resolved better
-  # https://github.com/coreos/fedora-coreos-tracker/issues/834
-  # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/601
-  # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/877
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    # Only operate on F34 since F35+ has been fixed
-    source /etc/os-release
-    [ ${VERSION_ID} -eq 34 ] || exit 0
-    # Get us back to Fedora 32's nsswitch.conf settings
-    sed -i 's/^hosts:.*/hosts:      files dns myhostname/' /etc/nsswitch.conf
-    mkdir -p /usr/lib/systemd/resolved.conf.d/
-    cat > /usr/lib/systemd/resolved.conf.d/fedora-coreos-stub-listener.conf <<'EOF'
-    # Fedora CoreOS is electing to not use systemd-resolved's internal
-    # logic for now because of issues with setting hostnames via reverse DNS.
-    # https://github.com/coreos/fedora-coreos-tracker/issues/649#issuecomment-736104003
-    [Resolve]
-    DNSStubListener=no
-    EOF
-
   # Set the fallback hostname to `localhost`. This was needed in F33/F34
   # because a fallback hostname of `fedora` + systemd-resolved broke
   # rDNS. It's now fixed in F35+ NetworkManager to handle the corner cases

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -122,7 +122,7 @@ if [ "$ID" == "fedora" ]; then
 elif [ "$ID" == "rhcos" ]; then
     # For the version comparison use string substitution to remove the
     # '.` from the version so we can use integer comparison
-    RHCOS_MINIMUM_VERSION="4.9"
+    RHCOS_MINIMUM_VERSION="4.7"
     if [ "${VERSION_ID/\./}" -ge "${RHCOS_MINIMUM_VERSION/\./}" ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG2
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -64,6 +64,7 @@ mac-address-blacklist=
 dhcp-timeout=90
 dns-search=
 method=auto
+required-timeout=20000
 
 [ipv6]
 addr-gen-mode=eui64

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -49,7 +49,6 @@ method=auto
 org.freedesktop.NetworkManager.origin=nm-initrd-generator"
 # EXPECTED_INITRD_NETWORK_CFG2
 #   - used on all RHCOS releases
-#   - used on FCOS F34
 EXPECTED_INITRD_NETWORK_CFG2="[connection]
 id=Wired Connection
 uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -113,10 +112,7 @@ normalize_connection_file() {
 source /etc/os-release
 # All current FCOS releases use the same config
 if [ "$ID" == "fedora" ]; then
-    if [ "$VERSION_ID" -eq "34" ]; then
-        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG2
-        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
-    elif [ "$VERSION_ID" -ge "35" ]; then
+    if [ "$VERSION_ID" -ge "35" ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG1
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
     else


### PR DESCRIPTION
Also added a commit that drops some <F34 cruft. Summary:

```
commit e07eb6cda1246258d128decc9ce54120c014f228
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 16 12:57:05 2021 -0500

    manifests/fedora-coreos-base: drop systemd-resolved neutering
    
    This was needed and applied in F33/F34. Now that we've moved to F35+
    we no longer need it.

commit 1b36aa63f382e37437958bd3a89cbedd6c135361
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 16 12:58:06 2021 -0500

    tests/default-network-behavior-change: Make RHCOS minimum version 4.7
    
    According to @miabbott we could backport this all the way to 4.7.

commit cd68811af67c80e6e80f3071f5b1caddee192040
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 16 12:46:40 2021 -0500

    tests/default-network-behavior-change: update default config
    
    RHCOS streams have brought in a new NM RPM and the default config
    from `nm-initrd-generator` has changed slightly. It looks like
    the upstream PR [1] has landed to fix [2] so this is an expected
    and desired change. The RPM change was:
    
    ```
    NetworkManager 1.30.0-10.el8_4.x86_64 -> 1.30.0-13.el8_4.x86_64
    ```
    
    [1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/907/
    [2] https://bugzilla.redhat.com/show_bug.cgi?id=1961666

commit 702b9554e83ed5b2dccdd4f8575fc33908e13274
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Nov 16 12:49:56 2021 -0500

    tests/default-network-behavior-change: drop references to F34
    
    Our testing stream has moved to F35 so effectively we can drop
    references to F34 in the code/tests.
```
