### PR TITLE
[next] manifest: remove microdnf as rpm-ostree uses libdnf now

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -222,9 +222,6 @@
     "diffutils": {
       "evra": "3.8-1.fc35.aarch64"
     },
-    "dnf-data": {
-      "evra": "4.9.0-1.fc35.noarch"
-    },
     "dnsmasq": {
       "evra": "2.86-3.fc35.aarch64"
     },
@@ -377,9 +374,6 @@
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.aarch64"
-    },
-    "gobject-introspection": {
-      "evra": "1.70.0-1.fc35.aarch64"
     },
     "gpgme": {
       "evra": "1.15.1-6.fc35.aarch64"
@@ -558,9 +552,6 @@
     "libdhash": {
       "evra": "0.5.0-48.fc35.aarch64"
     },
-    "libdnf": {
-      "evra": "0.64.0-1.fc35.aarch64"
-    },
     "libeconf": {
       "evra": "0.4.0-2.fc35.aarch64"
     },
@@ -683,9 +674,6 @@
     },
     "libpcap": {
       "evra": "14:1.10.1-2.fc35.aarch64"
-    },
-    "libpeas": {
-      "evra": "1.30.0-5.fc35.aarch64"
     },
     "libpkgconf": {
       "evra": "1.8.0-1.fc35.aarch64"
@@ -857,9 +845,6 @@
     },
     "mdadm": {
       "evra": "4.2-rc2.fc35.aarch64"
-    },
-    "microdnf": {
-      "evra": "3.8.0-2.fc35.aarch64"
     },
     "moby-engine": {
       "evra": "20.10.11-1.fc35.aarch64"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -222,9 +222,6 @@
     "diffutils": {
       "evra": "3.8-1.fc35.x86_64"
     },
-    "dnf-data": {
-      "evra": "4.9.0-1.fc35.noarch"
-    },
     "dnsmasq": {
       "evra": "2.86-3.fc35.x86_64"
     },
@@ -377,9 +374,6 @@
     },
     "gnutls": {
       "evra": "3.7.2-2.fc35.x86_64"
-    },
-    "gobject-introspection": {
-      "evra": "1.70.0-1.fc35.x86_64"
     },
     "gpgme": {
       "evra": "1.15.1-6.fc35.x86_64"
@@ -564,9 +558,6 @@
     "libdhash": {
       "evra": "0.5.0-48.fc35.x86_64"
     },
-    "libdnf": {
-      "evra": "0.64.0-1.fc35.x86_64"
-    },
     "libeconf": {
       "evra": "0.4.0-2.fc35.x86_64"
     },
@@ -689,9 +680,6 @@
     },
     "libpcap": {
       "evra": "14:1.10.1-2.fc35.x86_64"
-    },
-    "libpeas": {
-      "evra": "1.30.0-5.fc35.x86_64"
     },
     "libpkgconf": {
       "evra": "1.8.0-1.fc35.x86_64"
@@ -869,9 +857,6 @@
     },
     "microcode_ctl": {
       "evra": "2:2.1-47.fc35.x86_64"
-    },
-    "microdnf": {
-      "evra": "3.8.0-2.fc35.x86_64"
     },
     "moby-engine": {
       "evra": "20.10.11-1.fc35.x86_64"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,19 +10,3 @@ rojig:
 
 add-commit-metadata:
   fedora-coreos.stream: next
-
-# These packages are needed for installing packages thru microdnf
-# Currently, this is planned for use on the layering enhancement
-# enhancement: https://github.com/coreos/enhancements/pull/7
-# package request: https://github.com/coreos/fedora-coreos-tracker/issues/1050
-packages:
- - microdnf
-
-postprocess:
-  # Move microdnf so it is clear that it should not be used on host systems,
-  # it is intended just for containers. This was proposed here: 
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1050#issuecomment-996174981
-  - |
-    #!/usr/bin/env bash
-    mkdir -p /usr/lib/rpm-ostree/
-    mv /usr/bin/microdnf /usr/lib/rpm-ostree/


### PR DESCRIPTION
microdnf is no longer needed because of https://github.com/coreos/rpm-ostree/pull/3340

WIP: Waiting for rpm-ostree release.