### PR TITLE
denylist: extend snooze for ext.config.systemd.sytemd-journald-fix

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,7 +23,7 @@
   - ppc64le
 - pattern: ext.config.systemd.sytemd-journald-fix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1108#issuecomment-1061988853
-  snooze: 2022-04-01
+  snooze: 2022-04-20
   streams:
     - stable
     - testing


### PR DESCRIPTION
The fix has landed upstream and we're just waiting for a new rpm
build in Fedora. For now let's keep snoozing.