### PR TITLE
35coreos-multipath: improve config propagation logging

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
@@ -4,14 +4,22 @@ set -euo pipefail
 # Persist automatic multipath configuration, if any.
 # When booting with `rd.multipath=default`, the default multipath
 # configuration is written. We need to ensure that the multipath configuration
-# is persisted to the final target.
+# is persisted to the rootfs.
 
-if [ ! -f /sysroot/etc/multipath.conf ] && [ -f /etc/multipath.conf ]; then
-    echo "info: propagating automatic multipath configuration"
-    cp -v /etc/multipath.conf /sysroot/etc/
-    mkdir -p /sysroot/etc/multipath/multipath.conf.d
-    coreos-relabel /etc/multipath.conf
-    coreos-relabel /etc/multipath/multipath.conf.d
-else
-    echo "info: no initramfs automatic multipath configuration to propagate"
+if [ ! -f /etc/multipath.conf ]; then
+    echo "info: initrd file /etc/multipath.conf does not exist"
+    echo "info: no initrd multipath configuration to propagate"
+    exit 0
 fi
+
+if [ -f /sysroot/etc/multipath.conf ]; then
+    echo "info: real root file /etc/multipath.conf exists"
+    echo "info: not propagating initrd multipath configuration"
+    exit 0
+fi
+
+echo "info: propagating initrd multipath configuration"
+cp -v /etc/multipath.conf /sysroot/etc/
+mkdir -p /sysroot/etc/multipath/multipath.conf.d
+coreos-relabel /etc/multipath.conf
+coreos-relabel /etc/multipath/multipath.conf.d


### PR DESCRIPTION
We were saying "no initramfs automatic multipath configuration to
propagate" even when there was an initramfs config but the file already
existed in the real root. Let's split out those no op conditions more
and log clearer explicit messages.

This should be a purely cosmetic change. Prompted by looking at logging
from this service to debug a multipath-related issue.