### PR TITLE
denylist: snooze ext.config.files.dracut-executable

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -30,3 +30,8 @@
     - testing-devel
     - next
     - next-devel
+- pattern: ext.config.files.dracut-executable
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1155
+  snooze: 2022-04-18
+  streams:
+    - rawhide


### PR DESCRIPTION
Snooze the ext.config.files.dracut-executable test because a new
package came in that is causing it to fail. We'll investigate over
in https://github.com/coreos/fedora-coreos-tracker/issues/1155.