### PR TITLE
overrides: fast-track ostree-2022.4-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  ostree:
+    evr: 2022.4-2.fc37
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1204'
+      type: fast-track
+  ostree-devel:
+    evr: 2022.4-2.fc37
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1205'
+      type: fast-track
+  ostree-libs:
+    evr: 2022.4-2.fc37
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1207'
+      type: fast-track
+  ostree-tests:
+    evr: 2022.4-2.fc37
+    metadata:
+      reason: 'https://github.com/coreos/fedora-coreos-tracker/issues/1207'
+      type: fast-track


### PR DESCRIPTION
To fix the tests
- kola: s390x: test rpmostree.install-uninstall fails fedora-coreos-tracker#1204 ,
- kola: s390x: test rpmostree.upgrade-rollback fails fedora-coreos-tracker#1205,
- kola: s390x: ostree.hotfix test fails fedora-coreos-tracker#1207

that fail in `rawhide` branch which can be bumped if ostree-2022.4-2.fc37 is used.