### PR TITLE
manifest: Add `container-cmd`

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -11,6 +11,9 @@ rojig:
 add-commit-metadata:
   fedora-coreos.stream: ${stream}
 
+container-cmd:
+  - /usr/bin/bash
+
 include: fedora-coreos-base.yaml
 conditional-include:
   - if: prod == false


### PR DESCRIPTION
Builds on https://github.com/coreos/rpm-ostree/pull/3402

Relates to https://github.com/coreos/coreos-assembler/issues/2685

Basically, source of truth for the CMD moves from being hardcoded
in cosa hackiliy to being part of the ostree commit, which means
it survives a full round trip of
ostree → container → ostree → container