### PR TITLE
overrides: pin kernel-5.15.18-200.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,21 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b76e3a192
       type: fast-track
+  kernel:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-core:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-modules:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
   systemd:
     evr: 249.7-2.fc35
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).