### PR TITLE
tests: fix trust-cpu test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,7 +33,3 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
   arches:
   - s390x
-- pattern: ext.config.files.trust-cpu
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1209
-  streams:
-  - rawhide

--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -6,16 +6,12 @@ set -xeuo pipefail
 . $KOLA_EXT_DATA/commonlib.sh
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1830280
-tmpd=$(mktemp -d)
-cd "${tmpd}"
 case "$(arch)" in
     x86_64)
-        dmesg | grep ' random:' > random.txt
-        if ! grep -qe 'crng.*done.*trust.*CPU' <random.txt; then
-            sed -e 's/^/# /' < random.txt
+        config=$(grep ^CONFIG_RANDOM_TRUST_CPU /lib/modules/$(uname -r)/config)
+        if [ "$config" != "CONFIG_RANDOM_TRUST_CPU=y" ]; then
             fatal "Error: Failed to find crng trusting CPU"
         fi
         ok "random trust cpu" ;;
     *) echo "Don't know how to test hardware RNG state on arch=$(arch)" ;;
 esac
-rm -r "${tmpd}"


### PR DESCRIPTION
As mentioned in https://github.com/coreos/fedora-coreos-tracker/issues/1209,
due to upstream changes, our current mechanism for testing
if RANDOM_TRUST_CPU is enabled is no longer valid. Lets instead
check the kernel config file to get the same information.

fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1209