### PR TITLE
tests/extensions: bump timeout; limit to one platform

### DIFF
--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -2,9 +2,12 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet" }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu"}
 #
 # This test ensures that we can install some common tools as OS extensions.
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -2,9 +2,13 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet" }
+# kola: { "distros": "fcos", "tags": "needs-internet", "timeoutMin": 15 }
 #
 # This test ensures that we can install some common tools as OS extensions.
+#
+# - timeoutMin: 15
+#   - This is dependent on network and disk speed but we've seen the
+#     test take longer than 10 minutes in our aarch64 qemu tests.
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -2,13 +2,15 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "timeoutMin": 15 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #
 # - timeoutMin: 15
 #   - This is dependent on network and disk speed but we've seen the
 #     test take longer than 10 minutes in our aarch64 qemu tests.
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
```
commit bf526a6e5f3b609207d4058f35d4c7ea7e5ea4f6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Jan 29 16:44:44 2022 -0500

    tests/extensions: limit to running on one platform
    
    Our default is qemu, so let's run once there and no where else because
    the test should pass everywhere if it passes anywhere.

commit 805a5b7429b8e0952f982426a3ab9837f5d4c968
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Jan 29 16:39:36 2022 -0500

    tests/extensions: bump timeout for the package test
    
    This is dependent on network and disk speed but we've seen the
    test take longer than 10 minutes in our aarch64 qemu tests.

```
