### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  authselect:
-    evr: 1.3.0-9.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e7fb55da7d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
-      type: fast-track
-  authselect-libs:
-    evr: 1.3.0-9.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e7fb55da7d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1057
-      type: fast-track
   selinux-policy:
     evra: 35.13-1.fc36.noarch
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).