### PR TITLE
multipathd.socket: fix `remove workaround for rhel8.6`

### DIFF
--- a/manifests/shared-workarounds.yaml
+++ b/manifests/shared-workarounds.yaml
@@ -14,12 +14,15 @@ postprocess:
         # FCOS: Only operate on releases before F36. The fix has landed
         # in F36+ and there is no need for a workaround.
         [ ${VERSION_ID} -le 35 ] || exit 0
-    elif [[ "${ID}" == "rhcos" ]]; then
+    elif [[ "${ID}" == "rhel" ]]; then
         # RHCOS: Only operate on releases before RHEL8.5. The fix has 
         # landed in RHEL8.6+ and there is no need for a workaround.
         # https://bugzilla.redhat.com/show_bug.cgi?id=2008101
         # Fixed RPM version: device-mapper-multipath-0.8.4-18.el8
-        [ ${RHEL_VERSION//.} -le 85 ] || exit 0
+        # Using generic redhat-release package according to 
+        # https://github.com/openshift/os/pull/713, should check RHEL version
+        # with VERSION_ID
+        [ ${VERSION_ID//.} -le 85 ] || exit 0
     fi
     mkdir /usr/lib/systemd/system/multipathd.socket.d
     cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-config/pull/1550 does not work when https://github.com/openshift/os/pull/713 merged,
because it will use generic redhat-release package instead of redhat-release-coreos.

Need to check RHEL specific version using `VERSION_ID`(for example
`VERSION_ID=8.6`), and clarify rhel or fedora using `ID=rhel`,
as this will be executed before override according to
https://github.com/openshift/os/blob/master/manifest.yaml#L128-L150