### PR TITLE
manifests/system-configuration: add `acl`

### DIFF
--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -24,6 +24,7 @@ packages:
   # User configuration
   - passwd
   - shadow-utils
+  - acl
   # SELinux policy
   - selinux-policy-targeted
   # There are things that write outside of the journal still (such as the


### PR DESCRIPTION
This is currently getting pulled in by systemd, but won't anymore in
f36. Let's keep shipping it though since users might be relying on it to
manage permissions.