### PR TITLE
buildroot: Install `clang-tools-extra`

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -46,6 +46,8 @@ createrepo_c
 
 # Also, add clang since it's useful at least in CI for C/C++ projects
 clang lld
+# And the tools such as clang-format, used for style checking
+clang-tools-extra
 # All C/C++ projects should have CI that uses the sanitizers
 libubsan libasan libtsan
 # And all C/C++ projects should use clang-analyzer


### PR DESCRIPTION
For `clang-format`, which is used as of https://github.com/coreos/rpm-ostree/pull/3475