### PR TITLE
s390x: Remove fwupd package

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -14,14 +14,16 @@ packages:
  - linux-firmware
  # rpm-ostree
  - rpm-ostree nss-altfiles
- # firmware updates
- - fwupd
 
 # bootloader
 packages-aarch64:
   - grub2-efi-aa64 efibootmgr shim
+  # firmware updates
+  - fwupd
 packages-ppc64le:
   - grub2 ostree-grub2
+  # firmware updates
+  - fwupd
 packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
@@ -29,3 +31,5 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
+  # firmware updates
+  - fwupd

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -9,13 +9,21 @@ set -xeuo pipefail
 #   eth1 has the static IP address via kargs
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# - We use net.ifnames=0 to disable consistent network naming here because on
-#   different firmwares (BIOS vs UEFI) the NIC names are different.
-#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 
-# https://github.com/coreos/fedora-coreos-config/issues/1499
-# - Disable the test on s390x
 # kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip", "architectures": "!s390x" }
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - additionalNics: 1
+#   - Add 1 NIC for this test
+# - appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip"
+#   - The functionality we're testing here and the configuration for the NIC
+#   - We use net.ifnames=0 to disable consistent network naming here because on
+#     different firmwares (BIOS vs UEFI) the NIC names are different.
+#     See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# - architectures: !s390x
+#   - appendKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -1,14 +1,22 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"}
-# 
+# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8", "architectures": "!s390x"}
+#
 # Veirfy rd.net.timeout.dhcp and rd.net.dhcp.retry are supported
-# by NetworkManager. Append them to kernel parameter when boot, 
-# get total timeout is `timeout * retry`, 30*8(240) seconds 
+# by NetworkManager. Append them to kernel parameter when boot,
+# get total timeout is `timeout * retry`, 30*8(240) seconds
 # in this test scenario
 # See:
 # - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/559
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1879094#c10
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1877740
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
+#   - The functionality we're testing here.
+# - architectures: !s390x
+#   - appendFirstbootKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "net.ifnames=0", "architectures": "!s390x"}
-# - We use net.ifnames=0 to disable consistent network naming here because on
-#   different firmwares (BIOS vs UEFI) the NIC names are different.
-#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 
 # Set MTU on a VLAN subinterface for the bond using ignition config and check
 # - verify MTU on the bond matches config
@@ -19,8 +16,17 @@
 # Using kernel args to `configure MTU on a VLAN subinterface for the bond` refer to
 # https://github.com/coreos/fedora-coreos-config/pull/1401
 
-# https://github.com/coreos/fedora-coreos-config/issues/1499
-# - Disable the test on s390x
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - additionalNics: 2
+#   - Add 2 NIC for this test
+# - appendKernelArgs: "net.ifnames=0"
+#   - We use net.ifnames=0 to disable consistent network naming here because on
+#     different firmwares (BIOS vs UEFI) the NIC names are different.
+#     See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# - architectures: !s390x
+#   - appendKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,8 +1,5 @@
 #!/bin/bash
 # kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0", "architectures": "!s390x"}
-# - We use net.ifnames=0 to disable consistent network naming here because on
-#   different firmwares (BIOS vs UEFI) the NIC names are different.
-#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 
 # Configuring MTU on a VLAN subinterface for the bond,
 # - verify MTU on the bond matches config
@@ -10,8 +7,18 @@
 # - verify ip address on the VLAN subinterface for the bond matches config
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1932502#c9
 
-# https://github.com/coreos/fedora-coreos-config/issues/1499
-# - Disable the test on s390x
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - additionalNics: 2
+#   - Add 2 NIC for this test
+# - appendKernelArgs: "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0"
+#   - Configuration of the 2 NICs for this test
+#   - We use net.ifnames=0 to disable consistent network naming here because on
+#     different firmwares (BIOS vs UEFI) the NIC names are different.
+#     See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# - architectures: !s390x
+#   - appendKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -9,13 +9,22 @@ set -xeuo pipefail
 #   configuration wins, verify that eth1 gets ip via dhcp
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-# - We use net.ifnames=0 to disable consistent network naming here because on
-#   different firmwares (BIOS vs UEFI) the NIC names are different.
-#   See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 
 # https://github.com/coreos/fedora-coreos-config/issues/1499
 # - Disable the test on s390x
 # kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0", "architectures": "!s390x" }
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - additionalNics: 1
+#   - Add 1 NIC for this test
+# - appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0"
+#   - The functionality we're testing here and the configuration for the NIC
+#   - We use net.ifnames=0 to disable consistent network naming here because on
+#     different firmwares (BIOS vs UEFI) the NIC names are different.
+#     See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+# - architectures: !s390x
+#   - appendKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
On s390x, we do not need the fwupd package and newer versions of it cause problems in RHCOS, see https://github.com/openshift/os/issues/752.

I also put in a commit to not run the `ext.config.networking.kargs-rd-net` test on s390x, as it suffers from the same root problem of not correctly applying extra kernel arguments as the other new networking tests. See https://github.com/coreos/fedora-coreos-config/issues/1499#issuecomment-1076338932

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>