### PR TITLE
tests/coreos-platform-chrony-generator: make non-exclusive

### DIFF
--- a/tests/kola/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/chrony/coreos-platform-chrony-generator
@@ -2,9 +2,7 @@
 set -euo pipefail
 # Test the coreos-platform-chrony generator.
 
-# kola: { "platforms": "aws,azure,gcp" }
-
-cd "$(mktemp -d)"
+# kola: { "exclusive": false, "platforms": "aws,azure,gcp" }
 
 platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d =)"
 case "${platform}" in


### PR DESCRIPTION
There's nothing that mutates the host in there (after removing the
unnecessary `mktemp -d`) so let's just make it shared.