### PR TITLE
[rawhide] manifest: pull in authselect

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,10 @@ repos:
 add-commit-metadata:
   fedora-coreos.stream: rawhide
 
+packages:
+  # for nsswitch.conf
+  - authselect
+
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163


### PR DESCRIPTION
This is required now as per:
https://fedoraproject.org/wiki/Changes/Make_Authselect_Mandatory
https://src.fedoraproject.org/rpms/glibc/c/cadee80b1316?branch=rawhide
https://bugzilla.redhat.com/show_bug.cgi?id=2023741