### PR TITLE
manifests/fedora-coreos-base: mask systemd-network-generator.service

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,24 +10,6 @@
   arches:
     - aarch64
     - ppc64le
-- pattern: ext.config.networking.prefer-ignition-networking
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-21
-  streams:
-    - rawhide
-    - branched
-- pattern: ext.config.networking.force-persist-ip
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-21
-  streams:
-    - rawhide
-    - branched
-- pattern: ext.config.networking.mtu-on-bond-kargs
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-  snooze: 2022-03-21
-  streams:
-    - rawhide
-    - branched
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105
   snooze: 2022-03-21

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,34 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  systemd:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-container:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-libs:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-pam:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-resolved:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-udev:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
+packages: {}

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -86,6 +86,13 @@ postprocess:
   - |
     #!/usr/bin/env bash
     systemctl mask systemd-repart.service
+  # Mask systemd-network-generator. We need it for some things in the future
+  # (https://github.com/systemd/systemd/pull/21766/files), but for now it's
+  # just failing on boot because of SELinux:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1059#issuecomment-1013766710
+  - |
+    #!/usr/bin/env bash
+    systemctl mask systemd-network-generator.service
 
   # Set the fallback hostname to `localhost`. This was needed in F33/F34
   # because a fallback hostname of `fedora` + systemd-resolved broke


### PR DESCRIPTION
manifests/fedora-coreos-base: mask systemd-network-generator.service

systemd-network-generator fails to run because of SELinux. The existing
bug for this problem [1] has been open for months. Let's mask the service
and move on. We do want the generator to run in the future for things
like creating udev rules [2] but it's not 100% necessary for now.

We're making this change now because we're about to switch `next` over
to Fedora 36 where we can't just freeze on an older version of systemd
and we don't want to mask the tests any longer because we want the test
coverage.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2037047
[2] https://github.com/systemd/systemd/pull/21766
