### PR TITLE
[next] denylist: disable multipath.day1

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -40,7 +40,8 @@
     - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
-  snooze: 2022-03-14
+  streams:
+    - next
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
   snooze: 2022-03-14


### PR DESCRIPTION
This test failed in our `next` aarch64 run because the snooze
had expired. Let's convert it from a snooze to a full denial
so that we can kick off a new run and not leave the success
of the run up to chance.

See https://github.com/coreos/fedora-coreos-tracker/issues/1105