### PR TITLE
tests: Add OS module extensions test

### DIFF
--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
+# kola: { "distros": "fcos", "tags": "needs-internet" }
+#
+# This test ensures that we can install some common tools as OS extensions.
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Note: This version must be kept up to date for now, since there currently is no 'latest' (or similar) stream
+CRIO_VERSION=1.22
+
+declare -A commands=(
+  ["cri-o:${CRIO_VERSION}/default"]="crio"
+  ["nginx:mainline"]="nginx"
+)
+
+rpm-ostree ex module install "${!commands[@]}"
+rpm-ostree ex apply-live
+
+failed=""
+
+for m in "${!commands[@]}"; do
+  if [[ -z "$(command -v "${commands[$m]}")" ]]; then
+    echo "Could not find: ${commands[$m]}"
+    failed+=" ${1}"
+  fi
+done
+
+if [[ -n "${failed}" ]]; then
+  fatal "could not install: ${failed}"
+fi
+ok "successfully installed os rpm module extensions"

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -31,4 +31,4 @@ done
 if [[ -n "${failed}" ]]; then
   fatal "could not install: ${failed}"
 fi
-ok "successfully installed os extensions"
+ok "successfully installed os rpm package extensions"


### PR DESCRIPTION
Ensure that we can install commonly used RPM modules as overlay.

This is somewhat related to OKD's planned move to use the cri-o module, even though it is currently not added as an overlay there but part of the compose: https://github.com/openshift/okd-machine-os/pull/249

~~I'm not sure the perl overlay is actually commonly overlayed, but it seemed to make the most sense when looking at the output of `dnf module list`, other than cri-o of course.~~ replaced with nginx

/cc @jlebon
/cc @travier