### PR TITLE
[next-devel] manifest.yaml: update for conditional-include cleanups

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,12 +1,8 @@
-ref: fedora/${basearch}/coreos/next-devel
-include: manifests/fedora-coreos.yaml
+variables:
+  stream: next-devel
+  prod: false
 
-releasever: "35"
-
-rojig:
-  license: MIT
-  name: fedora-coreos
-  summary: Fedora CoreOS next-devel
+releasever: 35
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to
@@ -16,15 +12,4 @@ repos:
   - fedora
   - fedora-updates
 
-add-commit-metadata:
-  fedora-coreos.stream: next-devel
-
-postprocess:
-  # Disable Zincati and fedora-coreos-pinger on non-production streams
-  # https://github.com/coreos/fedora-coreos-tracker/issues/163
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    mkdir -p /etc/fedora-coreos-pinger/config.d /etc/zincati/config.d
-    echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nreporting.enabled = false' > /etc/fedora-coreos-pinger/config.d/90-disable-on-non-production-stream.toml
-    echo -e '# https://github.com/coreos/fedora-coreos-tracker/issues/163\nupdates.enabled = false' > /etc/zincati/config.d/90-disable-on-non-production-stream.toml
+include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Apply the same cleanups as in testing-devel's manifest in
https://github.com/coreos/fedora-coreos-config/pull/1538.