### PR TITLE
denylist: extend snooze for network karg tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,16 +24,16 @@
     - rawhide
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-01-25
+  snooze: 2022-01-31
   streams:
     - rawhide
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-01-25
+  snooze: 2022-01-31
   streams:
     - rawhide
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-01-25
+  snooze: 2022-01-31
   streams:
     - rawhide


### PR DESCRIPTION
Currently no movement on the report BZ. I marked it as a prioritized
bug so we can hopefully get some fix soon.

https://github.com/coreos/fedora-coreos-tracker/issues/1059
https://bugzilla.redhat.com/show_bug.cgi?id=2037047