### PR TITLE
manifest: Drop libvarlink-util for next stream

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -18,6 +18,13 @@ ostree-layers:
   - overlay/20platform-chrony
 
 conditional-include:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1130
+  - if: stream == "testing-devel"
+    include: varlink.yaml
+  - if: stream == "testing"
+    include: varlink.yaml
+  - if: stream == "stable"
+    include: varlink.yaml
   # https://github.com/coreos/fedora-coreos-tracker/issues/676
   - if: releasever >= 36
     include: iptables-nft.yaml
@@ -123,8 +130,6 @@ packages:
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
   # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071338097
   - containernetworking-plugins podman-plugins dnsmasq
-  # Remote IPC for podman
-  - libvarlink-util
   # Minimal NFS client
   - nfs-utils-coreos
   # Active Directory support

--- a/manifests/varlink.yaml
+++ b/manifests/varlink.yaml
@@ -1,0 +1,5 @@
+# Include libvarlink-util package selectively
+# before we drop it from the remaining streams 
+# https://github.com/coreos/fedora-coreos-tracker/issues/1130
+packages:
+  - libvarlink-util


### PR DESCRIPTION
Include the libvarlink package for selected streams conditionally. Removed the package for next stream as an initial step to fully drop it.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1130