### PR TITLE
kola/systemd-enable-units: remove journal check

### DIFF
--- a/tests/kola/ignition/systemd-enable-units/config.bu
+++ b/tests/kola/ignition/systemd-enable-units/config.bu
@@ -2,15 +2,15 @@ variant: fcos
 version: 1.3.0
 systemd:
   units:
-    - name: echo@.service
+    - name: touch@.service
       contents: |
         [Service]
         Type=oneshot
-        ExecStart=/bin/echo %i
+        ExecStart=/bin/touch /run/%i
         RemainAfterExit=yes
         [Install]
         WantedBy=multi-user.target
-    - name: echo@foo.service
+    - name: touch@foo.service
       enabled: true
     - name: podman.socket
       enabled: true

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -12,16 +12,16 @@ set -xeuo pipefail
 . $KOLA_EXT_DATA/commonlib.sh
 
 # make sure the presets worked and the instantiated unit is enabled
-if [ "$(systemctl is-enabled echo@foo.service)" != 'enabled' ]; then
-    fatal "echo@foo.service systemd unit should be enabled"
+if [ "$(systemctl is-enabled touch@foo.service)" != 'enabled' ]; then
+    fatal "touch@foo.service systemd unit should be enabled"
 fi
-ok "echo@foo.service systemd unit is enabled"
+ok "touch@foo.service systemd unit is enabled"
 
-# make sure the unit ran and wrote 'foo' to the journal
-if [ "$(journalctl -o cat -u echo@foo.service | sed -n 2p)" != 'foo' ]; then
-    fatal "echo@foo.service did not write 'foo' to journal"
+# make sure the unit ran
+if ! test -e /run/foo; then
+    fatal "touch@foo.service didn't run as /run/foo does not exist"
 fi
-ok "echo@foo.service ran and wrote 'foo' to the journal"
+ok "touch@foo.service ran as /run/foo exists"
 
 if [ "$(systemctl is-enabled podman.socket)" != 'enabled' ]; then
     fatal "podman.socket systemd unit should be enabled"


### PR DESCRIPTION
Instead of writing to journal, we just check a file that the systemd unit should have touched at `/run` exists.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1190