### PR TITLE
tests: bump timeout for raid1 reprovisioning

### DIFF
--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+# kola: {"platforms": "qemu", "timeoutMin": 15, "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
 
 set -xeuo pipefail
 


### PR DESCRIPTION
We're timing out sometimes on this test because it takes a while for
Ignition to set up RAID1 and Ignition provisioning time is now part of
the overall test timeout[1]. Bump it to 15 mins.

[1] https://github.com/coreos/coreos-assembler/pull/2660