### PR TITLE
kdump.crash: Disable test for aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,6 +12,10 @@
     - rawhide
   arches:
     - aarch64
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
+  arches:
+    - aarch64
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
   snooze: 2022-01-31


### PR DESCRIPTION
Disabling the kdump.crash for only aarch64 due to the test failure in multi-arch pipeline.
Failure: https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/multi-arch-pipeline/1/