### PR TITLE
tests/skopeo: Verify `experimental-image-proxy` exists

### DIFF
--- a/tests/kola/skopeo/data/commonlib.sh
+++ b/tests/kola/skopeo/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/skopeo/proxy
+++ b/tests/kola/skopeo/proxy
@@ -1,0 +1,11 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Verify this command exists since it's a hard dependency of ostree's container bits.
+skopeo experimental-image-proxy --help
+
+ok skopeo


### PR DESCRIPTION
Needed by the ostree-container stack.  I don't expect this test
to fail on FCOS; my main real goal is to trickle this down into
RHCOS where it would currently fail (and I have a fix pending).