### PR TITLE
[next-devel] overrides: fast-track Ignition 2.13.0-5.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,9 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1059
       type: pin
+  ignition:
+    evr: 2.13.0-5.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-cfe402447e
+      reason: https://github.com/coreos/ignition/issues/1092
+      type: fast-track


### PR DESCRIPTION
For https://github.com/coreos/ignition/issues/1092.