### PR TITLE
s390x: reencrypt boot- and rootfs if SecureExecution is enabled

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
@@ -1,0 +1,60 @@
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/disk/by-id/coreos-boot-disk",
+        "partitions": [
+          {
+            "label": "boot",
+            "number": 3
+          },
+          {
+            "label": "root",
+            "number": 4,
+            "resize": true,
+            "sizeMiB": 0
+          }
+        ]
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/mapper/boot",
+        "format": "ext4",
+        "label": "boot",
+        "wipeFilesystem": true
+      },
+      {
+        "device": "/dev/mapper/root",
+        "format": "xfs",
+        "label": "root",
+        "wipeFilesystem": true
+      }
+    ],
+    "luks": [
+      {
+        "device": "/dev/disk/by-partlabel/boot",
+        "label": "crypt_bootfs",
+        "name": "boot",
+        "options": [
+          "--integrity",
+          "hmac-sha256"
+        ],
+        "wipeVolume": true
+      },
+      {
+        "device": "/dev/disk/by-partlabel/root",
+        "label": "crypt_rootfs",
+        "name": "root",
+        "options": [
+          "--integrity",
+          "hmac-sha256"
+        ],
+        "wipeVolume": true
+      }
+    ]
+  }
+}

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
@@ -5,7 +5,7 @@
   "storage": {
     "disks": [
       {
-        "device": "/dev/disk/by-id/coreos-boot-disk",
+        "device": "${BOOTDEV}",
         "partitions": [
           {
             "label": "boot",
@@ -36,7 +36,7 @@
     ],
     "luks": [
       {
-        "device": "/dev/disk/by-partlabel/boot",
+        "device": "${BOOTDEV}3",
         "label": "crypt_bootfs",
         "name": "boot",
         "options": [
@@ -46,7 +46,7 @@
         "wipeVolume": true
       },
       {
-        "device": "/dev/disk/by-partlabel/root",
+        "device": "${BOOTDEV}4",
         "label": "crypt_rootfs",
         "name": "root",
         "options": [

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -62,4 +62,17 @@ EOF
     mkdir -p /run/udev/rules.d/
     ln -sf /usr/lib/coreos/80-coreos-boot-disk.rules \
           /run/udev/rules.d/80-coreos-boot-disk.rules
+
+    # IBM Secure Execution case
+    # During firstboot we have to reencrypt '/boot' and '/', to do that an Ignition config
+    # is injected. 'coreos-boot-disk' is required for this
+    secure_execution=0
+    if [[ $(uname -m) == s390x ]] && [[ -e /sys/firmware/uv/prot_virt_guest ]]; then
+        secure_execution=$(cat /sys/firmware/uv/prot_virt_guest)
+    fi
+    if [[ "${secure_execution}" = "1" ]]; then
+        mkdir -p /run/coreos/
+        touch /run/coreos/secure-execution
+        mv /usr/lib/coreos/01-secex.ign /usr/lib/ignition/base.d/01-secex.ign
+    fi
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -73,6 +73,5 @@ EOF
     if [[ "${secure_execution}" = "1" ]]; then
         mkdir -p /run/coreos/
         touch /run/coreos/secure-execution
-        mv /usr/lib/coreos/01-secex.ign /usr/lib/ignition/base.d/01-secex.ign
     fi
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -67,4 +67,7 @@ install() {
     install_ignition_unit coreos-ignition-unique-boot.service ignition-diskful.target
     install_ignition_unit coreos-unique-boot.service ignition-diskful.target
     install_ignition_unit coreos-ignition-setup-user.service
+
+    # IBM Secure Execution. Ignition config for reencryption of / and /boot
+    inst_simple "$moddir/01-secex.ign" /usr/lib/coreos/01-secex.ign
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-close-luks.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-close-luks.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ignition OSTree: Close Secure Execution LUKS
+DefaultDependencies=false
+After=ignition-ostree-transposefs-save.service
+Before=ignition-ostree-transposefs-restore.service
+Before=ignition-disks.service
+ConditionArchitecture=s390x
+ConditionKernelCommandLine=ostree
+ConditionPathExists=/run/coreos/secure-execution
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/cryptsetup luksClose crypt_bootfs
+ExecStart=/usr/sbin/cryptsetup luksClose crypt_rootfs
+

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-drop-luks.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-drop-luks.service
@@ -1,0 +1,19 @@
+# This is to be removed once we switch to 'keyring' and custom 'init'.
+[Unit]
+Description=Ignition OSTree: Delete Secure Execution LUKS Keys
+ConditionArchitecture=s390x
+ConditionKernelCommandLine=ostree
+ConditionPathExists=/run/coreos/secure-execution
+DefaultDependencies=no
+
+# We should drop the keys once cryptsetup had opened both rootfs and bootfs
+After=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-root.device
+
+# Run as early as possible
+Before=cryptsetup.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rm /etc/luks/boot /etc/luks/root /etc/crypttab

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.service
@@ -1,0 +1,18 @@
+# RHOCS 4.12.s390x has an old kernel with a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
+# Once we have kernel >= 4.18.0-387.el8.s390x we should drop this unit and copy config in coreos-diskful-generator
+[Unit]
+Description=Ignition OSTree: Inject secex config
+DefaultDependencies=false
+ConditionArchitecture=s390x
+ConditionKernelCommandLine=ostree
+ConditionPathExists=/run/coreos/secure-execution
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+After=cryptsetup.target
+Before=ignition-fetch-offline.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/ignition-ostree-secex-config

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -f /run/coreos/secure-execution ]]; then
+    bootdev=$(blkid --list-one --output device --match-token PARTLABEL=boot | sed 's,[0-9]\+$,,')
+    sed "s,\${BOOTDEV},$bootdev," < /usr/lib/coreos/01-secex.ign > /usr/lib/ignition/base.d/01-secex.ign
+fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -104,4 +104,9 @@ install() {
 
     install_ignition_unit ignition-ostree-close-luks.service
     install_ignition_unit ignition-ostree-drop-luks.service
+
+    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2075085
+    install_ignition_unit ignition-ostree-secex-config.service
+    inst_script "$moddir/ignition-ostree-secex-config.sh" \
+        /usr/libexec/ignition-ostree-secex-config
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -101,4 +101,7 @@ install() {
         /usr/libexec/coreos-check-rootfs-size
 
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel
+
+    install_ignition_unit ignition-ostree-close-luks.service
+    install_ignition_unit ignition-ostree-drop-luks.service
 }


### PR DESCRIPTION
Only for systems running with Secure Execution. During firstboot this reencryptes filesystems
labeled 'boot' and 'root'. Because growing of crypt-integrity device is not supported by cryptsetup,
this also grows rootfs before reencryption.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>