### PR TITLE
tests/iptables: adapt for RHCOS and f36+

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -25,3 +25,26 @@ get_ipv4_for_nic() {
 get_fcos_stream() {
     rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]'
 }
+
+is_fcos() (
+    source /etc/os-release
+    [ "${ID}" == "fedora" ] && [ "${VARIANT_ID}" == "coreos" ]
+)
+
+# Note when using this, you probably also want to check `get_rhel_maj_ver`.
+is_rhcos() (
+    source /etc/os-release
+    [ "${ID}" == "rhcos" ]
+)
+
+get_fedora_ver() (
+    source /etc/os-release
+    if is_fcos; then
+        echo "${VERSION_ID}"
+    fi
+)
+
+get_rhel_maj_ver() {
+    source /etc/os-release
+    echo "${RHEL_VERSION%%.*}"
+}

--- a/tests/kola/firewall/iptables/test.sh
+++ b/tests/kola/firewall/iptables/test.sh
@@ -6,21 +6,19 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# we're currently rolling out to next first
-case "$(get_fcos_stream)" in
-    "next-devel" | "next")
-        if ! iptables --version | grep nf_tables; then
-            iptables --version # output for logs
-            fatal "iptables version is not nft"
-        fi
-        ok "iptables in nft mode"
-        ;;
-    *)
-        # Make sure we're on legacy iptables
-        if ! iptables --version | grep legacy; then
-            iptables --version # output for logs
-            fatal "iptables version is not legacy"
-        fi
-        ok "iptables in legacy mode"
-        ;;
-esac
+# rollout is tied to f36+ on FCOS
+# RHCOS is already in nft
+# once all of FCOS is on f36, we can drop this branching
+if is_rhcos || [ "$(get_fedora_ver)" -ge 36 ]; then
+    if ! iptables --version | grep nf_tables; then
+        iptables --version # output for logs
+        fatal "iptables version is not nft"
+    fi
+    ok "iptables in nft mode"
+else
+    if ! iptables --version | grep legacy; then
+        iptables --version # output for logs
+        fatal "iptables version is not legacy"
+    fi
+    ok "iptables in legacy mode"
+fi


### PR DESCRIPTION
Don't make the test stream-based, but rather releasever-based. Handle
RHCOS correctly, which has long already switched to iptables-nft.

While we're here, add a bunch of query functions to the commonlib.
There are some tests in which we could use these in a follow-up.