### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,9 +21,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0813365f58
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
       type: fast-track
-  ignition:
-    evr: 2.13.0-5.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-cfe402447e
-      reason: https://github.com/coreos/ignition/issues/1092
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).