### PR TITLE
lockfiles: sync lockfiles with `testing-devel`

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -163,7 +163,7 @@
       "evra": "3.16.1-2.fc35.aarch64"
     },
     "crun": {
-      "evra": "1.4.2-1.fc35.aarch64"
+      "evra": "1.4.3-1.fc35.aarch64"
     },
     "crypto-policies": {
       "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
@@ -358,13 +358,13 @@
       "evra": "2.70.4-1.fc35.aarch64"
     },
     "glibc": {
-      "evra": "2.34-25.fc35.aarch64"
+      "evra": "2.34-28.fc35.aarch64"
     },
     "glibc-common": {
-      "evra": "2.34-25.fc35.aarch64"
+      "evra": "2.34-28.fc35.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-25.fc35.aarch64"
+      "evra": "2.34-28.fc35.aarch64"
     },
     "gmp": {
       "evra": "1:6.2.0-7.fc35.aarch64"
@@ -784,7 +784,7 @@
       "evra": "2.37.4-1.fc35.aarch64"
     },
     "libuv": {
-      "evra": "1:1.43.0-2.fc35.aarch64"
+      "evra": "1:1.44.1-1.fc35.aarch64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.aarch64"
@@ -814,10 +814,10 @@
       "evra": "2.5.1-30.fc35.aarch64"
     },
     "linux-firmware": {
-      "evra": "20220209-129.fc35.noarch"
+      "evra": "20220310-130.fc35.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220209-129.fc35.noarch"
+      "evra": "20220310-130.fc35.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-2.fc35.aarch64"
@@ -1168,10 +1168,10 @@
       "evra": "2.37.4-1.fc35.aarch64"
     },
     "vim-data": {
-      "evra": "2:8.2.4485-1.fc35.noarch"
+      "evra": "2:8.2.4529-1.fc35.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4485-1.fc35.aarch64"
+      "evra": "2:8.2.4529-1.fc35.aarch64"
     },
     "which": {
       "evra": "2.21-27.fc35.aarch64"
@@ -1205,16 +1205,16 @@
     }
   },
   "metadata": {
-    "generated": "2022-03-09T20:55:19Z",
+    "generated": "2022-03-13T20:52:58Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:21Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2022-03-09T01:52:13Z"
+        "generated": "2022-03-11T22:11:49Z"
       },
       "fedora-updates": {
-        "generated": "2022-03-09T19:24:42Z"
+        "generated": "2022-03-13T17:32:05Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,31 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 5.16.13-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b75eae92ca
-      type: fast-track
-  kernel-core:
-    evr: 5.16.13-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b75eae92ca
-      type: fast-track
-  kernel-modules:
-    evr: 5.16.13-200.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b75eae92ca
-      type: fast-track
-  rpm-ostree:
-    evr: 2022.5-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d39d0555a0
-      type: fast-track
-  rpm-ostree-libs:
-    evr: 2022.5-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d39d0555a0
-      type: fast-track
   systemd:
     evr: 249.7-2.fc35
     metadata:

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -163,7 +163,7 @@
       "evra": "3.16.1-2.fc35.x86_64"
     },
     "crun": {
-      "evra": "1.4.2-1.fc35.x86_64"
+      "evra": "1.4.3-1.fc35.x86_64"
     },
     "crypto-policies": {
       "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
@@ -358,13 +358,13 @@
       "evra": "2.70.4-1.fc35.x86_64"
     },
     "glibc": {
-      "evra": "2.34-25.fc35.x86_64"
+      "evra": "2.34-28.fc35.x86_64"
     },
     "glibc-common": {
-      "evra": "2.34-25.fc35.x86_64"
+      "evra": "2.34-28.fc35.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-25.fc35.x86_64"
+      "evra": "2.34-28.fc35.x86_64"
     },
     "gmp": {
       "evra": "1:6.2.0-7.fc35.x86_64"
@@ -793,7 +793,7 @@
       "evra": "2.37.4-1.fc35.x86_64"
     },
     "libuv": {
-      "evra": "1:1.43.0-2.fc35.x86_64"
+      "evra": "1:1.44.1-1.fc35.x86_64"
     },
     "libvarlink-util": {
       "evra": "22-3.fc35.x86_64"
@@ -823,10 +823,10 @@
       "evra": "2.5.1-30.fc35.x86_64"
     },
     "linux-firmware": {
-      "evra": "20220209-129.fc35.noarch"
+      "evra": "20220310-130.fc35.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220209-129.fc35.noarch"
+      "evra": "20220310-130.fc35.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-2.fc35.x86_64"
@@ -1180,10 +1180,10 @@
       "evra": "2.37.4-1.fc35.x86_64"
     },
     "vim-data": {
-      "evra": "2:8.2.4485-1.fc35.noarch"
+      "evra": "2:8.2.4529-1.fc35.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4485-1.fc35.x86_64"
+      "evra": "2:8.2.4529-1.fc35.x86_64"
     },
     "which": {
       "evra": "2.21-27.fc35.x86_64"
@@ -1217,16 +1217,16 @@
     }
   },
   "metadata": {
-    "generated": "2022-03-09T20:57:05Z",
+    "generated": "2022-03-13T20:53:11Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2021-10-26T05:31:27Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2022-03-09T01:52:37Z"
+        "generated": "2022-03-11T22:11:38Z"
       },
       "fedora-updates": {
-        "generated": "2022-03-09T19:25:12Z"
+        "generated": "2022-03-13T17:32:37Z"
       }
     }
   }


### PR DESCRIPTION
The lockfile bumper hasn't been working because the previous
`next-devel` doesn't have a QEMU image, which causes the upgrade
test to fail. Let's sync the lockfiles from `testing-devel` to
catch us up.