### PR TITLE
tests/memory: check kernel messages for oom-killer

### DIFF
--- a/tests/kola/memory/data/commonlib.sh
+++ b/tests/kola/memory/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/memory/oom-killer
+++ b/tests/kola/memory/oom-killer
@@ -1,0 +1,13 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+#
+# This test checks kernel messages for the occurance of oom-killer
+# https://bugzilla.redhat.com/show_bug.cgi?id=1931467
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+if dmesg | grep -q oom-killer; then
+    fatal "Error: found oom-killer in kernel messages"
+fi


### PR DESCRIPTION
Verify that oom-killer does not show up in dmesg.

https://bugzilla.redhat.com/show_bug.cgi?id=1931467