### PR TITLE
[rawhide] manifest: add aardvark-dns to package list for podman v4

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  tpm2-tss:
-    evr: 3.1.0-3.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/968
-      type: pin
+packages: {}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,10 +14,6 @@ repos:
 add-commit-metadata:
   fedora-coreos.stream: rawhide
 
-packages:
-  # for nsswitch.conf
-  - authselect
-
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,14 @@ repos:
 add-commit-metadata:
   fedora-coreos.stream: rawhide
 
+packages:
+  # For podman v4 netavark gets pulled in but it only recommends
+  # aardvark-dns (which provides name resolution based on container
+  # names). This functionality was previously provided by dnsname from
+  # podman-plugins in the podman v3 stack.
+  # See https://github.com/containers/netavark/pull/217
+  - aardvark-dns
+
 postprocess:
   # Disable Zincati and fedora-coreos-pinger on non-production streams
   # https://github.com/coreos/fedora-coreos-tracker/issues/163


### PR DESCRIPTION
aardvark-dns, which provides name resolution based on container name,
is recommended by netavark but not required. We need to name is so
it gets pulled in.
