### PR TITLE
overlay/coreos-diskful-generator: make symlink creation idempotent

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -60,6 +60,6 @@ EOF
 
     # create symlink for udev rule
     mkdir -p /run/udev/rules.d/
-    ln -s /usr/lib/coreos/80-coreos-boot-disk.rules \
+    ln -sf /usr/lib/coreos/80-coreos-boot-disk.rules \
           /run/udev/rules.d/80-coreos-boot-disk.rules
 fi


### PR DESCRIPTION
A generator can be run multiple times. This symlink is a bit of an abuse
of systemd generators because it writes things outside of the expected
output directories. So we need to make sure that we're idempotent.