### PR TITLE
[testing] overrides: fast-track coreos-installer 0.12.0-1.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  coreos-installer:
+    evr: 0.12.0-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-a9ed18c2c3
+      reason: https://github.com/coreos/coreos-installer/releases/tag/v0.12.0
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.12.0-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-a9ed18c2c3
+      reason: https://github.com/coreos/coreos-installer/releases/tag/v0.12.0
+      type: fast-track


### PR DESCRIPTION
(cherry picked from commit e6c13cce1c1ba90945c2e82634c6549fa65bd084)