### PR TITLE
tests: Add OS extensions test

### DIFF
--- a/tests/kola/extensions/data/commonlib.sh
+++ b/tests/kola/extensions/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/extensions/test.sh
+++ b/tests/kola/extensions/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
+# kola: { "distros": "fcos", "tags": "needs-internet" }
+#
+# This test ensures that we can install some common tools as OS extensions.
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+commands=(
+  'gdb'
+  'htop'
+  'strace'
+  'tcpdump'
+  'tree'
+  'vim'
+)
+
+rpm-ostree install --apply-live "${commands[@]}"
+
+failed=""
+
+for c in "${commands[@]}"; do
+  if [[ -z "$(command -v "${c}")" ]]; then
+    echo "Could not find: ${c}"
+    failed+=" ${1}"
+  fi
+done
+
+if [[ -n "${failed}" ]]; then
+  fatal "could not install: ${failed}"
+fi
+ok "successfully installed os extensions"


### PR DESCRIPTION
Ensure that we can install common tools that are not strictly required
for operation but do not really make sense to run from a container and
are usually useful as overlayed packages/OS extensions.