### PR TITLE
tests/k8s: enable all platforms

### DIFF
--- a/tests/kola/k8s/node-e2e/master
+++ b/tests/kola/k8s/node-e2e/master
@@ -3,5 +3,5 @@ set -xeuo pipefail
 # Just run on x86_64 for now. We'd need multi-arch images with go 1.17. We
 # could run on any platform, though need to replace `additionalDisks` by e.g.
 # `minDiskSpace` or something similar.
-# kola: {"minMemory": 4096, "timeoutMin": 45, "additionalDisks": ["15G"], "platforms": "qemu", "architectures": "x86_64", "requiredTag": "k8s", "tags": "needs-internet"}
+# kola: {"minMemory": 4096, "timeoutMin": 45, "additionalDisks": ["15G"], "architectures": "x86_64", "requiredTag": "k8s", "tags": "needs-internet"}
 exec "${KOLA_EXT_DATA}/node-e2e" "${KOLA_TEST_EXE}"


### PR DESCRIPTION
There shouldn't be anything platform-specific about this test, and it's
opt-in anyway, so just drop the `qemu` constraint.

Motivated by wanting to run it in AWS instead to offload the cluster and
try to also test on aarch64.