### PR TITLE
tests: Rework 'find' calls with multiple file type filters

### DIFF
--- a/tests/kola/files/file-directory-permissions
+++ b/tests/kola/files/file-directory-permissions
@@ -5,9 +5,11 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-list="$(find /etc -type f -type d -perm /022)"
+list="$(find /usr /etc -type f -perm /022 -o -type d -perm /022)"
+
 if [[ -n "${list}" ]]; then
-    find /etc -type f -type d -perm /022 -print0 | xargs -0 ls -al
+    find /usr /etc -type f -perm /022 -print0 -o -type d -perm /022 -print0 | xargs -0 ls -al
+    find /usr /etc -type f -perm /022 -print0 -o -type d -perm /022 -print0 | xargs -0 rpm -qf
     fatal "found files or directories with 'g+w' or 'o+w' permission"
 fi
 ok "no files with 'g+w' or 'o+w' permission found in /etc"

--- a/tests/kola/files/file-directory-permissions
+++ b/tests/kola/files/file-directory-permissions
@@ -5,9 +5,42 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-list="$(find /usr /etc -type f -perm /022 -o -type d -perm /022)"
+# List of known files and directories with group write permission
+list_known=()
 
-if [[ -n "${list}" ]]; then
+# List of known files and directories with group write permission (RHCOS only)
+list_known_rhcos=(
+    '/usr/share/licenses/publicsuffix-list-dafsa/COPYING'
+)
+
+is_fcos="false"
+if [[ "$(source /etc/os-release && echo "${ID}")" == "fedora" ]]; then
+    is_fcos="true"
+fi
+
+unknown=""
+while IFS= read -r -d '' e; do
+    found="false"
+    for k in "${list_known[@]}"; do
+        if [[ "${k}" == "${e}" ]]; then
+            found="true"
+            break
+        fi
+    done
+    if [[ "${is_fcos}" == "false" ]]; then
+        for k in "${list_known_rhcos[@]}"; do
+            if [[ "${k}" == "${e}" ]]; then
+                found="true"
+                break
+            fi
+        done
+    fi
+    if [[ "${found}" == "false" ]]; then
+        unknown+=" ${e}"
+    fi
+done< <(find /usr /etc -type f -perm /022 -print0 -o -type d -perm /022 -print0)
+
+if [[ -n "${unknown}" ]]; then
     find /usr /etc -type f -perm /022 -print0 -o -type d -perm /022 -print0 | xargs -0 ls -al
     find /usr /etc -type f -perm /022 -print0 -o -type d -perm /022 -print0 | xargs -0 rpm -qf
     fatal "found files or directories with 'g+w' or 'o+w' permission"

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -10,6 +10,7 @@ list_setgid_files=(
     '/usr/libexec/openssh/ssh-keysign'
     '/usr/libexec/utempter/utempter'
 )
+
 unknown_setgid_files=""
 while IFS= read -r -d '' e; do
     found="false"
@@ -22,7 +23,7 @@ while IFS= read -r -d '' e; do
     if [[ "${found}" == "false" ]]; then
         unknown_setgid_files+=" ${e}"
     fi
-done< <(find /usr /etc -type f,d -perm /2000 -print0)
+done< <(find /usr /etc -type f -perm /2000 -print0 -o -type d -perm /2000 -print0)
 
 if [[ -n "${unknown_setgid_files}" ]]; then
     echo "SetGID:${unknown_setgid_files}"

--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -25,6 +25,20 @@ list_setuid_files=(
     '/usr/sbin/unix_chkpwd'
 )
 
+# List of known files and directories with SetUID bit set (RHCOS only)
+list_setuid_files_rhcos=(
+    '/usr/libexec/dbus-1/dbus-daemon-launch-helper'
+    '/usr/libexec/sssd/krb5_child'
+    '/usr/libexec/sssd/ldap_child'
+    '/usr/libexec/sssd/proxy_child'
+    '/usr/libexec/sssd/selinux_child'
+)
+
+is_fcos="false"
+if [[ "$(source /etc/os-release && echo "${ID}")" == "fedora" ]]; then
+    is_fcos="true"
+fi
+
 unknown_setuid_files=""
 while IFS= read -r -d '' e; do
     found="false"
@@ -34,6 +48,14 @@ while IFS= read -r -d '' e; do
             break
         fi
     done
+    if [[ "${is_fcos}" == "false" ]]; then
+        for k in "${list_setuid_files_rhcos[@]}"; do
+            if [[ "${k}" == "${e}" ]]; then
+                found="true"
+                break
+            fi
+        done
+    fi
     if [[ "${found}" == "false" ]]; then
         unknown_setuid_files+=" ${e}"
     fi

--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -24,6 +24,7 @@ list_setuid_files=(
     '/usr/sbin/pam_timestamp_check'
     '/usr/sbin/unix_chkpwd'
 )
+
 unknown_setuid_files=""
 while IFS= read -r -d '' e; do
     found="false"
@@ -36,7 +37,7 @@ while IFS= read -r -d '' e; do
     if [[ "${found}" == "false" ]]; then
         unknown_setuid_files+=" ${e}"
     fi
-done< <(find /usr /etc -type f,d -perm /4000 -print0)
+done< <(find /usr /etc -type f -perm /4000 -print0 -o -type d -perm /4000 -print0)
 
 if [[ -n "${unknown_setuid_files}" ]]; then
     echo "SetUID:${unknown_setuid_files}"


### PR DESCRIPTION
Fedora has a recent enough `find` command to be able to use the `-type
f,d` option but that is not yet supported by `find` on RHEL.

We can not use `-type f -type d` instead as this filters on entries
being both a file and a directory which never happens.

Thus rework tests using that option to be compatible on both FCOS and
RHCOS. We can drop this change once RHCOS moves to RHEL 9.

Fixes: https://github.com/coreos/fedora-coreos-config/commit/dac1f6835e1e730409a4062c6562ece32bddaee1