### PR TITLE
tests: ensure that Ignition warnings are displayed on the console

### DIFF
--- a/tests/kola/clhm/ignition-warnings/config.bu
+++ b/tests/kola/clhm/ignition-warnings/config.bu
@@ -1,0 +1,16 @@
+variant: fcos
+version: 1.1.0
+systemd:
+  # This systemd unit doesn't have the Install
+  # section in it, so as part of the validation 
+  # step, Ignition will throw the following warning:
+  # 'warning at $.systemd.units.0.contents: unit "echo@.service" is enabled, but has no install section so enable does nothing'
+  units:
+    - name: echo.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=echo service template
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/echo %i

--- a/tests/kola/clhm/ignition-warnings/data/commonlib.sh
+++ b/tests/kola/clhm/ignition-warnings/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/clhm/ignition-warnings/test.sh
+++ b/tests/kola/clhm/ignition-warnings/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: { "platforms": "qemu-unpriv", "allowConfigWarnings": true }
+# - platforms: qemu-unpriv 
+#   - This test should pass everywhere if it passes anywhere. 
+# - allowConfigWarnings: true 
+#   - We intentionally exclude the Install section from a systemd unit.  
+#     This is valid but not ideal, so Butane warns about it.  
+# This test ensures that Ignition warnings are displayed on the console.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+WARN='\033[0;33m' # yellow
+RESET='\033[0m' # reset
+
+warningsfile="/etc/issue.d/30_coreos_ignition_warnings.issue"
+tmpd=$(mktemp -d)
+expectedwarningsfile="${tmpd}"/expectedwarningsfile
+
+# Check for the motd file
+if ! test -f ${warningsfile}; then
+    fatal "not found Ignition warnings issue file"
+fi
+
+echo -e "${WARN}Ignition: warning at $.systemd.units.0.contents: unit \"echo.service\" is enabled, but has no install section so enable does nothing${RESET}" > $expectedwarningsfile
+
+if ! diff $expectedwarningsfile $warningsfile; then
+    fatal "Ignition warning did not show up as expected in issue.d"
+fi
+ok "Successfully displayed Ignition warning on the console"


### PR DESCRIPTION
Follow up to https://github.com/coreos/fedora-coreos-config/pull/1621#pullrequestreview-930860551
This adds kola test coverage for displaying Ignition warnings on the console.