### PR TITLE
kola-denylist: remove kdump.crash from denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,8 +12,6 @@
     - rawhide
   arches:
     - aarch64
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/860
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
   snooze: 2022-01-20


### PR DESCRIPTION
kdump.crash should run and pass after fixes in https://github.com/coreos/coreos-assembler/pull/2639
Will need to skip kdump.crash test in `coreos-installer` and `afterburn` due CI failures.