### PR TITLE
[rawhide] overrides: fast-track ignition-2.14.0-1.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  ignition:
+    evr: 2.14.0-1.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-891e0e1d4e
+      type: fast-track
   systemd:
     evr: 251~rc2-2.fc37
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).