### PR TITLE
coreos-teardown-initramfs: handle new .txt file in ifcfg dir

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -94,9 +94,11 @@ are_default_NM_configs() {
 propagate_initramfs_networking() {
     # Check for any real root config in the two locations where a user could have
     # provided network configuration. On FCOS we only support keyfiles, but on RHCOS
-    # we support keyfiles and ifcfg
+    # we support keyfiles and ifcfg. We also need to ignore readme-ifcfg-rh.txt
+    # which is a cosmetic file added in
+    # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/96d7362
     if [ -n "$(ls -A /sysroot/etc/NetworkManager/system-connections/)" -o \
-         -n "$(ls -A /sysroot/etc/sysconfig/network-scripts/)" ]; then
+         -n "$(ls -A -I readme-ifcfg-rh.txt /sysroot/etc/sysconfig/network-scripts/)" ]; then
         echo "info: networking config is defined in the real root"
         realrootconfig=1
     else


### PR DESCRIPTION
Upstream NM started adding a readme-ifcfg-rh.txt file to explain
and encourage people to use keyfiles instead. This file doesn't
do anything, but breaks our logic that tries to determine if the
user provided networking config to the machine.

This file was added upstream in
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/96d7362