### PR TITLE
[next] manifest: add microdnf to be used internally by rpm-ostree

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -352,7 +352,7 @@
       "evra": "0.21-8.fc35.aarch64"
     },
     "git-core": {
-      "evra": "2.33.1-2.fc35.aarch64"
+      "evra": "2.34.1-1.fc35.aarch64"
     },
     "glib2": {
       "evra": "2.70.2-1.fc35.aarch64"
@@ -463,13 +463,13 @@
       "evra": "2.4.0-8.fc35.noarch"
     },
     "kernel": {
-      "evra": "5.15.12-200.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kernel-core": {
-      "evra": "5.15.12-200.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kernel-modules": {
-      "evra": "5.15.12-200.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kexec-tools": {
       "evra": "2.0.22-7.fc35.aarch64"
@@ -529,7 +529,7 @@
       "evra": "2.48-3.fc35.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-6.fc35.aarch64"
+      "evra": "0.8.2-8.fc35.aarch64"
     },
     "libcbor": {
       "evra": "0.7.0-4.fc35.aarch64"
@@ -781,7 +781,7 @@
       "evra": "2.37.2-1.fc35.aarch64"
     },
     "libuv": {
-      "evra": "1:1.42.0-2.fc35.aarch64"
+      "evra": "1:1.43.0-2.fc35.aarch64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.aarch64"
@@ -805,7 +805,7 @@
       "evra": "0.2.5-6.fc35.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.1-3.fc35.aarch64"
+      "evra": "1.5.1-4.fc35.aarch64"
     },
     "linux-atm-libs": {
       "evra": "2.5.1-30.fc35.aarch64"
@@ -919,10 +919,10 @@
       "evra": "1.77-8.fc35.aarch64"
     },
     "ostree": {
-      "evra": "2021.6-3.fc35.aarch64"
+      "evra": "2022.1-1.fc35.aarch64"
     },
     "ostree-libs": {
-      "evra": "2021.6-3.fc35.aarch64"
+      "evra": "2022.1-1.fc35.aarch64"
     },
     "p11-kit": {
       "evra": "0.23.22-4.fc35.aarch64"
@@ -1003,10 +1003,10 @@
       "evra": "4.17.0-1.fc35.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2021.14-2.fc35.aarch64"
+      "evra": "2022.1-2.fc35.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2021.14-2.fc35.aarch64"
+      "evra": "2022.1-2.fc35.aarch64"
     },
     "rpm-plugin-selinux": {
       "evra": "4.17.0-1.fc35.aarch64"
@@ -1030,10 +1030,10 @@
       "evra": "4.8-8.fc35.aarch64"
     },
     "selinux-policy": {
-      "evra": "35.7-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.7-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "setup": {
       "evra": "2.13.9.1-2.fc35.noarch"
@@ -1156,10 +1156,10 @@
       "evra": "2.37.2-1.fc35.aarch64"
     },
     "vim-data": {
-      "evra": "2:8.2.3755-1.fc35.noarch"
+      "evra": "2:8.2.4006-1.fc35.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.3755-1.fc35.aarch64"
+      "evra": "2:8.2.4006-1.fc35.aarch64"
     },
     "which": {
       "evra": "2.21-27.fc35.aarch64"
@@ -1193,16 +1193,16 @@
     }
   },
   "metadata": {
-    "generated": "2022-01-03T20:53:16Z",
+    "generated": "2022-01-11T21:53:36Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:21Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2022-01-01T21:29:04Z"
+        "generated": "2022-01-10T17:33:41Z"
       },
       "fedora-updates": {
-        "generated": "2022-01-03T00:34:36Z"
+        "generated": "2022-01-11T02:16:23Z"
       }
     }
   }

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -222,6 +222,9 @@
     "diffutils": {
       "evra": "3.8-1.fc35.aarch64"
     },
+    "dnf-data": {
+      "evra": "4.9.0-1.fc35.noarch"
+    },
     "dnsmasq": {
       "evra": "2.86-3.fc35.aarch64"
     },
@@ -374,6 +377,9 @@
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.aarch64"
+    },
+    "gobject-introspection": {
+      "evra": "1.70.0-1.fc35.aarch64"
     },
     "gpgme": {
       "evra": "1.15.1-6.fc35.aarch64"
@@ -552,6 +558,9 @@
     "libdhash": {
       "evra": "0.5.0-48.fc35.aarch64"
     },
+    "libdnf": {
+      "evra": "0.64.0-1.fc35.aarch64"
+    },
     "libeconf": {
       "evra": "0.4.0-2.fc35.aarch64"
     },
@@ -674,6 +683,9 @@
     },
     "libpcap": {
       "evra": "14:1.10.1-2.fc35.aarch64"
+    },
+    "libpeas": {
+      "evra": "1.30.0-5.fc35.aarch64"
     },
     "libpkgconf": {
       "evra": "1.8.0-1.fc35.aarch64"
@@ -845,6 +857,9 @@
     },
     "mdadm": {
       "evra": "4.2-rc2.fc35.aarch64"
+    },
+    "microdnf": {
+      "evra": "3.8.0-2.fc35.aarch64"
     },
     "moby-engine": {
       "evra": "20.10.11-1.fc35.aarch64"

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-core:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-modules:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -352,7 +352,7 @@
       "evra": "0.21-8.fc35.x86_64"
     },
     "git-core": {
-      "evra": "2.33.1-2.fc35.x86_64"
+      "evra": "2.34.1-1.fc35.x86_64"
     },
     "glib2": {
       "evra": "2.70.2-1.fc35.x86_64"
@@ -469,13 +469,13 @@
       "evra": "2.4.0-8.fc35.noarch"
     },
     "kernel": {
-      "evra": "5.15.12-200.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kernel-core": {
-      "evra": "5.15.12-200.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.15.12-200.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.22-7.fc35.x86_64"
@@ -535,7 +535,7 @@
       "evra": "2.48-3.fc35.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-6.fc35.x86_64"
+      "evra": "0.8.2-8.fc35.x86_64"
     },
     "libcbor": {
       "evra": "0.7.0-4.fc35.x86_64"
@@ -790,7 +790,7 @@
       "evra": "2.37.2-1.fc35.x86_64"
     },
     "libuv": {
-      "evra": "1:1.42.0-2.fc35.x86_64"
+      "evra": "1:1.43.0-2.fc35.x86_64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.x86_64"
@@ -814,7 +814,7 @@
       "evra": "0.2.5-6.fc35.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.1-3.fc35.x86_64"
+      "evra": "1.5.1-4.fc35.x86_64"
     },
     "linux-atm-libs": {
       "evra": "2.5.1-30.fc35.x86_64"
@@ -931,10 +931,10 @@
       "evra": "1.77-8.fc35.x86_64"
     },
     "ostree": {
-      "evra": "2021.6-3.fc35.x86_64"
+      "evra": "2022.1-1.fc35.x86_64"
     },
     "ostree-libs": {
-      "evra": "2021.6-3.fc35.x86_64"
+      "evra": "2022.1-1.fc35.x86_64"
     },
     "p11-kit": {
       "evra": "0.23.22-4.fc35.x86_64"
@@ -1015,10 +1015,10 @@
       "evra": "4.17.0-1.fc35.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2021.14-2.fc35.x86_64"
+      "evra": "2022.1-2.fc35.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2021.14-2.fc35.x86_64"
+      "evra": "2022.1-2.fc35.x86_64"
     },
     "rpm-plugin-selinux": {
       "evra": "4.17.0-1.fc35.x86_64"
@@ -1042,10 +1042,10 @@
       "evra": "4.8-8.fc35.x86_64"
     },
     "selinux-policy": {
-      "evra": "35.7-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.7-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "setup": {
       "evra": "2.13.9.1-2.fc35.noarch"
@@ -1168,10 +1168,10 @@
       "evra": "2.37.2-1.fc35.x86_64"
     },
     "vim-data": {
-      "evra": "2:8.2.3755-1.fc35.noarch"
+      "evra": "2:8.2.4006-1.fc35.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.3755-1.fc35.x86_64"
+      "evra": "2:8.2.4006-1.fc35.x86_64"
     },
     "which": {
       "evra": "2.21-27.fc35.x86_64"
@@ -1205,16 +1205,16 @@
     }
   },
   "metadata": {
-    "generated": "2022-01-03T20:53:16Z",
+    "generated": "2022-01-11T21:53:54Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:27Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2022-01-01T21:29:52Z"
+        "generated": "2022-01-10T17:33:45Z"
       },
       "fedora-updates": {
-        "generated": "2022-01-03T00:34:58Z"
+        "generated": "2022-01-11T02:16:43Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -222,6 +222,9 @@
     "diffutils": {
       "evra": "3.8-1.fc35.x86_64"
     },
+    "dnf-data": {
+      "evra": "4.9.0-1.fc35.noarch"
+    },
     "dnsmasq": {
       "evra": "2.86-3.fc35.x86_64"
     },
@@ -374,6 +377,9 @@
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.x86_64"
+    },
+    "gobject-introspection": {
+      "evra": "1.70.0-1.fc35.x86_64"
     },
     "gpgme": {
       "evra": "1.15.1-6.fc35.x86_64"
@@ -558,6 +564,9 @@
     "libdhash": {
       "evra": "0.5.0-48.fc35.x86_64"
     },
+    "libdnf": {
+      "evra": "0.64.0-1.fc35.x86_64"
+    },
     "libeconf": {
       "evra": "0.4.0-2.fc35.x86_64"
     },
@@ -680,6 +689,9 @@
     },
     "libpcap": {
       "evra": "14:1.10.1-2.fc35.x86_64"
+    },
+    "libpeas": {
+      "evra": "1.30.0-5.fc35.x86_64"
     },
     "libpkgconf": {
       "evra": "1.8.0-1.fc35.x86_64"
@@ -857,6 +869,9 @@
     },
     "microcode_ctl": {
       "evra": "2:2.1-47.fc35.x86_64"
+    },
+    "microdnf": {
+      "evra": "3.8.0-2.fc35.x86_64"
     },
     "moby-engine": {
       "evra": "20.10.11-1.fc35.x86_64"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,3 +10,19 @@ rojig:
 
 add-commit-metadata:
   fedora-coreos.stream: next
+
+# These packages are needed for installing packages thru microdnf
+# Currently, this is planned for use on the layering enhancement
+# enhancement: https://github.com/coreos/enhancements/pull/7
+# package request: https://github.com/coreos/fedora-coreos-tracker/issues/1050
+packages:
+ - microdnf
+
+postprocess:
+  # Move microdnf so it is clear that it should not be used on host systems,
+  # it is intended just for containers. This was proposed here: 
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1050#issuecomment-996174981
+  - |
+    #!/usr/bin/env bash
+    mkdir -p /usr/lib/rpm-ostree/
+    mv /usr/bin/microdnf /usr/lib/rpm-ostree/


### PR DESCRIPTION
Same as: https://github.com/coreos/fedora-coreos-config/pull/1381 but for `next`