### PR TITLE
denylist: drop denials for some s390x tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,23 +17,7 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
-- pattern: rpmostree.install-uninstall
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1204
-  arches:
-  - s390x
-- pattern: rpmostree.upgrade-rollback
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1205
-  arches:
-  - s390x
-- pattern: ostree.hotfix
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1207
-  arches:
-  - s390x
 - pattern: multipath.day2
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
-  arches:
-  - s390x
-- pattern: ext.config.ignition.resource.remote
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
   arches:
   - s390x


### PR DESCRIPTION
The tests 
- https://github.com/coreos/fedora-coreos-tracker/issues/1204 , 
- https://github.com/coreos/fedora-coreos-tracker/issues/1205, 
- https://github.com/coreos/fedora-coreos-tracker/issues/1207 

no longer fail because of an `ostree-2022.4-2.fc36 `update.

The `ext.config.ignition.resource.remote` (https://github.com/coreos/fedora-coreos-tracker/issues/1215) seems to be passing now as well (Not sure what changed there, but happy to see it passing.)