### PR TITLE
tests/k8s: use `minDisk` instead of `additionalDisks`

### DIFF
--- a/tests/kola/k8s/node-e2e/config.bu
+++ b/tests/kola/k8s/node-e2e/config.bu
@@ -6,9 +6,3 @@ ignition:
       # XXX: what this config does should probably be folded into the test
       # directly instead so that the release-specific cri-o is used
       - source: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/crio/crio_cgrpv2.ign
-storage:
-  filesystems:
-    - device: /dev/disk/by-id/virtio-disk1
-      format: xfs
-      path: /var
-      with_mount_unit: true

--- a/tests/kola/k8s/node-e2e/master
+++ b/tests/kola/k8s/node-e2e/master
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -xeuo pipefail
-# Just run on x86_64 for now. We'd need multi-arch images with go 1.17. We
-# could run on any platform, though need to replace `additionalDisks` by e.g.
-# `minDiskSpace` or something similar.
-# kola: {"minMemory": 4096, "timeoutMin": 45, "additionalDisks": ["15G"], "architectures": "x86_64", "requiredTag": "k8s", "tags": "needs-internet"}
+# Just run on x86_64 for now. We'd need multi-arch images with go 1.17.
+# kola: {"minMemory": 4096, "timeoutMin": 45, "minDisk": 20, "architectures": "x86_64", "requiredTag": "k8s", "tags": "needs-internet"}
 exec "${KOLA_EXT_DATA}/node-e2e" "${KOLA_TEST_EXE}"


### PR DESCRIPTION
The former is compatible with AWS while the latter is not. And it more
clearly represents our intent.