### PR TITLE
manifests: work around non-executable initrd script in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -30,8 +30,3 @@
     - testing-devel
     - next
     - next-devel
-- pattern: ext.config.files.dracut-executable
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1155
-  snooze: 2022-04-18
-  streams:
-    - rawhide

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -117,6 +117,20 @@ postprocess:
       echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
     fi
 
+  # Fedora 37 adds the nvmf dracut module to the initrd, causing
+  # ext.config.files.dracut-executable to notice that the module puts a
+  # non-executable file in /usr/sbin.  Dracut has been updated to fix the
+  # missing permission, and hopefully this can be removed for Fedora 38.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1155
+  # https://github.com/dracutdevs/dracut/pull/1777
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    source /etc/os-release
+    if [ ${VERSION_ID} -le 37 ]; then
+        chmod +x /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
+    fi
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.


### PR DESCRIPTION
The `95nvmf` Dracut module has always shipped a non-executable script, but we didn't notice until the rawhide `nvme` package caused that module to start installing itself.  Fix the executable bit until the upstream Dracut fix can propagate.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1155.