### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,16 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  coreos-installer:
-    evr: 0.11.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-753084fa88
-      reason: https://github.com/coreos/coreos-installer/releases/tag/v0.11.0
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.11.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-753084fa88
-      reason: https://github.com/coreos/coreos-installer/releases/tag/v0.11.0
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.