### PR TITLE
[rawhide] overrides: unpin kernel

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,18 +14,3 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
-  kernel:
-    evr: 5.15.0-60.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
-      type: pin
-  kernel-core:
-    evr: 5.15.0-60.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
-      type: pin
-  kernel-modules:
-    evr: 5.15.0-60.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1011'
-      type: pin


### PR DESCRIPTION
The multipath tests are passing again with the newer 5.16.0 kernel. See
https://github.com/coreos/fedora-coreos-tracker/issues/1011.