### PR TITLE
chrony: use /dev/ptp_hyperv instead of /dev/ptp0

### DIFF
--- a/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
@@ -66,8 +66,10 @@ EOF
 ) > "${confpath}"
 case "${platform}" in
     azure)
+        # the /dev/ptp_hyperv symlink is created by:
+        # https://github.com/systemd/systemd/blob/e67a5c14f0345f5ac456cfa109324dd9e70114d3/rules.d/50-udev-default.rules.in#L106
         (echo '# See also https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync'
-         echo 'refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0'
+         echo 'refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0'
          echo 'leapsectz right/UTC'
         ) >> "${confpath}" ;;
     aws)

--- a/tests/kola/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/chrony/coreos-platform-chrony-generator
@@ -7,7 +7,7 @@ set -euo pipefail
 platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d =)"
 case "${platform}" in
     aws) chronyc sources |grep '169.254.169.123'; echo "ok chrony aws" ;;
-    azure) chronyc sources |grep 'PHC0'; echo "ok chrony azure" ;;
+    azure) chronyc sources |grep 'PHC'; echo "ok chrony azure" ;;
     gcp) chronyc sources | grep metadata.google.internal; echo "ok chrony gcp" ;;
     *) echo "unhandled platform ${platform} ?"; exit 1 ;;
 esac


### PR DESCRIPTION
From the last paragraph in:

https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#check-for-ptp-clock-source

> In Linux VMs with Accelerated Networking enabled, you may see multiple
> PTP devices listed because the Mellanox mlx5 driver also creates a
> /dev/ptp device. Because the initialization order can be different
> each time Linux boots, the PTP device corresponding to the Azure host
> might be /dev/ptp0 or it might be /dev/ptp1, which makes it difficult
> to configure chronyd with the correct clock source. To solve this
> problem, the most recent Linux images have a udev rule that creates
> the symlink /dev/ptp_hyperv to whichever /dev/ptp entry corresponds to
> the Azure host. Chrony should be configured to use this symlink
> instead of /dev/ptp0 or /dev/ptp1.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1031

As mentioned there, we might have to backport udev rules to RHCOS as
well to make sure that symlink gets created there too.