### PR TITLE
05core: add coreos-network-initramfs-etc.service

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -107,6 +107,9 @@ propagate_initramfs_networking() {
                 echo "info: propagating initramfs networking config to the real root"
                 cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
                 coreos-relabel /etc/NetworkManager/system-connections/
+
+                mkdir -p /run/coreos
+                touch /run/coreos/network-propagated
             fi
         else
             echo "info: no initramfs networking information to propagate"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh
@@ -21,6 +21,9 @@ copy_firstboot_network() {
     echo "info: copying files from ${src} to ${initramfs_network_dir}"
     mkdir -p ${initramfs_network_dir}
     cp -v ${src}/* ${initramfs_network_dir}/
+
+    mkdir -p /run/coreos
+    echo "${src}" > /run/coreos/firstboot-network-src
 }
 
 if ! is-live-image; then

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -25,3 +25,5 @@ enable rtas_errd.service
 enable clevis-luks-askpass.path
 # Provide information if no ignition is provided
 enable coreos-check-ignition-config.service
+# Automatically enables `initramfs-etc` tracking of NM keyfiles
+enable coreos-network-initramfs-etc.service

--- a/overlay.d/05core/usr/lib/systemd/system/coreos-network-initramfs-etc.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-network-initramfs-etc.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=CoreOS Enable Network Initramfs-Etc
+# All services which use ConditionFirstBoot=yes should use
+# Before=first-boot-complete.target, which is a target that
+# was introduced in https://github.com/systemd/systemd/issues/4511
+# and hasn't propagated everywhere yet. Once the target propagates
+# everywhere, we can drop the systemd-machine-id-commit.service
+# from the Before= line.
+Before=first-boot-complete.target systemd-machine-id-commit.service
+Wants=first-boot-complete.target
+# If there are custom NM connection files,
+ConditionDirectoryNotEmpty=/etc/NetworkManager/system-connections/
+# and they come from `--copy-network` or `iso network embed`,
+ConditionPathExists=/run/coreos/firstboot-network-src
+ConditionPathExists=/run/coreos/network-propagated
+# and it's the first boot,
+ConditionFirstBoot=true
+
+# then automatically turn on initramfs-etc tracking of the NM configs.
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-network-initramfs-etc
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/05core/usr/libexec/coreos-network-initramfs-etc
+++ b/overlay.d/05core/usr/libexec/coreos-network-initramfs-etc
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Would've been really nice to be able to use
+# `ConditionKernelCommandLine=rd.neednet=1` for this, but that doesn't work
+# because the current boot doesn't have it; the *next* boot will.
+
+karg() {
+    local name="$1" value="${2:-}"
+    local cmdline=( $(rpm-ostree kargs) )
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+if [[ $(karg rd.neednet) == 1 ]]; then
+    rpm-ostree ex initramfs-etc --track /etc/NetworkManager/system-connections
+fi


### PR DESCRIPTION
A papercut right now is that when using Tang, one must use kernel
arguments to specify network configuration because network is required
on every boot.

This breaks the UX we're trying to emphasize, which is towards
specifying networking settings using NM keyfiles *once* and having it
apply everywhere.

Let's fix this by automatically detecting this case and enabling
`initramfs-etc` tracking of NM keyfiles on first boot. This will allow
users to stay on the NM keyfile path and have it transparently work even
when using Tang.

The new service does this from the real root. Long-term, I'd like to
investigate doing it earlier in the initramfs (this is related to
coreos/rpm-ostree#3006).

Modifications to NM keyfiles in the real root are automatically synced
on every new deployment, or explicitly when using
`rpm-ostree ex initramfs-etc --force-sync`.