### PR TITLE
manifest: explicitly list containerd

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -39,6 +39,8 @@ packages:
   - fedora-repos-archive
   # CL ships this.
   - moby-engine
+  # Already pulled in by moby-engine, but let's be explicit. Typhoon uses it.
+  - containerd
   # User metrics
   - fedora-coreos-pinger
   # Updates


### PR DESCRIPTION
This is already in the OS as a dependency of moby-engine, but Typhoon is
now also relying on this and likely other people deploying Kubernetes on
top of FCOS.

Unlike cri-o, the versioning of containerd wrt CRI is less tight, which
makes baking it into the host easier.

Things may change here in the future, and it's likely we will recommend
cri-o as an alternative runtime for k8s eventually. But for now, let's
at least be more explicit that we're shipping containerd.

For more information, see:
https://github.com/coreos/fedora-coreos-tracker/issues/767
https://github.com/poseidon/typhoon/issues/899#issuecomment-1010638811