### PR TITLE
05core/usr/libexec: avoid displaying duplicated Ignition warnings

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-ignition-write-issues
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-write-issues
@@ -27,10 +27,29 @@ behavior may occur. Ignition is not designed to run more than once per system.
 ${RESET}
 EOF
     fi
-    # This is for displaying Ignition warnings on the console
-    # TODO: find a way to query journal entries recorded before the system switches to real root
-    journalctl -t ignition -o cat -p warning | while read line; do
-        echo "Ignition: $line" >> /etc/issue.d/30_coreos_ignition_warnings.issue
+    # In Ignition, we've two config validation checks, the one after 
+    # fetching a config and the second after merging configs. Sometimes, 
+    # a warning goes away after merging, however, it's possible that a 
+    # warning appears in case merging creates a contradiction between 
+    # two fields. So this workflow eventually sends duplicate warnings 
+    # in journal entries. Hence, we need to avoid displaying duplicate 
+    # Ignition warnings on the console.
+    # For e.g. In the journal entries, we might see the following logs:
+    #
+    # warning at $.systemd.units.0.contents, line 1 col 997: unit "echo@.service" is enabled, but has no install section so enable does nothing 
+    # warning at $.systemd.units.0.contents: unit "echo@.service" is enabled, but has no install section so enable does nothing
+    # 
+    # In order to normalize these logs, we'd need to get rid of the line 
+    # and column numbers entirely using the sed command, and then use 
+    # `sort -u` to remove duplicate content. After this, we'd see the 
+    # following warning on the console:
+    #
+    # warning at $.systemd.units.0.contents: unit "echo@.service" is enabled, but has no install section so enable does nothing
+    #
+    # TODO: find a way to query journal entries recorded before the 
+    # system switches to real root
+    journalctl -t ignition -o cat -p warning | sed -r 's/, line [0-9]+ col [0-9]+//g' | sort -u | while read line; do
+        echo -e "${WARN}Ignition: $line${RESET}" >> /etc/issue.d/30_coreos_ignition_warnings.issue
     done
 else
     nreboots=$(($(journalctl --list-boots | wc -l) - 1))


### PR DESCRIPTION
In Ignition, we've two config validation checks, the one after fetching a config and the second after merging configs. Sometimes,
a warning goes away after merging, however, it's possible that a warning appears in case merging creates a contradiction between two fields. So this workflow eventually sends duplicate warnings in journal entries.

In the following example, the first warning is displayed after fetching a config (normal workflow), and the second one came after merging, so our task is to filter duplicate warnings.
```
Ignition: warning at $.systemd.units.0.contents, line 1 col 997: unit "echo@.service" is enabled, but has no install section so enable does nothing 
Ignition: warning at $.systemd.units.0.contents: unit "echo@.service" is enabled, but has no install section so enable does nothing
```
Output after this change:
```bash
Fedora CoreOS 35.20220413.dev.0
Kernel 5.16.18-200.fc35.x86_64 on an x86_64 (ttyS0)

SSH host key: SHA256:v4x1LauCLSbepvwV25KDTVgtw+8UN+uWdXwb6E/ZuLE (ED25519)
SSH host key: SHA256:Hd4XRpDVScGnsFHr4aSX0UpASbiLKyj8DwPdVTExd+4 (ECDSA)
SSH host key: SHA256:g4h0U+/ZDTfDtLk9/7x9wAsf+Ddji4/E2pY4hyrWSTM (RSA)
ens6: 10.0.2.15 fe80::a3fe:6bf8:46b:65f7
Ignition: ran on 2022/04/13 15:22:40 UTC (this boot)
Ignition: user-provided config was applied
Ignition: warning at $.systemd.units.0.contents: unit "echo.service" is enabled, but has no install section so enable does nothing

```