### PR TITLE
Re-enable kdump.crash for aarch64 in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,7 +8,6 @@
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
-    - aarch64
     - ppc64le
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105


### PR DESCRIPTION
Re-enabling kdump.crash for aarch64 for rawhide stream.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1075#issuecomment-1098060867