### PR TITLE
[branched] manifest.yaml: update for conditional-include cleanups

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,26 +1,11 @@
-ref: fedora/${basearch}/coreos/branched
-include: manifests/fedora-coreos.yaml
+variables:
+  stream: branched
+  prod: false
 
-releasever: "36"
-
-rojig:
-  license: MIT
-  name: fedora-coreos
-  summary: Fedora CoreOS branched
+releasever: 36
 
 repos:
   - fedora-next
   - fedora-next-updates
 
-add-commit-metadata:
-  fedora-coreos.stream: branched
-
-postprocess:
-  # Disable Zincati and fedora-coreos-pinger on non-production streams
-  # https://github.com/coreos/fedora-coreos-tracker/issues/163
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
-    echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
-    echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
+include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Apply the same cleanups as in testing-devel's manifest in
https://github.com/coreos/fedora-coreos-config/pull/1538.