### PR TITLE
[rhcos-4.9] ignition-ostree-uuid-root.service: add stricter ordering

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-root.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Ignition OSTree: Regenerate Filesystem UUID (root)
-# These conditions match mount-firstboot-sysroot.service
+# These conditions match ignition-ostree-mount-firstboot-sysroot.service
 DefaultDependencies=false
 ConditionKernelCommandLine=ostree
 ConditionPathExists=!/run/ostree-live
-Before=initrd-root-fs.target
+Before=sysroot.mount initrd-root-fs.target
 After=ignition-disks.service
 # If we've reprovisioned the rootfs, then there's no need to restamp
 ConditionPathExists=!/run/ignition-ostree-transposefs
@@ -12,6 +12,7 @@ ConditionPathExists=!/run/ignition-ostree-transposefs
 After=dev-disk-by\x2dlabel-root.device
 # Avoid racing with fsck
 Before=systemd-fsck@dev-disk-by\x2dlabel-root.service
+Before=systemd-fsck@dev-disk-by\x2dlabel-dm-mpath-root.service
 
 # Note we don't have a Requires: /dev/disk/by-label/root here like
 # the -subsequent service does because ignition-disks may have


### PR DESCRIPTION
In the multipath case, we're mounting
`/dev/disk/by-label/dm-mpath-root`, not `by-label/root`.

Also order against `sysroot.mount` because in the general case, there's
actually nothing that prevents the restamping to run at the same time as
the mount AFAICT if the `root` karg points to some other device path we
didn't predict.

See: https://github.com/openshift/os/issues/683 (which hopefully this
fixes).

(cherry picked from commit 11a11bcd530a4e67b778dcaccca3cbe189715b00)