### PR TITLE
pin systemd, fix karg test syntax

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,33 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
       type: pin
+  systemd:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-container:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-libs:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-pam:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-resolved:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-udev:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000: vlan=bond0.100:bond0 net.ifnames=0"}
+# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0"}
 # - We use net.ifnames=0 to disable consistent network naming here because on
 #   different firmwares (BIOS vs UEFI) the NIC names are different.
 #   See https://github.com/coreos/fedora-coreos-tracker/issues/1060


### PR DESCRIPTION
```
commit 398663b2fc490dcac56958a2589bec86938308c8
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Jan 15 22:43:14 2022 -0500

    overrides: pin to systemd-249.7-2.fc35
    
    SELinux denials are causing systemd-network-generator to fail
    running. https://github.com/coreos/fedora-coreos-tracker/issues/1059

commit ae1711e8980896b7c8e4dfef7fe9a1a66faa752f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Jan 15 22:38:00 2022 -0500

    tests: networking: fix syntax in networking kargs
    
    The trailing colon isn't correct syntax according to the definition.
    `nm-initrd-generator` allows it but `systemd-network-generator` will
    error out and say it's invalid.
```
