### PR TITLE
manifests: apply podman-v4.yaml manifest on F36+

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -21,6 +21,9 @@ conditional-include:
   # https://github.com/coreos/fedora-coreos-tracker/issues/676
   - if: releasever >= 36
     include: iptables-nft.yaml
+  # https://github.com/coreos/fedora-coreos-config/pull/1519
+  - if: releasever >= 36
+    include: podman-v4.yaml
 
 initramfs-args:
   - --no-hostonly

--- a/manifests/podman-v4.yaml
+++ b/manifests/podman-v4.yaml
@@ -1,0 +1,8 @@
+# Extra tweaks needed for podman v4
+packages:
+  # For podman v4 netavark gets pulled in but it only recommends
+  # aardvark-dns (which provides name resolution based on container
+  # names). This functionality was previously provided by dnsname from
+  # podman-plugins in the podman v3 stack.
+  # See https://github.com/containers/netavark/pull/217
+  - aardvark-dns


### PR DESCRIPTION
This will allow us to share the package inclusion rather than carrying
it in manifest.yaml on various branches.