### PR TITLE
coreos-gpt-setup: fix DM_MPATH variable spelling

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
@@ -8,7 +8,7 @@ UNINITIALIZED_GUID='00000000-0000-4000-a000-000000000001'
 
 # If it's on multipath, get the parent device from udev properties.
 # If it's LUKS2 encrypted, UUID woud start with "CRYPT-LUKS2"
-eval $(udevadm info --query property --export "$1" | grep -e DM_NAME -e DM_UUID -e DM_MAPTH)
+eval $(udevadm info --query property --export "$1" | grep -e DM_NAME -e DM_UUID -e DM_MPATH)
 
 if [[ -n "${DM_MPATH:-}" ]]; then
     PKNAME=/dev/mapper/$DM_MPATH


### PR DESCRIPTION
This was mis-spelled as part of e3309ad07ca959d7acda2f2c95f08ac0b4673018

I believe this is the root cause for the CI failure in
openshift/os#874