### PR TITLE
[branched] manifest: bump to F36

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,7 +24,3 @@ postprocess:
     mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
     echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
-
-packages:
-  # resolved was broken out to its own package in rawhide/f35
-  - systemd-resolved

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 ref: fedora/${basearch}/coreos/branched
 include: manifests/fedora-coreos.yaml
 
-releasever: "35"
+releasever: "36"
 
 rojig:
   license: MIT


### PR DESCRIPTION
```
commit 372a3e042424f69a2335b1bbb79664c34941b349
Date:   Wed Feb 9 22:48:06 2022 -0500

    manifest: bump to F36
    
    Fedora 36 just branched now.

commit 569ef98c64702bf0586b1f7dcad217e3a02f176f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Feb 9 22:47:08 2022 -0500

    manifest.yaml: remove now common manifest.yaml entries
    
    This is now in the shared `fedora-coreos-base.yaml` so we
    can remove them from the toplevel manifest.yaml.

```