### PR TITLE
[rawhide] unpin systemd; run authselect on first boot

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,33 +14,3 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
-  systemd:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin
-  systemd-container:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin
-  systemd-libs:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin
-  systemd-pam:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin
-  systemd-resolved:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin
-  systemd-udev:
-    evr: 249.7-2.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1046'
-      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,10 @@ repos:
 add-commit-metadata:
   fedora-coreos.stream: rawhide
 
+packages:
+  # for nsswitch.conf
+  - authselect
+
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,3 +27,50 @@ postprocess:
     mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
+
+  # The ownership of nsswitch.conf has moved to authselect in F36+
+  # and right now the file is created by running authselect in a
+  # %posttrans, which fails. We need to work around this problem.
+  # This workaround is twofold:
+  #
+  #   - Manually input nsswitch.conf during the build process so
+  #     that rpm-ostree won't fail when it tries to inject altfiles.
+  #   - Run `authselect` on first boot to create all the files it needs
+  #     and re-add altfiles entries to newly created nsswitch.conf.
+  #
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1051
+  - |
+    #!/usr/bin/bash
+    set -xeuo pipefail
+    cat <<'EOF' > /etc/nsswitch.conf
+    # In order of likelihood of use to accelerate lookup.
+    passwd:     files sss systemd
+    shadow:     files
+    group:      files sss systemd
+    hosts:      files resolve [!UNAVAIL=return] myhostname dns
+    services:   files sss
+    netgroup:   files sss
+    automount:  files sss
+    
+    aliases:    files
+    ethers:     files
+    gshadow:    files
+    networks:   files dns
+    protocols:  files
+    publickey:  files
+    rpc:        files
+    EOF
+    cat <<'EOF' > /usr/lib/systemd/system/rpm-ostree-authselect.service
+      [Unit]
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1051
+      Description=Run Authselect on RPM-OSTree System to Workaround Issue
+      ConditionPathExists=!/etc/authselect/nsswitch.conf
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/bin/authselect select sssd with-silent-lastlog --force
+      ExecStartPost=sed -i -E "s/^(passwd|group):(.*?)files/\1:\2files altfiles/" /etc/nsswitch.conf
+      [Install]
+      WantedBy=default.target
+    EOF
+    ln -s /usr/lib/systemd/system/rpm-ostree-authselect.service /etc/systemd/system/multi-user.target.wants/rpm-ostree-authselect.service


### PR DESCRIPTION
```
commit 7ec35dbd959bce1664ccaec6c23525831e1df74f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Dec 20 10:21:44 2021 -0500

    manifest: run authselect on first boot to workaround bug
    
    The ownership of nsswitch.conf has moved to authselect in F36+
    and right now the file is created by running authselect in a
    %posttrans, which fails. We need to work around this problem.
    This workaround is twofold:
    
      - Manually input nsswitch.conf during the build process so
        that rpm-ostree won't fail when it tries to inject altfiles.
      - Run `authselect` on first boot to create all the files it needs
        and re-add altfiles entries to newly created nsswitch.conf.
    
    Workaround for https://github.com/coreos/fedora-coreos-tracker/issues/1051

commit 5a2be4d864fa1c39fa6685fea3a38bac5c94930d
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Dec 16 11:44:04 2021 -0500

    manifest: pull in authselect
    
    This is required now as per:
    https://fedoraproject.org/wiki/Changes/Make_Authselect_Mandatory
    https://src.fedoraproject.org/rpms/glibc/c/cadee80b1316?branch=rawhide
    https://bugzilla.redhat.com/show_bug.cgi?id=2023741

commit 9e75411667e61c9940d567e1438ca92e28fbf144
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Dec 20 10:20:04 2021 -0500

    overrides: unpin systemd
    
    It turns out too many things are being built against the new
    systemd for us to effectively pin it. We'll snooze the test
    (ext.config.podman.dns) instead while we investigate the fix.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/1046
```
