### PR TITLE
coreos-teardown-initramfs: add space to bootif_kargs append

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -32,7 +32,7 @@ get_bootif_kargs() {
     fi
     rdbootif_karg=$(dracut_func getarg rd.bootif)
     if [ ! -z "$rdbootif_karg" ]; then
-        bootif_kargs+="rd.bootif=${rdbootif_karg}"
+        bootif_kargs+=" rd.bootif=${rdbootif_karg}"
     fi
     echo $bootif_kargs
 }


### PR DESCRIPTION
I missed this in 7bb4d6e.