### PR TITLE
denylist: snooze the coreos.boot-mirror.luks test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,3 +41,8 @@
   snooze: 2022-02-07
   streams:
     - rawhide
+- pattern: coreos.boot-mirror.luks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
+  snooze: 2022-02-14
+  streams:
+    - rawhide


### PR DESCRIPTION
The ignition-ostree-transposefs-restore.service is failing on boot
and we're dropping into the emergency shell. Let's snooze the test
for now on rawhide while we investigate.

See https://github.com/coreos/fedora-coreos-tracker/issues/1092