### PR TITLE
denylist: extend snooze for ostree.hotfix on rawhide/aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ostree.hotfix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
-  snooze: 2022-02-07
+  snooze: 2022-02-21
   streams:
     - rawhide
   arches:


### PR DESCRIPTION
We should get some help here soon but for now this is still
failing.