### PR TITLE
tests: extend timeout for podman.dns test

### DIFF
--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# kola: { "platforms": "qemu", "tags": "needs-internet", "exclusive": false }
 # Tests that rootless podman containers can DNS resolve external domains.
 # https://github.com/coreos/fedora-coreos-tracker/issues/923
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "exclusive": false}
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - tags: needs-internet
+#   - This test pulls a container from a registry.
+# - exclusive: false
+#   - This test doesn't make meaningful changes to the system and
+#     should be able to be combined with other tests.
+#   - Root reprovisioning requires at least 4GiB of memory.
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# kola: { "platforms": "qemu", "tags": "needs-internet", "exclusive": false }
+# kola: { "platforms": "qemu", "tags": "needs-internet", "exclusive": false, "timeoutMin": 3 }
 # Tests that rootless podman containers can DNS resolve external domains.
 # https://github.com/coreos/fedora-coreos-tracker/issues/923
 #
@@ -13,6 +13,9 @@ set -xeuo pipefail
 #   - This test doesn't make meaningful changes to the system and
 #     should be able to be combined with other tests.
 #   - Root reprovisioning requires at least 4GiB of memory.
+# - timeoutMin: 3
+#   - This test reaches out to the internet and it could take more
+#     time to pull down the container.
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
I've seen this timeout recently. It could take some extra time to
    grab the container from the registry so let's bump the timeout from
    the default of 1 minute for a non-exclusive test to 3 minutes.