### PR TITLE
[rawhide] overrides: fast-track podman-4.0.1-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,15 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
       type: pin
+  podman:
+    evr: 3:4.0.1-2.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b212ac738a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track
+  podman-plugins:
+    evr: 3:4.0.1-2.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b212ac738a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).