### PR TITLE
tests/k8s/systemd-env-read: search all lines of service logs

### DIFF
--- a/tests/kola/kubernetes/systemd-env-read/test.sh
+++ b/tests/kola/kubernetes/systemd-env-read/test.sh
@@ -26,7 +26,7 @@ fi
 ok "kube-env.service successfully started"
 
 # Verify that 'FCOS' was wrtitten to the journal
-if [ "$(journalctl -o cat -u kube-env.service | sed -n 2p)" != "FCOS" ]; then
+if ! journalctl -o cat -u kube-env.service | grep FCOS; then
     fatal "kube-env.service did not write 'FCOS' to journal"
 fi
 ok "kube-env.service ran and wrote 'FCOS' to the journal"


### PR DESCRIPTION
The previous version of this test was specifically searching the
second log entry of the `kube-env.service` for the magic "FCOS" entry.
However, it has been observed that the magic entry can appear *before*
the message that the service started.

```
Jan 27 19:58:13.313896 localhost echo[962]: FCOS
Jan 27 19:58:13.314524 localhost systemd[1]: Starting kube-env.service...
Jan 27 19:58:13.443933 localhost systemd[1]: Finished kube-env.service.
```

So change the logic to just search all of the logged lines from the
service.