### PR TITLE
manifests: make `releasever` a number and add iptables-nft.yaml for f36+

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -60,9 +60,3 @@
   streams:
     - rawhide
     - branched
-- pattern: ext.config.firewall.iptables
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/676
-  snooze: 2022-03-07
-  streams:
-    - rawhide
-    - branched

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 ref: fedora/${basearch}/coreos/testing-devel
 include: manifests/fedora-coreos.yaml
 
-releasever: "35"
+releasever: 35
 
 rojig:
   license: MIT

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -17,6 +17,11 @@ ostree-layers:
   - overlay/14NetworkManager-plugins
   - overlay/20platform-chrony
 
+conditional-include:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/676
+  - if: releasever >= 36
+    include: iptables-nft.yaml
+
 initramfs-args:
   - --no-hostonly
   # We don't support root on NFS, so we don't need it in the initramfs. It also

--- a/manifests/iptables-nft.yaml
+++ b/manifests/iptables-nft.yaml
@@ -1,0 +1,17 @@
+# Scripts for opting into staying on iptables-legacy after migration. Remove
+# after the next barrier release.
+ostree-layers:
+  - overlay/35coreos-iptables
+
+# Default to iptables-nft. Otherwise, legacy wins. We can drop this once/if we
+# remove iptables-legacy.
+postprocess:
+- |
+  #!/usr/bin/env bash
+  set -xeuo pipefail
+  ln -sf /usr/sbin/ip6tables-nft         /etc/alternatives/ip6tables
+  ln -sf /usr/sbin/ip6tables-nft-restore /etc/alternatives/ip6tables-restore
+  ln -sf /usr/sbin/ip6tables-nft-save    /etc/alternatives/ip6tables-save
+  ln -sf /usr/sbin/iptables-nft          /etc/alternatives/iptables
+  ln -sf /usr/sbin/iptables-nft-restore  /etc/alternatives/iptables-restore
+  ln -sf /usr/sbin/iptables-nft-save     /etc/alternatives/iptables-save


### PR DESCRIPTION
```
commit 84dea8c5624cae0650dac6f5cf0e807d5bad6131
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Tue Feb 22 21:30:07 2022 -0500

    manifests: make `releasever` a number

    This is supported by rpm-ostree now.
```
---
```
commit 617558c533f306d956dd1b93d61f109810f240c2
Date:   Tue Feb 22 21:31:37 2022 -0500

    manifests: add iptables-nft.yaml for f36+

    Add a new conditional include which migrates streams on Fedora 36 and
    higher to iptables-nft. This is magnitudes simpler than the current
    alternative rollout procedure detailed in:

    https://github.com/coreos/fedora-coreos-tracker/issues/676
```
---
```
kola-denylist: drop ext.config.firewall.iptables

This should be fixed now.
```