### PR TITLE
overrides: fast-track selinux-policy-36.7-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -147,6 +147,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b547780983
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
+  selinux-policy:
+    evra: 36.7-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-76963fee71
+      reason: https://pagure.io/releng/issue/10670#comment-794029
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 36.7-1.fc36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-76963fee71
+      reason: https://pagure.io/releng/issue/10670#comment-794029
+      type: fast-track
   squashfs-tools:
     evr: 4.5.1-1.fc36
     metadata:


### PR DESCRIPTION
Let's match what has been requested for stable but hasn't made it into
the latest compose yet. The compose had trouble.

See https://pagure.io/releng/issue/10670#comment-794029