### PR TITLE
[next-devel] overrides: pin to systemd-249.7-2.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,33 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
       type: pin
+  systemd:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-container:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-libs:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-pam:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-resolved:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin
+  systemd-udev:
+    evr: 249.7-2.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
+      type: pin


### PR DESCRIPTION
SELinux denials are causing systemd-network-generator to fail
running. https://github.com/coreos/fedora-coreos-tracker/issues/1059