### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,27 +9,10 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  coreos-installer:
-    evr: 0.13.1-3.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-952a857303
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.13.1-3.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-952a857303
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1116
-      type: fast-track
   flatpak-session-helper:
     evr: 1.12.7-1.fc36
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-ed21aecd23
-      type: fast-track
-  skopeo:
-    evr: 1:1.6.0-1.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bb9c00e112
       type: fast-track
   vim-data:
     evra: 2:8.2.4621-1.fc36.noarch


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).