### PR TITLE
[rawhide] overrides: pin selinux-policy-35.13-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -40,6 +40,16 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
       type: pin
+  selinux-policy:
+    evra: 35.13-1.fc36.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
+      type: pin
+  selinux-policy-targeted:
+    evra: 35.13-1.fc36.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
+      type: pin
   tpm2-tss:
     evr: 3.1.0-3.fc35
     metadata:


### PR DESCRIPTION
For some reason the `container_use_cephfs` SELinux boolean is no
longer defined in the new `selinux-policy-36.1-1.fc36`. We need
to figure out if this was on purpose or not and update our build
definition accordingly.

See https://github.com/coreos/fedora-coreos-tracker/issues/1090
