### PR TITLE
Revert "overlay: verify filesystem labeled 'boot' is unique after ignition"

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
@@ -14,8 +14,6 @@ karg() {
     echo "${value}"
 }
 
-rdcore verify-unique-fs-label --rereadpt boot
-
 # Mount /boot. Note that we mount /boot but we don't unmount it because we
 # are run in a systemd unit with MountFlags=slave so it is unmounted for us.
 bootmnt=/mnt/boot_partition


### PR DESCRIPTION
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1105

This reverts commit bd7a5c78911f5bcfc89b0af42f401144661abcb1.