### PR TITLE
manifests: fedora-coreos-base: add containernetworking-plugins explicitly

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -118,9 +118,11 @@ packages:
   # Containers
   - systemd-container catatonit
   - fuse-overlayfs slirp4netns
-  # name resolution for podman containers
+  # support for old style CNI networks and name resolution for
+  # podman containers with CNI networks
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
-  - podman-plugins dnsmasq
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071338097
+  - containernetworking-plugins podman-plugins dnsmasq
   # Remote IPC for podman
   - libvarlink-util
   # Minimal NFS client

--- a/manifests/podman-v4.yaml
+++ b/manifests/podman-v4.yaml
@@ -6,3 +6,9 @@ packages:
   # podman-plugins in the podman v3 stack.
   # See https://github.com/containers/netavark/pull/217
   - aardvark-dns
+  # Since we need `containernetworking-plugins` installed to continue
+  # to support CNI networks we need to also explicitly install
+  # `netavark` so we get both of them installed since both of them
+  # provide `container-network-stack`.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071458717
+  - netavark


### PR DESCRIPTION
In order to continue to support CNI networks in podman, which is what
any existing Fedora <= 35 system is using, we need to continue to ship
containernetworking-plugins.

It was dropped in [1]. Traditional yum based systems won't uninstall the
package on an upgrade, but OSTrees are "baked fresh" every time and
won't retain it because it's no longer a dependency. We need to name it
explicitly if we want upgrading FCOS users to be able to start their
containers.

[1] https://src.fedoraproject.org/rpms/podman/c/06c601234feac4f5da7b6e1d92430d62f556f3b9