### PR TITLE
workflows: fix override-handling jobs with current Git

### DIFF
--- a/.github/workflows/add-override.yml
+++ b/.github/workflows/add-override.yml
@@ -48,6 +48,9 @@ jobs:
           # We need an unbroken commit chain when pushing to the fork.  Don't
           # make assumptions about which commits are already available there.
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Update metadata
         env:
           TARGET: ${{ github.event.inputs.target }}

--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ matrix.branch }}
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Remove graduated overrides
         run: |
           git config user.name 'CoreOS Bot'


### PR DESCRIPTION
When running Git in a containerized job, we need to tell it that repos not owned by the current user are safe.

Sample failing jobs: [add-override](https://github.com/coreos/fedora-coreos-config/actions/runs/2309622296), [remove-graduated-overrides](https://github.com/coreos/fedora-coreos-config/actions/runs/2317724942).