### PR TITLE
manifests/bootable-rpm-ostree: drop `linux-firmware-whence`

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -11,7 +11,7 @@ packages:
  # linux-firmware now a recommends so let's explicitly include it
  # https://gitlab.com/cki-project/kernel-ark/-/commit/32271d0cd9bd52d386eb35497c4876a8f041f70b
  # https://src.fedoraproject.org/rpms/kernel/c/f55c3e9ed8605ff28cb9a922efbab1055947e213?branch=rawhide
- - linux-firmware linux-firmware-whence
+ - linux-firmware
  # rpm-ostree
  - rpm-ostree nss-altfiles
  # firmware updates


### PR DESCRIPTION
On Fedora, `linux-firmware` requires `linux-firmware-whence`, so we don't need to specify it.  On RHEL 8, `linux-firmware-whence` doesn't exist.