### PR TITLE
denylist: extend snooze for podman.base on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,7 +21,7 @@
     - rawhide
 - pattern: podman.base
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1049
-  snooze: 2022-01-10
+  snooze: 2022-01-31
   streams:
     - rawhide
 - pattern: ext.config.networking.prefer-ignition-networking


### PR DESCRIPTION
Still seeing it. There is some movement in the BZ, but
let's snooze again.

https://github.com/coreos/fedora-coreos-tracker/issues/1049
https://bugzilla.redhat.com/show_bug.cgi?id=2033016