### PR TITLE
kola-denylist.yaml: denylist ext.config.extensions.module

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,3 +25,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
   arches:
   - s390x
+- pattern: ext.config.extension.module
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1229
+  streams:
+  - rawhide


### PR DESCRIPTION
The test is failing in rawhide so let's denylist it there
for now.

see: https://github.com/coreos/fedora-coreos-tracker/issues/1229