### PR TITLE
[rawhide] Add @CoreOS/continuous COPR repo

### DIFF
--- a/copr-coreos-continuous.repo
+++ b/copr-coreos-continuous.repo
@@ -1,0 +1,8 @@
+[copr-coreos-continuous]
+name=@CoreOS/continuous COPR
+baseurl=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-$releasever-$basearch/
+type=rpm-md
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/pubkey.gpg
+repo_gpgcheck=0
+enabled=1

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -10,6 +10,7 @@ rojig:
 
 repos:
   - fedora-rawhide
+  - copr-coreos-continuous
 
 add-commit-metadata:
   fedora-coreos.stream: rawhide


### PR DESCRIPTION
Rawhide moves fast. And our packages adapt quickly. Add the
@CoreOS/continuous packages to shorten the cycle.

Part of https://github.com/coreos/fedora-coreos-tracker/issues/910.