### PR TITLE
[rawhide] overrides: fast-track container-selinux-2.176.0-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,12 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  container-selinux:
+    evra: 2:2.176.0-2.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c48b4a4380
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
+      type: fast-track
   selinux-policy:
     evra: 35.13-1.fc36.noarch
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,16 +15,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c48b4a4380
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
       type: fast-track
-  selinux-policy:
-    evra: 35.13-1.fc36.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
-      type: pin
-  selinux-policy-targeted:
-    evra: 35.13-1.fc36.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
-      type: pin
   tpm2-tss:
     evr: 3.1.0-3.fc35
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).