### PR TITLE
[rawhide] overrides: pin rpm-4.17.0-6.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  tpm2-tss:
-    evr: 3.1.0-3.fc35
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
-      type: pin
   authselect:
     evr: 1.3.0-3.fc36
     metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: pin
   authselect-libs:
     evr: 1.3.0-3.fc36
     metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
+      type: pin
+  tpm2-tss:
+    evr: 3.1.0-3.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/968
       type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).