### PR TITLE
denylist: extend snooze for ext.config.podman.dns

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,7 +16,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/860
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
-  snooze: 2022-01-20
+  snooze: 2022-01-31
   streams:
     - rawhide
 - pattern: podman.base


### PR DESCRIPTION
I poked upstream to see if we can further the discussion:
https://github.com/containers/podman/issues/12661#issuecomment-1017899651