### PR TITLE
networking: add test scripts for force-persist-ip

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -11,3 +11,13 @@ fatal() {
     echo "$@" >&2
     exit 1
 }
+
+get_ip_for_nic () {
+    local nic_name=$1
+    nic_ip=""
+    nic_ip=`ip -j addr show ${nic_name} | jq -r '.[0].addr_info | map(select(.family == "inet")) | .[0].local'`
+    if [ -z "$nic_ip" ]; then
+        echo "Error: can not get ${nic_name} ip"
+        exit 1
+    fi
+}

--- a/tests/kola/networking/force-persist-ip/config.bu
+++ b/tests/kola/networking/force-persist-ip/config.bu
@@ -1,0 +1,16 @@
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/NetworkManager/system-connections/ens5.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=ens5
+          type=ethernet
+          interface-name=ens5
+          [ipv4]
+          dns-search=
+          may-fail=false
+          method=auto

--- a/tests/kola/networking/force-persist-ip/data/commonlib.sh
+++ b/tests/kola/networking/force-persist-ip/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Setup configuration for a single NIC with two different ways:
+# - kargs provide static network config for ens5 and also coreos.force_persist_ip
+# - ignition provides dhcp network config for ens5
+# Expected result:
+# - with coreos.force_persist_ip ip=kargs win, verify that 
+#   ens5 has the static IP address via kargs
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8 coreos.force_persist_ip"}
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Verify ens5 get staic ip via kargs
+nic_name="ens5"
+nic_ip=""
+get_ip_for_nic ${nic_name}
+if [ ${nic_ip} != "10.10.10.10" ]; then
+    fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.10.10.10"
+fi
+ok "get ${nic_name} ip is 10.10.10.10"
+
+syscon="/etc/NetworkManager/system-connections"
+if [ ! -f "${syscon}/${nic_name}.nmconnection" ]; then
+    fatal "Error: can not find ${syscon}/${nic_name}.nmconnection"
+fi
+ok "find ${syscon}/${nic_name}.nmconnection"
+
+# Verify logs
+if ! journalctl -b 0 -u coreos-teardown-initramfs | \
+     grep -q "info: coreos.force_persist_ip detected: will force network config propagation"; then
+  fatal "Error: force network config propagation not work"
+fi
+ok "force network config propagation"

--- a/tests/kola/networking/prefer-ignition-networking/config.bu
+++ b/tests/kola/networking/prefer-ignition-networking/config.bu
@@ -1,0 +1,16 @@
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/NetworkManager/system-connections/ens5.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=ens5
+          type=ethernet
+          interface-name=ens5
+          [ipv4]
+          dns-search=
+          may-fail=false
+          method=auto

--- a/tests/kola/networking/prefer-ignition-networking/data/commonlib.sh
+++ b/tests/kola/networking/prefer-ignition-networking/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Setup configuration for a single NIC with two different ways:
+# - kargs provide static network config for ens5 without coreos.force_persist_ip
+# - ignition provides dhcp network config for ens5
+# Expected result:
+# - without coreos.force_persist_ip Ignition networking 
+#   configuration wins, verify that ens5 gets ip via dhcp
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8"}
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Verify ens5 get ip address via dhcp
+nic_name="ens5"
+nic_ip=""
+get_ip_for_nic ${nic_name}
+if [ ${nic_ip} != "10.0.2.31" ]; then
+    fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.0.2.31"
+fi
+ok "get ${nic_name} ip is 10.0.2.31"
+
+syscon="/etc/NetworkManager/system-connections"
+if [ ! -f "${syscon}/${nic_name}.nmconnection" ]; then
+    fatal "Error: can not find ${syscon}/${nic_name}.nmconnection"
+fi
+ok "find ${syscon}/${nic_name}.nmconnection"


### PR DESCRIPTION
This is to test with and without coreos.force_persist_ip.

Setup configuration for a single NIC with two different ways:

- karg ip=x provides static network config for ens5 and (or not)
  coreos.force_persist_ip
- ignition provides dhcp network config for ens5

Expected result:
- With coreos.force_persist_ip, ip=kargs wins, ens5 gets the static IP address via kargs
- Without coreos.force_persist_ip, Ignition networking configuration wins,
  ens5 gets ip via dhcp
See https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
    
commonlib.sh: add func get_ip_for_nic
    This is to add func get_ip_for_nic to get ip for the specified nic