### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,28 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  afterburn:
-    evr: 5.3.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bec21e906f
-      reason: https://github.com/coreos/afterburn/issues/733
-      type: fast-track
-  afterburn-dracut:
-    evr: 5.3.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bec21e906f
-      reason: https://github.com/coreos/afterburn/issues/733
-      type: fast-track
-  coreos-installer:
-    evr: 0.14.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b5d122ac00
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.14.0-1.fc35
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-b5d122ac00
-      type: fast-track
   systemd:
     evr: 249.12-3.fc35
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).