### PR TITLE
workflows/remove-graduated-overrides: allow manual runs; improve some display text

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -48,6 +48,6 @@ jobs:
           branch: ${{ matrix.branch }}-graduation
           push-to-fork: coreosbot-releng/fedora-coreos-config
           title: "[${{ matrix.branch }}] lockfiles: drop graduated overrides 🎓"
-          body: "Triggered by remove-graduated-overrides GitHub Action."
+          body: "Created by remove-graduated-overrides [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/remove-graduated-overrides.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml))."
           committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
           author: "CoreOS Bot <coreosbot@fedoraproject.org>"

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -3,6 +3,7 @@ name: Remove graduated overrides
 on:
   schedule:
     - cron: '0 */6 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -1,4 +1,4 @@
-name: remove-graduated-overrides
+name: Remove graduated overrides
 
 on:
   schedule:


### PR DESCRIPTION
It's occasionally convenient to force a workflow run, e.g. to rebase existing graduation PRs.