### PR TITLE
tests/root-reprovision: bump timeout for reprovision tests to 15m

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096}
+# kola: { "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15 }
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - minMemory: 4096
+#   - Root reprovisioning requires at least 4GiB of memory.
+# - timeoutMin: 15
+#   - This test includes a lot of disk I/O and needs a higher
+#     timeout value than the default.
 
 set -xeuo pipefail
 

--- a/tests/kola/root-reprovision/linear/test.sh
+++ b/tests/kola/root-reprovision/linear/test.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15 }
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+#   - additionalDisks is only supported on qemu.
+# - minMemory: 4096
+#   - Root reprovisioning requires at least 4GiB of memory.
+# - additionalDisks: ["5G", "5G"]
+#   - Linear RAID is setup on these disks.
+# - timeoutMin: 15
+#   - This test includes a lot of disk I/O and needs a higher
+#     timeout value than the default.
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x" }
+# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x", "timeoutMin": 15 }
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - minMemory: 4096
+#   - Root reprovisioning requires at least 4GiB of memory.
+# - architectures: !s390x
+#   - A TPM backend device is not available on s390x to suport TPM.
+# - timeoutMin: 15
+#   - This test includes a lot of disk I/O and needs a higher
+#     timeout value than the default.
 
 set -xeuo pipefail
 

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15 }
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+#   - additionalDisks is only supported on qemu.
+# - minMemory: 4096
+#   - Root reprovisioning requires at least 4GiB of memory.
+# - additionalDisks: ["5G", "5G"]
+#   - A RAID1 is setup on these disks.
+# - timeoutMin: 15
+#   - This test includes a lot of disk I/O and needs a higher
+#     timeout value than the default.
 
 set -xeuo pipefail
 

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
-# kola: {"distros": "fcos", "platforms": "qemu", "minMemory": 4096}
-# This test only runs on FCOS due to a problem enabling a swap partition on
-# RHCOS.  See: https://github.com/openshift/os/issues/665
+# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15 }
+#
+# - distros: fcos
+#   - This test only runs on FCOS due to a problem enabling a swap partition on
+#     RHCOS. See: https://github.com/openshift/os/issues/665
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - minMemory: 4096
+#   - Root reprovisioning requires at least 4GiB of memory.
+# - timeoutMin: 15
+#   - This test includes a lot of disk I/O and needs a higher
+#     timeout value than the default.
 
 set -xeuo pipefail
 


### PR DESCRIPTION
All of these tests include a lot of disk I/O and can take a long time.
They all flirt with the 10 minute timeout already and some can go over.
Let's bump them all to give us some breathing room.

Also updated each test to include an explanation for the kola.json
parameters.