### PR TITLE
manifests: move crun to user-experience

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -89,8 +89,6 @@ postprocess:
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.
 packages:
-  # Container tooling
-  - crun
   # Security
   - polkit
   # System setup

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -28,6 +28,7 @@ packages:
   # Remote Access
   - openssh-clients openssh-server
   # Container tooling
+  - crun
   - podman
   - runc
   - skopeo


### PR DESCRIPTION
There is desire to include `crun` as part of RHCOS so that early
testing of OCP workloads using `crun` can be validated [1]

This moves `crun` out of an FCOS only manifest into a manifest that is
shared with RHCOS.

[1] openshift/release#23609