### PR TITLE
overrides: fast-track ignition-2.14.0-1.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,6 +15,11 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aa2f62aabd
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1138
       type: fast-track
+  ignition:
+    evr: 2.14.0-1.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5df5dc8ec5
+      type: fast-track
   ostree:
     evr: 2022.3-2.fc36
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).