### PR TITLE
workflows: comment on `next-devel` PRs if the branch is closed

### DIFF
--- a/.github/workflows/next-devel.yml
+++ b/.github/workflows/next-devel.yml
@@ -1,0 +1,32 @@
+---
+name: next-devel
+on:
+  pull_request:
+    branches: [next-devel]
+    types: [opened, edited, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+# Privileged job to comment on next-devel PRs indicating whether next-devel
+# is currently open.  This job must not trust the contents of the PR.
+
+jobs:
+  branch-status:
+    name: "Check branch status"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post PR comment
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const url = 'https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/main/next-devel/status.json'
+            const resp = await github.request(url)
+            if (!JSON.parse(resp.data).enabled) {
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: ':no_entry: The `next-devel` branch is currently closed.  PRs should target only `testing-devel`.',
+              })
+            }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Fedora CoreOS Config
+
+[![next-devel status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/coreos/fedora-coreos-pipeline/main/next-devel/badge.json)](https://github.com/coreos/fedora-coreos-pipeline/blob/main/next-devel/README.md)
+
 Base manifest configuration for
 [Fedora CoreOS](https://coreos.fedoraproject.org/).
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ https://github.com/coreos/fedora-coreos-tracker.
 There is one branch for each stream. The default branch is
 [`testing-devel`](https://github.com/coreos/fedora-coreos-config/commits/testing-devel),
 on which all development happens. See
-[the design](https://github.com/coreos/fedora-coreos-tracker/blob/main//Design.md#release-streams)
-and [tooling](https://github.com/coreos/fedora-coreos-tracker/blob/main//stream-tooling.md)
+[the design](https://github.com/coreos/fedora-coreos-tracker/blob/main/Design.md#release-streams)
+and [tooling](https://github.com/coreos/fedora-coreos-tracker/blob/main/stream-tooling.md)
 docs for more information about streams.
 
 All file changes in `testing-devel` are propagated to other


### PR DESCRIPTION
When a next-devel PR is opened, reopened, marked ready for review, or its base branch is changed, post a comment if the branch is not currently accepting PRs.  This should help reduce confusion for occasional maintainers.

Also add a README badge indicating the current `next-devel` branch status.