### PR TITLE
overrides: fast-track rust-afterburn-5.3.0-1.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  afterburn:
+    evr: 5.3.0-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bec21e906f
+      reason: https://github.com/coreos/afterburn/issues/733
+      type: fast-track
+  afterburn-dracut:
+    evr: 5.3.0-1.fc35
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bec21e906f
+      reason: https://github.com/coreos/afterburn/issues/733
+      type: fast-track
   coreos-installer:
     evr: 0.14.0-1.fc35
     metadata:


### PR DESCRIPTION
Requested by @sohankunkerkar via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).