### PR TITLE
coreos-teardown-initramfs: account for BOOTIF kernel argument

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -22,6 +22,21 @@ dracut_func() {
     return $rc
 }
 
+# Get the BOOTIF and rd.bootif kernel arguments from
+# the kernel command line.
+get_bootif_kargs() {
+    bootif_kargs=""
+    bootif_karg=$(dracut_func getarg BOOTIF)
+    if [ ! -z "$bootif_karg" ]; then
+        bootif_kargs+="BOOTIF=${bootif_karg}"
+    fi
+    rdbootif_karg=$(dracut_func getarg rd.bootif)
+    if [ ! -z "$rdbootif_karg" ]; then
+        bootif_kargs+="rd.bootif=${rdbootif_karg}"
+    fi
+    echo $bootif_kargs
+}
+
 # Determine if the generated NM connection profiles match the default
 # that would be given to us if the user had provided no additional
 # configuration. i.e. did the user give us any network configuration
@@ -33,6 +48,9 @@ are_default_NM_configs() {
     # pick up our CoreOS default networking kargs from the afterburn dropin
     DEFAULT_KARGS_FILE=/usr/lib/systemd/system/afterburn-network-kargs.service.d/50-afterburn-network-kargs-default.conf
     source <(grep -o 'AFTERBURN_NETWORK_KARGS_DEFAULT=.*' $DEFAULT_KARGS_FILE)
+    # Also pick up BOOTIF/rd.bootif kargs and apply them here.
+    # See https://github.com/coreos/fedora-coreos-tracker/issues/1048
+    BOOTIF_KARGS=$(get_bootif_kargs)
     # Make two dirs for storing files to use in the comparison
     mkdir -p /run/coreos-teardown-initramfs/connections-compare-{1,2}
     # Make another that's just a throwaway for the initrd-data-dir
@@ -43,7 +61,8 @@ are_default_NM_configs() {
     # Do a new run with the default input
     /usr/libexec/nm-initrd-generator \
         -c /run/coreos-teardown-initramfs/connections-compare-2 \
-        -i /run/coreos-teardown-initramfs/initrd-data-dir -- $AFTERBURN_NETWORK_KARGS_DEFAULT
+        -i /run/coreos-teardown-initramfs/initrd-data-dir \
+        -- $AFTERBURN_NETWORK_KARGS_DEFAULT $BOOTIF_KARGS
     # remove unique identifiers from the files (so our diff can work)
     sed -i '/^uuid=/d' /run/coreos-teardown-initramfs/connections-compare-{1,2}/*
     # currently the output will differ based on whether rd.neednet=1

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -1,0 +1,28 @@
+#!/bin/bash
+# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "BOOTIF=52:54:00:12:34:56" }
+#
+# In addition to the pure network defaults case we should also make
+# sure that when BOOTIF= or rd.bootif= are provided on the kernel
+# command line (typically from PXE servers) that we don't propagate
+# networking configs either. See https://github.com/coreos/fedora-coreos-tracker/issues/1048
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - appendFirstbootKernelArgs: "BOOTIF=52:54:00:12:34:56"
+#   - Append BOOTIF kernel argument so we can test how nm-initrd-generator
+#     and the coreos-teardown-initramfs interact. The MAC address is from:
+#     https://github.com/coreos/coreos-assembler/blob/d5f1623aad6d133b2c7c00e784c04ab6828450c1/mantle/platform/metal.go#L468
+
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Run the test bits (sets the $fail var)
+. $KOLA_EXT_DATA/test-net-propagation.sh
+
+if [ -z "${fail:-}" ]; then
+    ok "success: no initramfs network propagation for default configuration with BOOTIF"
+else
+    fatal "fail: no initramfs network propagation for default configuration with BOOTIF"
+fi

--- a/tests/kola/networking/no-default-initramfs-net-propagation/data/test-net-propagation.sh
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/data/test-net-propagation.sh
@@ -1,0 +1,12 @@
+# common pieces of each of the no-default-initramfs-net-propagation tests
+if ! journalctl -t coreos-teardown-initramfs | \
+       grep 'info: skipping propagation of default networking configs'; then
+    echo "no log message claiming to skip initramfs network propagation" >&2
+    fail=1
+fi
+
+if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
+    echo "configs exist in /etc/NetworkManager/system-connections/, but shouldn't" >&2
+    fail=1
+fi
+

--- a/tests/kola/networking/no-default-initramfs-net-propagation/default
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/default
@@ -8,16 +8,8 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-if ! journalctl -t coreos-teardown-initramfs | \
-       grep 'info: skipping propagation of default networking configs'; then
-    echo "no log message claiming to skip initramfs network propagation" >&2
-    fail=1
-fi
-
-if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
-    echo "configs exist in /etc/NetworkManager/system-connections/, but shouldn't" >&2
-    fail=1
-fi
+# Run the test bits (sets the $fail var)
+. $KOLA_EXT_DATA/test-net-propagation.sh
 
 if [ -z "${fail:-}" ]; then
     ok "success: no initramfs network propagation for default configuration"


### PR DESCRIPTION
`nm-initrd-generator` will take into account the `BOOTIF=` kernel
argument. Let's account for that in our `propagate_initramfs_networking()`
code so don't propagate networking config if `BOOTIF` is the only
networking config.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1048