### PR TITLE
[rawhide] overrides: drop glibc pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,19 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  glibc:
-    evr: 2.35-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
-      type: pin
-  glibc-common:
-    evr: 2.35-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
-      type: pin
-  glibc-minimal-langpack:
-    evr: 2.35-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1113
-      type: pin
+packages: {}


### PR DESCRIPTION
We have a new rpm-ostree now with the lua scriptlet workaround needed
for https://github.com/coreos/fedora-coreos-tracker/issues/1113.