### PR TITLE
[rawhide] overrides: remove systemd-251~rc2-2.fc37 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,34 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  systemd:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
-  systemd-container:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
-  systemd-libs:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
-  systemd-pam:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
-  systemd-resolved:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
-  systemd-udev:
-    evr: 251~rc2-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1200
-      type: pin
+packages: {}


### PR DESCRIPTION
Based on the fixes in referenced systemd PR in https://github.com/coreos/fedora-coreos-tracker/issues/1200 we can remove the systemd-251~rc2-2.fc37 pin from the overrides.
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1200