### PR TITLE
manifests: drop libvarlink conditional includes

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -18,13 +18,6 @@ ostree-layers:
   - overlay/20platform-chrony
 
 conditional-include:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1130
-  - if: stream == "testing-devel"
-    include: varlink.yaml
-  - if: stream == "testing"
-    include: varlink.yaml
-  - if: stream == "stable"
-    include: varlink.yaml
   # https://github.com/coreos/fedora-coreos-tracker/issues/676
   - if: releasever >= 36
     include: iptables-nft.yaml

--- a/manifests/varlink.yaml
+++ b/manifests/varlink.yaml
@@ -1,5 +1,0 @@
-# Include libvarlink-util package selectively
-# before we drop it from the remaining streams 
-# https://github.com/coreos/fedora-coreos-tracker/issues/1130
-packages:
-  - libvarlink-util


### PR DESCRIPTION
Now that we have waited an amount of time let's drop libvarlink-util
altogether.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1130