### PR TITLE
[rawhide] overrides: pin rpm, container-selinux

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -20,10 +20,11 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: pin
   container-selinux:
-    evra: 2:2.173.2-1.fc36.noarch
+    evra: 2:2.176.0-1.fc36.noarch
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-2099c58543
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1089
-      type: pin
+      type: fast-track
   rpm:
     evr: 4.17.0-6.fc36
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,21 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: pin
+  rpm:
+    evr: 4.17.0-6.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
+      type: pin
+  rpm-libs:
+    evr: 4.17.0-6.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
+      type: pin
+  rpm-plugin-selinux:
+    evr: 4.17.0-6.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
+      type: pin
   tpm2-tss:
     evr: 3.1.0-3.fc35
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,11 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: pin
+  container-selinux:
+    evra: 2:2.173.2-1.fc36.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1089
+      type: pin
   rpm:
     evr: 4.17.0-6.fc36
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  tpm2-tss:
-    evr: 3.1.0-3.fc35
-    metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/968'
-      type: pin
   authselect:
     evr: 1.3.0-3.fc36
     metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: pin
   authselect-libs:
     evr: 1.3.0-3.fc36
     metadata:
-      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1057'
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
+      type: pin
+  tpm2-tss:
+    evr: 3.1.0-3.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/968
       type: pin


### PR DESCRIPTION
The new Composes are now failing because of the change to Relocate
the RPM database to /usr [1]. Let's pin on the old RPM for now.
Fix tracked at [2].

[1] https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1087
