### PR TITLE
tests/kola/ignition: add S3 ARN tests; test intra-cloud anonymous S3/GCS access

### DIFF
--- a/tests/kola/ignition/resource/authenticated-gs/config.bu
+++ b/tests/kola/ignition/resource/authenticated-gs/config.bu
@@ -9,6 +9,10 @@ ignition:
       - source: "gs://ignition-test-fixtures/resources/authenticated-var.ign"
 storage:
   files:
+    # Check that anonymous access works with credentials
+    - path: /var/resource/gs-anon
+      contents:
+        source: "gs://ignition-test-fixtures/resources/anonymous"
     - path: /var/resource/gs-auth
       contents:
         source: "gs://ignition-test-fixtures/resources/authenticated"

--- a/tests/kola/ignition/resource/authenticated-gs/data/expected/gs-anon
+++ b/tests/kola/ignition/resource/authenticated-gs/data/expected/gs-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/authenticated-s3/config.bu
+++ b/tests/kola/ignition/resource/authenticated-s3/config.bu
@@ -9,6 +9,10 @@ ignition:
       - source: "s3://ignition-test-fixtures/resources/authenticated-var-v3.ign"
 storage:
   files:
+    # Check that anonymous access works with credentials
+    - path: /var/resource/s3-anon
+      contents:
+        source: "s3://ignition-test-fixtures/resources/anonymous"
     - path: /var/resource/s3-auth
       contents:
         source: "s3://ignition-test-fixtures/resources/authenticated"

--- a/tests/kola/ignition/resource/authenticated-s3/config.bu
+++ b/tests/kola/ignition/resource/authenticated-s3/config.bu
@@ -2,7 +2,7 @@
 # associated with the instance
 
 variant: fcos
-version: 1.0.0
+version: 1.5.0-experimental
 ignition:
   config:
     merge:
@@ -12,3 +12,20 @@ storage:
     - path: /var/resource/s3-auth
       contents:
         source: "s3://ignition-test-fixtures/resources/authenticated"
+    - path: /var/resource/arn-auth
+      contents:
+        source: "arn:aws:s3:::ignition-test-fixtures/resources/authenticated"
+    # Publicly-readable object, fetched via an access point.  Access points
+    # don't allow anonymous access.
+    - path: /var/resource/arn-ap-anon
+      contents:
+        source: "arn:aws:s3:us-east-1:460538899914:accesspoint/ignition-test-fixtures-ap/object/resources/anonymous"
+    - path: /var/resource/arn-ap-auth
+      contents:
+        source: "arn:aws:s3:us-east-1:460538899914:accesspoint/ignition-test-fixtures-ap/object/resources/authenticated"
+    - path: /var/resource/arn-ap-versioned-original
+      contents:
+        source: "arn:aws:s3:us-east-1:460538899914:accesspoint/ignition-test-fixtures-ap/object/resources/versioned?versionId=Y9YqVujoLyHHSHJ4DslyXoaLvcilQJnU"
+    - path: /var/resource/arn-ap-versioned-latest
+      contents:
+        source: "arn:aws:s3:us-east-1:460538899914:accesspoint/ignition-test-fixtures-ap/object/resources/versioned"

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-anon
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-auth
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-auth
@@ -1,0 +1,1 @@
+kola-authenticated

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-versioned-latest
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-versioned-latest
@@ -1,0 +1,1 @@
+updated

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-versioned-original
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-ap-versioned-original
@@ -1,0 +1,1 @@
+original

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-auth
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/arn-auth
@@ -1,0 +1,1 @@
+kola-authenticated

--- a/tests/kola/ignition/resource/authenticated-s3/data/expected/s3-anon
+++ b/tests/kola/ignition/resource/authenticated-s3/data/expected/s3-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/remote/config.bu
+++ b/tests/kola/ignition/resource/remote/config.bu
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.2.0
+version: 1.5.0-experimental
 storage:
   files:
     - path: /var/resource/http
@@ -26,3 +26,12 @@ storage:
     - path: /var/resource/s3-versioned-https-latest
       contents:
         source: "https://ignition-test-fixtures.s3.amazonaws.com/resources/versioned"
+    - path: /var/resource/arn-anon
+      contents:
+        source: "arn:aws:s3:::ignition-test-fixtures/resources/anonymous"
+    - path: /var/resource/arn-versioned-original
+      contents:
+        source: "arn:aws:s3:::ignition-test-fixtures/resources/versioned?versionId=Y9YqVujoLyHHSHJ4DslyXoaLvcilQJnU"
+    - path: /var/resource/arn-versioned-latest
+      contents:
+        source: "arn:aws:s3:::ignition-test-fixtures/resources/versioned"

--- a/tests/kola/ignition/resource/remote/data/expected/arn-anon
+++ b/tests/kola/ignition/resource/remote/data/expected/arn-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/remote/data/expected/arn-versioned-latest
+++ b/tests/kola/ignition/resource/remote/data/expected/arn-versioned-latest
@@ -1,0 +1,1 @@
+updated

--- a/tests/kola/ignition/resource/remote/data/expected/arn-versioned-original
+++ b/tests/kola/ignition/resource/remote/data/expected/arn-versioned-original
@@ -1,0 +1,1 @@
+original

--- a/tests/kola/ignition/resource/remote/test.sh
+++ b/tests/kola/ignition/resource/remote/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # kola: { "tags": "needs-internet" }
 # - tags: needs-internet
-#   - We fetch resources from S3.
+#   - We fetch resources from S3 and GCS.
 
 set -xeuo pipefail
 

--- a/tests/kola/ignition/resource/remote/test.sh
+++ b/tests/kola/ignition/resource/remote/test.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# kola: { "tags": "needs-internet" }
+# kola: { "tags": "needs-internet", "noInstanceCreds": true }
 # - tags: needs-internet
 #   - We fetch resources from S3 and GCS.
+# - noInstanceCreds: don't pass AWS or GCP credentials to instance
+#   - This test verifies that Ignition can fetch anonymous resources within
+#     a cloud platform (S3 -> EC2, GCS -> GCE) when no credentials are
+#     supplied
 
 set -xeuo pipefail
 


### PR DESCRIPTION
Test the new ARN support in Ignition 2.14.0.  S3 access points can't be accessed anonymously, so even the public objects need to be tested from inside an EC2 instance.  Also test unauthenticated S3->EC2 and GCS->GCE fetches; the latter fails on Ignition < 2.14.0.