### PR TITLE
s390x: add secure-execution support

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -28,6 +28,7 @@ packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
   - /usr/sbin/zipl
+  - /usr/bin/genprotimg
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl

--- a/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
@@ -3,10 +3,6 @@ set -euo pipefail
 
 mount -o remount,rw /boot
 
-if [[ $(uname -m) = s390x ]]; then
-    zipl
-fi
-
 # We're done provisioning. Remove the whole /boot/ignition directory if present,
 # which may include a baked Ignition config. See
 # https://github.com/coreos/fedora-coreos-tracker/issues/889.
@@ -16,3 +12,8 @@ rm -rf /boot/ignition
 # this file. Fail if we are unable to remove it, rather than risking rerunning
 # Ignition at next boot.
 rm /boot/ignition.firstboot
+
+# rdcore zipl checks for /boot/ignition.firstboot
+if [[ $(uname -m) = s390x ]]; then
+    /usr/lib/dracut/modules.d/50rdcore/rdcore zipl --boot-mount=/boot
+fi


### PR DESCRIPTION
This adds `genprotimg` tool, for creating encrypted `sd-boot` image, and turns on (if required) SecureExecution during `firstboot-complete` 
Depends on: https://github.com/coreos/coreos-installer/pull/851