### PR TITLE
workflows: allow commenting on next-devel PRs from forks

### DIFF
--- a/.github/workflows/next-devel.yml
+++ b/.github/workflows/next-devel.yml
@@ -1,7 +1,9 @@
 ---
 name: next-devel
 on:
-  pull_request:
+  # This is a privileged event!  It runs with a r/w token, even in PRs from
+  # forks.
+  pull_request_target:
     branches: [next-devel]
     types: [opened, edited, reopened, ready_for_review]
 


### PR DESCRIPTION
This was written to be a privileged job, but wasn't actually declared as such.

Fixes #1387.