### PR TITLE
[testing] overrides: fast-track kernel-5.15.17-200.fc35, polkit-0.120-1.fc35.1

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,20 +10,23 @@
 
 packages:
   kernel:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   kernel-core:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   kernel-modules:
-    evr: 5.15.10-200.fc35
+    evr: 5.15.17-200.fc35
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
+      type: fast-track
   systemd:
     evr: 249.7-2.fc35
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -54,3 +54,15 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
       type: pin
+  polkit:
+    evr: 0.120-1.fc35.1
+    metadata:
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-da040e6b94
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1078
+  polkit-libs:
+    evr: 0.120-1.fc35.1
+    metadata:
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-da040e6b94
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1078


### PR DESCRIPTION
Fixes recent security issues.