### PR TITLE
35coreos-ignition: verify grub password directives

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-post-ignition-checks.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-post-ignition-checks.service
@@ -1,0 +1,17 @@
+# This unit will run late in the initrd process after the Ignition files
+# stage has completed successfully so that we may validate ignition changes
+
+[Unit]
+Description=CoreOS Post Ignition Checks
+ConditionPathExists=/usr/lib/initrd-release
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+# Start after Ignition has finished creating files and before ignition umount
+After=ignition-files.service
+Before=ignition-complete.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/coreos-post-ignition-checks
+RemainAfterExit=yes

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-post-ignition-checks.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-post-ignition-checks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# See coreos-post-ignition-checks.service for more information about this script
+set -euo pipefail
+
+# Verify that GRUB password directives are only used when GRUB is being used
+arch=$(uname -p)
+# Butane sugar will tell ignition to mount /boot to /sysroot/boot. We can simply check if
+# the file exists to see whether the check needs to be performed.
+# It is possible that the user creates a config, which will mount /boot at a different path
+# but that case is not officially supported. 
+if [ -f /sysroot/boot/grub2/user.cfg ]; then
+    # s390x does not use GRUB, ppcle64 uses petitboot with a GRUB config parser which does not support passwords
+    # So in both these cases, GRUB password is not supported
+    if grep -q password_pbkdf2 /sysroot/boot/grub2/user.cfg && [[ "$arch" =~ ^(s390x|ppc64le)$ ]]; then
+        echo "Ignition config provisioned a GRUB password, which is not supported on $arch"
+        exit 1
+    fi
+fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -23,7 +23,8 @@ install() {
         lsblk \
         sed \
         grep \
-        sgdisk
+        sgdisk \
+        uname
 
     inst_simple "$moddir/coreos-diskful-generator" \
         "$systemdutildir/system-generators/coreos-diskful-generator"
@@ -41,6 +42,11 @@ install() {
 
     inst_script "$moddir/coreos-ignition-setup-user.sh" \
         "/usr/sbin/coreos-ignition-setup-user"
+
+    inst_script "$moddir/coreos-post-ignition-checks.sh" \
+        "/usr/sbin/coreos-post-ignition-checks"
+    
+    install_ignition_unit coreos-post-ignition-checks.service
 
     # For consistency tear down the network and persist multipath between the initramfs and
     # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763


### PR DESCRIPTION
GRUB password directives should not be present in
/boot/grub2/user.cfg if the system is not using GRUB.
Let's add a check to verify this.