### PR TITLE
[testing] denylist: disable multipath.day1

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -40,7 +40,8 @@
     - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
-  snooze: 2022-03-14
+  streams:
+    - stable
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
   snooze: 2022-03-14


### PR DESCRIPTION
This test is failing occasionally on aarch64 and we need to
convert it from a snooze to a full denial so that it will work
in two weeks when we build `stable`.

See https://github.com/coreos/fedora-coreos-tracker/issues/1105