### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,23 +19,3 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-28295ab6c4
       type: fast-track
-  ostree:
-    evr: 2022.4-2.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1204
-      type: fast-track
-  ostree-devel:
-    evr: 2022.4-2.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1205
-      type: fast-track
-  ostree-libs:
-    evr: 2022.4-2.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1207
-      type: fast-track
-  ostree-tests:
-    evr: 2022.4-2.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1207
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).