### PR TITLE
overrides: drop kernel pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,21 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 5.15.18-200.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
-  kernel-core:
-    evr: 5.15.18-200.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
-  kernel-modules:
-    evr: 5.15.18-200.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
-      type: pin
   rpm-ostree:
     evr: 2022.5-1.fc35
     metadata:


### PR DESCRIPTION
This allows us to get the latest kernel-5.16.12-200.fc35. Moving to
a kernel newer than 5.16.11 picks up the fix fo CVE-2022-0847. We're
able to do this because the Fedora kernel maintainers agreed to again
pick up a revert that allows us to not regress on some AWS instance
types (https://github.com/coreos/fedora-coreos-tracker/issues/1066).

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1118