### PR TITLE
denylist, shared-workarounds: various updates

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,6 @@
   arches:
     - aarch64
     - ppc64le
-- pattern: ext.config.podman.dns
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1046
-  snooze: 2022-03-07
-  streams:
-    - rawhide
-    - branched
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
   snooze: 2022-03-07

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -53,11 +53,11 @@
   streams:
     - rawhide
     - branched
-- pattern: coreos.boot-mirror.luks/detach-primary
+- pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
-- pattern: coreos.boot-mirror/detach-primary
+- pattern: coreos.boot-mirror
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,25 +12,25 @@
     - ppc64le
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-07
+  snooze: 2022-03-14
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-07
+  snooze: 2022-03-14
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-07
+  snooze: 2022-03-14
   streams:
     - rawhide
     - branched
 - pattern: ext.config.extensions.module
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1104
-  snooze: 2022-03-07
+  snooze: 2022-03-14
   streams:
     - rawhide
 - pattern: ext.config.toolbox
@@ -43,7 +43,7 @@
   snooze: 2022-03-07
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
-  snooze: 2022-03-07
+  snooze: 2022-03-14
   streams:
     - rawhide
     - branched

--- a/manifests/shared-workarounds.yaml
+++ b/manifests/shared-workarounds.yaml
@@ -43,9 +43,8 @@ postprocess:
     set -xeuo pipefail
     source /etc/os-release
     if [[ ${NAME} =~ "Fedora" ]]; then
-        # FCOS: This fix hasn't landed in rawhide (F37) yet,
-        # but hopefully will soon.
-        [ ${VERSION_ID} -le 37 ] || exit 0
+        # FCOS: This fix has landed in F37+
+        [ ${VERSION_ID} -le 36 ] || exit 0
     else 
         # RHCOS: The fix hasn't landed in any version of RHEL yet
         true


### PR DESCRIPTION
```
commit 509a769f1b4200571d4483fc3e6bd944af46d172
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 7 11:23:40 2022 -0500

    denylist: extend snooze's for tests that are still failing
    
    These all are for rawhide/branched.

commit 65708eb7588c643740a65598eeb7afaa83862303
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 7 10:56:16 2022 -0500

    denylist: drop snooze for ext.config.podman.dns
    
    This is now fixed.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1046

commit 93161e0d9bd9a8fbeb7ad44b9b4d24bd5e89d3c3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 7 10:54:57 2022 -0500

    denylist: make boot-mirror denials apply to the main test
    
    I've heard that denylisting a subtest doesn't work. We have to deny
    the main test.

commit d37bb02e2f7eb7a46c0f59426630420472efa172
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 7 10:43:49 2022 -0500

    shared-workarounds: adjust service fix to not apply to F37+
    
    A new version of dracut (with the service fix) landed in F37/rawhide.
```
