### PR TITLE
[rawhide] overrides: fast-track rust-coreos-installer-0.13.1-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  coreos-installer:
+    evr: 0.13.1-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a48e2d1845
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.13.1-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a48e2d1845
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
+      type: fast-track


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).