### PR TITLE
[rawhide] overrides: pin on systemd-249.7-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,33 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
+  systemd:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin
+  systemd-container:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin
+  systemd-libs:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin
+  systemd-pam:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin
+  systemd-resolved:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin
+  systemd-udev:
+    evr: 249.7-2.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
+      type: pin

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -26,7 +26,7 @@ podman network rm testnetwork
 runascoreuser() {
     # NOTE: If we don't use `| cat` the output won't get copied
     # and won't show up in the output of the ext test.
-    sudo -u core "$@" | cat
+    sudo -u core "$@" 2>&1 | cat
 }
 
 main() {

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -47,7 +47,7 @@ runascoreuser() {
     # NOTE: If we don't use `| cat` the output won't get copied
     # to our unit and won't show up in the `systemctl status` output
     # of the ext test.
-    sudo -u core "$@" | cat
+    sudo -u core "$@" 2>&1 | cat
 }
 
 main() {


### PR DESCRIPTION
```
commit 391289c57d58fab8e39be688924b94ba661301e3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Dec 13 16:35:43 2021 -0500

    overrides: pin on systemd-249.7-2.fc36
    
    systemd 250 breaks the ext.config.podman.dns and we need to determine
    an appropriate fix. Pin on systemd-249.7-2.fc36 for now.

commit 800f859e06f1c06da382e8396385ef9579775f8d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Dec 13 16:32:19 2021 -0500

    tests: also redirect stderr in runascoreuser functions
    
    Otherwise we won't get stderr. This became obvious when investigating
    https://github.com/coreos/fedora-coreos-tracker/issues/1046 where
    running the test by hand yielded a lot more output (and the relevant
    error message).
```
