### PR TITLE
05core: report `ENOSPC` in initrd when entering e-shell

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-timeout/module-setup.sh
@@ -15,7 +15,8 @@ install_unit_wants() {
 install() {
     inst_multiple \
         cut \
-        date
+        date \
+        dd
 
     inst_hook emergency 99 "${moddir}/timeout.sh"
 


### PR DESCRIPTION
When a user tries to boot a live system with an appended rootfs without enough RAM, the kernel will unpack the initramfs and rootfs until it runs out of memory, and then continue booting with a partial OS image.  This causes random confusing boot errors, such as a service failing because its binary is missing, or the rootfs squashfs failing to mount with some error that looks like filesystem corruption.

Make this failure less confusing by having `timeout.sh` try to write a small file, and if that fails, tell the user that they need more RAM.  Suppress reporting of unit failures in this case, since the unit logs will just muddy the issue.

This works reliably when the rootfs image can't be unpacked, i.e. when the system has a moderate amount of RAM.  It doesn't work reliably when we're so low on RAM that the initramfs image can't be unpacked (because the compressed initramfs and rootfs images have used up our RAM); in that case we might be missing important binaries/libraries and boot can fail at any point.  It would be possible to construct a more robust detection mechanism, e.g. by running a statically-linked program that's unpacked first.  But this can't be completely robust (`/sbin/init` might not have been unpacked, so we might not boot at all) and doesn't seem worth it for now.

This code will also trigger if we run out of RAM in the `coreos.live.rootfs_url` case, which is nice but less important, since that
case produces a clear error during rootfs fetch.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1055.