### PR TITLE
workflows: add stamp file in `openshift/os` to ensure we push rebases

### DIFF
--- a/.github/workflows/openshift-os.yml
+++ b/.github/workflows/openshift-os.yml
@@ -53,7 +53,14 @@ jobs:
               echo "No non-trivial changes; exiting"
               exit 0
           fi
+
+          base=$(git rev-parse HEAD)
           git checkout testing-devel
+          # Hack: update a stamp to force create-pull-request to update the
+          # branch, even if we're just rebasing on a previous manual
+          # fedora-coreos-config sync
+          # https://github.com/peter-evans/create-pull-request/issues/1191
+          echo $base > ../.fedora-coreos-config-base
 
           marker=OPENSHIFT-OS-END-OF-LOG-MARKER-$RANDOM$RANDOM$RANDOM
           cat >> $GITHUB_ENV <<EOF


### PR DESCRIPTION
The `create-pull-request` action currently only force-pushes branches if their diff has changed.  However, if we've meanwhile landed a parallel `fedora-coreos-config` update PR via a different branch, the diff might be the same but the base commit will be different.  We need to push the branch in this case too, or else the PR will be left unmergeable due to conflicts.  As a workaround, write the base commit ID into a stamp file in the root of `openshift/os`, so the diff will change whenever the base does.

Works around https://github.com/peter-evans/create-pull-request/issues/1191.