### PR TITLE
denylist: remove denial, change denial, extend snoozes,

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,12 +41,6 @@
   streams:
     - rawhide
     - branched
-- pattern: ext.config.chrony.dhcp-propagation
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1097
-  snooze: 2022-02-28
-  streams:
-    - rawhide
-    - branched
 - pattern: ext.config.extensions.module
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1104
   snooze: 2022-02-28

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ostree.hotfix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
@@ -19,31 +19,31 @@
     - aarch64
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
 - pattern: ext.config.extensions.module
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1104
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
 - pattern: ext.config.toolbox
@@ -53,16 +53,16 @@
     - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
-  snooze: 2022-02-28
+  snooze: 2022-03-07
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched
 - pattern: ext.config.firewall.iptables
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/676
-  snooze: 2022-02-28
+  snooze: 2022-03-07
   streams:
     - rawhide
     - branched

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -64,5 +64,5 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/676
   snooze: 2022-02-28
   streams:
-    - next
-    - next-devel
+    - rawhide
+    - branched


### PR DESCRIPTION
```
commit 05e0f543d2519990516eda06bdb444b89c8f62a6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Feb 28 11:21:19 2022 -0500

    denylist: extend snoozes
    
    These are still problems and need to be extended.

commit 13f4f20a28da11e6051f2a703cd31122897c5c82
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Feb 28 10:59:50 2022 -0500

    denylist: switch snooze streams for ext.config.firewall.iptables
    
    In 8d8ad1d we switched the test to be based on the Fedora major
    rather than the stream so let's now snooze on the streams that are
    Fedora 36+ already.

commit 4a265835d98d4c8ed74ec65aad21931cb3e6e284
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Feb 28 10:58:17 2022 -0500

    denylist: drop ext.config.chrony.dhcp-propagation snooze
    
    The underlying issue seems to have been resolved in a recent
    selinux-policy update.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1097
```
