### PR TITLE
overlay: add 'partprobe' and retry verification of unique boot

### DIFF
--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -36,3 +36,4 @@ packages:
   # Boost starving threads
   # https://github.com/coreos/fedora-coreos-tracker/issues/753
   - stalld
+  - /usr/sbin/partprobe

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -23,7 +23,8 @@ install() {
         lsblk \
         sed \
         grep \
-        sgdisk
+        sgdisk \
+        partprobe
 
     inst_simple "$moddir/coreos-diskful-generator" \
         "$systemdutildir/system-generators/coreos-diskful-generator"


### PR DESCRIPTION
`rdcore` first tries the rereading of partition table by execution of the `partprobe` tool, so add it.
After change of partitions' UUIDs kernel and userspace have different info, to mitigate that try to verify the unique-boot
up to 3 times.

Required by: https://github.com/coreos/coreos-installer/pull/785
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1105

