### PR TITLE
[next-devel] overrides: fast-track rust-coreos-installer-0.14.0-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,6 +33,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-eda0049dd7
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
+  coreos-installer:
+    evr: 0.14.0-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-3aa1ba8c72
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.14.0-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-3aa1ba8c72
+      type: fast-track
   ethtool:
     evr: 2:5.17-1.fc36
     metadata:


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).