### PR TITLE
Add tool and GH workflow for adding fast-tracks and pins

### DIFF
--- a/.github/workflows/add-override.yml
+++ b/.github/workflows/add-override.yml
@@ -1,0 +1,90 @@
+---
+name: Add package override
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Target branch
+        default: testing-devel
+      what:
+        description: "Bodhi update (fast-track) or SRPM NVR (pin)"
+      pin:
+        description: "Pin (don't remove when stable)"
+        type: boolean
+      reason:
+        description: "Reason URL (optional for routine fast-tracks)"
+
+permissions:
+  # none at all
+  contents: none
+
+# This workflow could almost use the default GITHUB_TOKEN, if we were to
+# push the branch into this repo.  However, GitHub Actions has recursion
+# avoidance that would prevent CI from running on the PR:
+#
+# https://github.com/peter-evans/create-pull-request/blob/28fa4848947e/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+#
+# So we create the PR using a separate Personal Access Token in
+# COREOSBOT_RELENG_TOKEN, belonging to a machine account.  That allows CI to
+# run when the PR is first created.  However, it's also possible to rerun
+# the workflow and have it force-push the branch, reusing the same PR.  In
+# that case the push also cannot come from GITHUB_TOKEN, or CI will not
+# rerun.  Thus we also do the push using COREOSBOT_RELENG_TOKEN.  Since we
+# don't want to give the machine account privileges to this repo, we push
+# to a forked repo owned by the machine account.
+
+jobs:
+  add-override:
+    name: Add package override
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:latest
+    steps:
+      - name: Install dependencies
+        run: dnf install -y git jq python3-bodhi-client python3-pyyaml
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.target }}
+          # We need an unbroken commit chain when pushing to the fork.  Don't
+          # make assumptions about which commits are already available there.
+          fetch-depth: 0
+      - name: Update metadata
+        env:
+          TARGET: ${{ github.event.inputs.target }}
+          WHAT: ${{ github.event.inputs.what }}
+          PIN: ${{ github.event.inputs.pin }}
+          REASON: ${{ github.event.inputs.reason }}
+        run: |
+          set -euxo pipefail
+
+          if [ "${PIN}" = true ]; then
+              ci/overrides.py pin "${WHAT}" -r "${REASON}"
+              title="overrides: pin ${WHAT}"
+          else
+              ci/overrides.py fast-track "${WHAT}" ${REASON:+-r "${REASON}"}
+              srpms=$(ci/overrides.py srpms "${WHAT}" | paste -sd,)
+              title="overrides: fast-track ${srpms//,/, }"
+          fi
+
+          if [ "${TARGET}" = testing-devel ]; then
+              pr_title="${title}"
+          else
+              pr_title="[${TARGET}] ${title}"
+          fi
+          branch_name=override-$(echo "${TARGET}:${title}" | sha256sum | cut -c1-8)
+
+          echo "BRANCH_NAME=${branch_name}" >> ${GITHUB_ENV}
+          echo "COMMIT_TITLE=${title}" >> ${GITHUB_ENV}
+          echo "PR_TITLE=${pr_title}" >> ${GITHUB_ENV}
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          branch: ${{ env.BRANCH_NAME }}
+          commit-message: ${{ env.COMMIT_TITLE }}
+          push-to-fork: coreosbot-releng/fedora-coreos-config
+          title: ${{ env.PR_TITLE }}
+          body: "Requested by @${{ github.actor }} via [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/add-override.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/testing-devel/.github/workflows/add-override.yml))."
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          delete-branch: true

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -33,7 +33,7 @@ jobs:
           git config user.name 'CoreOS Bot'
           git config user.email coreosbot@fedoraproject.org
           ci/remove-graduated-overrides.py
-      - name: Open pull request
+      - name: Create commit
         run: |
           if ! git diff --quiet --exit-code; then
               git commit -am "lockfiles: drop graduated overrides 🎓" \

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -23,7 +23,8 @@ jobs:
           - rawhide
       fail-fast: false
     steps:
-      - run: dnf install -y rpm-ostree # see related TODO above
+      - name: Install dependencies
+        run: dnf install -y python3-bodhi-client rpm-ostree # see related TODO above
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           git config user.name 'CoreOS Bot'
           git config user.email coreosbot@fedoraproject.org
-          ci/remove-graduated-overrides.py
+          ci/overrides.py graduate
       - name: Create commit
         run: |
           if ! git diff --quiet --exit-code; then

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ hold back some packages, or pull in fixes ahead of Bodhi. To
 add such overrides, one needs to add the packages to
 `manifest-lock.overrides.yaml` (there are also arch-specific
 variants of these files for the rare occasions the override
-should only apply to a specific arch).
+should only apply to a specific arch). There is a
+[tool](ci/overrides.py) to help with this, and for simple
+cases, an [automated workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml)
+that runs the tool and submits a PR.
 
 Note that comments are not preserved in these files. The
 lockfile supports arbitrary keys under the `metadata` key to

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import os
 import sys
 import json
@@ -25,6 +26,20 @@ OVERRIDES_HEADER = """
 
 
 def main():
+    parser = argparse.ArgumentParser(description='Manage overrides.')
+    # "dest" to work around https://bugs.python.org/issue29298
+    subcommands = parser.add_subparsers(title='subcommands', required=True,
+            dest='command')
+
+    graduate = subcommands.add_parser('graduate',
+            description='Remove graduated overrides.')
+    graduate.set_defaults(func=do_graduate)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+def do_graduate(_args):
     treefile = get_treefile()
     base = get_dnf_base(treefile)
     setup_repos(base, treefile)

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -114,10 +114,7 @@ def graduate_lockfile(base, fn):
 
     if lockfile['packages'] != new_packages:
         lockfile['packages'] = new_packages
-        with open(fn, 'w') as f:
-            f.write(OVERRIDES_HEADER.strip())
-            f.write('\n\n')
-            yaml.dump(lockfile, f)
+        write_lockfile(fn, lockfile)
     else:
         print(f"{fn}: no packages graduated")
 
@@ -136,6 +133,13 @@ def sack_has_nevra_greater_or_equal(base, nevra):
 
     nevra_latest = hawkey.split_nevra(str(pkgs[0]))
     return nevra_latest >= nevra
+
+
+def write_lockfile(fn, contents):
+    with open(fn, 'w') as f:
+        f.write(OVERRIDES_HEADER.strip())
+        f.write('\n\n')
+        yaml.dump(contents, f)
 
 
 if __name__ == "__main__":

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -24,6 +24,8 @@ OVERRIDES_HEADER = """
 # for FCOS-specific packages (ignition, afterburn, etc.).
 """
 
+basedir = os.path.normpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+
 
 def main():
     parser = argparse.ArgumentParser(description='Manage overrides.')
@@ -50,13 +52,14 @@ def do_graduate(_args):
 
 def get_treefile():
     treefile = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
-                                        '--print-only', 'manifest.yaml'])
+                                        '--print-only',
+                                        os.path.join(basedir, 'manifest.yaml')])
     return json.loads(treefile)
 
 
 def get_dnf_base(treefile):
     base = dnf.Base()
-    base.conf.reposdir = "."
+    base.conf.reposdir = basedir
     base.conf.releasever = treefile['releasever']
     base.read_all_repos()
     return base
@@ -81,7 +84,7 @@ def get_lockfiles():
     # arch-specific lockfiles will require making dnf fetch metadata not just
     # for the basearch on which we're running
     # lockfiles += [f'manifest-lock.overrides.{arch}.yaml' for arch in ARCHES]
-    return lockfiles
+    return [os.path.join(basedir, f) for f in lockfiles]
 
 
 def graduate_lockfile(base, fn):

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -70,6 +70,11 @@ def main():
             help='ignore mismatched Fedora major version')
     pin.set_defaults(func=do_pin)
 
+    srpms = subcommands.add_parser('srpms',
+            description='Name the source RPMs for a Bodhi update.')
+    srpms.add_argument('update', help='ID or URL of Bodhi update')
+    srpms.set_defaults(func=do_srpms)
+
     graduate = subcommands.add_parser('graduate',
             description='Remove graduated overrides.')
     graduate.set_defaults(func=do_graduate)
@@ -122,6 +127,11 @@ def do_pin(args):
         )
     for lockfile_path in get_lockfiles():
         merge_overrides(lockfile_path, overrides)
+
+
+def do_srpms(args):
+    for nvr in get_source_nvrs(get_bodhi_update(args.update)):
+        print(nvr)
 
 
 def do_graduate(_args):

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -92,7 +92,7 @@ def graduate_lockfile(base, fn):
         return
 
     with open(fn) as f:
-        lockfile = yaml.load(f)
+        lockfile = yaml.safe_load(f)
     if 'packages' not in lockfile:
         return
 

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -45,7 +45,7 @@ def do_graduate(_args):
     setup_repos(base, treefile)
 
     for fn in get_lockfiles():
-        update_lockfile(base, fn)
+        graduate_lockfile(base, fn)
 
 
 def get_treefile():
@@ -84,7 +84,7 @@ def get_lockfiles():
     return lockfiles
 
 
-def update_lockfile(base, fn):
+def graduate_lockfile(base, fn):
     if not os.path.exists(fn):
         return
 


### PR DESCRIPTION
Rename and generalize `remove-graduated-overrides.py`.  Add subcommands for adding fast-tracks (from Bodhi update IDs or URLs) and pins (from SRPM NVRs).  Unless `--force` is specified, reject newly added overrides for the wrong Fedora major by comparing their dist tags to the `releasever` from `manifest.yaml`.

Add a wrapper GitHub workflow that creates a PR to one branch, pinning one SRPM or fast-tracking one Bodhi update.   More complex cases can use multiple workflow runs or manual PRs.