### PR TITLE
remove multipathd socket workaround

### DIFF
--- a/manifests/shared-workarounds.yaml
+++ b/manifests/shared-workarounds.yaml
@@ -2,32 +2,6 @@
 # and downstreams (i.e. Red Hat CoreOS).
 
 postprocess:
-  # Put in the fix for multipathd.socket on releases that haven't been fixed yet.
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2008098
-  # https://github.com/coreos/fedora-coreos-config/pull/1246
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    # Operate on RHCOS and FCOS. 
-    source /etc/os-release
-    if [[ ${NAME} =~ "Fedora" ]]; then
-        # FCOS: Only operate on releases before F36. The fix has landed
-        # in F36+ and there is no need for a workaround.
-        [ ${VERSION_ID} -le 35 ] || exit 0
-    else 
-        # RHCOS: The fix hasn't landed in any version of RHEL yet
-        true
-    fi
-    mkdir /usr/lib/systemd/system/multipathd.socket.d
-    cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'
-    # Temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2008098
-    [Unit]
-    ConditionKernelCommandLine=!multipath=off
-    ConditionKernelCommandLine=!nompath
-    ConditionPathExists=/etc/multipath.conf
-    ConditionVirtualization=!container
-    EOF
-
   # Put in the fix for multipathd.service in dracut on releases that haven't
   # been fixed yet.
   # https://github.com/dracutdevs/dracut/pull/1606
@@ -40,7 +14,7 @@ postprocess:
         # FCOS: This fix hasn't landed in rawhide (F36) yet,
         # but hopefully will soon.
         [ ${VERSION_ID} -le 36 ] || exit 0
-    else 
+    else
         # RHCOS: The fix hasn't landed in any version of RHEL yet
         true
     fi


### PR DESCRIPTION
The fixed systemd unit for the `multipathd.service` landed in RHEL
8.4.z as part of `device-mapper-multipath-0.8.4-10.el8_4.3` and it is
landing in RHEL 8.4.z, which will be consumed by RHCOS 4.10.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2054876