### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,10 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  ignition:
-    evr: 2.13.0-1.fc35 
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-6ff46bd8ea
-      reason: https://github.com/coreos/ignition/issues/1287
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.