### PR TITLE
manifests: move location of nvme-cli for sharing with RHCOS

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -132,8 +132,6 @@ packages:
   - console-login-helper-messages-motdgen
   # i18n
   - kbd
-  # nvme-cli for managing nvme disks
-  - nvme-cli
   # zram-generator (but not zram-generator-defaults) for F33 change
   # https://github.com/coreos/fedora-coreos-tracker/issues/509
   - zram-generator

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -33,3 +33,5 @@ packages:
   - runc
   - skopeo
   - toolbox
+  # nvme-cli for managing nvme disks
+  - nvme-cli


### PR DESCRIPTION
OCP/RHCOS customers want to have `nvme-cli` included as part of the
OS, so let's move the location of the package in the manifests to one
that is shared with RHCOS.

See: https://issues.redhat.com/browse/RFE-2503