### PR TITLE
networking: configure MTU on a VLAN subinterface for the bond works

### DIFF
--- a/tests/kola/networking/mtu-on-bond
+++ b/tests/kola/networking/mtu-on-bond
@@ -1,0 +1,35 @@
+#!/bin/bash
+# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000: vlan=bond0.100:bond0 net.ifnames=0"}
+# - We use net.ifnames=0 to disable consistent network naming here because on
+#   different firmwares (BIOS vs UEFI) the NIC names are different.
+#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+
+# Configuring MTU on a VLAN subinterface for the bond,
+# - verify MTU on the bond matches config
+# - verify MTU on the VLAN subinterface for the bond matches config
+# - verify ip address on the VLAN subinterface for the bond matches config
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1932502#c9
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+bond="bond0"
+vlan="bond0.100"
+for interface in $bond $vlan
+do
+    mtu=""
+    # MTU is changed to 9000 by `appendKernelArgs` in `kola` above
+    mtu=$(nmcli -g 802-3-ethernet.mtu connection show ${interface})
+    if [ "${mtu}" != "9000" ]; then
+        fatal "Error: get ${interface} mtu = ${mtu}, expected is 9000"
+    fi
+    ok "${interface} mtu is correct"
+done
+
+# Verify "bond0.100" gets ip address by `appendKernelArgs` in `kola` above
+nic_ip=$(get_ipv4_for_nic ${vlan})
+if [ "${nic_ip}" != "10.10.10.10" ]; then
+    fatal "Error: get ${vlan} ip = ${nic_ip}, expected is 10.10.10.10"
+fi
+ok "get ${vlan} ip is 10.10.10.10"


### PR DESCRIPTION
Configuring MTU on a VLAN subinterface for the bond,
- verify MTU on the bond matches config
- verify MTU on the VLAN subinterface for the bond matches config
- verify ip address on the VLAN subinterface for the bond matches config
See https://bugzilla.redhat.com/show_bug.cgi?id=1932502#c9