### PR TITLE
denylist: deny ext.config.ignition.resource.remote on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,3 +21,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
   arches:
   - s390x
+- pattern: ext.config.ignition.resource.remote
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  arches:
+  - s390x


### PR DESCRIPTION
Turns out the issue is a race condition and we need to denylist it
again while we investigate it more.

See https://github.com/coreos/fedora-coreos-tracker/issues/1215