### PR TITLE
kola-denylist: snooze new karg networking test on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,3 +34,8 @@
   snooze: 2022-01-25
   streams:
     - rawhide
+- pattern: ext.config.networking.mtu-on-bond
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+  snooze: 2022-01-25
+  streams:
+    - rawhide


### PR DESCRIPTION
Similar to 104ecf1 we need to snooze the new karg networking test
added in 0a577a1 on rawhide because of the same issue.

See https://github.com/coreos/fedora-coreos-tracker/issues/1059