### PR TITLE
[rawhide] overrides: fast-track tpm2-tss-3.2.0-0.3.rc0.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -16,7 +16,8 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1090
       type: fast-track
   tpm2-tss:
-    evr: 3.1.0-3.fc35
+    evr: 3.2.0-0.3.rc0.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5204b0e8fb
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/968
-      type: pin
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,15 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5204b0e8fb
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/968
       type: fast-track
+  coreos-installer:
+    evr: 0.12.0-4.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-21895d321c
+      reason: https://github.com/coreos/coreos-installer/pull/770
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.12.0-4.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-21895d321c
+      reason: https://github.com/coreos/coreos-installer/pull/770
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).