### PR TITLE
tests: check for mounting /boot by UUID on RHCOS

### DIFF
--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -xeuo pipefail
-# This test is only run on FCOS because we are not mounting /boot by UUID on
-# RHCOS, yet.
-# TODO-RHCOS: drop 'fcos' tag when RHCOS starts mounting /boot by UUID
-# kola: {"distros": "fcos", "platforms": "qemu"}
+# kola: {"platforms": "qemu"}
 
 # These are read-only not-necessarily-related checks that verify default system
 # configuration both on first and subsequent boots.

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-# This test is only running on FCOS because it is checking that /boot is
-# mounted by UUID and RHCOS is not doing that yet.
-# TODO-RHCOS: drop 'fcos' tag when RHCOS is mounting /boot by UUID
-#             See: https://github.com/openshift/os/issues/675
-# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x" }
+# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x" }
 set -xeuo pipefail
 
 ok() {


### PR DESCRIPTION
When the next git submodule update gets pulled into `openshift/os`,
RHCOS will start mounting `/boot` by UUID. (See openshift/os#678)

Let's drop the "fcos" tags on those tests that are checking for
mounting /boot by UUID, so we can change the behavior and get unit
tests enabled in one change.