### PR TITLE
[next] overrides: fast-track rust-coreos-installer-0.13.1-3.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  coreos-installer:
+    evr: 0.13.1-3.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0813365f58
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.13.1-3.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0813365f58
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
+      type: fast-track
   systemd:
     evr: 249.7-2.fc35
     metadata:


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).