### PR TITLE
kola-denylist.yaml: disable ext.config.files.trust-cpu on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,3 +33,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
   arches:
   - s390x
+- pattern: ext.config.files.trust-cpu
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1209
+  streams:
+  - rawhide


### PR DESCRIPTION
see https://github.com/coreos/fedora-coreos-tracker/issues/1209