### PR TITLE
[next-devel] overrides: fast-track vim-8.2.4845-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -122,14 +122,14 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
       type: fast-track
   vim-data:
-    evra: 2:8.2.4804-1.fc36.noarch
+    evra: 2:8.2.4845-1.fc36.noarch
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b43cbc3d2e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f5352c759
+      reason: https://github.com/coreos/fedora-coreos-config/pull/1720#issuecomment-1120068560
       type: fast-track
   vim-minimal:
-    evr: 2:8.2.4804-1.fc36
+    evr: 2:8.2.4845-1.fc36
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b43cbc3d2e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1101#issuecomment-1085987923
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f5352c759
+      reason: https://github.com/coreos/fedora-coreos-config/pull/1720#issuecomment-1120068560
       type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).