### PR TITLE
Must After sysroot.mount

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-liveiso-persist-osmet.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-liveiso-persist-osmet.service
@@ -4,6 +4,7 @@ DefaultDependencies=false
 ConditionPathExists=/run/ostree-live
 ConditionKernelCommandLine=coreos.liveiso
 RequiresMountsFor=/run/media/iso
+After=sysroot.mount
 Before=initrd-switch-root.target
 
 [Service]


### PR DESCRIPTION
May `coreos-liveiso-persist-osmet.service` and `sysroot.mount` will access `/run/media/iso/images/pxeboot/rootfs.img` at the same time.