### PR TITLE
tests/systemd-repart-service: only run on FCOS

### DIFF
--- a/tests/kola/disks/systemd-repart-service
+++ b/tests/kola/disks/systemd-repart-service
@@ -1,5 +1,9 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+# This test only runs on FCOS because the version of `systemd-udev` in RHCOS does
+# not include `systemd-repart`
+# TODO-RHCOS: consider dropping the "fcos" tag if/when `systemd-udev` in RHEL
+#             starts to include `systemd-repart`
+# kola: { "distros": "fcos", "exclusive": false }
 set -xeuo pipefail
 
 ok() {


### PR DESCRIPTION
The version of `systemd-udev` on RHCOS does not include the
`systemd-repart` service.

Missed this test as part of #1322.