### PR TITLE
ci/buildroot: install rpm-ostree test deps

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -37,12 +37,9 @@ jq
 # For golang projects like mantle and gangplank
 golang
 
-# Used by ostree/rpm-ostree CI (TODO: add to something like TestBuildRequires in spec files)
+# Used by ostree tests (TODO: add to something like TestBuildRequires in spec files)
 attr
-rsync
-python3-pyyaml
-parallel gjs
-createrepo_c
+gjs
 
 # Also, add clang since it's useful at least in CI for C/C++ projects
 clang lld

--- a/ci/buildroot/install-buildroot.sh
+++ b/ci/buildroot/install-buildroot.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-dn=$(dirname "$0")
-
 # This is invoked by Dockerfile
+
+dn=$(dirname "$0")
+tmpd=$(mktemp -d) && trap 'rm -rf ${tmpd}' EXIT
 
 echo "Installing base build requirements"
 dnf -y install /usr/bin/xargs 'dnf-command(builddep)'
@@ -16,8 +17,14 @@ echo "${brs}" | xargs dnf -y builddep
 
 echo "Installing build dependencies from canonical spec files"
 specs=$(grep -v '^#' "${dn}"/buildroot-specs.txt)
-tmpd=$(mktemp -d) && trap 'rm -rf ${tmpd}' EXIT
 (cd "${tmpd}" && echo "${specs}" | xargs curl -L --remote-name-all)
 (cd "${tmpd}" && find . -type f -print0 | xargs -0 dnf -y builddep --spec)
+rm -rf "${tmpd:?}"/*
+
+echo "Installing test dependencies from canonical upstream files"
+testdep_urls=$(grep -v '^#' "${dn}"/testdeps.txt)
+(cd "${tmpd}" && echo "${testdep_urls}" | xargs curl -L --remote-name-all)
+grep -hrv '^#' "${tmpd}" | xargs dnf -y install
+rm -rf "${tmpd:?}"/*
 
 echo 'Done!'

--- a/ci/buildroot/testdeps.txt
+++ b/ci/buildroot/testdeps.txt
@@ -1,0 +1,2 @@
+# for projects which have their canonical list of test deps upstream
+https://raw.githubusercontent.com/coreos/rpm-ostree/main/ci/testdeps.txt


### PR DESCRIPTION
Right now, the buildroot image only includes build deps. It's natural to
want to include test deps in there too so that devs can both build and
test.

Add a new file which lists URLs to upstream project files containing
test dependencies. Switch rpm-ostree to use that.

Delete entries for packages that are covered by the rpm-ostree test
deps.