### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,21 +14,3 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5df5dc8ec5
       type: fast-track
-  kernel:
-    evr: 5.17.9-300.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d4936254ad
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1167
-      type: fast-track
-  kernel-core:
-    evr: 5.17.9-300.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d4936254ad
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1167
-      type: fast-track
-  kernel-modules:
-    evr: 5.17.9-300.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d4936254ad
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1167
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).