### PR TITLE
manifests/user-experience: Set nano as default editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,11 @@ the corresponding entries in the lockfiles:
 There will be better tooling to come to enable this, though
 one easy way to do this is for now:
 - add packages to the correct YAML manifest
-- run `cosa fetch --update-lockfile`
-- commit only the new package entries
+- run `cosa fetch --update-lockfile` (this will only update the lockfile for
+  the current architecture, most likely `x86_64`)
+- copy the new lines to the lockfiles for other architectures (i.e. `aarch64`)
+- commit only the new package entries (skip the timestamped changes to avoid
+  merge conflicts with the lockfile updates made by the bot)
 
 ## Moving to a new major version (N) of Fedora
 

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -858,6 +858,12 @@
     "mpfr": {
       "evra": "4.1.0-8.fc35.aarch64"
     },
+    "nano": {
+      "evra": "5.8-4.fc35.aarch64"
+    },
+    "nano-default-editor": {
+      "evra": "5.8-4.fc35.noarch"
+    },
     "ncurses": {
       "evra": "6.2-8.20210508.fc35.aarch64"
     },

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -870,6 +870,12 @@
     "mpfr": {
       "evra": "4.1.0-8.fc35.x86_64"
     },
+    "nano": {
+      "evra": "5.8-4.fc35.x86_64"
+    },
+    "nano-default-editor": {
+      "evra": "5.8-4.fc35.noarch"
+    },
     "ncurses": {
       "evra": "6.2-8.20210508.fc35.x86_64"
     },

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -26,6 +26,8 @@ packages:
   - fedora-coreos-pinger
   # Updates
   - zincati
+  # Include and set the default editor
+  - nano nano-default-editor
 
 etc-group-members:
   # Add the docker group to /etc/group


### PR DESCRIPTION
Add nano and set it as default editor.

This is following the corresponding Fedora Change in Fedora 33:
https://fedoraproject.org/wiki/Changes/UseNanoByDefault

To revert to current default:
```
$ sudo rm /etc/profile.d/nano.{sh,csh}
```

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1058