### PR TITLE
overlay.d: make generators run once

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -12,6 +12,16 @@ set -e
 # https://github.com/systemd/systemd/issues/15638
 exec 1>/dev/kmsg; exec 2>&1
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
+self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 UNIT_DIR="${1:-/tmp}"
 
 cmdline=( $(</proc/cmdline) )

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -6,6 +6,16 @@
 # https://github.com/systemd/systemd/issues/15638
 exec 1>/dev/kmsg; exec 2>&1
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
+self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 command -v getarg >/dev/null || . /usr/lib/dracut-lib.sh
 
 set -e

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-generator
@@ -4,6 +4,16 @@
 # https://github.com/systemd/systemd/issues/15638
 exec 1>/dev/kmsg; exec 2>&1
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
+self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 command -v getargbool >/dev/null || . /usr/lib/dracut-lib.sh
 
 set -e

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -4,6 +4,16 @@ set -euo pipefail
 
 . /usr/lib/coreos/generator-lib.sh
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
+self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 # Turn out if you boot with "root=..." $UNIT_DIR is not writable.
 [ -w "${UNIT_DIR}" ] || {
     echo "skipping coreos-boot-mount-generator: ${UNIT_DIR} is not writable"

--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -4,6 +4,16 @@ set -euo pipefail
 
 . /usr/lib/coreos/generator-lib.sh
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
+self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 write_dropin() {
     local service="$1"; shift
     local args="$1"; shift

--- a/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
@@ -15,7 +15,16 @@ set -euo pipefail
 # https://github.com/systemd/systemd/issues/15638
 exec 1>/dev/kmsg; exec 2>&1
 
+# Generators get re-executed each time a daemon-reload happens.
+# We only need to run once.
 self=$(basename $0)
+if [ -e "/run/coreos-${self}" ]; then
+    echo "$self: generator has already run; skipping"
+    exit 0
+else
+    > "/run/coreos-${self}"
+fi
+
 confpath=/run/coreos-platform-chrony.conf
 
 # Yeah this isn't a completely accurate kernel argument parser but
@@ -25,12 +34,6 @@ case "${platform}" in
     azure|azurestack|aws|gcp) ;;  # OK, this is a platform we know how to support
     *) exit 0 ;;
 esac
-
-# Exit early if we have already been run once
-if [[ -f "${confpath}" ]]; then
-    echo "$self: ${confpath} already exists; skipping"
-    exit 0
-fi
 
 # Exit early if chrony configuration as been changed from the image default
 if ! cmp {/usr,}/etc/chrony.conf >/dev/null; then

--- a/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
@@ -11,9 +11,7 @@ set -euo pipefail
 #
 # Originally spawned from discussion in https://github.com/openshift/installer/pull/3513
 
-# Generators don't have logging right now
-# https://github.com/systemd/systemd/issues/15638
-exec 1>/dev/kmsg; exec 2>&1
+. /usr/lib/coreos/generator-lib.sh
 
 # Generators get re-executed each time a daemon-reload happens.
 # We only need to run once.
@@ -27,9 +25,7 @@ fi
 
 confpath=/run/coreos-platform-chrony.conf
 
-# Yeah this isn't a completely accurate kernel argument parser but
-# we don't have one shared across shell services at the moment.
-platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d =)"
+platform=$(karg ignition.platform.id)
 case "${platform}" in
     azure|azurestack|aws|gcp) ;;  # OK, this is a platform we know how to support
     *) exit 0 ;;


### PR DESCRIPTION
Generators get re-executed each time a systemctl daemon-reload happens.
Let's update our generators so that they only run once.

I was led down this path because I noticed this failure in the console logs:

```
[    5.733962] ln:
[    5.733968] failed to create symbolic link '/run/udev/rules.d/80-coreos-boot-disk.rules'
[    5.734511] : File exists
[    5.737931] systemd[1023]: /usr/lib/systemd/system-generators/coreos-diskful-generator failed with exit status 1.
```
