### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,24 +19,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b76e3a192
       type: fast-track
-  kernel:
-    evr: 5.15.17-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: fast-track
-  kernel-core:
-    evr: 5.15.17-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: fast-track
-  kernel-modules:
-    evr: 5.15.17-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aaa4e47375
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: fast-track
   systemd:
     evr: 249.7-2.fc35
     metadata:


### PR DESCRIPTION
Triggered by remove-graduated-overrides GitHub Action.