### PR TITLE
tests/kola/kubernetes/kube-watch: rework journal grepping

### DIFF
--- a/tests/kola/kubernetes/kube-watch/config.bu
+++ b/tests/kola/kubernetes/kube-watch/config.bu
@@ -12,14 +12,11 @@ systemd:
     - name: kube-watch.service
       # This is for verifying that `kubernetes_file_t` labeled files can be
       # watched by systemd
-      # NOTE: we've observed a race where the journal message shows up as
-      # coming from `echo` rather than `kube-watch`, so we're embedding
-      # a UUID in the message to make it easier to find.
       # See: https://github.com/coreos/fedora-coreos-tracker/issues/861
       # See: https://github.com/containers/container-selinux/issues/135
       contents: |
         [Service]
-        ExecStart=/usr/bin/echo "This is the kube-watch unique id: 27a259a8-7f2d-4144-8b8f-23dd201b630c"
+        ExecStart=/usr/bin/touch /var/tmp/kube-watched
         RemainAfterExit=yes
         Type=oneshot
         [Install]

--- a/tests/kola/kubernetes/kube-watch/test.sh
+++ b/tests/kola/kubernetes/kube-watch/test.sh
@@ -17,21 +17,22 @@ ok "kube-watch.path successfully activated"
 touch /etc/kubernetes/kubeconfig
 ok "successfully created /etc/kubernetes/kubeconfig"
 
-# If we check the status too soon it could still be activating..
-# Sleep in a loop until it's done "activating"
-while [ "$(systemctl is-active kube-watch.service)" == "activating" ]; do
-    echo "kube-watch is activating. sleeping for 1 second"
+# Give the service 30 seconds to activate
+active=0
+for i in {1..30}; do
+    if systemctl is-active kube-watch.service; then
+        active=1
+        break
+    fi
     sleep 1
 done
-if [ "$(systemctl is-active kube-watch.service)" != "active" ]; then
+if [[ $active != 1 ]]; then
+    systemctl status kube-watch.service
     fatal "kube-watch.service did not successfully activate"
 fi
 ok "kube-watch.service activated successfully"
 
-# NOTE: we've observed a race where the journal message shows up as
-# coming from `echo` rather than `kube-watch`, so we're embedding
-# a UUID in the message to make it easier to find.
-if ! journalctl -o cat -b | grep 27a259a8-7f2d-4144-8b8f-23dd201b630c; then
-    fatal "kube-watch.service did not print message to journal"
+if ! test -e /var/tmp/kube-watched; then
+    fatal "/var/tmp/kube-watched does not exist"
 fi
-ok "Found message from kube-watch.service in journal"
+ok "/var/tmp/kube-watched exists"


### PR DESCRIPTION
The way we check the systemd unit status is racy. Instead, wait up to 30
seconds for the journal message to appear. And then verify that the
service is active.

While we're here, use `journalctl`'s built-in `--grep`.

Also while we're here, use `-u kube-watch.service` to be more
constrained, which allows us to drop the unique UUID.

Closes: https://github.com/coreos/fedora-coreos-config/issues/1637