### PR TITLE
[rhcos-4.10] kola: re-enable kdump.crash for aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,5 +12,3 @@
     - rawhide
   arches:
     - aarch64
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/860

--- a/tests/kola/kdump/crash
+++ b/tests/kola/kdump/crash
@@ -3,7 +3,7 @@ set -xeuo pipefail
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
 # Only run on QEMU x86_64 for now:
 # https://github.com/coreos/fedora-coreos-tracker/issues/860
-# kola: {"platforms": "qemu-unpriv", "minMemory": 4096, "tags": "skip-base-checks", "architectures": "x86_64"}
+# kola: {"platforms": "qemu-unpriv", "minMemory": 4096, "tags": "skip-base-checks", "architectures": "x86_64 aarch64"}
 
 fatal() {
     echo "$@" >&2


### PR DESCRIPTION
Tested and re-enabling kdump test for aarch64

Issue: https://issues.redhat.com/browse/COS-1200