### PR TITLE
ci/overrides: fix Bodhi lookup with bodhi-client 6.x

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 import yaml
 import subprocess
 
-import bodhi.client
+import bodhi.client.bindings
 import dnf
 import hawkey
 import koji


### PR DESCRIPTION
We were assuming that `bodhi.client` re-exported `bodhi.client.bindings`, but apparently that wasn't contractual.  Import the module we actually need.

Fixes error:

    AttributeError: module 'bodhi.client' has no attribute 'bindings'