### PR TITLE
manifests/group: drop well-known static ID for "dbus" group

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -94,6 +94,9 @@ remove-from-packages:
   # Drop NetworkManager support for ifcfg files, see also corresponding
   # overlay.d/14NetworkManager-plugins
   - [NetworkManager, /usr/lib64/NetworkManager/.*/libnm-settings-plugin-ifcfg-rh.so]
+  # Drop a buggy configuration fragment which does not match static ID allocation:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2090397
+  - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
 
 remove-files:
   # We don't ship man(1) or info(1)

--- a/manifests/group
+++ b/manifests/group
@@ -25,7 +25,6 @@ nobody:x:99:
 users:x:100:
 ssh_keys:x:999:
 systemd-journal:x:190:
-dbus:x:81:
 polkitd:x:998:
 etcd:x:997:
 dip:x:40:


### PR DESCRIPTION
This drops a redundant override for the "dbus" group.
The group is created by the "dbus-common" package and has a static
group ID (GID) allocated in the `uidgid` table.
Out of an abundance of caution, it also temporarily removes a
buggy sysusers fragment which does not match Fedora allocation.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2090397