### PR TITLE
[rawhide] overrides: drop gcc-11.2.1-7.fc36 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,18 +24,3 @@ packages:
     metadata:
       reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
       type: pin
-  libgcc:
-    evr: 11.2.1-7.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
-      type: pin
-  libgomp:
-    evr: 11.2.1-7.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
-      type: pin
-  libstdc++:
-    evr: 11.2.1-7.fc36
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1071'
-      type: pin


### PR DESCRIPTION
It looks like one of the recent updates of gcc in rawhide fixed the
multipathd segfault. Seems to work with libcc-12.0.1-0.3.fc36
now.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1071