### PR TITLE
denylist: drop ostree.hotfix denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,14 +5,6 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: ostree.hotfix
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/942
-  snooze: 2022-03-07
-  streams:
-    - rawhide
-    - branched
-  arches:
-    - aarch64
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:


### PR DESCRIPTION
Since https://github.com/coreos/rpm-ostree/pull/3406 has now landed
in rpm-ostree 2022.3 and later we can remove this
denial and hopefully never see the test failure again.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/942