### PR TITLE
15fcos: add coreos-fix-systemd-journald.service

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -3,3 +3,5 @@ enable fedora-coreos-pinger.service
 enable coreos-check-ssh-keys.service
 # Check if cgroupsv1 is still being used
 enable coreos-check-cgroups.service
+# Fix systemd-journald if required
+enable coreos-fix-systemd-journald.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-fix-systemd-journald.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-fix-systemd-journald.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fix systemd-journald after switch root on Fedora CoreOS
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/1108
+DefaultDependencies=no
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-fix-systemd-journald
+RemainAfterExit=yes
+# can't send output to the journal because we might kill it
+StandardOutput=file:/run/coreos-fix-systemd-journald-stdout
+StandardError=file:/run/coreos-fix-systemd-journald-stderr
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-fix-systemd-journald
+++ b/overlay.d/15fcos/usr/libexec/coreos-fix-systemd-journald
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+# This is a workaround for cases where systemd-journald can fail to
+# process SIGTERM and get left over from the initramfs into the real
+# root. https://github.com/coreos/fedora-coreos-tracker/issues/1108
+set -eux -o pipefail
+
+# We find the PID of the systemd-journald process and then determine
+# if it's the one from the initramfs by checking the SELinux context.
+# If the context is `kernel_t` then we know it's been leaked from the
+# initramfs and it must be taken out. We must use SIGKILL because the
+# reason we're here in the first place is because it's not responding
+# to SIGTERM.
+jrnlpid=$(systemctl show --property=MainPID --value systemd-journald.service)
+context=$(ps --no-headers --format label $jrnlpid)
+if [ "${context}" == "system_u:system_r:kernel_t:s0" ]; then
+    kill -s KILL $jrnlpid
+    # Leave behind evidence that we had to fix things
+    mkdir -p /run/coreos
+    touch /run/coreos/coreos-fix-systemd-journald
+fi

--- a/tests/kola/systemd/data/commonlib.sh
+++ b/tests/kola/systemd/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/systemd/sytemd-journald-fix
+++ b/tests/kola/systemd/sytemd-journald-fix
@@ -1,0 +1,21 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+# This test identifies when the workaround for [1] gets used. We still
+# want to know how when it happens until it gets fixed. We can
+# denylist/snooze this test if we decide we don't want to see it for
+# a while.
+# [1] https://github.com/coreos/fedora-coreos-tracker/issues/1108
+# 
+# - exclusive: false
+#   - This problem really only happens for non-exclusive tests that 
+#     we've seen so far.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+if [ -f /run/coreos/coreos-fix-systemd-journald ]; then
+    echo "Workaround for https://github.com/coreos/fedora-coreos-tracker/issues/1108 used"
+    fatal "Error: The systemd-journald workaround was needed"
+fi
+ok "No systemd-journald workaround used"


### PR DESCRIPTION
This service will detect when systemd-journald has been leaked from the
initramfs and kill it so the system can recover. This is a workaround
for https://github.com/coreos/fedora-coreos-tracker/issues/1108