### PR TITLE
tests/kola/ignition: port resource fetching tests from mantle; move to new bucket; test `s3://` with versioned resources

### DIFF
--- a/tests/kola/ignition/resource/remote/config.bu
+++ b/tests/kola/ignition/resource/remote/config.bu
@@ -11,6 +11,12 @@ storage:
     - path: /var/resource/s3-anon
       contents:
         source: "s3://rh-kola-fixtures/resources/anonymous"
+    - path: /var/resource/s3-versioned-original
+      contents:
+        source: "s3://rh-kola-fixtures/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
+    - path: /var/resource/s3-versioned-latest
+      contents:
+        source: "s3://rh-kola-fixtures/resources/versioned"
     - path: /var/resource/s3-versioned-https-original
       contents:
         source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"

--- a/tests/kola/ignition/resource/remote/config.bu
+++ b/tests/kola/ignition/resource/remote/config.bu
@@ -4,22 +4,22 @@ storage:
   files:
     - path: /var/resource/http
       contents:
-        source: "http://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
+        source: "http://ignition-test-fixtures.s3.amazonaws.com/resources/anonymous"
     - path: /var/resource/https
       contents:
-        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
+        source: "https://ignition-test-fixtures.s3.amazonaws.com/resources/anonymous"
     - path: /var/resource/s3-anon
       contents:
-        source: "s3://rh-kola-fixtures/resources/anonymous"
+        source: "s3://ignition-test-fixtures/resources/anonymous"
     - path: /var/resource/s3-versioned-original
       contents:
-        source: "s3://rh-kola-fixtures/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
+        source: "s3://ignition-test-fixtures/resources/versioned?versionId=Y9YqVujoLyHHSHJ4DslyXoaLvcilQJnU"
     - path: /var/resource/s3-versioned-latest
       contents:
-        source: "s3://rh-kola-fixtures/resources/versioned"
+        source: "s3://ignition-test-fixtures/resources/versioned"
     - path: /var/resource/s3-versioned-https-original
       contents:
-        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
+        source: "https://ignition-test-fixtures.s3.amazonaws.com/resources/versioned?versionId=Y9YqVujoLyHHSHJ4DslyXoaLvcilQJnU"
     - path: /var/resource/s3-versioned-https-latest
       contents:
-        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned"
+        source: "https://ignition-test-fixtures.s3.amazonaws.com/resources/versioned"

--- a/tests/kola/ignition/resource/remote/config.bu
+++ b/tests/kola/ignition/resource/remote/config.bu
@@ -1,0 +1,19 @@
+variant: fcos
+version: 1.0.0
+storage:
+  files:
+    - path: /var/resource/http
+      contents:
+        source: "http://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
+    - path: /var/resource/https
+      contents:
+        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous"
+    - path: /var/resource/s3-anon
+      contents:
+        source: "s3://rh-kola-fixtures/resources/anonymous"
+    - path: /var/resource/s3-versioned-https-original
+      contents:
+        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned?versionId=Ym98GTx0npVaJznSAd0I1eUjFoZMP8Zo"
+    - path: /var/resource/s3-versioned-https-latest
+      contents:
+        source: "https://rh-kola-fixtures.s3.amazonaws.com/resources/versioned"

--- a/tests/kola/ignition/resource/remote/data/commonlib.sh
+++ b/tests/kola/ignition/resource/remote/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../data/commonlib.sh

--- a/tests/kola/ignition/resource/remote/data/expected/http
+++ b/tests/kola/ignition/resource/remote/data/expected/http
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/remote/data/expected/https
+++ b/tests/kola/ignition/resource/remote/data/expected/https
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/remote/data/expected/s3-anon
+++ b/tests/kola/ignition/resource/remote/data/expected/s3-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/remote/data/expected/s3-versioned-https-latest
+++ b/tests/kola/ignition/resource/remote/data/expected/s3-versioned-https-latest
@@ -1,0 +1,1 @@
+updated

--- a/tests/kola/ignition/resource/remote/data/expected/s3-versioned-https-original
+++ b/tests/kola/ignition/resource/remote/data/expected/s3-versioned-https-original
@@ -1,0 +1,1 @@
+original

--- a/tests/kola/ignition/resource/remote/data/expected/s3-versioned-latest
+++ b/tests/kola/ignition/resource/remote/data/expected/s3-versioned-latest
@@ -1,0 +1,1 @@
+updated

--- a/tests/kola/ignition/resource/remote/data/expected/s3-versioned-original
+++ b/tests/kola/ignition/resource/remote/data/expected/s3-versioned-original
@@ -1,0 +1,1 @@
+original

--- a/tests/kola/ignition/resource/remote/test.sh
+++ b/tests/kola/ignition/resource/remote/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# kola: { "tags": "needs-internet" }
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
+    fatal "fetched data mismatch"
+else
+    ok "fetched data ok"
+fi

--- a/tests/kola/ignition/resource/s3/config.bu
+++ b/tests/kola/ignition/resource/s3/config.bu
@@ -1,0 +1,14 @@
+# Objects accessible by any authenticated S3 user, such as the IAM role
+# associated with the instance
+
+variant: fcos
+version: 1.0.0
+ignition:
+  config:
+    merge:
+      - source: "s3://rh-kola-fixtures/resources/authenticated-var-v3.ign"
+storage:
+  files:
+    - path: /var/resource/s3-auth
+      contents:
+        source: "s3://rh-kola-fixtures/resources/authenticated"

--- a/tests/kola/ignition/resource/s3/config.bu
+++ b/tests/kola/ignition/resource/s3/config.bu
@@ -6,9 +6,9 @@ version: 1.0.0
 ignition:
   config:
     merge:
-      - source: "s3://rh-kola-fixtures/resources/authenticated-var-v3.ign"
+      - source: "s3://ignition-test-fixtures/resources/authenticated-var-v3.ign"
 storage:
   files:
     - path: /var/resource/s3-auth
       contents:
-        source: "s3://rh-kola-fixtures/resources/authenticated"
+        source: "s3://ignition-test-fixtures/resources/authenticated"

--- a/tests/kola/ignition/resource/s3/data/commonlib.sh
+++ b/tests/kola/ignition/resource/s3/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../data/commonlib.sh

--- a/tests/kola/ignition/resource/s3/data/expected/s3-auth
+++ b/tests/kola/ignition/resource/s3/data/expected/s3-auth
@@ -1,0 +1,1 @@
+kola-authenticated

--- a/tests/kola/ignition/resource/s3/data/expected/s3-config
+++ b/tests/kola/ignition/resource/s3/data/expected/s3-config
@@ -1,0 +1,1 @@
+kola-config

--- a/tests/kola/ignition/resource/s3/test.sh
+++ b/tests/kola/ignition/resource/s3/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# kola: { "tags": "needs-internet", "platforms": "aws" }
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
+    fatal "fetched data mismatch"
+else
+    ok "fetched data ok"
+fi
+
+# verify that the objects are inaccessible anonymously
+for obj in authenticated authenticated.ign; do
+    if curl -sf "https://rh-kola-fixtures.s3.amazonaws.com/resources/$obj"; then
+        fatal "anonymously fetching authenticated resource should have failed, but did not"
+    fi
+done
+
+# ...but that the anonymous object is accessible
+if ! curl -sf "https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous" > /dev/null; then
+    fatal "anonymous resource is inaccessible"
+fi
+
+ok "resource checks ok"


### PR DESCRIPTION
Reimplement tests from `mantle/kola/tests/ignition/resource.go`, using a bucket in a non-deprecated AWS account:

- `coreos.ignition.resource.remote`
- `coreos.ignition.resource.s3`
- `coreos.ignition.resource.s3.versioned` (merged into `.remote` test, since it's only separate for historical reasons)

Also test fetching versioned resources via `s3://`.