### PR TITLE
kola-denylist.yaml: disable ext.config.file.trust-cpu

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,3 +33,5 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
   arches:
   - s390x
+- pattern: ext.config.files.trust-cpu
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1209


### PR DESCRIPTION
see: https://github.com/coreos/fedora-coreos-tracker/issues/1209