### PR TITLE
tests/kola: Run qemu emulation test only in fcos

### DIFF
--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,8 +1,8 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "exclusive": false, "tags": "needs-internet", "architectures": "aarch64 s390x"}
+# kola: {"platforms": "qemu", "exclusive": false, "tags": "needs-internet", "distros": "fcos", "architectures": "aarch64 s390x"}
 # Test the x86_64 emulator on aarch64 and s390x images for now
 # https://github.com/coreos/fedora-coreos-tracker/issues/1237
-# 
+#
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
 # - exclusive: false
@@ -10,6 +10,8 @@
 #     should be able to be combined with other tests.
 # - tags: needs-internet
 #   - This test pulls a container from a registry.
+# - distros:
+#   - Only run on fcos, as rhel does not support emulation
 # - architectures: aarch64 s390x
 #   - We decided to ship x86_64 emulator to only these arches for now.
 #   - Refer to the above referenced issue for more details
@@ -21,8 +23,8 @@ set -xeuo pipefail
 case "$(arch)" in
     aarch64|s390x)
         containerArch=$(podman run --arch=amd64 --rm registry.fedoraproject.org/fedora:36 arch)
-        if [ "$containerArch" != "x86_64" ]; then 
-            fatal "Test failed: x86_64 qemu emulator failed to run" 
+        if [ "$containerArch" != "x86_64" ]; then
+            fatal "Test failed: x86_64 qemu emulator failed to run"
         fi
         ok "Test passed: x86_64 qemu emulator works on $(arch)" ;;
     *)


### PR DESCRIPTION
RHEL does not support emulation of other arches.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>