### PR TITLE
manifest: Remove libvarlink-util in next stream

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -123,8 +123,6 @@ packages:
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
   # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071338097
   - containernetworking-plugins podman-plugins dnsmasq
-  # Remote IPC for podman
-  - libvarlink-util
   # Minimal NFS client
   - nfs-utils-coreos
   # Active Directory support


### PR DESCRIPTION
Remove libvarlink-util package for `next` stream.