### PR TITLE
denylist: add snooze for ext.config.binfmt.qemu on aarch64/rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -45,3 +45,10 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1229
   streams:
   - rawhide
+- pattern: ext.config.binfmt.qemu
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
+  snooze: 2022-07-06
+  arches:
+  - aarch64
+  streams:
+  - rawhide


### PR DESCRIPTION
This recently added test is failing in on aarch64/rawhide. Let's
snooze while the investigation continues.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1241