### PR TITLE
tests/extensions.package: don't try vim on rawhide

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -21,3 +21,7 @@ get_ipv4_for_nic() {
     fi
     echo $ip
 }
+
+get_fcos_stream() {
+    rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]'
+}

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -14,8 +14,14 @@ commands=(
   'strace'
   'tcpdump'
   'tree'
-  'vim'
 )
+
+# Also try some OS extensions which have host bindings. But these we can only do
+# on !rawhide because the archive repo isn't active there.
+case "$(get_fcos_stream)" in
+    "rawhide") ;;
+    *) commands+=('vim') ;;
+esac
 
 rpm-ostree install --apply-live "${commands[@]}"
 


### PR DESCRIPTION
The `vim-enhanced` package has a shared base dep (`vim-common`) so is
subject to the binding issue which the updates archiver solves. Since
the archiver isn't enabled on rawhide, don't try it there.