### PR TITLE
kola-denylist: snooze multipath.day1 for a week

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -63,3 +63,6 @@
   snooze: 2022-03-15
   streams:
     - rawhide
+- pattern: multipath.day1
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
+  snooze: 2022-02-23


### PR DESCRIPTION
This will unblock lockfile bumps while we investigate the issue.