### PR TITLE
overrides: fast-track downgraded package

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  bind-libs:
+    evr: 32:9.16.28-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-64bbdcf7e5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  bind-license:
+    evra: 32:9.16.28-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-64bbdcf7e5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  bind-utils:
+    evr: 32:9.16.28-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-64bbdcf7e5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
   containerd:
     evr: 1.6.2-1.fc36
     metadata:
@@ -25,6 +43,30 @@ packages:
     evr: 1.7.7-1.fc36
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-dc0b6ca2cd
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  gdisk:
+    evr: 1.0.9-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-02a3900f62
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  kernel:
+    evr: 5.17.4-300.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e5d04200e2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  kernel-core:
+    evr: 5.17.4-300.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e5d04200e2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  kernel-modules:
+    evr: 5.17.4-300.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-e5d04200e2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
   libipa_hbac:
@@ -171,15 +213,33 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-cdc3365ffc
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
-  vim-data:
-    evra: 2:8.2.4701-1.fc36.noarch
+  tzdata:
+    evra: 2022a-2.fc36.noarch
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-44f5b2df35
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-35dd99034a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  vim-data:
+    evra: 2:8.2.4804-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b43cbc3d2e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
   vim-minimal:
-    evr: 2:8.2.4701-1.fc36
+    evr: 2:8.2.4804-1.fc36
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-44f5b2df35
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b43cbc3d2e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  xz:
+    evr: 5.2.5-9.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-07cd35f6b8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      type: fast-track
+  xz-libs:
+    evr: 5.2.5-9.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-07cd35f6b8
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track


### PR DESCRIPTION
Fast-track the downgraded package as it was older in `next-devel` than in `testing-devel`

Follow up on https://github.com/coreos/fedora-coreos-config/pull/1688.