### PR TITLE
updates for `ext.config.kdump.crash` test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,12 +8,6 @@
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
-    - aarch64
-  platforms:
-    - aws
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
-  arches:
     - ppc64le
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -17,6 +17,9 @@ conditional-include:
   - if: prod == false
     # long-term, would be good to support specifying a nested TreeComposeConfig
     include: disable-zincati-and-pinger.yaml
+  - if: basearch == "aarch64"
+    # Fixup for kdump on aarch64 AWS instances
+    include: kdump-aarch64-aws-workaround.yaml
 
 ostree-layers:
   - overlay/15fcos
@@ -85,6 +88,7 @@ postprocess:
     cat /usr/etc/rpm-ostreed.conf >> /tmp/rpm-ostreed.conf
     cp /tmp/rpm-ostreed.conf /usr/etc/rpm-ostreed.conf
     rm /tmp/rpm-ostreed.conf
+
 
 remove-from-packages:
   # Drop NetworkManager support for ifcfg files, see also corresponding

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -20,6 +20,9 @@ conditional-include:
   - if: basearch == "aarch64"
     # Fixup for kdump on aarch64 AWS instances
     include: kdump-aarch64-aws-workaround.yaml
+  - if: basearch != "s390x"
+    # And remove some cruft from grub2
+    include: grub2-removals.yaml
 
 ostree-layers:
   - overlay/15fcos
@@ -122,9 +125,3 @@ exclude-packages:
   # For (datacenter/cloud oriented) servers, we want to see the details by default.
   # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
   - plymouth
-
-# And remove some cruft from grub2
-arch-include:
-  x86_64: grub2-removals.yaml
-  aarch64: grub2-removals.yaml
-  ppc64le: grub2-removals.yaml

--- a/manifests/kdump-aarch64-aws-workaround.yaml
+++ b/manifests/kdump-aarch64-aws-workaround.yaml
@@ -1,0 +1,12 @@
+# This file includes a fixup for kdump on aarch64 AWS instances.
+# The issue seems specific to aarch64 AWS instances, but we'll go
+# ahead and apply it across the board for aarch64, since that's
+# the easiest thing to do. Hopefully the upstream issue will get
+# resolved soon.
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    # Remove irqpoll from the list of KDUMP_COMMANDLINE_APPEND. This
+    # causes issues on aarch64 AWS instances.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1187
+    sed -i -e 's/irqpoll //' /etc/sysconfig/kdump

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -37,3 +37,14 @@ packages:
   # Boost starving threads
   # https://github.com/coreos/fedora-coreos-tracker/issues/753
   - stalld
+
+postprocess:
+  # Make kdump work on firstboot
+  - |
+    #!/usr/bin/env bash
+    # Make kdump ignore `ignition.firstboot` when copying kargs from
+    # the running kernel to the kdump kernel when passing to be kexec.
+    # This makes it so kdump can be set up on the very first boot.
+    # Upstream request to have this upstream so we can stop carrying it here:
+    # https://lists.fedoraproject.org/archives/list/kexec@lists.fedoraproject.org/thread/5P4WIJLW2TSGF4PZGRZGOXYML4RXZU23/
+    sed -i -e 's/KDUMP_COMMANDLINE_REMOVE="/KDUMP_COMMANDLINE_REMOVE="ignition.firstboot /' /etc/sysconfig/kdump

--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -1,0 +1,9 @@
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_exist:
+    - crashkernel=256M
+systemd:
+  units:
+    - name: kdump.service
+      enabled: true

--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -2,7 +2,7 @@ variant: fcos
 version: 1.4.0
 kernel_arguments:
   should_exist:
-    - crashkernel=256M
+    - crashkernel=300M
 systemd:
   units:
     - name: kdump.service

--- a/tests/kola/kdump/crash/data/commonlib.sh
+++ b/tests/kola/kdump/crash/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -10,11 +10,6 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-      rpm-ostree kargs --append='crashkernel=256M'
-      systemctl enable kdump.service
-      /tmp/autopkgtest-reboot setcrashkernel
-      ;;
-  setcrashkernel)
       /tmp/autopkgtest-reboot-prepare aftercrash
       echo "Triggering sysrq"
       sync

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
-# kola: {"minMemory": 4096, "tags": "skip-base-checks", "architectures": "!s390x"}
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
-# https://github.com/coreos/fedora-coreos-config/issues/1500
-# - kdump.service is failling on s390x
+# kola: {"minMemory": 4096, "tags": "skip-base-checks", "timeoutMin": 15, "architectures": "!s390x"}
+# - minMemory: 4096
+#   - Testing kdump requires some reserved memory for the crashkernel.
+# - tags: skip-base-checks
+#   - Skip checks for things like kernel crashes in the console logs.
+#     For this test we trigger a kernel crash on purpose.
+# - architectures: !s390x
+#   - kdump.service is failing on s390x. See
+#     https://github.com/coreos/fedora-coreos-config/issues/1500
+# - timeoutMin: 15
+#   - This test includes a few reboots and the generation of a vmcore,
+#     which can take longer than the default 10 minute timeout.
 
 set -xeuo pipefail
 


### PR DESCRIPTION
```
commit 0be55468cac2a70f3f943909202579765a2bef67
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed May 4 14:50:06 2022 -0400

    manifests/fedora-coreos: switch grub2-removals to conditional-include
    
    This move the `arch-include` statments to `conditional-include`, which
    allows us to use `!=`. In this case what we were really trying to target
    was s390x IIUC.

commit 03156146da01544ba434360e91a0042a2879078b
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun May 1 23:01:42 2022 -0400

    manifests/fedora-coreos: fix kdump.crash test for aarch64 AWS
    
    The irqpoll` karg that gets added when the crash kernel is
    started causes issues on AWS aarch64 instances. Let's workaround
    by removing that from `KDUMP_COMMANDLINE_APPEND` in
    `/etc/sysconfig/kdump` for now.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/1187

commit ccb5447a1afd454ec7d143fec187960f588fadb4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue May 3 10:24:06 2022 -0400

    tests: kdump.crash: update crashkernel size based on our docs
    
    In our documentation [1] we recommend setting it to 300M as a
    starting baseline. Let's update from 256M to 300M here.
    
    [1] https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/

commit d69f0256f667e2351d747cd9523511138bf8f6db
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun May 1 23:13:29 2022 -0400

    tests: kdump.crash: extend timeout
    
    The kdump.crash test on the rawhide stream for aarch64 has started
    taking just longer than 10 minutes. Let's extend the timeout so those
    tests don't timeout and fail the entire run.
    
    Also added comments for the test's kola.json arguments.

commit 7eeb6b738ef3e48b0fdbc0243da1e7f805ca28e6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun May 1 22:55:45 2022 -0400

    make kdump work on first boot
    
    Up until this point people have had to reboot once after setting up
    kdump so that if a crash happens the crash kernel doesn't get started
    with the ignition.firstboot kernel argument. If we add `ignition.firstboot`
    to the list of arguments in `KDUMP_COMMANDLINE_REMOVE=` in
    `/etc/sysconfig/kdump` then we can set it up on first boot without issues.
    
    Here we also switch the kdump.crash test to set up kdump via Ignition
    to prove out the change works as desired.

```