### PR TITLE
denylist: extend snooze for multipath.day1

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -40,7 +40,7 @@
     - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
-  snooze: 2022-03-07
+  snooze: 2022-03-14
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
   snooze: 2022-03-14


### PR DESCRIPTION
I thought this one might have gone away but it seems to only present
itself on aarch64.