### PR TITLE
overlay.d: add service to check for unique-boot after ignition

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-unique-boot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-unique-boot.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=CoreOS Ensure Unique Boot Filesystem
+ConditionPathExists=/etc/initrd-release
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+# That's a weak dependency, so service won't fail if boot dissaperears
+Wants=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-boot.device
+
+# Start after ignition has finished with disks but before mounting them
+After=ignition-disks.service
+Before=ignition-mount.service
+Before=ignition-ostree-uuid-root.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rdcore verify-unique-fs-label --rereadpt boot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -64,6 +64,7 @@ install() {
     install_ignition_unit "coreos-boot-edit.service" \
         "ignition-diskful.target"
 
+    install_ignition_unit coreos-ignition-unique-boot.service ignition-diskful.target
     install_ignition_unit coreos-unique-boot.service ignition-diskful.target
     install_ignition_unit coreos-ignition-setup-user.service
 }


### PR DESCRIPTION
After ignition's stages partition table could be modified, and therefore
kernel may have an old picture of disks and partitions. During verification
we force kernel to reread the partition table for each disk and call udevsettle,
which in turn leads to modification of "/dev/disk/by-*/*" symlinks and systemd
may send SIGTERM to services with "Require=dev-disk-by\x2dlabel-boot.device".
To avoid that this checks for the unique fs labeled 'boot' after ignition's
disks stage was finished but before mounting stage.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1105