### PR TITLE
tests: networking.nic-naming: disable on Azure platform

### DIFF
--- a/tests/kola/networking/nic-naming
+++ b/tests/kola/networking/nic-naming
@@ -1,5 +1,14 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+
+# Disable on azure because of a limitation of the hv_netvsc driver
+# there. According to [1] and [2] the driver does not provide sufficient
+# information to systemd-udev for systemd's naming to work. It falls
+# back to basic ethX naming.
+#
+# [1] https://access.redhat.com/solutions/3204751
+# [2] https://github.com/Azure/WALinuxAgent/issues/1877
+
+# kola: { "exclusive": false, "platforms": "!azure" }
 set -xeuo pipefail
 
 ok() {


### PR DESCRIPTION
Disable on azure because of a limitation of the hv_netvsc driver
there. According to [1] and [2] the driver does not provide sufficient
information to systemd-udev for systemd's naming to work. It falls
back to basic ethX naming.

[1] https://access.redhat.com/solutions/3204751
[2] https://github.com/Azure/WALinuxAgent/issues/1877