### PR TITLE
Revert "overrides: fast-track kernel-5.18.4-201.fc36"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,21 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 5.18.4-201.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-4810298c00
-      type: fast-track
-  kernel-core:
-    evr: 5.18.4-201.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-4810298c00
-      type: fast-track
-  kernel-modules:
-    evr: 5.18.4-201.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-4810298c00
-      type: fast-track
   afterburn:
     evr: 5.3.0-2.fc36
     metadata:


### PR DESCRIPTION
This reverts commit a9a8e2a4423c52f96ab4407574a8738ce463e79e.

It was only a test to see if the 5.18 kernel would pass all pipeline
tests on various platforms. It passed! Now we can go back to tracking
what is in bodhi stable for the kernel.