### PR TITLE
Enable cliwrap (rawhide only for now)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,3 +8,6 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
+
+# Only enabled on rawhide right now
+cliwrap: true


### PR DESCRIPTION
The cliwrap code has existed for a long, long time.  However,
things change now with the advent of ostree-native containers.

I think it Just Makes Sense to enable `yum install foo` inside
an ostree container, which the code now does when this flag is enabled.

This will *also* cause the cliwrap code to appear on the host, but
I think that's less confusing than not doing so.