### PR TITLE
[rawhide] overrides: pin to authselect-1.3.0-3.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,13 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
       type: pin
+  authselect:
+    evr: 1.3.0-3.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      type: pin
+  authselect-libs:
+    evr: 1.3.0-3.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      type: pin


### PR DESCRIPTION
The %pre scripts were converted to lua which is currently incompatible
with rpm-ostree. Will track progress on getting it fixed in
https://github.com/coreos/fedora-coreos-tracker/issues/1057