### PR TITLE
denylist: enable coreos.boot-mirror.luks test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -47,12 +47,6 @@
   streams:
     - rawhide
     - branched
-- pattern: coreos.boot-mirror.luks
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
-  snooze: 2022-02-14
-  streams:
-    - rawhide
-    - branched
 - pattern: ext.config.chrony.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1097
   snooze: 2022-02-21


### PR DESCRIPTION
Can not reproduce `coreos.boot-mirror.luks` failed issue locally
 with rawhide after running 20 times, remove from denylist to see
if it happens again.

See https://github.com/coreos/fedora-coreos-tracker/issues/1092