### PR TITLE
[next-devel] Move to Fedora Linux 36

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -40,7 +40,7 @@
       "evra": "2.5.1-4.fc36.aarch64"
     },
     "audit-libs": {
-      "evra": "3.0.7-1.fc36.aarch64"
+      "evra": "3.0.7-3.fc36.aarch64"
     },
     "authselect": {
       "evra": "1.3.0-10.fc36.aarch64"
@@ -133,10 +133,13 @@
       "evra": "0.21.2-4.fc36.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.178.0-1.fc36.noarch"
+      "evra": "2:2.180.0-1.fc36.noarch"
     },
     "containerd": {
       "evra": "1.6.0-1.fc36.aarch64"
+    },
+    "containernetworking-plugins": {
+      "evra": "1.1.0-1.fc36.aarch64"
     },
     "containers-common": {
       "evra": "4:1-53.fc36.noarch"
@@ -169,7 +172,7 @@
       "evra": "3.16.1-7.fc36.aarch64"
     },
     "crun": {
-      "evra": "1.4.2-2.fc36.aarch64"
+      "evra": "1.4.3-1.fc36.aarch64"
     },
     "crypto-policies": {
       "evra": "20220203-2.git112f859.fc36.noarch"
@@ -310,7 +313,7 @@
       "evra": "1:4.9.0-1.fc36.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.12.5-1.fc36.aarch64"
+      "evra": "1.12.6-1.fc36.aarch64"
     },
     "fstrm": {
       "evra": "0.6.1-4.fc36.aarch64"
@@ -337,7 +340,7 @@
       "evra": "3.10.5-2.fc36.aarch64"
     },
     "fwupd": {
-      "evra": "1.7.5-1.fc36.aarch64"
+      "evra": "1.7.6-1.fc36.aarch64"
     },
     "gawk": {
       "evra": "5.1.1-2.fc36.aarch64"
@@ -403,7 +406,7 @@
       "evra": "3.23-6.fc36.aarch64"
     },
     "ignition": {
-      "evra": "2.13.0-4.fc36.aarch64"
+      "evra": "2.13.0-5.fc36.aarch64"
     },
     "inih": {
       "evra": "49-5.fc36.aarch64"
@@ -727,7 +730,7 @@
       "evra": "2:4.16.0-0.2.rc3.fc36.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.20-3.fc36.aarch64"
+      "evra": "0.7.21-1.fc36.aarch64"
     },
     "libss": {
       "evra": "1.46.5-2.fc36.aarch64"
@@ -772,7 +775,7 @@
       "evra": "1.3.2-1.rc1.fc36.1.aarch64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.6-48.fc36.aarch64"
+      "evra": "2.4.6-50.fc36.aarch64"
     },
     "libunistring": {
       "evra": "1.0-1.fc36.aarch64"
@@ -790,7 +793,7 @@
       "evra": "2.38-0.2.fc36.aarch64"
     },
     "libuv": {
-      "evra": "1:1.43.0-3.fc36.aarch64"
+      "evra": "1:1.44.1-1.fc36.aarch64"
     },
     "libvarlink-util": {
       "evra": "23-2.fc36.aarch64"
@@ -820,10 +823,10 @@
       "evra": "2.5.1-31.fc36.aarch64"
     },
     "linux-firmware": {
-      "evra": "20220209-129.fc36.noarch"
+      "evra": "20220310-130.fc36.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220209-129.fc36.noarch"
+      "evra": "20220310-130.fc36.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-3.fc36.aarch64"
@@ -1183,10 +1186,10 @@
       "evra": "2.38-0.2.fc36.aarch64"
     },
     "vim-data": {
-      "evra": "2:8.2.4428-1.fc36.noarch"
+      "evra": "2:8.2.4579-1.fc36.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4428-1.fc36.aarch64"
+      "evra": "2:8.2.4579-1.fc36.aarch64"
     },
     "which": {
       "evra": "2.21-32.fc36.aarch64"

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,1063 +1,1078 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.32.12-2.fc35.aarch64"
+      "evra": "1:1.36.0-0.11.fc36.aarch64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.32.12-2.fc35.aarch64"
+      "evra": "1:1.36.0-0.11.fc36.aarch64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.32.12-2.fc35.aarch64"
+      "evra": "1:1.36.0-0.11.fc36.aarch64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.32.12-2.fc35.aarch64"
+      "evra": "1:1.36.0-0.11.fc36.aarch64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.32.12-2.fc35.aarch64"
+      "evra": "1:1.36.0-0.11.fc36.aarch64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.3.1.1-2.fc35.noarch"
+      "evra": "2.5.0.2-2.fc36.noarch"
+    },
+    "aardvark-dns": {
+      "evra": "1.0.0-1.fc36.aarch64"
     },
     "acl": {
-      "evra": "2.3.1-2.fc35.aarch64"
+      "evra": "2.3.1-3.fc36.aarch64"
     },
     "adcli": {
-      "evra": "0.9.1-9.fc35.aarch64"
+      "evra": "0.9.1-10.fc36.aarch64"
     },
     "afterburn": {
-      "evra": "5.2.0-4.fc35.aarch64"
+      "evra": "5.2.0-4.fc36.aarch64"
     },
     "afterburn-dracut": {
-      "evra": "5.2.0-4.fc35.aarch64"
+      "evra": "5.2.0-4.fc36.aarch64"
     },
     "alternatives": {
-      "evra": "1.19-1.fc35.aarch64"
+      "evra": "1.19-2.fc36.aarch64"
     },
     "attr": {
-      "evra": "2.5.1-3.fc35.aarch64"
+      "evra": "2.5.1-4.fc36.aarch64"
     },
     "audit-libs": {
-      "evra": "3.0.7-2.fc35.aarch64"
+      "evra": "3.0.7-1.fc36.aarch64"
+    },
+    "authselect": {
+      "evra": "1.3.0-10.fc36.aarch64"
+    },
+    "authselect-libs": {
+      "evra": "1.3.0-10.fc36.aarch64"
     },
     "avahi-libs": {
-      "evra": "0.8-14.fc35.aarch64"
+      "evra": "0.8-15.fc36.aarch64"
     },
     "basesystem": {
-      "evra": "11-12.fc35.noarch"
+      "evra": "11-13.fc36.noarch"
     },
     "bash": {
-      "evra": "5.1.8-2.fc35.aarch64"
+      "evra": "5.1.16-2.fc36.aarch64"
     },
     "bash-completion": {
-      "evra": "1:2.11-3.fc35.noarch"
+      "evra": "1:2.11-6.fc36.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.16.24-1.fc35.aarch64"
+      "evra": "32:9.16.25-2.fc36.aarch64"
     },
     "bind-license": {
-      "evra": "32:9.16.24-1.fc35.noarch"
+      "evra": "32:9.16.25-2.fc36.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.16.24-1.fc35.aarch64"
+      "evra": "32:9.16.25-2.fc36.aarch64"
     },
     "bootupd": {
-      "evra": "0.2.6-1.fc35.aarch64"
+      "evra": "0.2.6-2.fc36.aarch64"
     },
     "bsdtar": {
-      "evra": "3.5.3-1.fc35.aarch64"
+      "evra": "3.5.3-1.fc36.aarch64"
     },
     "btrfs-progs": {
-      "evra": "5.16.2-1.fc35.aarch64"
+      "evra": "5.16.2-1.fc36.aarch64"
     },
     "bubblewrap": {
-      "evra": "0.5.0-1.fc35.aarch64"
+      "evra": "0.5.0-2.fc36.aarch64"
     },
     "bzip2": {
-      "evra": "1.0.8-9.fc35.aarch64"
+      "evra": "1.0.8-11.fc36.aarch64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-9.fc35.aarch64"
+      "evra": "1.0.8-11.fc36.aarch64"
     },
     "c-ares": {
-      "evra": "1.17.2-1.fc35.aarch64"
+      "evra": "1.17.2-2.fc36.aarch64"
     },
     "ca-certificates": {
-      "evra": "2021.2.52-1.0.fc35.noarch"
+      "evra": "2021.2.52-3.fc36.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-1.fc35.aarch64"
+      "evra": "0.1.7-5.fc36.aarch64"
     },
     "chrony": {
-      "evra": "4.2-1.fc35.aarch64"
+      "evra": "4.2-5.fc36.aarch64"
     },
     "cifs-utils": {
-      "evra": "6.13-3.fc35.aarch64"
+      "evra": "6.14-1.fc36.aarch64"
     },
     "clevis": {
-      "evra": "18-4.fc35.aarch64"
+      "evra": "18-6.fc36.aarch64"
     },
     "clevis-dracut": {
-      "evra": "18-4.fc35.aarch64"
+      "evra": "18-6.fc36.aarch64"
     },
     "clevis-luks": {
-      "evra": "18-4.fc35.aarch64"
+      "evra": "18-6.fc36.aarch64"
     },
     "clevis-systemd": {
-      "evra": "18-4.fc35.aarch64"
+      "evra": "18-6.fc36.aarch64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-9.fc35.noarch"
+      "evra": "0.31-10.fc36.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.0-2.fc35.aarch64"
+      "evra": "2:2.1.0-2.fc36.aarch64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.180.0-1.fc35.noarch"
+      "evra": "2:2.178.0-1.fc36.noarch"
     },
     "containerd": {
-      "evra": "1.6.0-1.fc35.aarch64"
-    },
-    "containernetworking-plugins": {
-      "evra": "1.1.0-1.fc35.aarch64"
+      "evra": "1.6.0-1.fc36.aarch64"
     },
     "containers-common": {
-      "evra": "4:1-45.fc35.noarch"
+      "evra": "4:1-53.fc36.noarch"
     },
     "coreos-installer": {
-      "evra": "0.13.1-1.fc35.aarch64"
+      "evra": "0.13.1-1.fc36.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.13.1-1.fc35.aarch64"
+      "evra": "0.13.1-1.fc36.aarch64"
     },
     "coreutils": {
-      "evra": "8.32-32.fc35.aarch64"
+      "evra": "9.0-3.fc36.aarch64"
     },
     "coreutils-common": {
-      "evra": "8.32-32.fc35.aarch64"
+      "evra": "9.0-3.fc36.aarch64"
     },
     "cpio": {
-      "evra": "2.13-11.fc35.aarch64"
+      "evra": "2.13-12.fc36.aarch64"
     },
     "cracklib": {
-      "evra": "2.9.6-27.fc35.aarch64"
+      "evra": "2.9.6-28.fc36.aarch64"
     },
     "cracklib-dicts": {
-      "evra": "2.9.6-27.fc35.aarch64"
+      "evra": "2.9.6-28.fc36.aarch64"
     },
     "criu": {
-      "evra": "3.16.1-2.fc35.aarch64"
+      "evra": "3.16.1-7.fc36.aarch64"
     },
     "criu-libs": {
-      "evra": "3.16.1-2.fc35.aarch64"
+      "evra": "3.16.1-7.fc36.aarch64"
     },
     "crun": {
-      "evra": "1.4.3-1.fc35.aarch64"
+      "evra": "1.4.2-2.fc36.aarch64"
     },
     "crypto-policies": {
-      "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
+      "evra": "20220203-2.git112f859.fc36.noarch"
     },
     "cryptsetup": {
-      "evra": "2.4.3-1.fc35.aarch64"
+      "evra": "2.4.3-2.fc36.aarch64"
     },
     "cryptsetup-libs": {
-      "evra": "2.4.3-1.fc35.aarch64"
-    },
-    "cups-libs": {
-      "evra": "1:2.3.3op2-15.fc35.aarch64"
+      "evra": "2.4.3-2.fc36.aarch64"
     },
     "curl": {
-      "evra": "7.79.1-1.fc35.aarch64"
+      "evra": "7.81.0-2.fc36.aarch64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.27-14.fc35.aarch64"
+      "evra": "2.1.27-17.fc36.aarch64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.27-14.fc35.aarch64"
+      "evra": "2.1.27-17.fc36.aarch64"
     },
     "dbus": {
-      "evra": "1:1.12.22-1.fc35.aarch64"
+      "evra": "1:1.13.20-3.fc36.aarch64"
     },
     "dbus-broker": {
-      "evra": "29-4.fc35.aarch64"
+      "evra": "29-5.fc36.aarch64"
     },
     "dbus-common": {
-      "evra": "1:1.12.22-1.fc35.noarch"
+      "evra": "1:1.13.20-3.fc36.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.12.22-1.fc35.aarch64"
+      "evra": "1:1.13.20-3.fc36.aarch64"
     },
     "device-mapper": {
-      "evra": "1.02.175-6.fc35.aarch64"
+      "evra": "1.02.175-7.fc36.aarch64"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-6.fc35.aarch64"
+      "evra": "1.02.175-7.fc36.aarch64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-6.fc35.aarch64"
+      "evra": "1.02.175-7.fc36.aarch64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-6.fc35.aarch64"
+      "evra": "1.02.175-7.fc36.aarch64"
     },
     "device-mapper-multipath": {
-      "evra": "0.8.6-5.fc35.aarch64"
+      "evra": "0.8.7-8.fc36.aarch64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.8.6-5.fc35.aarch64"
+      "evra": "0.8.7-8.fc36.aarch64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-6.fc35.aarch64"
+      "evra": "0.9.0-7.fc36.aarch64"
     },
     "diffutils": {
-      "evra": "3.8-1.fc35.aarch64"
+      "evra": "3.8-2.fc36.aarch64"
     },
     "dnsmasq": {
-      "evra": "2.86-5.fc35.aarch64"
+      "evra": "2.86-5.fc36.aarch64"
     },
     "dosfstools": {
-      "evra": "4.2-2.fc35.aarch64"
+      "evra": "4.2-3.fc36.aarch64"
     },
     "dracut": {
-      "evra": "055-6.fc35.aarch64"
+      "evra": "055-8.fc36.1.aarch64"
     },
     "dracut-network": {
-      "evra": "055-6.fc35.aarch64"
+      "evra": "055-8.fc36.1.aarch64"
     },
     "dracut-squash": {
-      "evra": "055-6.fc35.aarch64"
+      "evra": "055-8.fc36.1.aarch64"
     },
     "e2fsprogs": {
-      "evra": "1.46.3-1.fc35.aarch64"
+      "evra": "1.46.5-2.fc36.aarch64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.3-1.fc35.aarch64"
+      "evra": "1.46.5-2.fc36.aarch64"
     },
     "efi-filesystem": {
-      "evra": "5-4.fc35.noarch"
+      "evra": "5-5.fc36.noarch"
     },
     "efibootmgr": {
-      "evra": "16-11.fc35.aarch64"
+      "evra": "16-12.fc36.aarch64"
     },
     "efivar-libs": {
-      "evra": "37-17.fc35.aarch64"
+      "evra": "38-2.fc36.aarch64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.186-1.fc35.noarch"
+      "evra": "0.186-1.fc36.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.186-1.fc35.aarch64"
+      "evra": "0.186-1.fc36.aarch64"
     },
     "elfutils-libs": {
-      "evra": "0.186-1.fc35.aarch64"
+      "evra": "0.186-1.fc36.aarch64"
     },
     "ethtool": {
-      "evra": "2:5.16-1.fc35.aarch64"
+      "evra": "2:5.16-2.fc36.aarch64"
     },
     "expat": {
-      "evra": "2.4.4-1.fc35.aarch64"
+      "evra": "2.4.6-1.fc36.aarch64"
     },
     "fedora-coreos-pinger": {
-      "evra": "0.0.4-12.fc35.aarch64"
+      "evra": "0.0.4-13.fc36.aarch64"
     },
     "fedora-gpg-keys": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-release-common": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-repos": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "file": {
-      "evra": "5.40-9.fc35.aarch64"
+      "evra": "5.41-4.fc36.aarch64"
     },
     "file-libs": {
-      "evra": "5.40-9.fc35.aarch64"
+      "evra": "5.41-4.fc36.aarch64"
     },
     "filesystem": {
-      "evra": "3.14-7.fc35.aarch64"
+      "evra": "3.16-2.fc36.aarch64"
     },
     "findutils": {
-      "evra": "1:4.8.0-4.fc35.aarch64"
+      "evra": "1:4.9.0-1.fc36.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.12.6-1.fc35.aarch64"
+      "evra": "1.12.5-1.fc36.aarch64"
     },
     "fstrm": {
-      "evra": "0.6.1-3.fc35.aarch64"
+      "evra": "0.6.1-4.fc36.aarch64"
     },
     "fuse": {
-      "evra": "2.9.9-13.fc35.aarch64"
+      "evra": "2.9.9-14.fc36.aarch64"
     },
     "fuse-common": {
-      "evra": "3.10.5-1.fc35.aarch64"
+      "evra": "3.10.5-2.fc36.aarch64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-13.fc35.aarch64"
+      "evra": "2.9.9-14.fc36.aarch64"
     },
     "fuse-overlayfs": {
-      "evra": "1.7.1-2.fc35.aarch64"
+      "evra": "1.8.1-3.fc36.aarch64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.2-2.fc35.aarch64"
+      "evra": "3.7.2-3.fc36.aarch64"
     },
     "fuse3": {
-      "evra": "3.10.5-1.fc35.aarch64"
+      "evra": "3.10.5-2.fc36.aarch64"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-1.fc35.aarch64"
+      "evra": "3.10.5-2.fc36.aarch64"
     },
     "fwupd": {
-      "evra": "1.7.6-1.fc35.aarch64"
+      "evra": "1.7.5-1.fc36.aarch64"
     },
     "gawk": {
-      "evra": "5.1.0-4.fc35.aarch64"
+      "evra": "5.1.1-2.fc36.aarch64"
     },
     "gdbm-libs": {
-      "evra": "1:1.22-1.fc35.aarch64"
+      "evra": "1:1.22-2.fc36.aarch64"
     },
     "gdisk": {
-      "evra": "1.0.8-2.fc35.aarch64"
+      "evra": "1.0.8-3.fc36.aarch64"
     },
     "gettext": {
-      "evra": "0.21-8.fc35.aarch64"
+      "evra": "0.21-9.fc36.aarch64"
     },
     "gettext-libs": {
-      "evra": "0.21-8.fc35.aarch64"
+      "evra": "0.21-9.fc36.aarch64"
     },
     "git-core": {
-      "evra": "2.35.1-1.fc35.aarch64"
+      "evra": "2.35.1-1.fc36.aarch64"
     },
     "glib2": {
-      "evra": "2.70.4-1.fc35.aarch64"
+      "evra": "2.71.3-1.fc36.aarch64"
     },
     "glibc": {
-      "evra": "2.34-28.fc35.aarch64"
+      "evra": "2.35-2.fc36.aarch64"
     },
     "glibc-common": {
-      "evra": "2.34-28.fc35.aarch64"
+      "evra": "2.35-2.fc36.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-28.fc35.aarch64"
+      "evra": "2.35-2.fc36.aarch64"
     },
     "gmp": {
-      "evra": "1:6.2.0-7.fc35.aarch64"
+      "evra": "1:6.2.1-2.fc36.aarch64"
     },
     "gnupg2": {
-      "evra": "2.3.4-1.fc35.aarch64"
+      "evra": "2.3.4-2.fc36.aarch64"
     },
     "gnutls": {
-      "evra": "3.7.2-3.fc35.aarch64"
+      "evra": "3.7.3-2.fc36.aarch64"
     },
     "gpgme": {
-      "evra": "1.15.1-6.fc35.aarch64"
+      "evra": "1.15.1-6.fc36.aarch64"
     },
     "grep": {
-      "evra": "3.6-4.fc35.aarch64"
+      "evra": "3.7-2.fc36.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.06-10.fc35.noarch"
+      "evra": "1:2.06-14.fc36.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-10.fc35.aarch64"
+      "evra": "1:2.06-14.fc36.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.06-10.fc35.aarch64"
+      "evra": "1:2.06-14.fc36.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-10.fc35.aarch64"
+      "evra": "1:2.06-14.fc36.aarch64"
     },
     "gzip": {
-      "evra": "1.10-5.fc35.aarch64"
+      "evra": "1.11-2.fc36.aarch64"
     },
     "hostname": {
-      "evra": "3.23-5.fc35.aarch64"
+      "evra": "3.23-6.fc36.aarch64"
     },
     "ignition": {
-      "evra": "2.13.0-3.fc35.aarch64"
+      "evra": "2.13.0-4.fc36.aarch64"
     },
     "inih": {
-      "evra": "49-4.fc35.aarch64"
+      "evra": "49-5.fc36.aarch64"
     },
     "iproute": {
-      "evra": "5.13.0-2.fc35.aarch64"
+      "evra": "5.15.0-2.fc36.aarch64"
     },
     "iproute-tc": {
-      "evra": "5.13.0-2.fc35.aarch64"
+      "evra": "5.15.0-2.fc36.aarch64"
     },
     "iptables-legacy": {
-      "evra": "1.8.7-13.fc35.aarch64"
+      "evra": "1.8.7-15.fc36.aarch64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.7-13.fc35.aarch64"
+      "evra": "1.8.7-15.fc36.aarch64"
     },
     "iptables-libs": {
-      "evra": "1.8.7-13.fc35.aarch64"
+      "evra": "1.8.7-15.fc36.aarch64"
     },
     "iptables-nft": {
-      "evra": "1.8.7-13.fc35.aarch64"
+      "evra": "1.8.7-15.fc36.aarch64"
     },
     "iptables-services": {
-      "evra": "1.8.7-13.fc35.noarch"
+      "evra": "1.8.7-15.fc36.noarch"
     },
     "iputils": {
-      "evra": "20210722-1.fc35.aarch64"
+      "evra": "20211215-2.fc36.aarch64"
     },
     "irqbalance": {
       "evra": "2:1.7.0-8.fc35.aarch64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-0.git095f59c.fc35.2.aarch64"
+      "evra": "6.2.1.4-4.git2a8f9d8.fc36.aarch64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-0.git095f59c.fc35.2.aarch64"
+      "evra": "6.2.1.4-4.git2a8f9d8.fc36.aarch64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-2.fc35.aarch64"
+      "evra": "0.101-4.fc36.aarch64"
     },
     "jansson": {
-      "evra": "2.13.1-3.fc35.aarch64"
+      "evra": "2.13.1-4.fc36.aarch64"
     },
     "jose": {
-      "evra": "11-3.fc35.aarch64"
+      "evra": "11-5.fc36.aarch64"
     },
     "jq": {
-      "evra": "1.6-10.fc35.aarch64"
+      "evra": "1.6-13.fc36.aarch64"
     },
     "json-c": {
-      "evra": "0.15-2.fc35.aarch64"
+      "evra": "0.15-3.fc36.aarch64"
     },
     "json-glib": {
-      "evra": "1.6.6-1.fc35.aarch64"
+      "evra": "1.6.6-2.fc36.aarch64"
     },
     "kbd": {
-      "evra": "2.4.0-8.fc35.aarch64"
+      "evra": "2.4.0-9.fc36.aarch64"
     },
     "kbd-misc": {
-      "evra": "2.4.0-8.fc35.noarch"
+      "evra": "2.4.0-9.fc36.noarch"
     },
     "kernel": {
-      "evra": "5.16.14-200.fc35.aarch64"
+      "evra": "5.17.0-0.rc7.116.fc36.aarch64"
     },
     "kernel-core": {
-      "evra": "5.16.14-200.fc35.aarch64"
+      "evra": "5.17.0-0.rc7.116.fc36.aarch64"
     },
     "kernel-modules": {
-      "evra": "5.16.14-200.fc35.aarch64"
+      "evra": "5.17.0-0.rc7.116.fc36.aarch64"
     },
     "kexec-tools": {
-      "evra": "2.0.22-7.fc35.aarch64"
+      "evra": "2.0.23-5.fc36.aarch64"
     },
     "keyutils": {
-      "evra": "1.6.1-3.fc35.aarch64"
+      "evra": "1.6.1-4.fc36.aarch64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-3.fc35.aarch64"
+      "evra": "1.6.1-4.fc36.aarch64"
     },
     "kmod": {
-      "evra": "29-4.fc35.aarch64"
+      "evra": "29-7.fc36.aarch64"
     },
     "kmod-libs": {
-      "evra": "29-4.fc35.aarch64"
+      "evra": "29-7.fc36.aarch64"
     },
     "kpartx": {
-      "evra": "0.8.6-5.fc35.aarch64"
+      "evra": "0.8.7-8.fc36.aarch64"
     },
     "krb5-libs": {
-      "evra": "1.19.2-2.fc35.aarch64"
+      "evra": "1.19.2-6.fc36.aarch64"
     },
     "less": {
-      "evra": "590-2.fc35.aarch64"
+      "evra": "590-3.fc36.aarch64"
     },
     "libacl": {
-      "evra": "2.3.1-2.fc35.aarch64"
+      "evra": "2.3.1-3.fc36.aarch64"
     },
     "libaio": {
-      "evra": "0.3.111-12.fc35.aarch64"
+      "evra": "0.3.111-13.fc36.aarch64"
     },
     "libarchive": {
-      "evra": "3.5.3-1.fc35.aarch64"
+      "evra": "3.5.3-1.fc36.aarch64"
     },
     "libargon2": {
-      "evra": "20171227-7.fc35.aarch64"
+      "evra": "20171227-8.fc36.aarch64"
     },
     "libassuan": {
-      "evra": "2.5.5-3.fc35.aarch64"
+      "evra": "2.5.5-4.fc36.aarch64"
     },
     "libattr": {
-      "evra": "2.5.1-3.fc35.aarch64"
+      "evra": "2.5.1-4.fc36.aarch64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-48.fc35.aarch64"
+      "evra": "0.1.1-50.fc36.aarch64"
     },
     "libblkid": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
+    },
+    "libbpf": {
+      "evra": "2:0.5.0-2.fc36.aarch64"
     },
     "libbrotli": {
-      "evra": "1.0.9-6.fc35.aarch64"
+      "evra": "1.0.9-7.fc36.aarch64"
     },
     "libbsd": {
-      "evra": "0.10.0-8.fc35.aarch64"
+      "evra": "0.10.0-9.fc36.aarch64"
     },
     "libcap": {
-      "evra": "2.48-3.fc35.aarch64"
+      "evra": "2.48-4.fc36.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-8.fc35.aarch64"
+      "evra": "0.8.2-9.fc36.aarch64"
     },
     "libcbor": {
-      "evra": "0.7.0-4.fc35.aarch64"
+      "evra": "0.7.0-5.fc36.aarch64"
     },
     "libcollection": {
-      "evra": "0.7.0-48.fc35.aarch64"
+      "evra": "0.7.0-50.fc36.aarch64"
     },
     "libcom_err": {
-      "evra": "1.46.3-1.fc35.aarch64"
+      "evra": "1.46.5-2.fc36.aarch64"
     },
     "libcurl": {
-      "evra": "7.79.1-1.fc35.aarch64"
+      "evra": "7.81.0-2.fc36.aarch64"
     },
     "libdaemon": {
-      "evra": "0.14-22.fc35.aarch64"
+      "evra": "0.14-23.fc36.aarch64"
     },
     "libdb": {
-      "evra": "5.3.28-50.fc35.aarch64"
+      "evra": "5.3.28-51.fc36.aarch64"
     },
     "libdhash": {
-      "evra": "0.5.0-48.fc35.aarch64"
+      "evra": "0.5.0-50.fc36.aarch64"
     },
     "libeconf": {
-      "evra": "0.4.0-2.fc35.aarch64"
+      "evra": "0.4.0-3.fc36.aarch64"
     },
     "libedit": {
-      "evra": "3.1-40.20210910cvs.fc35.aarch64"
+      "evra": "3.1-41.20210910cvs.fc36.aarch64"
     },
     "libevent": {
-      "evra": "2.1.12-4.fc35.aarch64"
+      "evra": "2.1.12-6.fc36.aarch64"
     },
     "libfdisk": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "libffi": {
-      "evra": "3.1-29.fc35.aarch64"
+      "evra": "3.4.2-8.fc36.aarch64"
     },
     "libfido2": {
-      "evra": "1.8.0-1.fc35.aarch64"
+      "evra": "1.10.0-3.fc36.aarch64"
     },
     "libgcab1": {
-      "evra": "1.4-5.fc35.aarch64"
+      "evra": "1.4-6.fc36.aarch64"
     },
     "libgcc": {
-      "evra": "11.2.1-9.fc35.aarch64"
+      "evra": "12.0.1-0.12.fc36.aarch64"
     },
     "libgcrypt": {
-      "evra": "1.9.4-1.fc35.aarch64"
+      "evra": "1.10.0-1.fc36.aarch64"
     },
     "libgomp": {
-      "evra": "11.2.1-9.fc35.aarch64"
+      "evra": "12.0.1-0.12.fc36.aarch64"
     },
     "libgpg-error": {
-      "evra": "1.43-1.fc35.aarch64"
+      "evra": "1.44-1.fc36.aarch64"
     },
     "libgudev": {
-      "evra": "237-1.fc35.aarch64"
+      "evra": "237-2.fc36.aarch64"
     },
     "libgusb": {
-      "evra": "0.3.9-1.fc35.aarch64"
+      "evra": "0.3.10-2.fc36.aarch64"
     },
     "libibverbs": {
-      "evra": "39.0-1.fc35.aarch64"
+      "evra": "39.0-1.fc36.aarch64"
     },
     "libicu": {
-      "evra": "69.1-2.fc35.aarch64"
+      "evra": "69.1-5.fc36.aarch64"
     },
     "libidn2": {
-      "evra": "2.3.2-3.fc35.aarch64"
+      "evra": "2.3.2-4.fc36.aarch64"
     },
     "libini_config": {
-      "evra": "1.3.1-48.fc35.aarch64"
+      "evra": "1.3.1-50.fc36.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "libjcat": {
-      "evra": "0.1.9-1.fc35.aarch64"
+      "evra": "0.1.10-1.fc36.aarch64"
     },
     "libjose": {
-      "evra": "11-3.fc35.aarch64"
+      "evra": "11-5.fc36.aarch64"
     },
     "libkcapi": {
-      "evra": "1.3.1-3.fc35.aarch64"
+      "evra": "1.3.1-4.fc36.aarch64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.3.1-3.fc35.aarch64"
+      "evra": "1.3.1-4.fc36.aarch64"
     },
     "libksba": {
-      "evra": "1.6.0-2.fc35.aarch64"
+      "evra": "1.6.0-3.fc36.aarch64"
     },
     "libldb": {
-      "evra": "2.4.1-1.fc35.aarch64"
+      "evra": "2.5.0-1.fc36.aarch64"
     },
     "libluksmeta": {
-      "evra": "9-12.fc35.aarch64"
+      "evra": "9-13.fc36.aarch64"
     },
     "libmaxminddb": {
-      "evra": "1.6.0-1.fc35.aarch64"
+      "evra": "1.6.0-2.fc36.aarch64"
     },
     "libmnl": {
-      "evra": "1.0.4-14.fc35.aarch64"
+      "evra": "1.0.4-15.fc36.aarch64"
     },
     "libmodulemd": {
-      "evra": "2.14.0-1.fc35.aarch64"
+      "evra": "2.14.0-2.fc36.aarch64"
     },
     "libmount": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "libndp": {
-      "evra": "1.8-2.fc35.aarch64"
+      "evra": "1.8-3.fc36.aarch64"
     },
     "libnet": {
-      "evra": "1.2-4.fc35.aarch64"
+      "evra": "1.2-5.fc36.aarch64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-3.fc35.aarch64"
+      "evra": "1.0.8-4.fc36.aarch64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-20.fc35.aarch64"
+      "evra": "1.0.1-21.fc36.aarch64"
     },
     "libnfsidmap": {
-      "evra": "1:2.5.4-2.rc3.fc35.aarch64"
+      "evra": "1:2.5.4-2.rc3.fc36.1.aarch64"
     },
     "libnftnl": {
-      "evra": "1.2.0-2.fc35.aarch64"
+      "evra": "1.2.1-2.fc36.aarch64"
     },
     "libnghttp2": {
-      "evra": "1.45.1-1.fc35.aarch64"
+      "evra": "1.46.0-2.fc36.aarch64"
     },
     "libnl3": {
-      "evra": "3.5.0-8.fc35.aarch64"
+      "evra": "3.5.0-9.fc36.aarch64"
     },
     "libnl3-cli": {
-      "evra": "3.5.0-8.fc35.aarch64"
+      "evra": "3.5.0-9.fc36.aarch64"
     },
     "libnsl2": {
-      "evra": "1.3.0-4.fc35.aarch64"
+      "evra": "2.0.0-3.fc36.aarch64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-48.fc35.aarch64"
+      "evra": "0.2.1-50.fc36.aarch64"
     },
     "libpcap": {
-      "evra": "14:1.10.1-2.fc35.aarch64"
+      "evra": "14:1.10.1-3.fc36.aarch64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-1.fc35.aarch64"
+      "evra": "1.8.0-2.fc36.aarch64"
     },
     "libpsl": {
-      "evra": "0.21.1-4.fc35.aarch64"
+      "evra": "0.21.1-5.fc36.aarch64"
     },
     "libpwquality": {
-      "evra": "1.4.4-6.fc35.aarch64"
+      "evra": "1.4.4-7.fc36.aarch64"
     },
     "libref_array": {
-      "evra": "0.1.5-48.fc35.aarch64"
+      "evra": "0.1.5-50.fc36.aarch64"
     },
     "librepo": {
-      "evra": "1.14.2-1.fc35.aarch64"
+      "evra": "1.14.2-2.fc36.aarch64"
     },
     "libreport-filesystem": {
-      "evra": "2.15.2-8.fc35.noarch"
+      "evra": "2.17.1-1.fc36.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-1.fc35.aarch64"
+      "evra": "2.5.3-2.fc36.aarch64"
     },
     "libselinux": {
-      "evra": "3.3-1.fc35.aarch64"
+      "evra": "3.3-4.fc36.aarch64"
     },
     "libselinux-utils": {
-      "evra": "3.3-1.fc35.aarch64"
+      "evra": "3.3-4.fc36.aarch64"
     },
     "libsemanage": {
-      "evra": "3.3-1.fc35.aarch64"
+      "evra": "3.3-3.fc36.aarch64"
     },
     "libsepol": {
-      "evra": "3.3-2.fc35.aarch64"
+      "evra": "3.3-3.fc36.aarch64"
     },
     "libsigsegv": {
-      "evra": "2.13-3.fc35.aarch64"
+      "evra": "2.14-2.fc36.aarch64"
     },
     "libslirp": {
-      "evra": "4.6.1-2.fc35.aarch64"
+      "evra": "4.6.1-3.fc36.aarch64"
     },
     "libsmartcols": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.15.5-1.fc35.aarch64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.21-1.fc35.aarch64"
+      "evra": "0.7.20-3.fc36.aarch64"
     },
     "libss": {
-      "evra": "1.46.3-1.fc35.aarch64"
+      "evra": "1.46.5-2.fc36.aarch64"
     },
     "libssh": {
-      "evra": "0.9.6-1.fc35.aarch64"
+      "evra": "0.9.6-4.fc36.aarch64"
     },
     "libssh-config": {
-      "evra": "0.9.6-1.fc35.noarch"
+      "evra": "0.9.6-4.fc36.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "libstdc++": {
-      "evra": "11.2.1-9.fc35.aarch64"
+      "evra": "12.0.1-0.12.fc36.aarch64"
     },
     "libtalloc": {
-      "evra": "2.3.3-2.fc35.aarch64"
+      "evra": "2.3.3-3.fc36.aarch64"
     },
     "libtasn1": {
-      "evra": "4.16.0-6.fc35.aarch64"
+      "evra": "4.18.0-2.fc36.aarch64"
     },
     "libtdb": {
-      "evra": "1.4.4-3.fc35.aarch64"
+      "evra": "1.4.6-1.fc36.aarch64"
     },
     "libteam": {
-      "evra": "1.31-4.fc35.aarch64"
+      "evra": "1.31-5.fc36.aarch64"
     },
     "libtevent": {
-      "evra": "0.11.0-1.fc35.aarch64"
+      "evra": "0.11.0-2.fc36.aarch64"
     },
     "libtirpc": {
-      "evra": "1.3.2-1.fc35.aarch64"
+      "evra": "1.3.2-1.rc1.fc36.1.aarch64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.6-50.fc35.aarch64"
+      "evra": "2.4.6-48.fc36.aarch64"
     },
     "libunistring": {
-      "evra": "0.9.10-14.fc35.aarch64"
+      "evra": "1.0-1.fc36.aarch64"
     },
     "libusb1": {
-      "evra": "1.0.24-4.fc35.aarch64"
+      "evra": "1.0.25-8.fc36.aarch64"
     },
     "libuser": {
       "evra": "0.63-7.fc35.aarch64"
     },
     "libutempter": {
-      "evra": "1.2.1-5.fc35.aarch64"
+      "evra": "1.2.1-6.fc36.aarch64"
     },
     "libuuid": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "libuv": {
-      "evra": "1:1.44.1-1.fc35.aarch64"
+      "evra": "1:1.43.0-3.fc36.aarch64"
     },
     "libvarlink-util": {
-      "evra": "22-3.fc35.aarch64"
+      "evra": "23-2.fc36.aarch64"
     },
     "libverto": {
-      "evra": "0.3.2-2.fc35.aarch64"
+      "evra": "0.3.2-3.fc36.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.15.5-1.fc35.aarch64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.aarch64"
     },
     "libxcrypt": {
-      "evra": "4.4.28-1.fc35.aarch64"
+      "evra": "4.4.28-1.fc36.aarch64"
     },
     "libxml2": {
-      "evra": "2.9.13-1.fc35.aarch64"
+      "evra": "2.9.13-1.fc36.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.6-1.fc35.aarch64"
+      "evra": "0.3.7-1.fc36.aarch64"
     },
     "libyaml": {
-      "evra": "0.2.5-6.fc35.aarch64"
+      "evra": "0.2.5-7.fc36.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.2-1.fc35.aarch64"
+      "evra": "1.5.2-1.fc36.aarch64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-30.fc35.aarch64"
+      "evra": "2.5.1-31.fc36.aarch64"
     },
     "linux-firmware": {
-      "evra": "20220310-130.fc35.noarch"
+      "evra": "20220209-129.fc36.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220310-130.fc35.noarch"
+      "evra": "20220209-129.fc36.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.29-2.fc35.aarch64"
+      "evra": "0.9.29-3.fc36.aarch64"
     },
     "logrotate": {
-      "evra": "3.18.1-2.fc35.aarch64"
+      "evra": "3.19.0-2.fc36.aarch64"
     },
     "lsof": {
-      "evra": "4.94.0-2.fc35.aarch64"
+      "evra": "4.94.0-3.fc36.aarch64"
     },
     "lua-libs": {
-      "evra": "5.4.4-1.fc35.aarch64"
+      "evra": "5.4.4-1.fc36.aarch64"
     },
     "luksmeta": {
-      "evra": "9-12.fc35.aarch64"
+      "evra": "9-13.fc36.aarch64"
     },
     "lvm2": {
-      "evra": "2.03.11-6.fc35.aarch64"
+      "evra": "2.03.11-7.fc36.aarch64"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-6.fc35.aarch64"
+      "evra": "2.03.11-7.fc36.aarch64"
     },
     "lz4-libs": {
-      "evra": "1.9.3-3.fc35.aarch64"
+      "evra": "1.9.3-4.fc36.aarch64"
     },
     "lzo": {
-      "evra": "2.10-5.fc35.aarch64"
+      "evra": "2.10-6.fc36.aarch64"
     },
     "mdadm": {
-      "evra": "4.2-rc2.fc35.aarch64"
+      "evra": "4.2-rc2.fc36.1.aarch64"
     },
     "moby-engine": {
-      "evra": "20.10.12-1.fc35.aarch64"
+      "evra": "20.10.12-3.fc36.aarch64"
     },
     "mokutil": {
-      "evra": "2:0.5.0-1.fc35.aarch64"
+      "evra": "2:0.5.0-2.fc36.aarch64"
     },
-    "mozjs78": {
-      "evra": "78.15.0-1.fc35.aarch64"
+    "mozjs91": {
+      "evra": "91.6.0-1.fc36.aarch64"
     },
     "mpfr": {
-      "evra": "4.1.0-8.fc35.aarch64"
+      "evra": "4.1.0-9.fc36.aarch64"
     },
     "nano": {
-      "evra": "5.8-4.fc35.aarch64"
+      "evra": "6.0-2.fc36.aarch64"
     },
     "nano-default-editor": {
-      "evra": "5.8-4.fc35.noarch"
+      "evra": "6.0-2.fc36.noarch"
     },
     "ncurses": {
-      "evra": "6.2-8.20210508.fc35.aarch64"
+      "evra": "6.2-9.20210508.fc36.aarch64"
     },
     "ncurses-base": {
-      "evra": "6.2-8.20210508.fc35.noarch"
+      "evra": "6.2-9.20210508.fc36.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.2-8.20210508.fc35.aarch64"
+      "evra": "6.2-9.20210508.fc36.aarch64"
     },
     "net-tools": {
-      "evra": "2.0-0.60.20160912git.fc35.aarch64"
+      "evra": "2.0-0.61.20160912git.fc36.aarch64"
+    },
+    "netavark": {
+      "evra": "1.0.0-1.fc36.aarch64"
     },
     "nettle": {
-      "evra": "3.7.3-2.fc35.aarch64"
+      "evra": "3.7.3-3.fc36.aarch64"
     },
     "newt": {
-      "evra": "0.52.21-11.fc35.aarch64"
+      "evra": "0.52.21-12.fc36.aarch64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.5.4-2.rc3.fc35.aarch64"
+      "evra": "1:2.5.4-2.rc3.fc36.1.aarch64"
     },
     "nftables": {
-      "evra": "1:1.0.0-1.fc35.aarch64"
+      "evra": "1:1.0.1-3.fc36.aarch64"
     },
     "npth": {
-      "evra": "1.6-7.fc35.aarch64"
+      "evra": "1.6-8.fc36.aarch64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-19.fc35.aarch64"
+      "evra": "2.18.1-20.fc36.aarch64"
     },
     "numactl-libs": {
-      "evra": "2.0.14-4.fc35.aarch64"
+      "evra": "2.0.14-5.fc36.aarch64"
     },
     "nvme-cli": {
-      "evra": "1.11.1-4.fc35.aarch64"
+      "evra": "1.11.1-5.fc36.aarch64"
     },
     "oniguruma": {
-      "evra": "6.9.7.1-1.fc35.1.aarch64"
+      "evra": "6.9.7.1-1.fc36.2.aarch64"
     },
     "openldap": {
-      "evra": "2.4.59-3.fc35.aarch64"
+      "evra": "2.6.1-2.fc36.aarch64"
+    },
+    "openldap-compat": {
+      "evra": "2.6.1-2.fc36.aarch64"
     },
     "openssh": {
-      "evra": "8.7p1-3.fc35.aarch64"
+      "evra": "8.8p1-1.fc36.1.aarch64"
     },
     "openssh-clients": {
-      "evra": "8.7p1-3.fc35.aarch64"
+      "evra": "8.8p1-1.fc36.1.aarch64"
     },
     "openssh-server": {
-      "evra": "8.7p1-3.fc35.aarch64"
+      "evra": "8.8p1-1.fc36.1.aarch64"
     },
     "openssl": {
-      "evra": "1:1.1.1l-2.fc35.aarch64"
+      "evra": "1:3.0.0-1.fc36.aarch64"
     },
     "openssl-libs": {
-      "evra": "1:1.1.1l-2.fc35.aarch64"
+      "evra": "1:3.0.0-1.fc36.aarch64"
     },
     "os-prober": {
-      "evra": "1.77-8.fc35.aarch64"
+      "evra": "1.77-9.fc36.aarch64"
     },
     "ostree": {
-      "evra": "2022.1-1.fc35.aarch64"
+      "evra": "2022.1-2.fc36.aarch64"
     },
     "ostree-libs": {
-      "evra": "2022.1-1.fc35.aarch64"
+      "evra": "2022.1-2.fc36.aarch64"
     },
     "p11-kit": {
-      "evra": "0.23.22-4.fc35.aarch64"
+      "evra": "0.24.1-2.fc36.aarch64"
     },
     "p11-kit-trust": {
-      "evra": "0.23.22-4.fc35.aarch64"
+      "evra": "0.24.1-2.fc36.aarch64"
     },
     "pam": {
-      "evra": "1.5.2-7.fc35.aarch64"
+      "evra": "1.5.2-11.fc36.aarch64"
+    },
+    "pam-libs": {
+      "evra": "1.5.2-11.fc36.aarch64"
     },
     "passwd": {
-      "evra": "0.80-11.fc35.aarch64"
+      "evra": "0.80-12.fc36.aarch64"
     },
     "pcre": {
-      "evra": "8.45-1.fc35.aarch64"
+      "evra": "8.45-1.fc36.1.aarch64"
     },
     "pcre2": {
-      "evra": "10.39-1.fc35.aarch64"
+      "evra": "10.39-1.fc36.1.aarch64"
     },
     "pcre2-syntax": {
-      "evra": "10.39-1.fc35.noarch"
+      "evra": "10.39-1.fc36.1.noarch"
     },
     "pigz": {
-      "evra": "2.5-2.fc35.aarch64"
+      "evra": "2.6-2.fc36.aarch64"
     },
     "pkgconf": {
-      "evra": "1.8.0-1.fc35.aarch64"
+      "evra": "1.8.0-2.fc36.aarch64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-1.fc35.noarch"
+      "evra": "1.8.0-2.fc36.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-1.fc35.aarch64"
+      "evra": "1.8.0-2.fc36.aarch64"
     },
     "podman": {
-      "evra": "3:3.4.4-1.fc35.aarch64"
+      "evra": "3:4.0.2-1.fc36.aarch64"
     },
     "podman-plugins": {
-      "evra": "3:3.4.4-1.fc35.aarch64"
+      "evra": "3:4.0.2-1.fc36.aarch64"
     },
     "policycoreutils": {
-      "evra": "3.3-1.fc35.aarch64"
+      "evra": "3.3-4.fc36.aarch64"
     },
     "polkit": {
-      "evra": "0.120-1.fc35.2.aarch64"
+      "evra": "0.120-5.fc36.aarch64"
     },
     "polkit-libs": {
-      "evra": "0.120-1.fc35.2.aarch64"
+      "evra": "0.120-5.fc36.aarch64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-20.fc35.aarch64"
+      "evra": "0.1-21.fc36.aarch64"
     },
     "popt": {
-      "evra": "1.18-6.fc35.aarch64"
+      "evra": "1.18-7.fc36.aarch64"
     },
     "procps-ng": {
-      "evra": "3.3.17-3.fc35.aarch64"
+      "evra": "3.3.17-4.fc36.aarch64"
     },
     "protobuf-c": {
-      "evra": "1.4.0-1.fc35.aarch64"
+      "evra": "1.4.0-4.fc36.aarch64"
     },
     "psmisc": {
-      "evra": "23.4-2.fc35.aarch64"
+      "evra": "23.4-3.fc36.aarch64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20210518-2.fc35.noarch"
+      "evra": "20210518-4.fc36.noarch"
     },
     "readline": {
-      "evra": "8.1-3.fc35.aarch64"
+      "evra": "8.1-6.fc36.aarch64"
     },
     "rpcbind": {
-      "evra": "1.2.6-1.fc35.aarch64"
+      "evra": "1.2.6-2.fc36.aarch64"
     },
     "rpm": {
-      "evra": "4.17.0-4.fc35.aarch64"
+      "evra": "4.17.0-9.fc36.aarch64"
     },
     "rpm-libs": {
-      "evra": "4.17.0-4.fc35.aarch64"
+      "evra": "4.17.0-9.fc36.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2022.5-1.fc35.aarch64"
+      "evra": "2022.5-1.fc36.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2022.5-1.fc35.aarch64"
+      "evra": "2022.5-1.fc36.aarch64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.17.0-4.fc35.aarch64"
+      "evra": "4.17.0-9.fc36.aarch64"
     },
     "rsync": {
-      "evra": "3.2.3-8.fc35.aarch64"
+      "evra": "3.2.3-14.fc36.aarch64"
     },
     "runc": {
-      "evra": "2:1.1.0-1.fc35.aarch64"
+      "evra": "2:1.1.0-2.fc36.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.15.5-1.fc35.aarch64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.15.5-1.fc35.noarch"
+      "evra": "2:4.16.0-0.2.rc3.fc36.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.15.5-1.fc35.aarch64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.aarch64"
     },
     "sed": {
-      "evra": "4.8-8.fc35.aarch64"
+      "evra": "4.8-10.fc36.aarch64"
     },
     "selinux-policy": {
-      "evra": "35.15-1.fc35.noarch"
+      "evra": "36.3-1.fc36.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.15-1.fc35.noarch"
+      "evra": "36.3-1.fc36.noarch"
     },
     "setup": {
-      "evra": "2.13.9.1-2.fc35.noarch"
+      "evra": "2.13.9.1-3.fc36.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-2.fc35.aarch64"
+      "evra": "1.46-3.fc36.aarch64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-2.fc35.aarch64"
+      "evra": "1.46-3.fc36.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.9-9.fc35.aarch64"
+      "evra": "2:4.11.1-2.fc36.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.9-9.fc35.aarch64"
+      "evra": "2:4.11.1-2.fc36.aarch64"
     },
     "shared-mime-info": {
       "evra": "2.1-3.fc35.aarch64"
@@ -1066,155 +1081,158 @@
       "evra": "15.4-5.aarch64"
     },
     "skopeo": {
-      "evra": "1:1.5.2-1.fc35.aarch64"
+      "evra": "1:1.5.2-2.fc36.aarch64"
     },
     "slang": {
-      "evra": "2.3.2-10.fc35.aarch64"
+      "evra": "2.3.2-11.fc36.aarch64"
     },
     "slirp4netns": {
-      "evra": "1.1.12-2.fc35.aarch64"
+      "evra": "1.2.0-0.2.beta.0.fc36.aarch64"
     },
     "snappy": {
-      "evra": "1.1.9-3.fc35.aarch64"
+      "evra": "1.1.9-4.fc36.aarch64"
     },
     "socat": {
-      "evra": "1.7.4.2-1.fc35.aarch64"
+      "evra": "1.7.4.2-2.fc36.aarch64"
     },
     "sqlite-libs": {
-      "evra": "3.36.0-3.fc35.aarch64"
+      "evra": "3.36.0-5.fc36.aarch64"
     },
     "squashfs-tools": {
-      "evra": "4.5-3.20210913gite048580.fc35.aarch64"
+      "evra": "4.5-18.20220221gitbc0c097.fc36.aarch64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.2-8.fc35.aarch64"
+      "evra": "0.1.3-2.fc36.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-client": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-common": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.6.3-1.fc35.aarch64"
+      "evra": "2.6.3-1.fc36.aarch64"
     },
     "stalld": {
-      "evra": "1.14.1-1.fc35.aarch64"
+      "evra": "1.15-2.fc36.aarch64"
     },
     "sudo": {
-      "evra": "1.9.7p2-2.fc35.aarch64"
+      "evra": "1.9.8-5.p2.fc36.aarch64"
     },
     "systemd": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "systemd-container": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "systemd-libs": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "systemd-pam": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "systemd-resolved": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "systemd-udev": {
-      "evra": "249.7-2.fc35.aarch64"
+      "evra": "250.3-4.fc36.aarch64"
     },
     "tar": {
-      "evra": "2:1.34-2.fc35.aarch64"
+      "evra": "2:1.34-3.fc36.aarch64"
     },
     "teamd": {
-      "evra": "1.31-4.fc35.aarch64"
+      "evra": "1.31-5.fc36.aarch64"
     },
     "toolbox": {
-      "evra": "0.0.99.3-2.fc35.aarch64"
+      "evra": "0.0.99.3-4.fc36.aarch64"
     },
     "tpm2-tools": {
-      "evra": "5.2-1.fc35.aarch64"
+      "evra": "5.2-2.fc36.aarch64"
     },
     "tpm2-tss": {
-      "evra": "3.1.0-3.fc35.aarch64"
+      "evra": "3.2.0-1.fc36.aarch64"
     },
     "tzdata": {
-      "evra": "2021e-1.fc35.noarch"
+      "evra": "2021e-3.fc36.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-3.fc35.aarch64"
+      "evra": "0.13.0-4.fc36.aarch64"
     },
     "util-linux": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "util-linux-core": {
-      "evra": "2.37.4-1.fc35.aarch64"
+      "evra": "2.38-0.2.fc36.aarch64"
     },
     "vim-data": {
-      "evra": "2:8.2.4529-1.fc35.noarch"
+      "evra": "2:8.2.4428-1.fc36.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4529-1.fc35.aarch64"
+      "evra": "2:8.2.4428-1.fc36.aarch64"
     },
     "which": {
-      "evra": "2.21-27.fc35.aarch64"
+      "evra": "2.21-32.fc36.aarch64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-1.fc35.aarch64"
+      "evra": "1.0.20210914-2.fc36.aarch64"
     },
     "xfsprogs": {
-      "evra": "5.12.0-2.fc35.aarch64"
+      "evra": "5.14.2-2.fc36.aarch64"
+    },
+    "xxhash-libs": {
+      "evra": "0.8.1-2.fc36.aarch64"
     },
     "xz": {
-      "evra": "5.2.5-7.fc35.aarch64"
+      "evra": "5.2.5-8.fc36.aarch64"
     },
     "xz-libs": {
-      "evra": "5.2.5-7.fc35.aarch64"
+      "evra": "5.2.5-8.fc36.aarch64"
     },
     "yajl": {
-      "evra": "2.1.0-17.fc35.aarch64"
+      "evra": "2.1.0-18.fc36.aarch64"
     },
     "zchunk-libs": {
-      "evra": "1.2.0-1.fc35.aarch64"
+      "evra": "1.2.0-1.fc36.aarch64"
     },
     "zincati": {
-      "evra": "0.0.24-1.fc35.aarch64"
+      "evra": "0.0.24-3.fc36.aarch64"
     },
     "zlib": {
-      "evra": "1.2.11-30.fc35.aarch64"
+      "evra": "1.2.11-31.fc36.aarch64"
     },
     "zram-generator": {
-      "evra": "1.1.1-3.fc35.aarch64"
+      "evra": "1.1.1-4.fc36.aarch64"
     }
   },
   "metadata": {
-    "generated": "2022-03-16T20:53:19Z",
+    "generated": "2022-03-18T14:39:53Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2021-10-26T05:31:21Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2022-03-15T22:26:29Z"
+        "generated": "2022-03-17T20:51:44Z"
       },
-      "fedora-updates": {
-        "generated": "2022-03-16T15:51:55Z"
+      "fedora-next": {
+        "generated": "2022-03-18T10:19:54Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2022-02-08T18:40:57Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,66 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  audit-libs:
+    evr: 3.0.7-3.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-11e524ac6b
+      type: fast-track
+  container-selinux:
+    evra: 2:2.180.0-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-85497715e7
+      type: fast-track
+  containernetworking-plugins:
+    evr: 1.1.0-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-74ac1ccc20
+      type: fast-track
+  crun:
+    evr: 1.4.3-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d752f16f57
+      type: fast-track
+  flatpak-session-helper:
+    evr: 1.12.6-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a0c7327002
+      type: fast-track
+  fwupd:
+    evr: 1.7.6-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-9f518b89c8
+      type: fast-track
+  ignition:
+    evr: 2.13.0-5.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-84c7350697
+      type: fast-track
+  libsolv:
+    evr: 0.7.21-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-8405280ac8
+      type: fast-track
+  libtool-ltdl:
+    evr: 2.4.6-50.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-08c0abe851
+      type: fast-track
+  libuv:
+    evr: 1:1.44.1-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-26f49880d6
+      type: fast-track
+  linux-firmware:
+    evra: 20220310-130.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-21cd9a78e2
+      type: fast-track
+  linux-firmware-whence:
+    evra: 20220310-130.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-21cd9a78e2
+      type: fast-track
   podman:
     evr: 3:4.0.2-1.fc36
     metadata:
@@ -30,4 +90,14 @@ packages:
     evr: 2022.5-1.fc36
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7502260dab
+      type: fast-track
+  vim-data:
+    evra: 2:8.2.4579-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d5b08afacc
+      type: fast-track
+  vim-minimal:
+    evr: 2:8.2.4579-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d5b08afacc
       type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,39 +9,25 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  systemd:
-    evr: 249.7-2.fc35
+  podman:
+    evr: 3:4.0.2-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-container:
-    evr: 249.7-2.fc35
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-958c9fd48f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track
+  podman-plugins:
+    evr: 3:4.0.2-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-libs:
-    evr: 249.7-2.fc35
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-958c9fd48f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1046#issuecomment-1054585092
+      type: fast-track
+  rpm-ostree:
+    evr: 2022.5-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-pam:
-    evr: 249.7-2.fc35
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7502260dab
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2022.5-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-resolved:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  systemd-udev:
-    evr: 249.7-2.fc35
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
-      type: pin
-  ignition:
-    evr: 2.13.0-5.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-cfe402447e
-      reason: https://github.com/coreos/ignition/issues/1092
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7502260dab
       type: fast-track

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -40,7 +40,7 @@
       "evra": "2.5.1-4.fc36.x86_64"
     },
     "audit-libs": {
-      "evra": "3.0.7-1.fc36.x86_64"
+      "evra": "3.0.7-3.fc36.x86_64"
     },
     "authselect": {
       "evra": "1.3.0-10.fc36.x86_64"
@@ -133,10 +133,13 @@
       "evra": "0.21.2-4.fc36.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.178.0-1.fc36.noarch"
+      "evra": "2:2.180.0-1.fc36.noarch"
     },
     "containerd": {
       "evra": "1.6.0-1.fc36.x86_64"
+    },
+    "containernetworking-plugins": {
+      "evra": "1.1.0-1.fc36.x86_64"
     },
     "containers-common": {
       "evra": "4:1-53.fc36.noarch"
@@ -169,7 +172,7 @@
       "evra": "3.16.1-7.fc36.x86_64"
     },
     "crun": {
-      "evra": "1.4.2-2.fc36.x86_64"
+      "evra": "1.4.3-1.fc36.x86_64"
     },
     "crypto-policies": {
       "evra": "20220203-2.git112f859.fc36.noarch"
@@ -310,7 +313,7 @@
       "evra": "1:4.9.0-1.fc36.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.12.5-1.fc36.x86_64"
+      "evra": "1.12.6-1.fc36.x86_64"
     },
     "fstrm": {
       "evra": "0.6.1-4.fc36.x86_64"
@@ -337,7 +340,7 @@
       "evra": "3.10.5-2.fc36.x86_64"
     },
     "fwupd": {
-      "evra": "1.7.5-1.fc36.x86_64"
+      "evra": "1.7.6-1.fc36.x86_64"
     },
     "gawk": {
       "evra": "5.1.1-2.fc36.x86_64"
@@ -409,7 +412,7 @@
       "evra": "3.23-6.fc36.x86_64"
     },
     "ignition": {
-      "evra": "2.13.0-4.fc36.x86_64"
+      "evra": "2.13.0-5.fc36.x86_64"
     },
     "inih": {
       "evra": "49-5.fc36.x86_64"
@@ -736,7 +739,7 @@
       "evra": "2.4.3-5.fc36.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.20-3.fc36.x86_64"
+      "evra": "0.7.21-1.fc36.x86_64"
     },
     "libss": {
       "evra": "1.46.5-2.fc36.x86_64"
@@ -781,7 +784,7 @@
       "evra": "1.3.2-1.rc1.fc36.1.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.6-48.fc36.x86_64"
+      "evra": "2.4.6-50.fc36.x86_64"
     },
     "libunistring": {
       "evra": "1.0-1.fc36.x86_64"
@@ -799,7 +802,7 @@
       "evra": "2.38-0.2.fc36.x86_64"
     },
     "libuv": {
-      "evra": "1:1.43.0-3.fc36.x86_64"
+      "evra": "1:1.44.1-1.fc36.x86_64"
     },
     "libvarlink-util": {
       "evra": "23-2.fc36.x86_64"
@@ -829,10 +832,10 @@
       "evra": "2.5.1-31.fc36.x86_64"
     },
     "linux-firmware": {
-      "evra": "20220209-129.fc36.noarch"
+      "evra": "20220310-130.fc36.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220209-129.fc36.noarch"
+      "evra": "20220310-130.fc36.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.29-3.fc36.x86_64"
@@ -1195,10 +1198,10 @@
       "evra": "2.38-0.2.fc36.x86_64"
     },
     "vim-data": {
-      "evra": "2:8.2.4428-1.fc36.noarch"
+      "evra": "2:8.2.4579-1.fc36.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4428-1.fc36.x86_64"
+      "evra": "2:8.2.4579-1.fc36.x86_64"
     },
     "which": {
       "evra": "2.21-32.fc36.x86_64"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1075 +1,1090 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.32.12-2.fc35.x86_64"
+      "evra": "1:1.36.0-0.11.fc36.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.32.12-2.fc35.x86_64"
+      "evra": "1:1.36.0-0.11.fc36.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.32.12-2.fc35.x86_64"
+      "evra": "1:1.36.0-0.11.fc36.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.32.12-2.fc35.x86_64"
+      "evra": "1:1.36.0-0.11.fc36.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.32.12-2.fc35.x86_64"
+      "evra": "1:1.36.0-0.11.fc36.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.3.1.1-2.fc35.noarch"
+      "evra": "2.5.0.2-2.fc36.noarch"
+    },
+    "aardvark-dns": {
+      "evra": "1.0.0-1.fc36.x86_64"
     },
     "acl": {
-      "evra": "2.3.1-2.fc35.x86_64"
+      "evra": "2.3.1-3.fc36.x86_64"
     },
     "adcli": {
-      "evra": "0.9.1-9.fc35.x86_64"
+      "evra": "0.9.1-10.fc36.x86_64"
     },
     "afterburn": {
-      "evra": "5.2.0-4.fc35.x86_64"
+      "evra": "5.2.0-4.fc36.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.2.0-4.fc35.x86_64"
+      "evra": "5.2.0-4.fc36.x86_64"
     },
     "alternatives": {
-      "evra": "1.19-1.fc35.x86_64"
+      "evra": "1.19-2.fc36.x86_64"
     },
     "attr": {
-      "evra": "2.5.1-3.fc35.x86_64"
+      "evra": "2.5.1-4.fc36.x86_64"
     },
     "audit-libs": {
-      "evra": "3.0.7-2.fc35.x86_64"
+      "evra": "3.0.7-1.fc36.x86_64"
+    },
+    "authselect": {
+      "evra": "1.3.0-10.fc36.x86_64"
+    },
+    "authselect-libs": {
+      "evra": "1.3.0-10.fc36.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.8-14.fc35.x86_64"
+      "evra": "0.8-15.fc36.x86_64"
     },
     "basesystem": {
-      "evra": "11-12.fc35.noarch"
+      "evra": "11-13.fc36.noarch"
     },
     "bash": {
-      "evra": "5.1.8-2.fc35.x86_64"
+      "evra": "5.1.16-2.fc36.x86_64"
     },
     "bash-completion": {
-      "evra": "1:2.11-3.fc35.noarch"
+      "evra": "1:2.11-6.fc36.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.16.24-1.fc35.x86_64"
+      "evra": "32:9.16.25-2.fc36.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.16.24-1.fc35.noarch"
+      "evra": "32:9.16.25-2.fc36.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.16.24-1.fc35.x86_64"
+      "evra": "32:9.16.25-2.fc36.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.6-1.fc35.x86_64"
+      "evra": "0.2.6-2.fc36.x86_64"
     },
     "bsdtar": {
-      "evra": "3.5.3-1.fc35.x86_64"
+      "evra": "3.5.3-1.fc36.x86_64"
     },
     "btrfs-progs": {
-      "evra": "5.16.2-1.fc35.x86_64"
+      "evra": "5.16.2-1.fc36.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.5.0-1.fc35.x86_64"
+      "evra": "0.5.0-2.fc36.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-9.fc35.x86_64"
+      "evra": "1.0.8-11.fc36.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-9.fc35.x86_64"
+      "evra": "1.0.8-11.fc36.x86_64"
     },
     "c-ares": {
-      "evra": "1.17.2-1.fc35.x86_64"
+      "evra": "1.17.2-2.fc36.x86_64"
     },
     "ca-certificates": {
-      "evra": "2021.2.52-1.0.fc35.noarch"
+      "evra": "2021.2.52-3.fc36.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-1.fc35.x86_64"
+      "evra": "0.1.7-5.fc36.x86_64"
     },
     "chrony": {
-      "evra": "4.2-1.fc35.x86_64"
+      "evra": "4.2-5.fc36.x86_64"
     },
     "cifs-utils": {
-      "evra": "6.13-3.fc35.x86_64"
+      "evra": "6.14-1.fc36.x86_64"
     },
     "clevis": {
-      "evra": "18-4.fc35.x86_64"
+      "evra": "18-6.fc36.x86_64"
     },
     "clevis-dracut": {
-      "evra": "18-4.fc35.x86_64"
+      "evra": "18-6.fc36.x86_64"
     },
     "clevis-luks": {
-      "evra": "18-4.fc35.x86_64"
+      "evra": "18-6.fc36.x86_64"
     },
     "clevis-systemd": {
-      "evra": "18-4.fc35.x86_64"
+      "evra": "18-6.fc36.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-9.fc35.noarch"
+      "evra": "0.31-10.fc36.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.0-2.fc35.x86_64"
+      "evra": "2:2.1.0-2.fc36.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.2-3.fc35.noarch"
+      "evra": "0.21.2-4.fc36.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.180.0-1.fc35.noarch"
+      "evra": "2:2.178.0-1.fc36.noarch"
     },
     "containerd": {
-      "evra": "1.6.0-1.fc35.x86_64"
-    },
-    "containernetworking-plugins": {
-      "evra": "1.1.0-1.fc35.x86_64"
+      "evra": "1.6.0-1.fc36.x86_64"
     },
     "containers-common": {
-      "evra": "4:1-45.fc35.noarch"
+      "evra": "4:1-53.fc36.noarch"
     },
     "coreos-installer": {
-      "evra": "0.13.1-1.fc35.x86_64"
+      "evra": "0.13.1-1.fc36.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.13.1-1.fc35.x86_64"
+      "evra": "0.13.1-1.fc36.x86_64"
     },
     "coreutils": {
-      "evra": "8.32-32.fc35.x86_64"
+      "evra": "9.0-3.fc36.x86_64"
     },
     "coreutils-common": {
-      "evra": "8.32-32.fc35.x86_64"
+      "evra": "9.0-3.fc36.x86_64"
     },
     "cpio": {
-      "evra": "2.13-11.fc35.x86_64"
+      "evra": "2.13-12.fc36.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.6-27.fc35.x86_64"
+      "evra": "2.9.6-28.fc36.x86_64"
     },
     "cracklib-dicts": {
-      "evra": "2.9.6-27.fc35.x86_64"
+      "evra": "2.9.6-28.fc36.x86_64"
     },
     "criu": {
-      "evra": "3.16.1-2.fc35.x86_64"
+      "evra": "3.16.1-7.fc36.x86_64"
     },
     "criu-libs": {
-      "evra": "3.16.1-2.fc35.x86_64"
+      "evra": "3.16.1-7.fc36.x86_64"
     },
     "crun": {
-      "evra": "1.4.3-1.fc35.x86_64"
+      "evra": "1.4.2-2.fc36.x86_64"
     },
     "crypto-policies": {
-      "evra": "20210819-1.gitd0fdcfb.fc35.noarch"
+      "evra": "20220203-2.git112f859.fc36.noarch"
     },
     "cryptsetup": {
-      "evra": "2.4.3-1.fc35.x86_64"
+      "evra": "2.4.3-2.fc36.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.4.3-1.fc35.x86_64"
-    },
-    "cups-libs": {
-      "evra": "1:2.3.3op2-15.fc35.x86_64"
+      "evra": "2.4.3-2.fc36.x86_64"
     },
     "curl": {
-      "evra": "7.79.1-1.fc35.x86_64"
+      "evra": "7.81.0-2.fc36.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.27-14.fc35.x86_64"
+      "evra": "2.1.27-17.fc36.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.27-14.fc35.x86_64"
+      "evra": "2.1.27-17.fc36.x86_64"
     },
     "dbus": {
-      "evra": "1:1.12.22-1.fc35.x86_64"
+      "evra": "1:1.13.20-3.fc36.x86_64"
     },
     "dbus-broker": {
-      "evra": "29-4.fc35.x86_64"
+      "evra": "29-5.fc36.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.12.22-1.fc35.noarch"
+      "evra": "1:1.13.20-3.fc36.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.12.22-1.fc35.x86_64"
+      "evra": "1:1.13.20-3.fc36.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.175-6.fc35.x86_64"
+      "evra": "1.02.175-7.fc36.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-6.fc35.x86_64"
+      "evra": "1.02.175-7.fc36.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-6.fc35.x86_64"
+      "evra": "1.02.175-7.fc36.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-6.fc35.x86_64"
+      "evra": "1.02.175-7.fc36.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.8.6-5.fc35.x86_64"
+      "evra": "0.8.7-8.fc36.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.8.6-5.fc35.x86_64"
+      "evra": "0.8.7-8.fc36.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-6.fc35.x86_64"
+      "evra": "0.9.0-7.fc36.x86_64"
     },
     "diffutils": {
-      "evra": "3.8-1.fc35.x86_64"
+      "evra": "3.8-2.fc36.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.86-5.fc35.x86_64"
+      "evra": "2.86-5.fc36.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-2.fc35.x86_64"
+      "evra": "4.2-3.fc36.x86_64"
     },
     "dracut": {
-      "evra": "055-6.fc35.x86_64"
+      "evra": "055-8.fc36.1.x86_64"
     },
     "dracut-network": {
-      "evra": "055-6.fc35.x86_64"
+      "evra": "055-8.fc36.1.x86_64"
     },
     "dracut-squash": {
-      "evra": "055-6.fc35.x86_64"
+      "evra": "055-8.fc36.1.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.46.3-1.fc35.x86_64"
+      "evra": "1.46.5-2.fc36.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.3-1.fc35.x86_64"
+      "evra": "1.46.5-2.fc36.x86_64"
     },
     "efi-filesystem": {
-      "evra": "5-4.fc35.noarch"
+      "evra": "5-5.fc36.noarch"
     },
     "efibootmgr": {
-      "evra": "16-11.fc35.x86_64"
+      "evra": "16-12.fc36.x86_64"
     },
     "efivar-libs": {
-      "evra": "37-17.fc35.x86_64"
+      "evra": "38-2.fc36.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.186-1.fc35.noarch"
+      "evra": "0.186-1.fc36.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.186-1.fc35.x86_64"
+      "evra": "0.186-1.fc36.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.186-1.fc35.x86_64"
+      "evra": "0.186-1.fc36.x86_64"
     },
     "ethtool": {
-      "evra": "2:5.16-1.fc35.x86_64"
+      "evra": "2:5.16-2.fc36.x86_64"
     },
     "expat": {
-      "evra": "2.4.4-1.fc35.x86_64"
+      "evra": "2.4.6-1.fc36.x86_64"
     },
     "fedora-coreos-pinger": {
-      "evra": "0.0.4-12.fc35.x86_64"
+      "evra": "0.0.4-13.fc36.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-release-common": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "35-36.noarch"
+      "evra": "36-0.16.noarch"
     },
     "fedora-repos": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "35-1.noarch"
+      "evra": "36-0.4.noarch"
     },
     "file": {
-      "evra": "5.40-9.fc35.x86_64"
+      "evra": "5.41-4.fc36.x86_64"
     },
     "file-libs": {
-      "evra": "5.40-9.fc35.x86_64"
+      "evra": "5.41-4.fc36.x86_64"
     },
     "filesystem": {
-      "evra": "3.14-7.fc35.x86_64"
+      "evra": "3.16-2.fc36.x86_64"
     },
     "findutils": {
-      "evra": "1:4.8.0-4.fc35.x86_64"
+      "evra": "1:4.9.0-1.fc36.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.12.6-1.fc35.x86_64"
+      "evra": "1.12.5-1.fc36.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-3.fc35.x86_64"
+      "evra": "0.6.1-4.fc36.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-13.fc35.x86_64"
+      "evra": "2.9.9-14.fc36.x86_64"
     },
     "fuse-common": {
-      "evra": "3.10.5-1.fc35.x86_64"
+      "evra": "3.10.5-2.fc36.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-13.fc35.x86_64"
+      "evra": "2.9.9-14.fc36.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.7.1-2.fc35.x86_64"
+      "evra": "1.8.1-3.fc36.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.2-2.fc35.x86_64"
+      "evra": "3.7.2-3.fc36.x86_64"
     },
     "fuse3": {
-      "evra": "3.10.5-1.fc35.x86_64"
+      "evra": "3.10.5-2.fc36.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-1.fc35.x86_64"
+      "evra": "3.10.5-2.fc36.x86_64"
     },
     "fwupd": {
-      "evra": "1.7.6-1.fc35.x86_64"
+      "evra": "1.7.5-1.fc36.x86_64"
     },
     "gawk": {
-      "evra": "5.1.0-4.fc35.x86_64"
+      "evra": "5.1.1-2.fc36.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.22-1.fc35.x86_64"
+      "evra": "1:1.22-2.fc36.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.8-2.fc35.x86_64"
+      "evra": "1.0.8-3.fc36.x86_64"
     },
     "gettext": {
-      "evra": "0.21-8.fc35.x86_64"
+      "evra": "0.21-9.fc36.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.21-8.fc35.x86_64"
+      "evra": "0.21-9.fc36.x86_64"
     },
     "git-core": {
-      "evra": "2.35.1-1.fc35.x86_64"
+      "evra": "2.35.1-1.fc36.x86_64"
     },
     "glib2": {
-      "evra": "2.70.4-1.fc35.x86_64"
+      "evra": "2.71.3-1.fc36.x86_64"
     },
     "glibc": {
-      "evra": "2.34-28.fc35.x86_64"
+      "evra": "2.35-2.fc36.x86_64"
     },
     "glibc-common": {
-      "evra": "2.34-28.fc35.x86_64"
+      "evra": "2.35-2.fc36.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.34-28.fc35.x86_64"
+      "evra": "2.35-2.fc36.x86_64"
     },
     "gmp": {
-      "evra": "1:6.2.0-7.fc35.x86_64"
+      "evra": "1:6.2.1-2.fc36.x86_64"
     },
     "gnupg2": {
-      "evra": "2.3.4-1.fc35.x86_64"
+      "evra": "2.3.4-2.fc36.x86_64"
     },
     "gnutls": {
-      "evra": "3.7.2-3.fc35.x86_64"
+      "evra": "3.7.3-2.fc36.x86_64"
     },
     "gpgme": {
-      "evra": "1.15.1-6.fc35.x86_64"
+      "evra": "1.15.1-6.fc36.x86_64"
     },
     "grep": {
-      "evra": "3.6-4.fc35.x86_64"
+      "evra": "3.7-2.fc36.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.06-10.fc35.noarch"
+      "evra": "1:2.06-14.fc36.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-10.fc35.x86_64"
+      "evra": "1:2.06-14.fc36.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.06-10.fc35.x86_64"
+      "evra": "1:2.06-14.fc36.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-10.fc35.noarch"
+      "evra": "1:2.06-14.fc36.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-10.fc35.x86_64"
+      "evra": "1:2.06-14.fc36.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-10.fc35.x86_64"
+      "evra": "1:2.06-14.fc36.x86_64"
     },
     "gzip": {
-      "evra": "1.10-5.fc35.x86_64"
+      "evra": "1.11-2.fc36.x86_64"
     },
     "hostname": {
-      "evra": "3.23-5.fc35.x86_64"
+      "evra": "3.23-6.fc36.x86_64"
     },
     "ignition": {
-      "evra": "2.13.0-3.fc35.x86_64"
+      "evra": "2.13.0-4.fc36.x86_64"
     },
     "inih": {
-      "evra": "49-4.fc35.x86_64"
+      "evra": "49-5.fc36.x86_64"
     },
     "iproute": {
-      "evra": "5.13.0-2.fc35.x86_64"
+      "evra": "5.15.0-2.fc36.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.13.0-2.fc35.x86_64"
+      "evra": "5.15.0-2.fc36.x86_64"
     },
     "iptables-legacy": {
-      "evra": "1.8.7-13.fc35.x86_64"
+      "evra": "1.8.7-15.fc36.x86_64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.7-13.fc35.x86_64"
+      "evra": "1.8.7-15.fc36.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.7-13.fc35.x86_64"
+      "evra": "1.8.7-15.fc36.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.7-13.fc35.x86_64"
+      "evra": "1.8.7-15.fc36.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.7-13.fc35.noarch"
+      "evra": "1.8.7-15.fc36.noarch"
     },
     "iputils": {
-      "evra": "20210722-1.fc35.x86_64"
+      "evra": "20211215-2.fc36.x86_64"
     },
     "irqbalance": {
       "evra": "2:1.7.0-8.fc35.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-0.git095f59c.fc35.2.x86_64"
+      "evra": "6.2.1.4-4.git2a8f9d8.fc36.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-0.git095f59c.fc35.2.x86_64"
+      "evra": "6.2.1.4-4.git2a8f9d8.fc36.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-2.fc35.x86_64"
+      "evra": "0.101-4.fc36.x86_64"
     },
     "jansson": {
-      "evra": "2.13.1-3.fc35.x86_64"
+      "evra": "2.13.1-4.fc36.x86_64"
     },
     "jose": {
-      "evra": "11-3.fc35.x86_64"
+      "evra": "11-5.fc36.x86_64"
     },
     "jq": {
-      "evra": "1.6-10.fc35.x86_64"
+      "evra": "1.6-13.fc36.x86_64"
     },
     "json-c": {
-      "evra": "0.15-2.fc35.x86_64"
+      "evra": "0.15-3.fc36.x86_64"
     },
     "json-glib": {
-      "evra": "1.6.6-1.fc35.x86_64"
+      "evra": "1.6.6-2.fc36.x86_64"
     },
     "kbd": {
-      "evra": "2.4.0-8.fc35.x86_64"
+      "evra": "2.4.0-9.fc36.x86_64"
     },
     "kbd-misc": {
-      "evra": "2.4.0-8.fc35.noarch"
+      "evra": "2.4.0-9.fc36.noarch"
     },
     "kernel": {
-      "evra": "5.16.14-200.fc35.x86_64"
+      "evra": "5.17.0-0.rc7.116.fc36.x86_64"
     },
     "kernel-core": {
-      "evra": "5.16.14-200.fc35.x86_64"
+      "evra": "5.17.0-0.rc7.116.fc36.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.16.14-200.fc35.x86_64"
+      "evra": "5.17.0-0.rc7.116.fc36.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.22-7.fc35.x86_64"
+      "evra": "2.0.23-5.fc36.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.1-3.fc35.x86_64"
+      "evra": "1.6.1-4.fc36.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-3.fc35.x86_64"
+      "evra": "1.6.1-4.fc36.x86_64"
     },
     "kmod": {
-      "evra": "29-4.fc35.x86_64"
+      "evra": "29-7.fc36.x86_64"
     },
     "kmod-libs": {
-      "evra": "29-4.fc35.x86_64"
+      "evra": "29-7.fc36.x86_64"
     },
     "kpartx": {
-      "evra": "0.8.6-5.fc35.x86_64"
+      "evra": "0.8.7-8.fc36.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.19.2-2.fc35.x86_64"
+      "evra": "1.19.2-6.fc36.x86_64"
     },
     "less": {
-      "evra": "590-2.fc35.x86_64"
+      "evra": "590-3.fc36.x86_64"
     },
     "libacl": {
-      "evra": "2.3.1-2.fc35.x86_64"
+      "evra": "2.3.1-3.fc36.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-12.fc35.x86_64"
+      "evra": "0.3.111-13.fc36.x86_64"
     },
     "libarchive": {
-      "evra": "3.5.3-1.fc35.x86_64"
+      "evra": "3.5.3-1.fc36.x86_64"
     },
     "libargon2": {
-      "evra": "20171227-7.fc35.x86_64"
+      "evra": "20171227-8.fc36.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.5-3.fc35.x86_64"
+      "evra": "2.5.5-4.fc36.x86_64"
     },
     "libattr": {
-      "evra": "2.5.1-3.fc35.x86_64"
+      "evra": "2.5.1-4.fc36.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-48.fc35.x86_64"
+      "evra": "0.1.1-50.fc36.x86_64"
     },
     "libblkid": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
+    },
+    "libbpf": {
+      "evra": "2:0.5.0-2.fc36.x86_64"
     },
     "libbrotli": {
-      "evra": "1.0.9-6.fc35.x86_64"
+      "evra": "1.0.9-7.fc36.x86_64"
     },
     "libbsd": {
-      "evra": "0.10.0-8.fc35.x86_64"
+      "evra": "0.10.0-9.fc36.x86_64"
     },
     "libcap": {
-      "evra": "2.48-3.fc35.x86_64"
+      "evra": "2.48-4.fc36.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-8.fc35.x86_64"
+      "evra": "0.8.2-9.fc36.x86_64"
     },
     "libcbor": {
-      "evra": "0.7.0-4.fc35.x86_64"
+      "evra": "0.7.0-5.fc36.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-48.fc35.x86_64"
+      "evra": "0.7.0-50.fc36.x86_64"
     },
     "libcom_err": {
-      "evra": "1.46.3-1.fc35.x86_64"
+      "evra": "1.46.5-2.fc36.x86_64"
     },
     "libcurl": {
-      "evra": "7.79.1-1.fc35.x86_64"
+      "evra": "7.81.0-2.fc36.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-22.fc35.x86_64"
+      "evra": "0.14-23.fc36.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-50.fc35.x86_64"
+      "evra": "5.3.28-51.fc36.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-48.fc35.x86_64"
+      "evra": "0.5.0-50.fc36.x86_64"
     },
     "libeconf": {
-      "evra": "0.4.0-2.fc35.x86_64"
+      "evra": "0.4.0-3.fc36.x86_64"
     },
     "libedit": {
-      "evra": "3.1-40.20210910cvs.fc35.x86_64"
+      "evra": "3.1-41.20210910cvs.fc36.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-4.fc35.x86_64"
+      "evra": "2.1.12-6.fc36.x86_64"
     },
     "libfdisk": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "libffi": {
-      "evra": "3.1-29.fc35.x86_64"
+      "evra": "3.4.2-8.fc36.x86_64"
     },
     "libfido2": {
-      "evra": "1.8.0-1.fc35.x86_64"
+      "evra": "1.10.0-3.fc36.x86_64"
     },
     "libgcab1": {
-      "evra": "1.4-5.fc35.x86_64"
+      "evra": "1.4-6.fc36.x86_64"
     },
     "libgcc": {
-      "evra": "11.2.1-9.fc35.x86_64"
+      "evra": "12.0.1-0.12.fc36.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.9.4-1.fc35.x86_64"
+      "evra": "1.10.0-1.fc36.x86_64"
     },
     "libgomp": {
-      "evra": "11.2.1-9.fc35.x86_64"
+      "evra": "12.0.1-0.12.fc36.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.43-1.fc35.x86_64"
+      "evra": "1.44-1.fc36.x86_64"
     },
     "libgudev": {
-      "evra": "237-1.fc35.x86_64"
+      "evra": "237-2.fc36.x86_64"
     },
     "libgusb": {
-      "evra": "0.3.9-1.fc35.x86_64"
+      "evra": "0.3.10-2.fc36.x86_64"
     },
     "libibverbs": {
-      "evra": "39.0-1.fc35.x86_64"
+      "evra": "39.0-1.fc36.x86_64"
     },
     "libicu": {
-      "evra": "69.1-2.fc35.x86_64"
+      "evra": "69.1-5.fc36.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.2-3.fc35.x86_64"
+      "evra": "2.3.2-4.fc36.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-48.fc35.x86_64"
+      "evra": "1.3.1-50.fc36.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.9-1.fc35.x86_64"
+      "evra": "0.1.10-1.fc36.x86_64"
     },
     "libjose": {
-      "evra": "11-3.fc35.x86_64"
+      "evra": "11-5.fc36.x86_64"
     },
     "libkcapi": {
-      "evra": "1.3.1-3.fc35.x86_64"
+      "evra": "1.3.1-4.fc36.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.3.1-3.fc35.x86_64"
+      "evra": "1.3.1-4.fc36.x86_64"
     },
     "libksba": {
-      "evra": "1.6.0-2.fc35.x86_64"
+      "evra": "1.6.0-3.fc36.x86_64"
     },
     "libldb": {
-      "evra": "2.4.1-1.fc35.x86_64"
+      "evra": "2.5.0-1.fc36.x86_64"
     },
     "libluksmeta": {
-      "evra": "9-12.fc35.x86_64"
+      "evra": "9-13.fc36.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.6.0-1.fc35.x86_64"
+      "evra": "1.6.0-2.fc36.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.4-14.fc35.x86_64"
+      "evra": "1.0.4-15.fc36.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.14.0-1.fc35.x86_64"
+      "evra": "2.14.0-2.fc36.x86_64"
     },
     "libmount": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "libndp": {
-      "evra": "1.8-2.fc35.x86_64"
+      "evra": "1.8-3.fc36.x86_64"
     },
     "libnet": {
-      "evra": "1.2-4.fc35.x86_64"
+      "evra": "1.2-5.fc36.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-3.fc35.x86_64"
+      "evra": "1.0.8-4.fc36.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-20.fc35.x86_64"
+      "evra": "1.0.1-21.fc36.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.5.4-2.rc3.fc35.x86_64"
+      "evra": "1:2.5.4-2.rc3.fc36.1.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.0-2.fc35.x86_64"
+      "evra": "1.2.1-2.fc36.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.45.1-1.fc35.x86_64"
+      "evra": "1.46.0-2.fc36.x86_64"
     },
     "libnl3": {
-      "evra": "3.5.0-8.fc35.x86_64"
+      "evra": "3.5.0-9.fc36.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.5.0-8.fc35.x86_64"
+      "evra": "3.5.0-9.fc36.x86_64"
     },
     "libnsl2": {
-      "evra": "1.3.0-4.fc35.x86_64"
+      "evra": "2.0.0-3.fc36.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-48.fc35.x86_64"
+      "evra": "0.2.1-50.fc36.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.1-2.fc35.x86_64"
+      "evra": "14:1.10.1-3.fc36.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-1.fc35.x86_64"
+      "evra": "1.8.0-2.fc36.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.1-4.fc35.x86_64"
+      "evra": "0.21.1-5.fc36.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.4-6.fc35.x86_64"
+      "evra": "1.4.4-7.fc36.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-48.fc35.x86_64"
+      "evra": "0.1.5-50.fc36.x86_64"
     },
     "librepo": {
-      "evra": "1.14.2-1.fc35.x86_64"
+      "evra": "1.14.2-2.fc36.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.15.2-8.fc35.noarch"
+      "evra": "2.17.1-1.fc36.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-1.fc35.x86_64"
+      "evra": "2.5.3-2.fc36.x86_64"
     },
     "libselinux": {
-      "evra": "3.3-1.fc35.x86_64"
+      "evra": "3.3-4.fc36.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.3-1.fc35.x86_64"
+      "evra": "3.3-4.fc36.x86_64"
     },
     "libsemanage": {
-      "evra": "3.3-1.fc35.x86_64"
+      "evra": "3.3-3.fc36.x86_64"
     },
     "libsepol": {
-      "evra": "3.3-2.fc35.x86_64"
+      "evra": "3.3-3.fc36.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.13-3.fc35.x86_64"
+      "evra": "2.14-2.fc36.x86_64"
     },
     "libslirp": {
-      "evra": "4.6.1-2.fc35.x86_64"
+      "evra": "4.6.1-3.fc36.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.15.5-1.fc35.x86_64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.x86_64"
     },
     "libsmbios": {
-      "evra": "2.4.3-4.fc35.x86_64"
+      "evra": "2.4.3-5.fc36.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.21-1.fc35.x86_64"
+      "evra": "0.7.20-3.fc36.x86_64"
     },
     "libss": {
-      "evra": "1.46.3-1.fc35.x86_64"
+      "evra": "1.46.5-2.fc36.x86_64"
     },
     "libssh": {
-      "evra": "0.9.6-1.fc35.x86_64"
+      "evra": "0.9.6-4.fc36.x86_64"
     },
     "libssh-config": {
-      "evra": "0.9.6-1.fc35.noarch"
+      "evra": "0.9.6-4.fc36.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "libstdc++": {
-      "evra": "11.2.1-9.fc35.x86_64"
+      "evra": "12.0.1-0.12.fc36.x86_64"
     },
     "libtalloc": {
-      "evra": "2.3.3-2.fc35.x86_64"
+      "evra": "2.3.3-3.fc36.x86_64"
     },
     "libtasn1": {
-      "evra": "4.16.0-6.fc35.x86_64"
+      "evra": "4.18.0-2.fc36.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.4-3.fc35.x86_64"
+      "evra": "1.4.6-1.fc36.x86_64"
     },
     "libteam": {
-      "evra": "1.31-4.fc35.x86_64"
+      "evra": "1.31-5.fc36.x86_64"
     },
     "libtevent": {
-      "evra": "0.11.0-1.fc35.x86_64"
+      "evra": "0.11.0-2.fc36.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.2-1.fc35.x86_64"
+      "evra": "1.3.2-1.rc1.fc36.1.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.6-50.fc35.x86_64"
+      "evra": "2.4.6-48.fc36.x86_64"
     },
     "libunistring": {
-      "evra": "0.9.10-14.fc35.x86_64"
+      "evra": "1.0-1.fc36.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.24-4.fc35.x86_64"
+      "evra": "1.0.25-8.fc36.x86_64"
     },
     "libuser": {
       "evra": "0.63-7.fc35.x86_64"
     },
     "libutempter": {
-      "evra": "1.2.1-5.fc35.x86_64"
+      "evra": "1.2.1-6.fc36.x86_64"
     },
     "libuuid": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "libuv": {
-      "evra": "1:1.44.1-1.fc35.x86_64"
+      "evra": "1:1.43.0-3.fc36.x86_64"
     },
     "libvarlink-util": {
-      "evra": "22-3.fc35.x86_64"
+      "evra": "23-2.fc36.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-2.fc35.x86_64"
+      "evra": "0.3.2-3.fc36.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.15.5-1.fc35.x86_64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.28-1.fc35.x86_64"
+      "evra": "4.4.28-1.fc36.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.13-1.fc35.x86_64"
+      "evra": "2.9.13-1.fc36.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.6-1.fc35.x86_64"
+      "evra": "0.3.7-1.fc36.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-6.fc35.x86_64"
+      "evra": "0.2.5-7.fc36.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.2-1.fc35.x86_64"
+      "evra": "1.5.2-1.fc36.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-30.fc35.x86_64"
+      "evra": "2.5.1-31.fc36.x86_64"
     },
     "linux-firmware": {
-      "evra": "20220310-130.fc35.noarch"
+      "evra": "20220209-129.fc36.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220310-130.fc35.noarch"
+      "evra": "20220209-129.fc36.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.29-2.fc35.x86_64"
+      "evra": "0.9.29-3.fc36.x86_64"
     },
     "logrotate": {
-      "evra": "3.18.1-2.fc35.x86_64"
+      "evra": "3.19.0-2.fc36.x86_64"
     },
     "lsof": {
-      "evra": "4.94.0-2.fc35.x86_64"
+      "evra": "4.94.0-3.fc36.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.4-1.fc35.x86_64"
+      "evra": "5.4.4-1.fc36.x86_64"
     },
     "luksmeta": {
-      "evra": "9-12.fc35.x86_64"
+      "evra": "9-13.fc36.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.11-6.fc35.x86_64"
+      "evra": "2.03.11-7.fc36.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-6.fc35.x86_64"
+      "evra": "2.03.11-7.fc36.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.3-3.fc35.x86_64"
+      "evra": "1.9.3-4.fc36.x86_64"
     },
     "lzo": {
-      "evra": "2.10-5.fc35.x86_64"
+      "evra": "2.10-6.fc36.x86_64"
     },
     "mdadm": {
-      "evra": "4.2-rc2.fc35.x86_64"
+      "evra": "4.2-rc2.fc36.1.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-47.1.fc35.x86_64"
+      "evra": "2:2.1-49.fc36.x86_64"
     },
     "moby-engine": {
-      "evra": "20.10.12-1.fc35.x86_64"
+      "evra": "20.10.12-3.fc36.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.5.0-1.fc35.x86_64"
+      "evra": "2:0.5.0-2.fc36.x86_64"
     },
-    "mozjs78": {
-      "evra": "78.15.0-1.fc35.x86_64"
+    "mozjs91": {
+      "evra": "91.6.0-1.fc36.x86_64"
     },
     "mpfr": {
-      "evra": "4.1.0-8.fc35.x86_64"
+      "evra": "4.1.0-9.fc36.x86_64"
     },
     "nano": {
-      "evra": "5.8-4.fc35.x86_64"
+      "evra": "6.0-2.fc36.x86_64"
     },
     "nano-default-editor": {
-      "evra": "5.8-4.fc35.noarch"
+      "evra": "6.0-2.fc36.noarch"
     },
     "ncurses": {
-      "evra": "6.2-8.20210508.fc35.x86_64"
+      "evra": "6.2-9.20210508.fc36.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.2-8.20210508.fc35.noarch"
+      "evra": "6.2-9.20210508.fc36.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.2-8.20210508.fc35.x86_64"
+      "evra": "6.2-9.20210508.fc36.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.60.20160912git.fc35.x86_64"
+      "evra": "2.0-0.61.20160912git.fc36.x86_64"
+    },
+    "netavark": {
+      "evra": "1.0.0-1.fc36.x86_64"
     },
     "nettle": {
-      "evra": "3.7.3-2.fc35.x86_64"
+      "evra": "3.7.3-3.fc36.x86_64"
     },
     "newt": {
-      "evra": "0.52.21-11.fc35.x86_64"
+      "evra": "0.52.21-12.fc36.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.5.4-2.rc3.fc35.x86_64"
+      "evra": "1:2.5.4-2.rc3.fc36.1.x86_64"
     },
     "nftables": {
-      "evra": "1:1.0.0-1.fc35.x86_64"
+      "evra": "1:1.0.1-3.fc36.x86_64"
     },
     "npth": {
-      "evra": "1.6-7.fc35.x86_64"
+      "evra": "1.6-8.fc36.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-19.fc35.x86_64"
+      "evra": "2.18.1-20.fc36.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.14-4.fc35.x86_64"
+      "evra": "2.0.14-5.fc36.x86_64"
     },
     "nvme-cli": {
-      "evra": "1.11.1-4.fc35.x86_64"
+      "evra": "1.11.1-5.fc36.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.7.1-1.fc35.1.x86_64"
+      "evra": "6.9.7.1-1.fc36.2.x86_64"
     },
     "openldap": {
-      "evra": "2.4.59-3.fc35.x86_64"
+      "evra": "2.6.1-2.fc36.x86_64"
+    },
+    "openldap-compat": {
+      "evra": "2.6.1-2.fc36.x86_64"
     },
     "openssh": {
-      "evra": "8.7p1-3.fc35.x86_64"
+      "evra": "8.8p1-1.fc36.1.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.7p1-3.fc35.x86_64"
+      "evra": "8.8p1-1.fc36.1.x86_64"
     },
     "openssh-server": {
-      "evra": "8.7p1-3.fc35.x86_64"
+      "evra": "8.8p1-1.fc36.1.x86_64"
     },
     "openssl": {
-      "evra": "1:1.1.1l-2.fc35.x86_64"
+      "evra": "1:3.0.0-1.fc36.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:1.1.1l-2.fc35.x86_64"
+      "evra": "1:3.0.0-1.fc36.x86_64"
     },
     "os-prober": {
-      "evra": "1.77-8.fc35.x86_64"
+      "evra": "1.77-9.fc36.x86_64"
     },
     "ostree": {
-      "evra": "2022.1-1.fc35.x86_64"
+      "evra": "2022.1-2.fc36.x86_64"
     },
     "ostree-libs": {
-      "evra": "2022.1-1.fc35.x86_64"
+      "evra": "2022.1-2.fc36.x86_64"
     },
     "p11-kit": {
-      "evra": "0.23.22-4.fc35.x86_64"
+      "evra": "0.24.1-2.fc36.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.23.22-4.fc35.x86_64"
+      "evra": "0.24.1-2.fc36.x86_64"
     },
     "pam": {
-      "evra": "1.5.2-7.fc35.x86_64"
+      "evra": "1.5.2-11.fc36.x86_64"
+    },
+    "pam-libs": {
+      "evra": "1.5.2-11.fc36.x86_64"
     },
     "passwd": {
-      "evra": "0.80-11.fc35.x86_64"
+      "evra": "0.80-12.fc36.x86_64"
     },
     "pcre": {
-      "evra": "8.45-1.fc35.x86_64"
+      "evra": "8.45-1.fc36.1.x86_64"
     },
     "pcre2": {
-      "evra": "10.39-1.fc35.x86_64"
+      "evra": "10.39-1.fc36.1.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.39-1.fc35.noarch"
+      "evra": "10.39-1.fc36.1.noarch"
     },
     "pigz": {
-      "evra": "2.5-2.fc35.x86_64"
+      "evra": "2.6-2.fc36.x86_64"
     },
     "pkgconf": {
-      "evra": "1.8.0-1.fc35.x86_64"
+      "evra": "1.8.0-2.fc36.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-1.fc35.noarch"
+      "evra": "1.8.0-2.fc36.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-1.fc35.x86_64"
+      "evra": "1.8.0-2.fc36.x86_64"
     },
     "podman": {
-      "evra": "3:3.4.4-1.fc35.x86_64"
+      "evra": "3:4.0.2-1.fc36.x86_64"
     },
     "podman-plugins": {
-      "evra": "3:3.4.4-1.fc35.x86_64"
+      "evra": "3:4.0.2-1.fc36.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.3-1.fc35.x86_64"
+      "evra": "3.3-4.fc36.x86_64"
     },
     "polkit": {
-      "evra": "0.120-1.fc35.2.x86_64"
+      "evra": "0.120-5.fc36.x86_64"
     },
     "polkit-libs": {
-      "evra": "0.120-1.fc35.2.x86_64"
+      "evra": "0.120-5.fc36.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-20.fc35.x86_64"
+      "evra": "0.1-21.fc36.x86_64"
     },
     "popt": {
-      "evra": "1.18-6.fc35.x86_64"
+      "evra": "1.18-7.fc36.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.17-3.fc35.x86_64"
+      "evra": "3.3.17-4.fc36.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.4.0-1.fc35.x86_64"
+      "evra": "1.4.0-4.fc36.x86_64"
     },
     "psmisc": {
-      "evra": "23.4-2.fc35.x86_64"
+      "evra": "23.4-3.fc36.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20210518-2.fc35.noarch"
+      "evra": "20210518-4.fc36.noarch"
     },
     "readline": {
-      "evra": "8.1-3.fc35.x86_64"
+      "evra": "8.1-6.fc36.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.6-1.fc35.x86_64"
+      "evra": "1.2.6-2.fc36.x86_64"
     },
     "rpm": {
-      "evra": "4.17.0-4.fc35.x86_64"
+      "evra": "4.17.0-9.fc36.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.17.0-4.fc35.x86_64"
+      "evra": "4.17.0-9.fc36.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2022.5-1.fc35.x86_64"
+      "evra": "2022.5-1.fc36.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2022.5-1.fc35.x86_64"
+      "evra": "2022.5-1.fc36.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.17.0-4.fc35.x86_64"
+      "evra": "4.17.0-9.fc36.x86_64"
     },
     "rsync": {
-      "evra": "3.2.3-8.fc35.x86_64"
+      "evra": "3.2.3-14.fc36.x86_64"
     },
     "runc": {
-      "evra": "2:1.1.0-1.fc35.x86_64"
+      "evra": "2:1.1.0-2.fc36.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.15.5-1.fc35.x86_64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.15.5-1.fc35.noarch"
+      "evra": "2:4.16.0-0.2.rc3.fc36.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.15.5-1.fc35.x86_64"
+      "evra": "2:4.16.0-0.2.rc3.fc36.x86_64"
     },
     "sed": {
-      "evra": "4.8-8.fc35.x86_64"
+      "evra": "4.8-10.fc36.x86_64"
     },
     "selinux-policy": {
-      "evra": "35.15-1.fc35.noarch"
+      "evra": "36.3-1.fc36.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "35.15-1.fc35.noarch"
+      "evra": "36.3-1.fc36.noarch"
     },
     "setup": {
-      "evra": "2.13.9.1-2.fc35.noarch"
+      "evra": "2.13.9.1-3.fc36.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-2.fc35.x86_64"
+      "evra": "1.46-3.fc36.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-2.fc35.x86_64"
+      "evra": "1.46-3.fc36.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.9-9.fc35.x86_64"
+      "evra": "2:4.11.1-2.fc36.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.9-9.fc35.x86_64"
+      "evra": "2:4.11.1-2.fc36.x86_64"
     },
     "shared-mime-info": {
       "evra": "2.1-3.fc35.x86_64"
@@ -1078,155 +1093,158 @@
       "evra": "15.4-5.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.5.2-1.fc35.x86_64"
+      "evra": "1:1.5.2-2.fc36.x86_64"
     },
     "slang": {
-      "evra": "2.3.2-10.fc35.x86_64"
+      "evra": "2.3.2-11.fc36.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.1.12-2.fc35.x86_64"
+      "evra": "1.2.0-0.2.beta.0.fc36.x86_64"
     },
     "snappy": {
-      "evra": "1.1.9-3.fc35.x86_64"
+      "evra": "1.1.9-4.fc36.x86_64"
     },
     "socat": {
-      "evra": "1.7.4.2-1.fc35.x86_64"
+      "evra": "1.7.4.2-2.fc36.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.36.0-3.fc35.x86_64"
+      "evra": "3.36.0-5.fc36.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.5-3.20210913gite048580.fc35.x86_64"
+      "evra": "4.5-18.20220221gitbc0c097.fc36.x86_64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.2-8.fc35.x86_64"
+      "evra": "0.1.3-2.fc36.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-client": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-common": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.6.3-1.fc35.x86_64"
+      "evra": "2.6.3-1.fc36.x86_64"
     },
     "stalld": {
-      "evra": "1.14.1-1.fc35.x86_64"
+      "evra": "1.15-2.fc36.x86_64"
     },
     "sudo": {
-      "evra": "1.9.7p2-2.fc35.x86_64"
+      "evra": "1.9.8-5.p2.fc36.x86_64"
     },
     "systemd": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "systemd-container": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "systemd-libs": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "systemd-pam": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "systemd-resolved": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "systemd-udev": {
-      "evra": "249.7-2.fc35.x86_64"
+      "evra": "250.3-4.fc36.x86_64"
     },
     "tar": {
-      "evra": "2:1.34-2.fc35.x86_64"
+      "evra": "2:1.34-3.fc36.x86_64"
     },
     "teamd": {
-      "evra": "1.31-4.fc35.x86_64"
+      "evra": "1.31-5.fc36.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.99.3-2.fc35.x86_64"
+      "evra": "0.0.99.3-4.fc36.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.2-1.fc35.x86_64"
+      "evra": "5.2-2.fc36.x86_64"
     },
     "tpm2-tss": {
-      "evra": "3.1.0-3.fc35.x86_64"
+      "evra": "3.2.0-1.fc36.x86_64"
     },
     "tzdata": {
-      "evra": "2021e-1.fc35.noarch"
+      "evra": "2021e-3.fc36.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-3.fc35.x86_64"
+      "evra": "0.13.0-4.fc36.x86_64"
     },
     "util-linux": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.37.4-1.fc35.x86_64"
+      "evra": "2.38-0.2.fc36.x86_64"
     },
     "vim-data": {
-      "evra": "2:8.2.4529-1.fc35.noarch"
+      "evra": "2:8.2.4428-1.fc36.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4529-1.fc35.x86_64"
+      "evra": "2:8.2.4428-1.fc36.x86_64"
     },
     "which": {
-      "evra": "2.21-27.fc35.x86_64"
+      "evra": "2.21-32.fc36.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-1.fc35.x86_64"
+      "evra": "1.0.20210914-2.fc36.x86_64"
     },
     "xfsprogs": {
-      "evra": "5.12.0-2.fc35.x86_64"
+      "evra": "5.14.2-2.fc36.x86_64"
+    },
+    "xxhash-libs": {
+      "evra": "0.8.1-2.fc36.x86_64"
     },
     "xz": {
-      "evra": "5.2.5-7.fc35.x86_64"
+      "evra": "5.2.5-8.fc36.x86_64"
     },
     "xz-libs": {
-      "evra": "5.2.5-7.fc35.x86_64"
+      "evra": "5.2.5-8.fc36.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-17.fc35.x86_64"
+      "evra": "2.1.0-18.fc36.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.2.0-1.fc35.x86_64"
+      "evra": "1.2.0-1.fc36.x86_64"
     },
     "zincati": {
-      "evra": "0.0.24-1.fc35.x86_64"
+      "evra": "0.0.24-3.fc36.x86_64"
     },
     "zlib": {
-      "evra": "1.2.11-30.fc35.x86_64"
+      "evra": "1.2.11-31.fc36.x86_64"
     },
     "zram-generator": {
-      "evra": "1.1.1-3.fc35.x86_64"
+      "evra": "1.1.1-4.fc36.x86_64"
     }
   },
   "metadata": {
-    "generated": "2022-03-16T20:54:17Z",
+    "generated": "2022-03-18T14:39:53Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2021-10-26T05:31:27Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2022-03-15T22:26:15Z"
+        "generated": "2022-03-17T20:51:44Z"
       },
-      "fedora-updates": {
-        "generated": "2022-03-16T15:52:25Z"
+      "fedora-next": {
+        "generated": "2022-03-18T10:19:54Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2022-02-08T18:40:57Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,14 +2,14 @@ variables:
   stream: next-devel
   prod: false
 
-releasever: 35
+releasever: 36
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned. These repos are also used by the remove-graduated-overrides
   # GitHub Action.
-  - fedora
-  - fedora-updates
+  - fedora-next
+  - fedora-next-updates
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
The Fedora Linux 36 beta should be next week or the following week.
Let's go ahead and switch `next-devel` to Fedora 36 so we can start
getting some more testing on it.