### PR TITLE
[branched] overrides: fast-track rpm-ostree-2022.5-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -22,12 +22,12 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
       type: fast-track
   rpm-ostree:
-    evr: 2022.4-1.fc36
+    evr: 2022.5-1.fc36
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-28b9d9582c
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7502260dab
       type: fast-track
   rpm-ostree-libs:
-    evr: 2022.4-1.fc36
+    evr: 2022.5-1.fc36
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-28b9d9582c
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7502260dab
       type: fast-track


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).