### PR TITLE
tests: use net.ifnames=0 for karg network tests

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -12,12 +12,12 @@ fatal() {
     exit 1
 }
 
-get_ip_for_nic () {
+get_ipv4_for_nic() {
     local nic_name=$1
-    nic_ip=""
-    nic_ip=`ip -j addr show ${nic_name} | jq -r '.[0].addr_info | map(select(.family == "inet")) | .[0].local'`
-    if [ -z "$nic_ip" ]; then
-        echo "Error: can not get ${nic_name} ip"
+    local ip=$(ip -j addr show ${nic_name} | jq -r '.[0].addr_info | map(select(.family == "inet")) | .[0].local')
+    if [ -z "$ip" ]; then
+        echo "Error: can not get ip for ${nic_name}"
         exit 1
     fi
+    echo $ip
 }

--- a/tests/kola/networking/force-persist-ip/config.bu
+++ b/tests/kola/networking/force-persist-ip/config.bu
@@ -2,14 +2,14 @@ variant: fcos
 version: 1.4.0
 storage:
   files:
-    - path: /etc/NetworkManager/system-connections/ens5.nmconnection
+    - path: /etc/NetworkManager/system-connections/eth1.nmconnection
       mode: 0600
       contents:
         inline: |
           [connection]
-          id=ens5
+          id=eth1
           type=ethernet
-          interface-name=ens5
+          interface-name=eth1
           [ipv4]
           dns-search=
           may-fail=false

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -17,8 +17,7 @@ set -xeuo pipefail
 
 # Verify ens5 get staic ip via kargs
 nic_name="ens5"
-nic_ip=""
-get_ip_for_nic ${nic_name}
+nic_ip=$(get_ipv4_for_nic ${nic_name})
 if [ ${nic_ip} != "10.10.10.10" ]; then
     fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.10.10.10"
 fi

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -2,21 +2,22 @@
 set -xeuo pipefail
 
 # Setup configuration for a single NIC with two different ways:
-# - kargs provide static network config for ens5 and also coreos.force_persist_ip
-# - ignition provides dhcp network config for ens5
+# - kargs provide static network config for eth1 and also coreos.force_persist_ip
+# - ignition provides dhcp network config for eth1
 # Expected result:
 # - with coreos.force_persist_ip ip=kargs win, verify that 
-#   ens5 has the static IP address via kargs
+#   eth1 has the static IP address via kargs
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# These tests fail on aarch64. Limit to x86_64 for now:
-# 	- https://github.com/coreos/fedora-coreos-tracker/issues/1060
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8 coreos.force_persist_ip", "architectures": "x86_64"}
+# - We use net.ifnames=0 to disable consistent network naming here because on
+#   different firmwares (BIOS vs UEFI) the NIC names are different.
+#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip" }
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# Verify ens5 get staic ip via kargs
-nic_name="ens5"
+# Verify eth1 gets staic ip via kargs
+nic_name="eth1"
 nic_ip=$(get_ipv4_for_nic ${nic_name})
 if [ ${nic_ip} != "10.10.10.10" ]; then
     fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.10.10.10"

--- a/tests/kola/networking/prefer-ignition-networking/config.bu
+++ b/tests/kola/networking/prefer-ignition-networking/config.bu
@@ -2,14 +2,14 @@ variant: fcos
 version: 1.4.0
 storage:
   files:
-    - path: /etc/NetworkManager/system-connections/ens5.nmconnection
+    - path: /etc/NetworkManager/system-connections/eth1.nmconnection
       mode: 0600
       contents:
         inline: |
           [connection]
-          id=ens5
+          id=eth1
           type=ethernet
-          interface-name=ens5
+          interface-name=eth1
           [ipv4]
           dns-search=
           may-fail=false

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -2,21 +2,22 @@
 set -xeuo pipefail
 
 # Setup configuration for a single NIC with two different ways:
-# - kargs provide static network config for ens5 without coreos.force_persist_ip
-# - ignition provides dhcp network config for ens5
+# - kargs provide static network config for eth1 without coreos.force_persist_ip
+# - ignition provides dhcp network config for eth1
 # Expected result:
 # - without coreos.force_persist_ip Ignition networking 
-#   configuration wins, verify that ens5 gets ip via dhcp
+#   configuration wins, verify that eth1 gets ip via dhcp
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# These tests fail on aarch64. Limit to x86_64 for now:
-# 	- https://github.com/coreos/fedora-coreos-tracker/issues/1060
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens5:none:8.8.8.8", "architectures": "x86_64"}
+# - We use net.ifnames=0 to disable consistent network naming here because on
+#   different firmwares (BIOS vs UEFI) the NIC names are different.
+#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0" }
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# Verify ens5 get ip address via dhcp
-nic_name="ens5"
+# Verify eth1 gets ip address via dhcp
+nic_name="eth1"
 nic_ip=$(get_ipv4_for_nic ${nic_name})
 if [ ${nic_ip} != "10.0.2.31" ]; then
     fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.0.2.31"

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -17,8 +17,7 @@ set -xeuo pipefail
 
 # Verify ens5 get ip address via dhcp
 nic_name="ens5"
-nic_ip=""
-get_ip_for_nic ${nic_name}
+nic_ip=$(get_ipv4_for_nic ${nic_name})
 if [ ${nic_ip} != "10.0.2.31" ]; then
     fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.0.2.31"
 fi


### PR DESCRIPTION
In order to allow the tests to work on both x86_64/BIOS, x86_64/UEFI
and aarch64/UEFI we use net.ifnames=0 so we can use eth1 in all
instances and it just works. Otherwise on x86_64/BIOS we get ens5
and on UEFI we get enp0s4.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1060
