### PR TITLE
 tests/trust-cpu: Loosen regexp for validating crng state

### DIFF
--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -11,7 +11,7 @@ cd "${tmpd}"
 case "$(arch)" in
     x86_64)
         dmesg | grep ' random:' > random.txt
-        if ! grep -qe 'crng done.*trust.*CPU' <random.txt; then
+        if ! grep -qe 'crng.*done.*trust.*CPU' <random.txt; then
             sed -e 's/^/# /' < random.txt
             fatal "Error: Failed to find crng trusting CPU"
         fi


### PR DESCRIPTION

There's now an `init` in the middle:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=161212c7fd1d9069b232785c75492e50941e2ea8