### PR TITLE
[rawhide] overrides: pin glibc-2.35-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  glibc:
+    evr: 2.35-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
+      type: pin
+  glibc-common:
+    evr: 2.35-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
+      type: pin
+  glibc-minimal-langpack:
+    evr: 2.35-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).