### PR TITLE
Use new `overlay.d/cosa-no-autolayer` option

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -10,6 +10,13 @@ include:
   - user-experience.yaml
   - shared-workarounds.yaml
 
+ostree-layers:
+  - overlay/05core
+  - overlay/08nouveau
+  - overlay/09misc
+  - overlay/14NetworkManager-plugins
+  - overlay/20platform-chrony
+
 initramfs-args:
   - --no-hostonly
   # We don't support root on NFS, so we don't need it in the initramfs. It also

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -4,6 +4,9 @@
 
 include: fedora-coreos-base.yaml
 
+ostree-layers:
+  - overlay/15fcos
+
 automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
 mutate-os-release: "${releasever}"
 

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -1,3 +1,8 @@
+These overlay directories are automatically committed to the build OSTree repo
+by coreos-assembler. They are then explicitly included in our various manifest
+files via `ostree-layers` (this used to be done automatically, but that's no
+longer the case).
+
 05core
 -----
 


### PR DESCRIPTION
Tell coreos-assembler to not automatically add the overlays to the final
manifest. Add references to the auto-generated OSTree layers in our
lower-level manifests where most appropriate.

Prep for using this to make an overlay only active on the `next-devel`
stream.

Requires: https://github.com/coreos/coreos-assembler/pull/2641