### PR TITLE
[next-devel] overrides: fast-track selinux-policy-36.8-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -158,16 +158,16 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
   selinux-policy:
-    evra: 36.7-1.fc36.noarch
+    evra: 36.8-1.fc36.noarch
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-76963fee71
-      reason: https://pagure.io/releng/issue/10670#comment-794029
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-47789bbc9d
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1156
       type: fast-track
   selinux-policy-targeted:
-    evra: 36.7-1.fc36.noarch
+    evra: 36.8-1.fc36.noarch
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-76963fee71
-      reason: https://pagure.io/releng/issue/10670#comment-794029
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-47789bbc9d
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1156
       type: fast-track
   squashfs-tools:
     evr: 4.5.1-1.fc36


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).