### PR TITLE
denylist: snooze ostree.hotfix podman.base tests on rawhide stream

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ostree.hotfix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
-  snooze: 2021-10-25
+  snooze: 2022-01-10
   streams:
     - rawhide
   arches:
@@ -17,5 +17,10 @@
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
   snooze: 2022-01-20
+  streams:
+    - rawhide
+- pattern: podman.base
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1049
+  snooze: 2022-01-10
   streams:
     - rawhide


### PR DESCRIPTION
The ostree.hotfix tests rears it's ugly head a few weeks a month
and the podman.base test is surfacing kernel locking dep warnings.
Since no one is going to dig into these for the next few weeks let's
snooze them in the hopes we can finally get a new aarch64 rawhide
build.