### PR TITLE
denylist: snooze `ext.config.extensions.module` for now

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -53,3 +53,8 @@
   streams:
     - rawhide
     - branched
+- pattern: ext.config.extensions.module
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1104
+  snooze: 2022-02-21
+  streams:
+    - rawhide


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1104.