### PR TITLE
s390x: Skip incompatible kola tests

### DIFF
--- a/tests/kola/kdump/crash
+++ b/tests/kola/kdump/crash
@@ -1,6 +1,8 @@
 #!/bin/bash
-# kola: {"minMemory": 4096, "tags": "skip-base-checks"}
+# kola: {"minMemory": 4096, "tags": "skip-base-checks", "architectures": "!s390x"}
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
+# https://github.com/coreos/fedora-coreos-config/issues/1500
+# - kdump.service is failling on s390x
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -5,14 +5,17 @@ set -xeuo pipefail
 # - kargs provide static network config for eth1 and also coreos.force_persist_ip
 # - ignition provides dhcp network config for eth1
 # Expected result:
-# - with coreos.force_persist_ip ip=kargs win, verify that 
+# - with coreos.force_persist_ip ip=kargs win, verify that
 #   eth1 has the static IP address via kargs
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
 # - We use net.ifnames=0 to disable consistent network naming here because on
 #   different firmwares (BIOS vs UEFI) the NIC names are different.
 #   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip" }
+
+# https://github.com/coreos/fedora-coreos-config/issues/1499
+# - Disable the test on s390x
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip", "architectures": "!s390x" }
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "net.ifnames=0"}
+# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "net.ifnames=0", "architectures": "!s390x"}
 # - We use net.ifnames=0 to disable consistent network naming here because on
 #   different firmwares (BIOS vs UEFI) the NIC names are different.
 #   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
@@ -16,8 +16,11 @@
 #        vlan=bond0.100:bond0"
 # $/usr/libexec/nm-initrd-generator -s -- $kargs
 
-# Using kernel args to `configure MTU on a VLAN subinterface for the bond` refer to 
+# Using kernel args to `configure MTU on a VLAN subinterface for the bond` refer to
 # https://github.com/coreos/fedora-coreos-config/pull/1401
+
+# https://github.com/coreos/fedora-coreos-config/issues/1499
+# - Disable the test on s390x
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0"}
+# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0", "architectures": "!s390x"}
 # - We use net.ifnames=0 to disable consistent network naming here because on
 #   different firmwares (BIOS vs UEFI) the NIC names are different.
 #   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
@@ -9,6 +9,9 @@
 # - verify MTU on the VLAN subinterface for the bond matches config
 # - verify ip address on the VLAN subinterface for the bond matches config
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1932502#c9
+
+# https://github.com/coreos/fedora-coreos-config/issues/1499
+# - Disable the test on s390x
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -5,14 +5,17 @@ set -xeuo pipefail
 # - kargs provide static network config for eth1 without coreos.force_persist_ip
 # - ignition provides dhcp network config for eth1
 # Expected result:
-# - without coreos.force_persist_ip Ignition networking 
+# - without coreos.force_persist_ip Ignition networking
 #   configuration wins, verify that eth1 gets ip via dhcp
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
 # - We use net.ifnames=0 to disable consistent network naming here because on
 #   different firmwares (BIOS vs UEFI) the NIC names are different.
 #   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0" }
+
+# https://github.com/coreos/fedora-coreos-config/issues/1499
+# - Disable the test on s390x
+# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0", "architectures": "!s390x" }
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -23,11 +23,14 @@ ok "boot mounted by UUID"
 # check that we took ownership of the bootfs
 [ -f /boot/.root_uuid ]
 
-# check for the UUID dropins
-[ -f /boot/grub2/bootuuid.cfg ]
-mount -o ro /dev/disk/by-label/EFI-SYSTEM /boot/efi
-[ -f /boot/efi/EFI/*/bootuuid.cfg ]
-umount /boot/efi
+# s390x does not have grub, skip this part
+if [ "$(arch)" != "s390x" ]; then
+  # check for the UUID dropins
+  [ -f /boot/grub2/bootuuid.cfg ]
+  mount -o ro /dev/disk/by-label/EFI-SYSTEM /boot/efi
+  [ -f /boot/efi/EFI/*/bootuuid.cfg ]
+  umount /boot/efi
+fi
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")


### PR DESCRIPTION
Skip tests that are new and currently failling on s390x. These tests need further investigation wether or not they can be adapted on s390x.
Also skip grub specific part of the reboot test, as s390x does not use grub.