### PR TITLE
Disable kdump.crash test for aws

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,6 +8,12 @@
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
+    - aarch64
+  platforms:
+    - aws
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
+  arches:
     - ppc64le
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725


### PR DESCRIPTION
Disable kdump.crash for aws platform due to CI [failure](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-aws/251/) on `kola-aws`