### PR TITLE
35coreos-multipath: propagate config on first boot

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -2,20 +2,20 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
-install_ignition_unit() {
+install_unit() {
     local unit=$1; shift
-    local target=${1:-complete}
+    local target=${1:-initrd}
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
     # note we `|| exit 1` here so we error out if e.g. the units are missing
     # see https://github.com/coreos/fedora-coreos-config/issues/799
-    systemctl -q --root="$initdir" add-requires "ignition-${target}.target" "$unit" || exit 1
+    systemctl -q --root="$initdir" add-requires "${target}.target" "$unit" || exit 1
 }
 
 install() {
     inst_script "$moddir/coreos-propagate-multipath-conf.sh" \
         "/usr/sbin/coreos-propagate-multipath-conf"
 
-    install_ignition_unit coreos-propagate-multipath-conf.service subsequent
+    install_unit coreos-propagate-multipath-conf.service
 
     inst_simple "$moddir/coreos-multipath-generator" \
         "$systemdutildir/system-generators/coreos-multipath-generator"


### PR DESCRIPTION
In #829, we changed multipath config propagation to happen on subsequent
boots to handle upgrading nodes. Back then, we didn't yet support first
boot multipath, so not propagating on first boot didn't matter anyway.

But with #1011 we now support multipath on first boot. So we need to
adapt this so we always propagate, including on first boot.