### PR TITLE
tests/extensions: bump timeout for the module test

### DIFF
--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -2,12 +2,15 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu"}
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
+# - timeoutMin: 15
+#   - This is dependent on network and disk speed but we've seen the
+#     test take longer than 10 minutes in our aarch64 qemu tests.
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
This is dependent on network and disk speed but we've seen the
test take longer than 10 minutes in our aarch64 qemu tests.