### PR TITLE
[branched] overrides: fast-track podman-4.0.1-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  podman:
+    evr: 3:4.0.1-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-6e5b30e2f3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track
+  podman-plugins:
+    evr: 3:4.0.1-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-6e5b30e2f3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).