### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,12 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  containerd:
-    evr: 1.6.4-1.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-aa2f62aabd
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1138
-      type: fast-track
   ignition:
     evr: 2.14.0-1.fc36
     metadata:
@@ -37,16 +31,4 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d4936254ad
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1167
-      type: fast-track
-  ostree:
-    evr: 2022.3-3.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d9971c4e47
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/701
-      type: fast-track
-  ostree-libs:
-    evr: 2022.3-3.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d9971c4e47
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/701
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).