### PR TITLE
kola-denylist: snooze karg networking tests on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,3 +24,13 @@
   snooze: 2022-01-10
   streams:
     - rawhide
+- pattern: ext.config.networking.prefer-ignition-networking
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+  snooze: 2022-01-25
+  streams:
+    - rawhide
+- pattern: ext.config.networking.force-persist-ip
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+  snooze: 2022-01-25
+  streams:
+    - rawhide


### PR DESCRIPTION
They are failing right now because `systemd-network-generator` is
having issues writing files because of SELinux. See:

- https://github.com/coreos/fedora-coreos-tracker/issues/1059
- https://bugzilla.redhat.com/show_bug.cgi?id=2037047