### PR TITLE
[stable] denylist: convert sytemd-journald-fix test from snooze

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,7 +23,6 @@
   - ppc64le
 - pattern: ext.config.systemd.sytemd-journald-fix
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1108#issuecomment-1061988853
-  snooze: 2022-04-20
   streams:
     - stable
     - testing


### PR DESCRIPTION
The snooze expired and we're seeing it fail in the `stable` build.