### PR TITLE
Skip kola ext.config.shared.kdump.crash test for ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,6 +17,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
     - aarch64
+    - ppc64le
 - pattern: ext.config.podman.dns
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
   snooze: 2022-03-07
@@ -66,3 +67,11 @@
   streams:
     - rawhide
     - branched
+- pattern: coreos.boot-mirror.luks/detach-primary
+  tracker: https://github.com/coreos/coreos-assembler/issues/2725
+  arches:
+  - ppc64le
+- pattern: coreos.boot-mirror/detach-primary
+  tracker: https://github.com/coreos/coreos-assembler/issues/2725
+  arches:
+  - ppc64le


### PR DESCRIPTION
- This test is failing with a Kernel Panic, blocking the CI
- More info: https://github.com/coreos/coreos-assembler/issues/2725

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>