### PR TITLE
Re-enable kdump.crash for aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,7 +8,6 @@
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
-    - aarch64
     - ppc64le
 - pattern: multipath.day1
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1105


### PR DESCRIPTION
Re-enabling kdump.crash for aarch64 for testing-devel.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1075#issuecomment-1098060867

The test looks to be passing for `37.20220419.91.0` , `35.20220418.20.0` and `36.20220418.10.0` .