### PR TITLE
denylist: deny `ext.config.ignition.resource.remote` on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,3 +33,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
   arches:
   - s390x
+- pattern: ext.config.ignition.resource.remote
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  arches:
+  - s390x


### PR DESCRIPTION
We're seeing a weird failure there. Let's denylist it for now while
it is investigated.

See https://github.com/coreos/fedora-coreos-tracker/issues/1215