### PR TITLE
tests/kola: fix `platforms` key for `coreos-platform-chrony-generator`

### DIFF
--- a/tests/kola/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/chrony/coreos-platform-chrony-generator
@@ -2,7 +2,7 @@
 set -euo pipefail
 # Test the coreos-platform-chrony generator.
 
-# kola: { "exclusive": false, "platforms": "aws,azure,gcp" }
+# kola: { "exclusive": false, "platforms": "aws azure gcp" }
 
 platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d =)"
 case "${platform}" in


### PR DESCRIPTION
It's a space-separated list, not comma-separated.

This... may have caused us to never actually run that test. Though it's
possible also something changed in cosa, but I'm not seeing it right
now.

Fixes: b73a3757a8d9 ("20platform-chrony: Add support for AWS")