### PR TITLE
Add and test x86_64 emulator support on s390x and aarch64

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -195,6 +195,10 @@ packages:
 # Anyways, it was requested by the Red Hat perf team for RHCOS, so we have it here.
 # https://serverfault.com/questions/513807/is-there-still-a-use-for-irqbalance-on-modern-hardware
 # https://access.redhat.com/solutions/41535
+# 
+# Include the qemu-user-static-x86 package on aarch64 and s390x FCOS images
+# to allow access to the large inventory of containers only built for x86_64.
+# https://github.com/coreos/fedora-coreos-tracker/issues/1237
 packages-x86_64:
   - irqbalance
 packages-ppc64le:
@@ -204,6 +208,9 @@ packages-ppc64le:
   - ppc64-diag-rtas
 packages-aarch64:
   - irqbalance
+  - qemu-user-static-x86
+packages-s390x:
+  - qemu-user-static-x86
 
 # See https://github.com/coreos/bootupd
 arch-include:

--- a/tests/kola/binfmt/data/commonlib.sh
+++ b/tests/kola/binfmt/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,0 +1,31 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "exclusive": false, "tags": "needs-internet", "architectures": "aarch64 s390x"}
+# Test the x86_64 emulator on aarch64 and s390x images for now
+# https://github.com/coreos/fedora-coreos-tracker/issues/1237
+# 
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+# - exclusive: false
+#   - This test doesn't make meaningful changes to the system and
+#     should be able to be combined with other tests.
+# - tags: needs-internet
+#   - This test pulls a container from a registry.
+# - architectures: aarch64 s390x
+#   - We decided to ship x86_64 emulator to only these arches for now.
+#   - Refer to the above referenced issue for more details
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+case "$(arch)" in
+    aarch64|s390x)
+        containerArch=$(podman run --arch=amd64 --rm registry.fedoraproject.org/fedora:36 arch)
+        if [ "$containerArch" != "x86_64" ]; then 
+            fatal "Test failed: x86_64 qemu emulator failed to run" 
+        fi
+        ok "Test passed: x86_64 qemu emulator works on $(arch)" ;;
+    *)
+    # We shouldn't reach this point
+    fatal "No qemu-user-static support for $(arch)" ;;
+esac


### PR DESCRIPTION
Fixes: [https://github.com/coreos/fedora-coreos-tracker/issues/1237](https://github.com/coreos/fedora-coreos-tracker/issues/1088)