### PR TITLE
[next-devel] overrides: fast-track Ignition 2.13.0-3.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -64,3 +64,9 @@ packages:
     metadata:
       type: fast-track
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-87a938a18c
+  ignition:
+    evr: 2.13.0-3.fc35
+    metadata:
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b238d6fbbf
+      reason: https://github.com/coreos/ignition/issues/1305


### PR DESCRIPTION
Fixes https://github.com/coreos/ignition/issues/1305.