### PR TITLE
tests/kola/chrony: grep metadata server IP on GCP

### DIFF
--- a/tests/kola/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/chrony/coreos-platform-chrony-generator
@@ -8,6 +8,6 @@ platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d 
 case "${platform}" in
     aws) chronyc sources |grep '169.254.169.123'; echo "ok chrony aws" ;;
     azure) chronyc sources |grep 'PHC'; echo "ok chrony azure" ;;
-    gcp) chronyc sources | grep metadata.google.internal; echo "ok chrony gcp" ;;
+    gcp) chronyc sources | grep '169.254.169.254'; echo "ok chrony gcp" ;;
     *) echo "unhandled platform ${platform} ?"; exit 1 ;;
 esac


### PR DESCRIPTION
The output of `chronyc sources` on GCP contains the resolved IP address,
even though the config we write uses the hostname. GCP documents[1] the
IP address of the metadata server as 169.254.169.254 so we can just
hardcode it here like we do for AWS.

[1] https://cloud.google.com/compute/docs/internal-dns