### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,24 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 5.16.15-201.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-de4474b89d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1121
-      type: fast-track
-  kernel-core:
-    evr: 5.16.15-201.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-de4474b89d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1121
-      type: fast-track
-  kernel-modules:
-    evr: 5.16.15-201.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-de4474b89d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1121
-      type: fast-track
   ignition:
     evr: 2.13.0-5.fc35
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).