### PR TITLE
denylist: ext.config.files.file-directory-permissions on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -52,3 +52,7 @@
   - aarch64
   streams:
   - rawhide
+- pattern: ext.config.files.file-directory-permissions
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
+  arches:
+  - s390x


### PR DESCRIPTION
some files added by s390utils base have write permission by default.
we need to denylist now and later the package be skipped once we have https://github.com/coreos/fedora-coreos-tracker/issues/1217.