### PR TITLE
tests/kdump.crash: add in sleep to workaround XFS race condition

### DIFF
--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -23,6 +23,10 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
           fatal "kdump.service failed to start"
       fi
       /tmp/autopkgtest-reboot-prepare aftercrash
+      # Add in a sleep to workaround race condition where XFS/kernel errors happen
+      # during crash kernel boot.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1195
+      sleep 5
       echo "Triggering sysrq"
       sync
       echo 1 > /proc/sys/kernel/sysrq

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -19,6 +19,9 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
+      if [ $(systemctl show -p Result kdump.service) != "Result=success" ]; then
+          fatal "kdump.service failed to start"
+      fi
       /tmp/autopkgtest-reboot-prepare aftercrash
       echo "Triggering sysrq"
       sync


### PR DESCRIPTION

This seems to make the test no longer fail. We still need to investigate
the root cause. See https://github.com/coreos/fedora-coreos-tracker/issues/1195

Also add in a check to make sure the kdump.service comes up OK.