### PR TITLE
image.yaml: Switch to `ostree-format: "oci-chunked"`

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,5 +3,5 @@
 # streams.
 include: image-base.yaml
 
-# https://github.com/coreos/coreos-assembler/pull/2216
-ostree-format: "oci"
+# Plan to move this to all streams soon
+ostree-format: "oci-chunked"


### PR DESCRIPTION
OK, it's time to start trying this out in "production".

https://bodhi.fedoraproject.org/updates/FEDORA-2022-4813f1daaf
is queued (and already in coreos-assembler).

I've pushed an updated demo of this to `quay.io/cgwalters/fcos-chunked`
which you can try today.