### PR TITLE
kola-denylist: update mtu-on-bond test name

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,7 +34,7 @@
   snooze: 2022-01-25
   streams:
     - rawhide
-- pattern: ext.config.networking.mtu-on-bond
+- pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
   snooze: 2022-01-25
   streams:


### PR DESCRIPTION
The test name changed in bf37b9c.