### PR TITLE
overrides: fast-track kernel-5.15.17-200.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -16,20 +16,23 @@ packages:
       reason: https://github.com/coreos/ignition/issues/1305
       type: fast-track
   kernel:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   kernel-core:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   kernel-modules:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   systemd:
     evr: 249.7-2.fc35
     metadata:


### PR DESCRIPTION
This kernel has a revert [1] that allows us to get AWS instance types
working again [2] and also is newer so it includes a fix for recent
CVE-2022-0185 [3].

[1] https://gitlab.com/cki-project/kernel-ark/-/commit/63aede4
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1066#issuecomment-1019560658
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2042052