### PR TITLE
denylist: snooze ext.config.podman.dns test on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -14,3 +14,8 @@
     - aarch64
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/860
+- pattern: ext.config.podman.dns
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
+  snooze: 2022-01-20
+  streams:
+    - rawhide


### PR DESCRIPTION
It turns out too many things are being built against the new
systemd for us to effectively pin it. Let's snooze the test
(ext.config.podman.dns) instead while we investigate the fix.

See https://github.com/coreos/fedora-coreos-tracker/issues/1046