### PR TITLE
Use bigtime=1 for XFS by default

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,10 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# See https://github.com/coreos/fedora-coreos-tracker/pull/51
+rootfs: "xfs"
+# See https://man7.org/linux/man-pages/man8/xfs_admin.8.html
+# Let's opt-in to supporting bigger timestamps as a forward looking
+# system.
+rootfs-args: "-m bigtime=1"

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -12,6 +12,22 @@ fatal() {
     exit 1
 }
 
+_TEST_TEMPDIR=""
+ensure_tmpdir() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    cd "${tmpdir}"
+    touch .tmpdir
+}
+
+cleanup_tmpdir() {
+    tmpdir=$(pwd)
+    cd /
+    if test -f "${tmpdir}"/.tmpdir; then
+        rm -rf "${tmpdir}"
+    fi
+}
+
 get_ipv4_for_nic() {
     local nic_name=$1
     local ip=$(ip -j addr show ${nic_name} | jq -r '.[0].addr_info | map(select(.family == "inet")) | .[0].local')

--- a/tests/kola/disks/root-xfs-bigtime
+++ b/tests/kola/disks/root-xfs-bigtime
@@ -1,0 +1,21 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+# Test that we have bigtime=1 for XFS
+# xref https://man7.org/linux/man-pages/man8/xfs_admin.8.html
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+tmpd=$(mktemp -d) && trap 'rm -rf ${tmpd}' EXIT
+cd "${tmpd}"
+
+if stat -f / | grep 'Type: xfs'; then
+    xfs_info / > xfsinfo.txt
+    if ! grep -q bigtime=1 xfsinfo.txt; then
+        fatal "failed to find bigtime=1 for /"
+    fi
+else
+    echo "notice: rootfs was not xfs"
+fi
+ok xfs bigtime


### PR DESCRIPTION
I was randomly looking at kernel changes recently and noticed
that XFS today has the [Year 2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem)
by default.

While one would hope that most FCOS systems are deployed in a
reprovisionable environment, and are reprovisioned...let's still
be forward looking here and enable this by default - but only
for the testing-devel stream for now.