### PR TITLE
[rawhide] overrides: drop rpm-4.17.0-6.fc36 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,21 +21,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e7fb55da7d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
       type: fast-track
-  rpm:
-    evr: 4.17.0-6.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
-      type: pin
-  rpm-libs:
-    evr: 4.17.0-6.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
-      type: pin
-  rpm-plugin-selinux:
-    evr: 4.17.0-6.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1087
-      type: pin
   selinux-policy:
     evra: 35.13-1.fc36.noarch
     metadata:


### PR DESCRIPTION
The workaround for https://github.com/coreos/rpm-ostree/issues/3397
has landed upstream in https://github.com/coreos/rpm-ostree/commit/12147dd,
which made it into rpm-ostree v2022.2. This rpm-ostree is now in
COSA so we can drop this pin.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1087