### PR TITLE
tests/kola/root-reprovision: add test for linear device

### DIFF
--- a/tests/kola/root-reprovision/linear/config.bu
+++ b/tests/kola/root-reprovision/linear/config.bu
@@ -1,0 +1,14 @@
+variant: fcos
+version: 1.4.0
+storage:
+  raid:
+    - name: foobar
+      level: linear
+      devices:
+      - /dev/disk/by-id/virtio-disk1
+      - /dev/disk/by-id/virtio-disk2
+  filesystems:
+    - device: /dev/md/foobar
+      format: xfs
+      wipe_filesystem: true
+      label: root

--- a/tests/kola/root-reprovision/linear/data/commonlib.sh
+++ b/tests/kola/root-reprovision/linear/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/root-reprovision/linear/test.sh
+++ b/tests/kola/root-reprovision/linear/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+srcdev=$(findmnt -nvr / -o SOURCE)
+[[ ${srcdev} == $(realpath /dev/md/foobar) ]]
+
+blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
+[[ ${blktype} == linear ]]
+
+fstype=$(findmnt -nvr / -o FSTYPE)
+[[ ${fstype} == xfs ]]
+ok "source is XFS on linear device"
+
+rootflags=$(findmnt /sysroot -no OPTIONS)
+if ! grep prjquota <<< "${rootflags}"; then
+    fatal "missing prjquota in root mount flags: ${rootflags}"
+fi
+ok "root mounted with prjquota"
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      # check that ignition-ostree-growfs didn't run
+      if [ -e /run/ignition-ostree-growfs.stamp ]; then
+          fatal "ignition-ostree-growfs ran"
+      fi
+
+      # reboot once to sanity-check we can find root on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      grep root=UUID= /proc/cmdline
+      grep rd.md.uuid= /proc/cmdline
+      ok "found root kargs"
+      ;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac


### PR DESCRIPTION
It's a type of RAID device, which isn't completely obvious from the name.  Mostly copied from `root-reprovision/raid1`.