### PR TITLE
workflows/remove-graduated-overrides: enable continuous repo

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -24,6 +24,10 @@ jobs:
           - rawhide
       fail-fast: false
     steps:
+      - name: Enable CoreOS continuous repo
+        run: |
+          version_id=$(. /etc/os-release && echo ${VERSION_ID})
+          echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
       - name: Install dependencies
         run: dnf install -y python3-bodhi-client rpm-ostree # see related TODO above
       - name: Checkout


### PR DESCRIPTION
Until we actually use cosa for this, we should match its input repos.
Currently that means enabling the continuous repo.

This should give us a more recent rpm-ostree which has support for
`releasever` as a number.