### PR TITLE
[next] tests: Limit kola networking karg tests to x86_64 for now

### DIFF
--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -9,7 +9,9 @@ set -xeuo pipefail
 #   ens5 has the static IP address via kargs
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8 coreos.force_persist_ip"}
+# These tests fail on aarch64. Limit to x86_64 for now:
+# 	- https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8 coreos.force_persist_ip", "architectures": "x86_64"}
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -9,7 +9,9 @@ set -xeuo pipefail
 #   configuration wins, verify that ens5 gets ip via dhcp
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8"}
+# These tests fail on aarch64. Limit to x86_64 for now:
+# 	- https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8", "architectures": "x86_64"}
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
These tests fail on aarch64 becaue the interface names are different.
Limit to x86_64 for now. See https://github.com/coreos/fedora-coreos-tracker/issues/1060

(cherry picked from commit 0409b297baa2088d497d795b62600a418bced75d)