### PR TITLE
overlay/15fcos: coreos-check-ssh-keys: limit search to current boot

### DIFF
--- a/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-ssh-keys
@@ -9,17 +9,20 @@ main() {
 
     # See https://github.com/coreos/ignition/pull/964 for the MESSAGE_ID 
     # source. It will track the authorized-ssh-keys entries in journald 
-    # provided via Ignition.
+    # provided via Ignition. Limit journal output to the most recent boot
+    # so we don't get output from re-used /var/ partitions.
     ignitionusers=$(
-            journalctl -o json-pretty MESSAGE_ID=225067b87bbd4a0cb6ab151f82fa364b | \
+            journalctl -b 0 -o json-pretty MESSAGE_ID=225067b87bbd4a0cb6ab151f82fa364b | \
             jq -r '.MESSAGE' | \
             xargs -I{} echo "Ignition: {}")
 
     # See https://github.com/coreos/afterburn/pull/397 for the MESSAGE_ID 
     # source. It will track the authorized-ssh-keys entries in journald  
-    # provided via Afterburn.
+    # provided via Afterburn.Limit journal output to the most recent boot
+    # so we don't get output from re-used /var/ partitions.
+
     afterburnusers=$(
-            journalctl -o json-pretty MESSAGE_ID=0f7d7a502f2d433caa1323440a6b4190 | \
+            journalctl -b 0 -o json-pretty MESSAGE_ID=0f7d7a502f2d433caa1323440a6b4190 | \
             jq -r '.MESSAGE' | \
             xargs -I{} echo "Afterburn: {}")
 


### PR DESCRIPTION
fixed the problem by limiting the journal output to the most recent boot - jira #1033