### PR TITLE
denylist: extend snooze for journald fix test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,7 +23,7 @@
   - ppc64le
 - pattern: ext.config.systemd.sytemd-journald-fix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1108#issuecomment-1061988853
-  snooze: 2022-03-18
+  snooze: 2022-04-01
   streams:
     - stable
     - testing


### PR DESCRIPTION
This is still happening reliably. Snooze and keep following
up upstream.