### PR TITLE
coreos-copy-firstboot-network: support /etc/coreos-firstboot-network

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -37,9 +37,6 @@ After=dracut-cmdline.service
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
 After=coreos-gpt-setup.service
-# Since we are mounting /boot/, require the device first
-Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device
 # And since the boot device may be on multipath; optionally wait for it to
 # appear via the dynamic target.
 After=coreos-multipath-wait.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -1,12 +1,17 @@
-# This unit will run early in boot and detect if the user copied
-# in firstboot networking config files into the installed system
-# (most likely by using `coreos-installer install --copy-network`).
+# This unit will run early in boot and detect if:
+# - In the diskful case, the user copied in firstboot networking config files
+#   into `/boot` (most likely by using `coreos-installer install
+#   --copy-network`).
+# - In the live case, the user provided firstboot networking config files in
+#   `/etc` (most likely by using `coreos-installer iso network embed`).
+#
 # Since this unit is modifying network configuration there are some
 # dependencies that we have:
 #
-# - Need to look for networking configuration on the /boot partition
+# - In the diskful case, we need to look for networking configuration on the
+#   /boot partition
 #     - i.e. after /dev/disk/by-label/boot is available
-#     - and after the ignition-dracut GPT generator (see below)
+#     - which is implied by running after coreos-gpt-setup (see below)
 # - Need to run before networking is brought up.
 #     - This is done in nm-initrd.service [1]
 #     - i.e. Before=nm-initrd.service
@@ -29,6 +34,8 @@
 Description=Copy CoreOS Firstboot Networking Config
 ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
+# We're pulled in by ignition-complete.target; as good practice, add a matching
+# Before to be explicit about it gating on this unit passing.
 Before=ignition-complete.target
 Before=nm-initrd.service
 # compat: remove when everyone is on dracut 054+

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.service
@@ -29,7 +29,7 @@
 Description=Copy CoreOS Firstboot Networking Config
 ConditionPathExists=/usr/lib/initrd-release
 DefaultDependencies=false
-Before=ignition-diskful.target
+Before=ignition-complete.target
 Before=nm-initrd.service
 # compat: remove when everyone is on dracut 054+
 Before=dracut-initqueue.service

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -7,6 +7,7 @@ bootmnt=/mnt/boot_partition
 bootdev=/dev/disk/by-label/boot
 firstboot_network_dir_basename="coreos-firstboot-network"
 boot_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
+etc_firstboot_network_dir="/etc/${firstboot_network_dir_basename}"
 initramfs_network_dir="/run/NetworkManager/system-connections/"
 
 copy_firstboot_network() {
@@ -35,6 +36,14 @@ if ! is-live-image; then
         # https://github.com/coreos/coreos-installer/pull/212
         copy_firstboot_network "${boot_firstboot_network_dir}"
     else
-        echo "info: no files to copy from ${boot_firstboot_network_dir}. skipping"
+        echo "info: no files to copy from ${boot_firstboot_network_dir}; skipping"
+    fi
+else
+    if [ -n "$(ls -A ${etc_firstboot_network_dir} 2>/dev/null)" ]; then
+        # Also placed there by coreos-installer but in a different flow, see:
+        # https://github.com/coreos/coreos-installer/pull/713
+        copy_firstboot_network "${etc_firstboot_network_dir}"
+    else
+        echo "info: no files to copy from ${etc_firstboot_network_dir}; skipping"
     fi
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -9,7 +9,6 @@ bootdev=/dev/disk/by-label/boot
 firstboot_network_dir_basename="coreos-firstboot-network"
 initramfs_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
 initramfs_network_dir="/run/NetworkManager/system-connections/"
-realroot_firstboot_network_dir="/boot/${firstboot_network_dir_basename}"
 
 # Mount /boot. Note that we mount /boot but we don't unmount boot because we
 # are run in a systemd unit with MountFlags=slave so it is unmounted for us.

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -16,15 +16,23 @@ initramfs_network_dir="/run/NetworkManager/system-connections/"
 # running alongside other code that also has it mounted ro
 mount -o ro ${bootdev} ${bootmnt}
 
-if [ -n "$(ls -A ${boot_firstboot_network_dir} 2>/dev/null)" ]; then
+copy_firstboot_network() {
+    local src=$1; shift
+
     # Clear out any files that may have already been generated from
     # kargs by nm-initrd-generator
     rm -f ${initramfs_network_dir}/*
-    # Copy files that were placed into boot (most likely by coreos-installer)
+    # Copy files that were placed into the source
     # to the appropriate location for NetworkManager to use the configuration.
-    echo "info: copying files from ${boot_firstboot_network_dir} to ${initramfs_network_dir}"
+    echo "info: copying files from ${src} to ${initramfs_network_dir}"
     mkdir -p ${initramfs_network_dir}
-    cp -v ${boot_firstboot_network_dir}/* ${initramfs_network_dir}/
+    cp -v ${src}/* ${initramfs_network_dir}/
+}
+
+if [ -n "$(ls -A ${boot_firstboot_network_dir} 2>/dev/null)" ]; then
+    # Likely placed there by coreos-installer, see:
+    # https://github.com/coreos/coreos-installer/pull/212
+    copy_firstboot_network "${boot_firstboot_network_dir}"
 else
     echo "info: no files to copy from ${boot_firstboot_network_dir}. skipping"
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -7,7 +7,7 @@ bootmnt=/mnt/boot_partition
 mkdir -p ${bootmnt}
 bootdev=/dev/disk/by-label/boot
 firstboot_network_dir_basename="coreos-firstboot-network"
-initramfs_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
+boot_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
 initramfs_network_dir="/run/NetworkManager/system-connections/"
 
 # Mount /boot. Note that we mount /boot but we don't unmount boot because we
@@ -16,15 +16,15 @@ initramfs_network_dir="/run/NetworkManager/system-connections/"
 # running alongside other code that also has it mounted ro
 mount -o ro ${bootdev} ${bootmnt}
 
-if [ -n "$(ls -A ${initramfs_firstboot_network_dir} 2>/dev/null)" ]; then
+if [ -n "$(ls -A ${boot_firstboot_network_dir} 2>/dev/null)" ]; then
     # Clear out any files that may have already been generated from
     # kargs by nm-initrd-generator
     rm -f ${initramfs_network_dir}/*
     # Copy files that were placed into boot (most likely by coreos-installer)
     # to the appropriate location for NetworkManager to use the configuration.
-    echo "info: copying files from ${initramfs_firstboot_network_dir} to ${initramfs_network_dir}"
+    echo "info: copying files from ${boot_firstboot_network_dir} to ${initramfs_network_dir}"
     mkdir -p ${initramfs_network_dir}
-    cp -v ${initramfs_firstboot_network_dir}/* ${initramfs_network_dir}/
+    cp -v ${boot_firstboot_network_dir}/* ${initramfs_network_dir}/
 else
-    echo "info: no files to copy from ${initramfs_firstboot_network_dir}. skipping"
+    echo "info: no files to copy from ${boot_firstboot_network_dir}. skipping"
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # For a description of how this is used see coreos-copy-firstboot-network.service
 
 bootmnt=/mnt/boot_partition
-mkdir -p ${bootmnt}
 bootdev=/dev/disk/by-label/boot
 firstboot_network_dir_basename="coreos-firstboot-network"
 boot_firstboot_network_dir="${bootmnt}/${firstboot_network_dir_basename}"
@@ -14,6 +13,7 @@ initramfs_network_dir="/run/NetworkManager/system-connections/"
 # are run in a systemd unit with MountFlags=slave so it is unmounted for us.
 # Mount as read-only since we don't strictly need write access and we may be
 # running alongside other code that also has it mounted ro
+mkdir -p ${bootmnt}
 mount -o ro ${bootdev} ${bootmnt}
 
 copy_firstboot_network() {

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
@@ -15,10 +15,8 @@ install() {
 
     inst_simple "$moddir/coreos-copy-firstboot-network.sh" \
         "/usr/sbin/coreos-copy-firstboot-network"
-    # Only run this when ignition runs and only when the system
-    # has disks. ignition-diskful.target should suffice.
     install_and_enable_unit "coreos-copy-firstboot-network.service" \
-        "ignition-diskful.target"
+        "ignition-complete.target"
 
     # Dropin with firstboot network configuration kargs, applied via
     # Afterburn.


### PR DESCRIPTION
This adds support for copying NetworkManager keyfiles from
`/etc/coreos-firstboot-network`. It's similar in functionality to the
existing support for `/boot/coreos-firstboot-network`, but is intended
for the live path (ISO or PXE boot) where there is no boot partition.

Users won't interact directly with this; instead, it's expected that
`coreos-installer` will provide high-level commands to customize the ISO
or PXE artifacts to embed keyfiles via the existing layered initrd
mechanisms.

Closes: coreos/fedora-coreos-tracker#841