### PR TITLE
ci/overrides: don't load sack if overrides empty

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -277,9 +277,6 @@ def setup_repos(base, treefile):
         base.repos[repo].enable()
         eprint(f"- {repo}")
 
-    eprint("Downloading metadata")
-    base.fill_sack(load_system_repo=False)
-
 
 def get_lockfiles():
     lockfiles = ['manifest-lock.overrides.yaml']
@@ -296,8 +293,12 @@ def graduate_lockfile(base, fn):
 
     with open(fn) as f:
         lockfile = yaml.safe_load(f)
-    if 'packages' not in lockfile:
+    if len(lockfile.get('packages', {})) == 0:
         return
+
+    if base.sack is None:
+        eprint("Downloading metadata")
+        base.fill_sack(load_system_repo=False)
 
     new_packages = {}
     for name, lock in lockfile['packages'].items():


### PR DESCRIPTION
Right now, `next-devel` and `branched` are inactive. But to reduce
churn, the `remove-graduated-overrides` GitHub Action is left running on
those branches since it's harmless. However, the repos on inactive
branches might not be valid, causing workflow failures.

But anyway, there are no active overrides on these branches, so we can
work around this by exiting earlier.

I think a more appropriate fix for this is to query whether `next-devel`
is open or closed (though we'd need something similar for `branched`
too), but we do also want this optimization anyway.