### PR TITLE
[rawhide] overrides: fast-track rpm-ostree-2022.4-1.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -36,3 +36,13 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b212ac738a
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
       type: fast-track
+  rpm-ostree:
+    evr: 2022.4-1.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-868a901b98
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2022.4-1.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-868a901b98
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).