### PR TITLE
tests: verify no unknown files in /etc/sysconfig/network-scripts/

### DIFF
--- a/tests/kola/networking/no-default-initramfs-net-propagation/data/test-net-propagation.sh
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/data/test-net-propagation.sh
@@ -10,3 +10,10 @@ if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
     fail=1
 fi
 
+# Also check /etc/sysconfig/network-scripts/ because ifcfg files are
+# supported downstream. Need to ignore readme-ifcfg-rh.txt here because of
+# https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/96d7362
+if [ -n "$(ls -A -I readme-ifcfg-rh.txt /etc/sysconfig/network-scripts/)" ]; then
+    echo "configs exist in /etc/sysconfig/network-scripts/, but shouldn't" >&2
+    fail=1
+fi


### PR DESCRIPTION
Add a check to the no-default-initramfs-net-propagation test to make
sure there aren't any unknown files in /etc/sysconfig/network-scripts/.
This will allow us to drop the a corresponding test from mantle/kola [1].

[1] https://github.com/coreos/coreos-assembler/blob/5ee768b7ea069c08a7fa0b5b36dbb03bc9cd19ee/mantle/kola/tests/coretest/core.go#L251-L264