### PR TITLE
manifests: add afterburn-dracut

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -91,8 +91,6 @@ postprocess:
 packages:
   # Security
   - polkit
-  # System setup
-  - afterburn-dracut
   # SSH
   - ssh-key-dir
   # Containers

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -4,7 +4,7 @@
 
 packages:
   # Configuring SSH keys, cloud provider check-in, etc
-  - afterburn
+  - afterburn afterburn-dracut
   # NTP support
   - chrony
   # Installing CoreOS itself


### PR DESCRIPTION
The Fedora `afterburn` source package currently outputs an `afterburn` and `afterburn-dracut` subpackage. In the process of unifying spec files across Fedora/RHEL/C9S, we'd like to do the same for RHCOS. Before splitting, we need to make sure that RHCOS won't lose the dracut bits. So lower `afterburn-dracut` to a shared manifest.