### PR TITLE
tests/kdump.crash: bump crashkernel size, add check for future

### DIFF
--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -2,7 +2,10 @@ variant: fcos
 version: 1.4.0
 kernel_arguments:
   should_exist:
-    - crashkernel=300M
+    # We need to make sure we have a large enough crashkernel for FCOS
+    # and RHCOS here. Currently the worst case is aarch64 RHCOS where
+    # the `kdumpctl estimate` says "Recommended crashkernel: 448M"
+    - crashkernel=500M
 systemd:
   units:
     - name: kdump.service

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -22,6 +22,11 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       if [ $(systemctl show -p Result kdump.service) != "Result=success" ]; then
           fatal "kdump.service failed to start"
       fi
+      # Verify that the crashkernel reserved memory is large enough
+      output=$(kdumpctl estimate)
+      if grep -q "WARNING: Current crashkernel size is lower than recommended size" <<< "$output"; then
+          fatal "The reserved crashkernel size is lower than recommended."
+      fi
       /tmp/autopkgtest-reboot-prepare aftercrash
       # Add in a sleep to workaround race condition where XFS/kernel errors happen
       # during crash kernel boot.


### PR DESCRIPTION
It turns out kdump has a tool that can be used to estimate the
appropriate size for the crashkernel reserved memory known as
`kdumpctl estimate`. On FCOS/RHCOS here are the numbers I saw
for the architectures in our universe:

```
- 161M aarch64 FCOS
- 448M aarch64 RHCOS

- 134M ppc64le FCOS
- 384M ppc64le RHCOS

- 192M s390x FCOS
- 160M s390x RHCOS

- 157M x86_64 FCOS
- 165M x86_64 RHCOS
```

Bump the crashkernel here to 500M to handle our worst case and also
add a check to make sure that if we ever are under the minimum
recommended size we'll get notified.