### PR TITLE
[stable] ci: temporarily override cosa image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
 
-cosaPod {
+cosaPod(image: 'quay.io/coreos-assembler/coreos-assembler:v0.13.0') {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")


### PR DESCRIPTION
This pins coreos-assembler image to workaround the changes in
https://github.com/coreos/coreos-assembler/pull/2742