### PR TITLE
denylist: snooze the ext.config.firewall.iptables test on next*

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -66,3 +66,9 @@
   streams:
     - rawhide
     - branched
+- pattern: ext.config.firewall.iptables
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/676
+  snooze: 2022-02-28
+  streams:
+    - next
+    - next-devel


### PR DESCRIPTION
We merged an update to the test that checks for iptables-nft on
next/next-devel but we haven't switched to iptables-nft there yet
because we are coupling that with the rebase to F36.

I imagine what we'll do is modify the test to be conditional on
Fedora 36 rather than the stream but we have to wait to make that
change until we actually switch rawhide/branched over as well,
which will most likely happen after https://github.com/coreos/rpm-ostree/pull/3439
lands.