### PR TITLE
ci/continuous: New container that pulls from continuous COPR

### DIFF
--- a/ci/continuous/Dockerfile
+++ b/ci/continuous/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/coreos-assembler/fcos:testing-devel
+ADD fcos-continuous.repo /etc/yum.repos.d
+ADD overrides.yaml /etc/rpm-ostree/origin.d/overrides.yaml
+RUN rpm-ostree ex rebuild

--- a/ci/continuous/fcos-continuous.repo
+++ b/ci/continuous/fcos-continuous.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:group_CoreOS:continuous]
+name=Copr repo for continuous owned by @CoreOS
+baseurl=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/ci/continuous/overrides.yaml
+++ b/ci/continuous/overrides.yaml
@@ -1,0 +1,11 @@
+ex-override-replace:
+  - from:
+      repo: copr:copr.fedorainfracloud.org:group_CoreOS:continuous
+    packages:
+      - ostree
+      - ostree-libs
+      - rpm-ostree
+      - rpm-ostree-libs
+      - ignition
+      - coreos-installer
+      - coreos-installer-bootinfra


### PR DESCRIPTION
History goes in cycles.  One of the key original raison d'être of
ostree was having people consume git main/master of projects.  But...
because RPM doesn't make it easy to revert things, we really
end up going only at the same speed as the rest of Fedora sadly.

Anyways, we've talked about this a few times in FCOS; xref
https://github.com/coreos/fedora-coreos-tracker/issues/910

This adds a container image that is built *as* a container layering
on top of the base image, using the recently landed
https://github.com/coreos/rpm-ostree/pull/3605/

My plan is to add build automation (in the pipeline? or OCP Prow?)
that sticks this at e.g. `quay.io/coreos-assembler/fcos:testing-devel-continous`.