### PR TITLE
denylist: drop denial, extend snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,11 +28,6 @@
   streams:
     - rawhide
     - branched
-- pattern: ext.config.extensions.module
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1104
-  snooze: 2022-03-14
-  streams:
-    - rawhide
 - pattern: ext.config.toolbox
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1103
   snooze: 2022-03-15

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,19 +12,19 @@
     - ppc64le
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-14
+  snooze: 2022-03-21
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-14
+  snooze: 2022-03-21
   streams:
     - rawhide
     - branched
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-14
+  snooze: 2022-03-21
   streams:
     - rawhide
     - branched
@@ -35,10 +35,10 @@
     - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
-  snooze: 2022-03-14
+  snooze: 2022-03-21
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
-  snooze: 2022-03-14
+  snooze: 2022-03-21
   streams:
     - rawhide
     - branched


### PR DESCRIPTION
```
commit 445dfc7dbb131a93f8302933c17086b680f21d14
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 14 22:45:04 2022 -0400

    denylist: extend snoozes for tests that are still failing
    
    These tests are still failing and are still being investigated. See:
    
    - https://github.com/coreos/fedora-coreos-tracker/issues/1059
    - https://github.com/coreos/fedora-coreos-tracker/issues/1092
    - https://github.com/coreos/fedora-coreos-tracker/issues/1105

commit 2b3b32c5ed7a367dc94ab721570447ebd9461ec7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Mar 14 22:43:41 2022 -0400

    denylist: drop ext.config.extensions.module snooze
    
    This test seems to be passing now.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1104
```
