### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,25 +9,13 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  coreos-installer:
-    evr: 0.13.1-3.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a48e2d1845
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.13.1-3.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a48e2d1845
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
-      type: fast-track
   iproute:
     evr: 5.15.0-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142 
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142
       type: pin
   iproute-tc:
     evr: 5.15.0-1.fc36
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142 
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142
       type: pin


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).