### PR TITLE
[rawhide] overrides: drop iproute pin; pin kernel

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,14 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  iproute:
-    evr: 5.15.0-1.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142
-      type: pin
-  iproute-tc:
-    evr: 5.15.0-1.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1142
-      type: pin
+packages: {}

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
+      type: pin
+  kernel-core:
+    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
+      type: pin
+  kernel-modules:
+    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
+      type: pin


### PR DESCRIPTION
```
commit 646cde0a43785c70a70bd36381bbdbba64476c9f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 4 09:10:34 2022 -0400

    overrides: pin on kernel-5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
    
    The newer kernel-5.18.0-0.rc0.20220401gite8b767f5e04097a.15.fc37
    gives us circular locking dep warnings and it causes failures in our
    tests.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/1152

commit c64f88665dd8d0b2d2d898d3cd247b7af6c2284e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 4 09:08:21 2022 -0400

    overrides: drop iproute-5.15.0-1.fc36 pin
    
    A new version of iproute has been released without the python dep
    any longer.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1142
```
