### PR TITLE
denylist: apply snoozes to the branched stream as well

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,6 +10,7 @@
   snooze: 2022-02-21
   streams:
     - rawhide
+    - branched
   arches:
     - aarch64
 - pattern: ext.config.kdump.crash
@@ -21,33 +22,40 @@
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: podman.base
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1049
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
   snooze: 2022-02-14
   streams:
     - rawhide
+    - branched
 - pattern: ext.config.chrony.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1097
   snooze: 2022-02-21
   streams:
     - rawhide
+    - branched


### PR DESCRIPTION
Since we're re-enabling `branched` we need these to apply
there too.