### PR TITLE
tests/kola/chrony: fix running test on GCP

### DIFF
--- a/tests/kola/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/chrony/coreos-platform-chrony-generator
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "exclusive": false, "platforms": "aws azure gcp" }
+# kola: { "exclusive": false, "platforms": "aws azure gce" }
 # Test the coreos-platform-chrony generator.
 
 set -xeuo pipefail


### PR DESCRIPTION
kola calls the platform `gce` for historical reasons.