### PR TITLE
denylist: snooze ext.config.toolbox test in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -58,3 +58,8 @@
   snooze: 2022-02-21
   streams:
     - rawhide
+- pattern: ext.config.toolbox
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1103
+  snooze: 2022-03-15
+  streams:
+    - rawhide


### PR DESCRIPTION
There is no registry.fedoraproject.org/fedora-toolbox:37 in the
registry. Let's snooze the test for a month and hopefully it will
exist by then.

See https://github.com/coreos/fedora-coreos-tracker/issues/1103