### PR TITLE
networking: veirfy rd.net.timeout.dhcp and rd.net.dhcp.retry are supported by NetworkManager.

### DIFF
--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"}
+# 
+# Veirfy rd.net.timeout.dhcp and rd.net.dhcp.retry are supported
+# by NetworkManager. Append them to kernel parameter when boot, 
+# get total timeout is `timeout * retry`, 30*8(240) seconds 
+# in this test scenario
+# See:
+# - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/559
+# - https://bugzilla.redhat.com/show_bug.cgi?id=1879094#c10
+# - https://bugzilla.redhat.com/show_bug.cgi?id=1877740
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# check kernel parameter
+cmdline="/proc/cmdline"
+for rd in rd.net.timeout.dhcp rd.net.dhcp.retry;
+do
+    if ! grep -q $rd $cmdline; then
+        fatal "Error: can not find $rd in kernel parameter"
+    fi
+done
+
+log=$(journalctl -b -u NetworkManager | grep "beginning transaction")
+timeout=$(echo $log | awk -F'[( )]' '{print $(NF-2)}')
+if [ $timeout -ne 240 ]; then
+    fatal "Error: actual dhcp timeout is $timeout, expected 240"
+fi
+ok "Total dhcp timeout matches expected value"


### PR DESCRIPTION
Append rd.net.timeout.dhcp and rd.net.dhcp.retry to kernel parameter
when boot, get total dhcp timeout is `rd.net.timeout.dhcp * rd.net.dhcp.retry`
seconds
See:
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/559
- https://bugzilla.redhat.com/show_bug.cgi?id=1879094#c10
- https://bugzilla.redhat.com/show_bug.cgi?id=1877740