### PR TITLE
[next-devel] manifest: default to iptables-nft

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -19,6 +19,11 @@ repos:
 add-commit-metadata:
   fedora-coreos.stream: next-devel
 
+# Scripts for opting into staying on iptables-legacy after migration. Remove
+# after the next barrier release.
+ostree-layers:
+  - overlay/35coreos-iptables
+
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,3 +28,15 @@ postprocess:
     mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
+  # Default to iptables-nft. Otherwise, legacy wins. This needs to be lowered in
+  # a shared manifest once we're ready to migrate `testing`. We can drop this
+  # once/if we remove iptables-legacy.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    ln -sf /usr/sbin/ip6tables-nft         /etc/alternatives/ip6tables
+    ln -sf /usr/sbin/ip6tables-nft-restore /etc/alternatives/ip6tables-restore
+    ln -sf /usr/sbin/ip6tables-nft-save    /etc/alternatives/ip6tables-save
+    ln -sf /usr/sbin/iptables-nft          /etc/alternatives/iptables
+    ln -sf /usr/sbin/iptables-nft-restore  /etc/alternatives/iptables-restore
+    ln -sf /usr/sbin/iptables-nft-save     /etc/alternatives/iptables-save


### PR DESCRIPTION
Ship with iptables-nft by default. This requires a postprocessing script
until we can fully drop iptables-legacy from the base.

For more information, see:
https://github.com/coreos/fedora-coreos-tracker/issues/676
https://github.com/coreos/fedora-coreos-config/pull/1324