### PR TITLE
overrides: fast-track ostree-2022.3-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  ostree:
+    evr: 2022.3-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-893b870b9b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/701
+      type: fast-track
+  ostree-libs:
+    evr: 2022.3-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-893b870b9b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/701
+      type: fast-track


### PR DESCRIPTION
Has fixes for selinux UX. See
https://github.com/coreos/fedora-coreos-tracker/issues/701