### PR TITLE
[rawhide] overrides: drop kernel pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,19 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  kernel:
-    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
-      type: pin
-  kernel-core:
-    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
-      type: pin
-  kernel-modules:
-    evr: 5.18.0-0.rc0.20220325git34af78c4e616.7.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1152
-      type: pin
+packages: {}


### PR DESCRIPTION
We no longer check for circular locking deps [1] so we can unpin
the kernel now.

[1] https://github.com/coreos/coreos-assembler/pull/2796