### PR TITLE
manifests: drop the multipath.socket workaround on RHCOS

### DIFF
--- a/manifests/shared-workarounds.yaml
+++ b/manifests/shared-workarounds.yaml
@@ -8,21 +8,16 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-    # Operate on RHCOS and FCOS. 
+    # Operate on RHCOS and FCOS.
     source /etc/os-release
     if [[ ${NAME} =~ "Fedora" ]]; then
         # FCOS: Only operate on releases before F36. The fix has landed
         # in F36+ and there is no need for a workaround.
         [ ${VERSION_ID} -le 35 ] || exit 0
     elif [[ "${ID}" == "rhel" ]]; then
-        # RHCOS: Only operate on releases before RHEL8.5. The fix has 
-        # landed in RHEL8.6+ and there is no need for a workaround.
-        # https://bugzilla.redhat.com/show_bug.cgi?id=2008101
-        # Fixed RPM version: device-mapper-multipath-0.8.4-18.el8
-        # Using generic redhat-release package according to 
-        # https://github.com/openshift/os/pull/713, should check RHEL version
-        # with VERSION_ID
-        [ ${VERSION_ID//.} -le 85 ] || exit 0
+        # RHCOS: The fix has landed in RHEL 8.6, 8.5.z, 8.4.z EUS, so we should
+        # be able to just exit out safely.
+        exit 0
     fi
     mkdir /usr/lib/systemd/system/multipathd.socket.d
     cat > /usr/lib/systemd/system/multipathd.socket.d/50-start-conditions.conf <<'EOF'
@@ -45,7 +40,7 @@ postprocess:
     if [[ ${NAME} =~ "Fedora" ]]; then
         # FCOS: This fix has landed in F36+
         [ ${VERSION_ID} -le 35 ] || exit 0
-    else 
+    else
         # RHCOS: The fix hasn't landed in any version of RHEL yet
         true
     fi


### PR DESCRIPTION
The fixed systemd unit for the multipathd.socket is now present in
RHEL 8.6, RHEL 8.5.z, and RHEL 8.4.z EUS, so let's stop applying
the workaround on RHCOS systems.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2008101
See: https://bugzilla.redhat.com/show_bug.cgi?id=2054877
See: https://bugzilla.redhat.com/show_bug.cgi?id=2054876