### PR TITLE
denylist: snooze the detection of the journald fix

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,3 +55,12 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
+- pattern: ext.config.systemd.sytemd-journald-fix
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1108#issuecomment-1061988853
+  snooze: 2022-03-18
+  streams:
+    - stable
+    - testing
+    - testing-devel
+    - next
+    - next-devel


### PR DESCRIPTION
The test lets us know when the workaround was used so we can keep
an eye on how often the problem occurs. It's happening often enough
that it's not super useful. Let's snooze it for 10 days.