### PR TITLE
[next-devel] manifest-lock: import from testing-devel

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -52,13 +52,13 @@
       "evra": "1:2.11-3.fc35.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.16.22-1.fc35.aarch64"
+      "evra": "32:9.16.24-1.fc35.aarch64"
     },
     "bind-license": {
-      "evra": "32:9.16.22-1.fc35.noarch"
+      "evra": "32:9.16.24-1.fc35.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.16.22-1.fc35.aarch64"
+      "evra": "32:9.16.24-1.fc35.aarch64"
     },
     "bootupd": {
       "evra": "0.2.6-1.fc35.aarch64"
@@ -67,7 +67,7 @@
       "evra": "3.5.2-2.fc35.aarch64"
     },
     "btrfs-progs": {
-      "evra": "5.14.2-1.fc35.aarch64"
+      "evra": "5.15.1-1.fc35.aarch64"
     },
     "bubblewrap": {
       "evra": "0.5.0-1.fc35.aarch64"
@@ -82,10 +82,10 @@
       "evra": "1.17.2-1.fc35.aarch64"
     },
     "ca-certificates": {
-      "evra": "2021.2.50-3.fc35.noarch"
+      "evra": "2021.2.52-1.0.fc35.noarch"
     },
     "catatonit": {
-      "evra": "0.1.6-1.fc35.aarch64"
+      "evra": "0.1.7-1.fc35.aarch64"
     },
     "chrony": {
       "evra": "4.1-3.fc35.aarch64"
@@ -112,22 +112,22 @@
       "evra": "2:2.0.30-2.fc35.aarch64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "container-selinux": {
       "evra": "2:2.170.0-2.fc35.noarch"
     },
     "containerd": {
-      "evra": "1.5.7-1.fc35.aarch64"
+      "evra": "1.5.8-1.fc35.aarch64"
     },
     "containernetworking-plugins": {
       "evra": "1.0.1-1.fc35.aarch64"
@@ -136,10 +136,10 @@
       "evra": "4:1-32.fc35.noarch"
     },
     "coreos-installer": {
-      "evra": "0.10.1-1.fc35.aarch64"
+      "evra": "0.12.0-2.fc35.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.10.1-1.fc35.aarch64"
+      "evra": "0.12.0-2.fc35.aarch64"
     },
     "coreutils": {
       "evra": "8.32-31.fc35.aarch64"
@@ -163,19 +163,19 @@
       "evra": "3.16.1-2.fc35.aarch64"
     },
     "crun": {
-      "evra": "1.2-1.fc35.aarch64"
+      "evra": "1.4-1.fc35.aarch64"
     },
     "crypto-policies": {
       "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
     },
     "cryptsetup": {
-      "evra": "2.4.1-1.fc35.aarch64"
+      "evra": "2.4.2-1.fc35.aarch64"
     },
     "cryptsetup-libs": {
-      "evra": "2.4.1-1.fc35.aarch64"
+      "evra": "2.4.2-1.fc35.aarch64"
     },
     "cups-libs": {
-      "evra": "1:2.3.3op2-8.fc35.aarch64"
+      "evra": "1:2.3.3op2-11.fc35.aarch64"
     },
     "curl": {
       "evra": "7.79.1-1.fc35.aarch64"
@@ -253,16 +253,16 @@
       "evra": "37-17.fc35.aarch64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.185-5.fc35.noarch"
+      "evra": "0.186-1.fc35.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.185-5.fc35.aarch64"
+      "evra": "0.186-1.fc35.aarch64"
     },
     "elfutils-libs": {
-      "evra": "0.185-5.fc35.aarch64"
+      "evra": "0.186-1.fc35.aarch64"
     },
     "ethtool": {
-      "evra": "2:5.14-1.fc35.aarch64"
+      "evra": "2:5.15-1.fc35.aarch64"
     },
     "expat": {
       "evra": "2.4.1-2.fc35.aarch64"
@@ -274,13 +274,13 @@
       "evra": "35-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-repos": {
       "evra": "35-1.noarch"
@@ -334,7 +334,7 @@
       "evra": "3.10.5-1.fc35.aarch64"
     },
     "fwupd": {
-      "evra": "1.7.1-1.fc35.aarch64"
+      "evra": "1.7.3-1.fc35.aarch64"
     },
     "gawk": {
       "evra": "5.1.0-4.fc35.aarch64"
@@ -352,25 +352,25 @@
       "evra": "0.21-8.fc35.aarch64"
     },
     "git-core": {
-      "evra": "2.33.1-1.fc35.aarch64"
+      "evra": "2.34.1-1.fc35.aarch64"
     },
     "glib2": {
-      "evra": "2.70.1-1.fc35.aarch64"
+      "evra": "2.70.2-1.fc35.aarch64"
     },
     "glibc": {
-      "evra": "2.34-8.fc35.aarch64"
+      "evra": "2.34-11.fc35.aarch64"
     },
     "glibc-common": {
-      "evra": "2.34-8.fc35.aarch64"
+      "evra": "2.34-11.fc35.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-8.fc35.aarch64"
+      "evra": "2.34-11.fc35.aarch64"
     },
     "gmp": {
       "evra": "1:6.2.0-7.fc35.aarch64"
     },
     "gnupg2": {
-      "evra": "2.3.3-1.fc35.aarch64"
+      "evra": "2.3.4-1.fc35.aarch64"
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.aarch64"
@@ -382,16 +382,16 @@
       "evra": "3.6-4.fc35.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.06-8.fc35.noarch"
+      "evra": "1:2.06-10.fc35.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-8.fc35.aarch64"
+      "evra": "1:2.06-10.fc35.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.06-8.fc35.aarch64"
+      "evra": "1:2.06-10.fc35.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-8.fc35.aarch64"
+      "evra": "1:2.06-10.fc35.aarch64"
     },
     "gzip": {
       "evra": "1.10-5.fc35.aarch64"
@@ -400,7 +400,7 @@
       "evra": "3.23-5.fc35.aarch64"
     },
     "ignition": {
-      "evra": "2.12.0-3.fc35.aarch64"
+      "evra": "2.13.0-1.fc35.aarch64"
     },
     "inih": {
       "evra": "49-4.fc35.aarch64"
@@ -463,13 +463,13 @@
       "evra": "2.4.0-8.fc35.noarch"
     },
     "kernel": {
-      "evra": "5.14.16-301.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kernel-core": {
-      "evra": "5.14.16-301.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kernel-modules": {
-      "evra": "5.14.16-301.fc35.aarch64"
+      "evra": "5.15.7-200.fc35.aarch64"
     },
     "kexec-tools": {
       "evra": "2.0.22-7.fc35.aarch64"
@@ -529,7 +529,7 @@
       "evra": "2.48-3.fc35.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-6.fc35.aarch64"
+      "evra": "0.8.2-8.fc35.aarch64"
     },
     "libcbor": {
       "evra": "0.7.0-4.fc35.aarch64"
@@ -574,25 +574,25 @@
       "evra": "1.4-5.fc35.aarch64"
     },
     "libgcc": {
-      "evra": "11.2.1-1.fc35.aarch64"
+      "evra": "11.2.1-7.fc35.aarch64"
     },
     "libgcrypt": {
       "evra": "1.9.4-1.fc35.aarch64"
     },
     "libgomp": {
-      "evra": "11.2.1-1.fc35.aarch64"
+      "evra": "11.2.1-7.fc35.aarch64"
     },
     "libgpg-error": {
-      "evra": "1.42-3.fc35.aarch64"
+      "evra": "1.43-1.fc35.aarch64"
     },
     "libgudev": {
       "evra": "237-1.fc35.aarch64"
     },
     "libgusb": {
-      "evra": "0.3.8-1.fc35.aarch64"
+      "evra": "0.3.9-1.fc35.aarch64"
     },
     "libibverbs": {
-      "evra": "37.0-1.fc35.aarch64"
+      "evra": "38.0-1.fc35.aarch64"
     },
     "libicu": {
       "evra": "69.1-2.fc35.aarch64"
@@ -604,10 +604,10 @@
       "evra": "1.3.1-48.fc35.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "libjcat": {
-      "evra": "0.1.8-2.fc35.aarch64"
+      "evra": "0.1.9-1.fc35.aarch64"
     },
     "libjose": {
       "evra": "11-3.fc35.aarch64"
@@ -628,7 +628,7 @@
       "evra": "9-12.fc35.aarch64"
     },
     "libmaxminddb": {
-      "evra": "1.5.2-2.fc35.aarch64"
+      "evra": "1.6.0-1.fc35.aarch64"
     },
     "libmnl": {
       "evra": "1.0.4-14.fc35.aarch64"
@@ -694,7 +694,7 @@
       "evra": "2.15.2-6.fc35.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.2-1.fc35.aarch64"
+      "evra": "2.5.3-1.fc35.aarch64"
     },
     "libselinux": {
       "evra": "3.3-1.fc35.aarch64"
@@ -706,7 +706,7 @@
       "evra": "3.3-1.fc35.aarch64"
     },
     "libsepol": {
-      "evra": "3.3-1.fc35.aarch64"
+      "evra": "3.3-2.fc35.aarch64"
     },
     "libsigsegv": {
       "evra": "2.13-3.fc35.aarch64"
@@ -718,7 +718,7 @@
       "evra": "2.37.2-1.fc35.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.15.1-0.fc35.aarch64"
+      "evra": "2:4.15.3-0.fc35.aarch64"
     },
     "libsolv": {
       "evra": "0.7.19-3.fc35.aarch64"
@@ -733,19 +733,19 @@
       "evra": "0.9.6-1.fc35.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "libstdc++": {
-      "evra": "11.2.1-1.fc35.aarch64"
+      "evra": "11.2.1-7.fc35.aarch64"
     },
     "libtalloc": {
       "evra": "2.3.3-2.fc35.aarch64"
@@ -781,7 +781,7 @@
       "evra": "2.37.2-1.fc35.aarch64"
     },
     "libuv": {
-      "evra": "1:1.42.0-2.fc35.aarch64"
+      "evra": "1:1.43.0-2.fc35.aarch64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.aarch64"
@@ -790,31 +790,31 @@
       "evra": "0.3.2-2.fc35.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.15.1-0.fc35.aarch64"
+      "evra": "2:4.15.3-0.fc35.aarch64"
     },
     "libxcrypt": {
-      "evra": "4.4.26-4.fc35.aarch64"
+      "evra": "4.4.27-1.fc35.aarch64"
     },
     "libxml2": {
       "evra": "2.9.12-6.fc35.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.3-1.fc35.aarch64"
+      "evra": "0.3.6-1.fc35.aarch64"
     },
     "libyaml": {
       "evra": "0.2.5-6.fc35.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.0-2.fc35.aarch64"
+      "evra": "1.5.1-4.fc35.aarch64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-28.fc34.aarch64"
+      "evra": "2.5.1-30.fc35.aarch64"
     },
     "linux-firmware": {
-      "evra": "20211027-126.fc35.noarch"
+      "evra": "20211216-127.fc35.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20211027-126.fc35.noarch"
+      "evra": "20211216-127.fc35.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-2.fc35.aarch64"
@@ -847,10 +847,10 @@
       "evra": "4.2-rc2.fc35.aarch64"
     },
     "moby-engine": {
-      "evra": "20.10.9-1.fc35.aarch64"
+      "evra": "20.10.11-1.fc35.aarch64"
     },
     "mokutil": {
-      "evra": "2:0.4.0-6.fc35.aarch64"
+      "evra": "2:0.5.0-1.fc35.aarch64"
     },
     "mozjs78": {
       "evra": "78.15.0-1.fc35.aarch64"
@@ -901,13 +901,13 @@
       "evra": "2.4.59-3.fc35.aarch64"
     },
     "openssh": {
-      "evra": "8.7p1-2.fc35.aarch64"
+      "evra": "8.7p1-3.fc35.aarch64"
     },
     "openssh-clients": {
-      "evra": "8.7p1-2.fc35.aarch64"
+      "evra": "8.7p1-3.fc35.aarch64"
     },
     "openssh-server": {
-      "evra": "8.7p1-2.fc35.aarch64"
+      "evra": "8.7p1-3.fc35.aarch64"
     },
     "openssl": {
       "evra": "1:1.1.1l-2.fc35.aarch64"
@@ -919,10 +919,10 @@
       "evra": "1.77-8.fc35.aarch64"
     },
     "ostree": {
-      "evra": "2021.5-2.fc35.aarch64"
+      "evra": "2022.1-1.fc35.aarch64"
     },
     "ostree-libs": {
-      "evra": "2021.5-2.fc35.aarch64"
+      "evra": "2022.1-1.fc35.aarch64"
     },
     "p11-kit": {
       "evra": "0.23.22-4.fc35.aarch64"
@@ -958,10 +958,10 @@
       "evra": "1.8.0-1.fc35.aarch64"
     },
     "podman": {
-      "evra": "3:3.4.1-1.fc35.aarch64"
+      "evra": "3:3.4.4-1.fc35.aarch64"
     },
     "podman-plugins": {
-      "evra": "3:3.4.1-1.fc35.aarch64"
+      "evra": "3:3.4.4-1.fc35.aarch64"
     },
     "policycoreutils": {
       "evra": "3.3-1.fc35.aarch64"
@@ -1003,10 +1003,10 @@
       "evra": "4.17.0-1.fc35.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2021.13-2.fc35.aarch64"
+      "evra": "2022.1-2.fc35.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2021.13-2.fc35.aarch64"
+      "evra": "2022.1-2.fc35.aarch64"
     },
     "rpm-plugin-selinux": {
       "evra": "4.17.0-1.fc35.aarch64"
@@ -1018,22 +1018,22 @@
       "evra": "2:1.0.2-2.fc35.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.15.1-0.fc35.aarch64"
+      "evra": "2:4.15.3-0.fc35.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.15.1-0.fc35.noarch"
+      "evra": "2:4.15.3-0.fc35.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.15.1-0.fc35.aarch64"
+      "evra": "2:4.15.3-0.fc35.aarch64"
     },
     "sed": {
       "evra": "4.8-8.fc35.aarch64"
     },
     "selinux-policy": {
-      "evra": "35.5-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.5-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "setup": {
       "evra": "2.13.9.1-2.fc35.noarch"
@@ -1045,10 +1045,10 @@
       "evra": "1.46-2.fc35.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.9-5.fc35.aarch64"
+      "evra": "2:4.9-8.fc35.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.9-5.fc35.aarch64"
+      "evra": "2:4.9-8.fc35.aarch64"
     },
     "shared-mime-info": {
       "evra": "2.1-3.fc35.aarch64"
@@ -1057,7 +1057,7 @@
       "evra": "15.4-5.aarch64"
     },
     "skopeo": {
-      "evra": "1:1.5.0-2.fc35.aarch64"
+      "evra": "1:1.5.2-1.fc35.aarch64"
     },
     "slang": {
       "evra": "2.3.2-10.fc35.aarch64"
@@ -1069,7 +1069,7 @@
       "evra": "1.1.9-3.fc35.aarch64"
     },
     "socat": {
-      "evra": "1.7.4.1-3.fc35.aarch64"
+      "evra": "1.7.4.2-1.fc35.aarch64"
     },
     "sqlite-libs": {
       "evra": "3.36.0-3.fc35.aarch64"
@@ -1081,28 +1081,28 @@
       "evra": "0.1.2-8.fc35.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-client": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-common": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.6.0-2.fc35.aarch64"
+      "evra": "2.6.1-1.fc35.aarch64"
     },
     "stalld": {
       "evra": "1.14.1-1.fc35.aarch64"
@@ -1111,22 +1111,22 @@
       "evra": "1.9.7p2-2.fc35.aarch64"
     },
     "systemd": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "systemd-container": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "systemd-libs": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "systemd-pam": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "systemd-resolved": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "systemd-udev": {
-      "evra": "249.6-2.fc35.aarch64"
+      "evra": "249.7-2.fc35.aarch64"
     },
     "tar": {
       "evra": "2:1.34-2.fc35.aarch64"
@@ -1155,8 +1155,11 @@
     "util-linux-core": {
       "evra": "2.37.2-1.fc35.aarch64"
     },
+    "vim-data": {
+      "evra": "2:8.2.4006-1.fc35.noarch"
+    },
     "vim-minimal": {
-      "evra": "2:8.2.3568-1.fc35.aarch64"
+      "evra": "2:8.2.4006-1.fc35.aarch64"
     },
     "which": {
       "evra": "2.21-27.fc35.aarch64"
@@ -1180,26 +1183,26 @@
       "evra": "1.1.15-2.fc35.aarch64"
     },
     "zincati": {
-      "evra": "0.0.23-1.fc35.aarch64"
+      "evra": "0.0.24-1.fc35.aarch64"
     },
     "zlib": {
       "evra": "1.2.11-30.fc35.aarch64"
     },
     "zram-generator": {
-      "evra": "1.0.1-3.fc35.aarch64"
+      "evra": "1.1.1-3.fc35.aarch64"
     }
   },
   "metadata": {
-    "generated": "2021-11-09T20:55:12Z",
+    "generated": "2022-01-11T21:53:36Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:21Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2021-11-07T21:44:22Z"
+        "generated": "2022-01-10T17:33:41Z"
       },
       "fedora-updates": {
-        "generated": "2021-11-09T02:00:29Z"
+        "generated": "2022-01-11T02:16:23Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-core:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-modules:
+    evr: 5.15.7-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -52,13 +52,13 @@
       "evra": "1:2.11-3.fc35.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.16.22-1.fc35.x86_64"
+      "evra": "32:9.16.24-1.fc35.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.16.22-1.fc35.noarch"
+      "evra": "32:9.16.24-1.fc35.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.16.22-1.fc35.x86_64"
+      "evra": "32:9.16.24-1.fc35.x86_64"
     },
     "bootupd": {
       "evra": "0.2.6-1.fc35.x86_64"
@@ -67,7 +67,7 @@
       "evra": "3.5.2-2.fc35.x86_64"
     },
     "btrfs-progs": {
-      "evra": "5.14.2-1.fc35.x86_64"
+      "evra": "5.15.1-1.fc35.x86_64"
     },
     "bubblewrap": {
       "evra": "0.5.0-1.fc35.x86_64"
@@ -82,10 +82,10 @@
       "evra": "1.17.2-1.fc35.x86_64"
     },
     "ca-certificates": {
-      "evra": "2021.2.50-3.fc35.noarch"
+      "evra": "2021.2.52-1.0.fc35.noarch"
     },
     "catatonit": {
-      "evra": "0.1.6-1.fc35.x86_64"
+      "evra": "0.1.7-1.fc35.x86_64"
     },
     "chrony": {
       "evra": "4.1-3.fc35.x86_64"
@@ -112,22 +112,22 @@
       "evra": "2:2.0.30-2.fc35.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.2-2.fc35.noarch"
+      "evra": "0.21.2-3.fc35.noarch"
     },
     "container-selinux": {
       "evra": "2:2.170.0-2.fc35.noarch"
     },
     "containerd": {
-      "evra": "1.5.7-1.fc35.x86_64"
+      "evra": "1.5.8-1.fc35.x86_64"
     },
     "containernetworking-plugins": {
       "evra": "1.0.1-1.fc35.x86_64"
@@ -136,10 +136,10 @@
       "evra": "4:1-32.fc35.noarch"
     },
     "coreos-installer": {
-      "evra": "0.10.1-1.fc35.x86_64"
+      "evra": "0.12.0-2.fc35.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.10.1-1.fc35.x86_64"
+      "evra": "0.12.0-2.fc35.x86_64"
     },
     "coreutils": {
       "evra": "8.32-31.fc35.x86_64"
@@ -163,19 +163,19 @@
       "evra": "3.16.1-2.fc35.x86_64"
     },
     "crun": {
-      "evra": "1.2-1.fc35.x86_64"
+      "evra": "1.4-1.fc35.x86_64"
     },
     "crypto-policies": {
       "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
     },
     "cryptsetup": {
-      "evra": "2.4.1-1.fc35.x86_64"
+      "evra": "2.4.2-1.fc35.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.4.1-1.fc35.x86_64"
+      "evra": "2.4.2-1.fc35.x86_64"
     },
     "cups-libs": {
-      "evra": "1:2.3.3op2-8.fc35.x86_64"
+      "evra": "1:2.3.3op2-11.fc35.x86_64"
     },
     "curl": {
       "evra": "7.79.1-1.fc35.x86_64"
@@ -253,16 +253,16 @@
       "evra": "37-17.fc35.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.185-5.fc35.noarch"
+      "evra": "0.186-1.fc35.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.185-5.fc35.x86_64"
+      "evra": "0.186-1.fc35.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.185-5.fc35.x86_64"
+      "evra": "0.186-1.fc35.x86_64"
     },
     "ethtool": {
-      "evra": "2:5.14-1.fc35.x86_64"
+      "evra": "2:5.15-1.fc35.x86_64"
     },
     "expat": {
       "evra": "2.4.1-2.fc35.x86_64"
@@ -274,13 +274,13 @@
       "evra": "35-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "35-33.noarch"
+      "evra": "35-36.noarch"
     },
     "fedora-repos": {
       "evra": "35-1.noarch"
@@ -334,7 +334,7 @@
       "evra": "3.10.5-1.fc35.x86_64"
     },
     "fwupd": {
-      "evra": "1.7.1-1.fc35.x86_64"
+      "evra": "1.7.3-1.fc35.x86_64"
     },
     "gawk": {
       "evra": "5.1.0-4.fc35.x86_64"
@@ -352,25 +352,25 @@
       "evra": "0.21-8.fc35.x86_64"
     },
     "git-core": {
-      "evra": "2.33.1-1.fc35.x86_64"
+      "evra": "2.34.1-1.fc35.x86_64"
     },
     "glib2": {
-      "evra": "2.70.1-1.fc35.x86_64"
+      "evra": "2.70.2-1.fc35.x86_64"
     },
     "glibc": {
-      "evra": "2.34-8.fc35.x86_64"
+      "evra": "2.34-11.fc35.x86_64"
     },
     "glibc-common": {
-      "evra": "2.34-8.fc35.x86_64"
+      "evra": "2.34-11.fc35.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-8.fc35.x86_64"
+      "evra": "2.34-11.fc35.x86_64"
     },
     "gmp": {
       "evra": "1:6.2.0-7.fc35.x86_64"
     },
     "gnupg2": {
-      "evra": "2.3.3-1.fc35.x86_64"
+      "evra": "2.3.4-1.fc35.x86_64"
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.x86_64"
@@ -382,22 +382,22 @@
       "evra": "3.6-4.fc35.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.06-8.fc35.noarch"
+      "evra": "1:2.06-10.fc35.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-8.fc35.x86_64"
+      "evra": "1:2.06-10.fc35.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.06-8.fc35.x86_64"
+      "evra": "1:2.06-10.fc35.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-8.fc35.noarch"
+      "evra": "1:2.06-10.fc35.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-8.fc35.x86_64"
+      "evra": "1:2.06-10.fc35.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-8.fc35.x86_64"
+      "evra": "1:2.06-10.fc35.x86_64"
     },
     "gzip": {
       "evra": "1.10-5.fc35.x86_64"
@@ -406,7 +406,7 @@
       "evra": "3.23-5.fc35.x86_64"
     },
     "ignition": {
-      "evra": "2.12.0-3.fc35.x86_64"
+      "evra": "2.13.0-1.fc35.x86_64"
     },
     "inih": {
       "evra": "49-4.fc35.x86_64"
@@ -469,13 +469,13 @@
       "evra": "2.4.0-8.fc35.noarch"
     },
     "kernel": {
-      "evra": "5.14.16-301.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kernel-core": {
-      "evra": "5.14.16-301.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.14.16-301.fc35.x86_64"
+      "evra": "5.15.7-200.fc35.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.22-7.fc35.x86_64"
@@ -535,7 +535,7 @@
       "evra": "2.48-3.fc35.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-6.fc35.x86_64"
+      "evra": "0.8.2-8.fc35.x86_64"
     },
     "libcbor": {
       "evra": "0.7.0-4.fc35.x86_64"
@@ -580,25 +580,25 @@
       "evra": "1.4-5.fc35.x86_64"
     },
     "libgcc": {
-      "evra": "11.2.1-1.fc35.x86_64"
+      "evra": "11.2.1-7.fc35.x86_64"
     },
     "libgcrypt": {
       "evra": "1.9.4-1.fc35.x86_64"
     },
     "libgomp": {
-      "evra": "11.2.1-1.fc35.x86_64"
+      "evra": "11.2.1-7.fc35.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.42-3.fc35.x86_64"
+      "evra": "1.43-1.fc35.x86_64"
     },
     "libgudev": {
       "evra": "237-1.fc35.x86_64"
     },
     "libgusb": {
-      "evra": "0.3.8-1.fc35.x86_64"
+      "evra": "0.3.9-1.fc35.x86_64"
     },
     "libibverbs": {
-      "evra": "37.0-1.fc35.x86_64"
+      "evra": "38.0-1.fc35.x86_64"
     },
     "libicu": {
       "evra": "69.1-2.fc35.x86_64"
@@ -610,10 +610,10 @@
       "evra": "1.3.1-48.fc35.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.8-2.fc35.x86_64"
+      "evra": "0.1.9-1.fc35.x86_64"
     },
     "libjose": {
       "evra": "11-3.fc35.x86_64"
@@ -634,7 +634,7 @@
       "evra": "9-12.fc35.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.5.2-2.fc35.x86_64"
+      "evra": "1.6.0-1.fc35.x86_64"
     },
     "libmnl": {
       "evra": "1.0.4-14.fc35.x86_64"
@@ -700,7 +700,7 @@
       "evra": "2.15.2-6.fc35.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.2-1.fc35.x86_64"
+      "evra": "2.5.3-1.fc35.x86_64"
     },
     "libselinux": {
       "evra": "3.3-1.fc35.x86_64"
@@ -712,7 +712,7 @@
       "evra": "3.3-1.fc35.x86_64"
     },
     "libsepol": {
-      "evra": "3.3-1.fc35.x86_64"
+      "evra": "3.3-2.fc35.x86_64"
     },
     "libsigsegv": {
       "evra": "2.13-3.fc35.x86_64"
@@ -724,7 +724,7 @@
       "evra": "2.37.2-1.fc35.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.15.1-0.fc35.x86_64"
+      "evra": "2:4.15.3-0.fc35.x86_64"
     },
     "libsmbios": {
       "evra": "2.4.3-4.fc35.x86_64"
@@ -742,19 +742,19 @@
       "evra": "0.9.6-1.fc35.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "libstdc++": {
-      "evra": "11.2.1-1.fc35.x86_64"
+      "evra": "11.2.1-7.fc35.x86_64"
     },
     "libtalloc": {
       "evra": "2.3.3-2.fc35.x86_64"
@@ -790,7 +790,7 @@
       "evra": "2.37.2-1.fc35.x86_64"
     },
     "libuv": {
-      "evra": "1:1.42.0-2.fc35.x86_64"
+      "evra": "1:1.43.0-2.fc35.x86_64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.x86_64"
@@ -799,31 +799,31 @@
       "evra": "0.3.2-2.fc35.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.15.1-0.fc35.x86_64"
+      "evra": "2:4.15.3-0.fc35.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.26-4.fc35.x86_64"
+      "evra": "4.4.27-1.fc35.x86_64"
     },
     "libxml2": {
       "evra": "2.9.12-6.fc35.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.3-1.fc35.x86_64"
+      "evra": "0.3.6-1.fc35.x86_64"
     },
     "libyaml": {
       "evra": "0.2.5-6.fc35.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.0-2.fc35.x86_64"
+      "evra": "1.5.1-4.fc35.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-28.fc34.x86_64"
+      "evra": "2.5.1-30.fc35.x86_64"
     },
     "linux-firmware": {
-      "evra": "20211027-126.fc35.noarch"
+      "evra": "20211216-127.fc35.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20211027-126.fc35.noarch"
+      "evra": "20211216-127.fc35.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-2.fc35.x86_64"
@@ -859,10 +859,10 @@
       "evra": "2:2.1-47.fc35.x86_64"
     },
     "moby-engine": {
-      "evra": "20.10.9-1.fc35.x86_64"
+      "evra": "20.10.11-1.fc35.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.4.0-6.fc35.x86_64"
+      "evra": "2:0.5.0-1.fc35.x86_64"
     },
     "mozjs78": {
       "evra": "78.15.0-1.fc35.x86_64"
@@ -913,13 +913,13 @@
       "evra": "2.4.59-3.fc35.x86_64"
     },
     "openssh": {
-      "evra": "8.7p1-2.fc35.x86_64"
+      "evra": "8.7p1-3.fc35.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.7p1-2.fc35.x86_64"
+      "evra": "8.7p1-3.fc35.x86_64"
     },
     "openssh-server": {
-      "evra": "8.7p1-2.fc35.x86_64"
+      "evra": "8.7p1-3.fc35.x86_64"
     },
     "openssl": {
       "evra": "1:1.1.1l-2.fc35.x86_64"
@@ -931,10 +931,10 @@
       "evra": "1.77-8.fc35.x86_64"
     },
     "ostree": {
-      "evra": "2021.5-2.fc35.x86_64"
+      "evra": "2022.1-1.fc35.x86_64"
     },
     "ostree-libs": {
-      "evra": "2021.5-2.fc35.x86_64"
+      "evra": "2022.1-1.fc35.x86_64"
     },
     "p11-kit": {
       "evra": "0.23.22-4.fc35.x86_64"
@@ -970,10 +970,10 @@
       "evra": "1.8.0-1.fc35.x86_64"
     },
     "podman": {
-      "evra": "3:3.4.1-1.fc35.x86_64"
+      "evra": "3:3.4.4-1.fc35.x86_64"
     },
     "podman-plugins": {
-      "evra": "3:3.4.1-1.fc35.x86_64"
+      "evra": "3:3.4.4-1.fc35.x86_64"
     },
     "policycoreutils": {
       "evra": "3.3-1.fc35.x86_64"
@@ -1015,10 +1015,10 @@
       "evra": "4.17.0-1.fc35.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2021.13-2.fc35.x86_64"
+      "evra": "2022.1-2.fc35.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2021.13-2.fc35.x86_64"
+      "evra": "2022.1-2.fc35.x86_64"
     },
     "rpm-plugin-selinux": {
       "evra": "4.17.0-1.fc35.x86_64"
@@ -1030,22 +1030,22 @@
       "evra": "2:1.0.2-2.fc35.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.15.1-0.fc35.x86_64"
+      "evra": "2:4.15.3-0.fc35.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.15.1-0.fc35.noarch"
+      "evra": "2:4.15.3-0.fc35.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.15.1-0.fc35.x86_64"
+      "evra": "2:4.15.3-0.fc35.x86_64"
     },
     "sed": {
       "evra": "4.8-8.fc35.x86_64"
     },
     "selinux-policy": {
-      "evra": "35.5-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.5-1.fc35.noarch"
+      "evra": "35.8-1.fc35.noarch"
     },
     "setup": {
       "evra": "2.13.9.1-2.fc35.noarch"
@@ -1057,10 +1057,10 @@
       "evra": "1.46-2.fc35.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.9-5.fc35.x86_64"
+      "evra": "2:4.9-8.fc35.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.9-5.fc35.x86_64"
+      "evra": "2:4.9-8.fc35.x86_64"
     },
     "shared-mime-info": {
       "evra": "2.1-3.fc35.x86_64"
@@ -1069,7 +1069,7 @@
       "evra": "15.4-5.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.5.0-2.fc35.x86_64"
+      "evra": "1:1.5.2-1.fc35.x86_64"
     },
     "slang": {
       "evra": "2.3.2-10.fc35.x86_64"
@@ -1081,7 +1081,7 @@
       "evra": "1.1.9-3.fc35.x86_64"
     },
     "socat": {
-      "evra": "1.7.4.1-3.fc35.x86_64"
+      "evra": "1.7.4.2-1.fc35.x86_64"
     },
     "sqlite-libs": {
       "evra": "3.36.0-3.fc35.x86_64"
@@ -1093,28 +1093,28 @@
       "evra": "0.1.2-8.fc35.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-client": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-common": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.6.0-2.fc35.x86_64"
+      "evra": "2.6.1-1.fc35.x86_64"
     },
     "stalld": {
       "evra": "1.14.1-1.fc35.x86_64"
@@ -1123,22 +1123,22 @@
       "evra": "1.9.7p2-2.fc35.x86_64"
     },
     "systemd": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "systemd-container": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "systemd-libs": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "systemd-pam": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "systemd-resolved": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "systemd-udev": {
-      "evra": "249.6-2.fc35.x86_64"
+      "evra": "249.7-2.fc35.x86_64"
     },
     "tar": {
       "evra": "2:1.34-2.fc35.x86_64"
@@ -1167,8 +1167,11 @@
     "util-linux-core": {
       "evra": "2.37.2-1.fc35.x86_64"
     },
+    "vim-data": {
+      "evra": "2:8.2.4006-1.fc35.noarch"
+    },
     "vim-minimal": {
-      "evra": "2:8.2.3568-1.fc35.x86_64"
+      "evra": "2:8.2.4006-1.fc35.x86_64"
     },
     "which": {
       "evra": "2.21-27.fc35.x86_64"
@@ -1192,26 +1195,26 @@
       "evra": "1.1.15-2.fc35.x86_64"
     },
     "zincati": {
-      "evra": "0.0.23-1.fc35.x86_64"
+      "evra": "0.0.24-1.fc35.x86_64"
     },
     "zlib": {
       "evra": "1.2.11-30.fc35.x86_64"
     },
     "zram-generator": {
-      "evra": "1.0.1-3.fc35.x86_64"
+      "evra": "1.1.1-3.fc35.x86_64"
     }
   },
   "metadata": {
-    "generated": "2021-11-09T20:56:32Z",
+    "generated": "2022-01-11T21:53:54Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:27Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2021-11-07T21:43:50Z"
+        "generated": "2022-01-10T17:33:45Z"
       },
       "fedora-updates": {
-        "generated": "2021-11-09T02:00:39Z"
+        "generated": "2022-01-11T02:16:43Z"
       }
     }
   }


### PR DESCRIPTION
splitting this from #1381 to better debug where the the CI failure is coming from.