### PR TITLE
denylist: snooze ext.config.chrony.dhcp-propagation in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,3 +46,8 @@
   snooze: 2022-02-14
   streams:
     - rawhide
+- pattern: ext.config.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1097
+  snooze: 2022-02-21
+  streams:
+    - rawhide


### PR DESCRIPTION
SELinux denials are causing some issues and we need to have them looked
at. See https://github.com/coreos/fedora-coreos-tracker/issues/1097