### PR TITLE
[rawhide] override: libgcc 11.2.1-7.fc36 for aarch64

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,18 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
       type: pin
+  libgcc:
+    evr: 11.2.1-7.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
+      type: pin
+  libgomp:
+    evr: 11.2.1-7.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
+      type: pin
+  libstdc++:
+    evr: 11.2.1-7.fc36
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
+      type: pin


### PR DESCRIPTION
Fix issue https://github.com/coreos/fedora-coreos-tracker/issues/1071
The new libgcc 12.0.0-0.5.fc36.aarch64 is causing multipath issues
to start. In order to fix it for now, let's override it.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>