### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,12 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  ignition:
-    evr: 2.13.0-3.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b238d6fbbf
-      reason: https://github.com/coreos/ignition/issues/1305
-      type: fast-track
   kernel:
     evr: 5.15.17-200.fc35
     metadata:


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.