### PR TITLE
image-base: specify VMware OS and HW versions

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -26,8 +26,12 @@ ostree-remote: fedora
 # https://lists.gnu.org/archive/html/grub-devel/2021-06/msg00031.html
 bootfs_metadata_csum_seed: true
 
+vmware-os-type: fedora64Guest
+# VMware hardware versions: https://kb.vmware.com/s/article/1003746
+# We use the newest version allowed by the oldest non-EOL VMware
+# Workstation/Player/Fusion/ESXi release: https://lifecycle.vmware.com/
+vmware-hw-version: 13
+
 # After this, we plan to add support for the Ignition
 # storage/filesystems sections.  (Although one can do
 # that on boot as well)
-
-


### PR DESCRIPTION
Stick with hardware version 13 for now, but switch the OS ID from RHEL 7 to 64-bit Fedora.

For https://github.com/coreos/coreos-assembler/pull/2762.