### PR TITLE
denylist: drop ext.config.toolbox denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,11 +28,6 @@
   streams:
     - rawhide
     - branched
-- pattern: ext.config.toolbox
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1103
-  snooze: 2022-03-15
-  streams:
-    - rawhide
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
   snooze: 2022-03-21


### PR DESCRIPTION
The toolbox container for F37 now exists in the registry so
the test passes.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1103