### PR TITLE
manifests: add curl to file-transfer manifest

### DIFF
--- a/manifests/file-transfer.yaml
+++ b/manifests/file-transfer.yaml
@@ -3,3 +3,6 @@ packages:
   - git-core
   - gnupg2
   - rsync
+  # Explicit dependency on curl because we use it in coreos-livepxe-rootfs.sh
+  # We need curl and not curl-minimal because we support TFTP.
+  - curl


### PR DESCRIPTION
This is used in coreos-livepxe-rootfs.sh [1], although I'm sure there
are probably more places too.

[1] https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh