### PR TITLE
denylist: drop denial for coreos.boot-mirror.luks on rawhide/branched

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -32,12 +32,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
   snooze: 2022-03-21
 - pattern: coreos.boot-mirror.luks
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1092
-  snooze: 2022-03-21
-  streams:
-    - rawhide
-    - branched
-- pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le


### PR DESCRIPTION
We're no longer seeing a test failure there. It appears the following
kernel transition fixed the issue:

```
kernel 5.17.0-0.rc5.20220225git53ab78cd6d5a.106.fc37.x86_64 → 5.17.0-0.rc6.109.fc37.x86_64
```

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1092