### PR TITLE
denylist: snooze the coreos.boot-mirror.luks test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -66,3 +66,9 @@
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
   snooze: 2022-02-23
+- pattern: coreos.boot-mirror.luks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
+  snooze: 2022-02-28
+  streams:
+    - rawhide
+    - branched


### PR DESCRIPTION
This issue is back again.

See https://github.com/coreos/fedora-coreos-tracker/issues/1092#issuecomment-1043059521