### PR TITLE
overrides: pin NetworkManager

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,29 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  NetworkManager:
+    evr: 1:1.38.0-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
+      type: pin
+  NetworkManager-cloud-setup:
+    evr: 1:1.38.0-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
+      type: pin
+  NetworkManager-libnm:
+    evr: 1:1.38.0-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
+      type: pin
+  NetworkManager-team:
+    evr: 1:1.38.0-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
+      type: pin
+  NetworkManager-tui:
+    evr: 1:1.38.0-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
+      type: pin


### PR DESCRIPTION
We need to pin NetworkManager to silence a failure in rawhide:
https://github.com/coreos/fedora-coreos-tracker/issues/1245.