### PR TITLE
Move from `initramfs-args` in manifest to `dracut.conf.d` files

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -17,18 +17,6 @@ ostree-layers:
   - overlay/14NetworkManager-plugins
   - overlay/20platform-chrony
 
-initramfs-args:
-  - --no-hostonly
-  # We don't support root on NFS, so we don't need it in the initramfs. It also
-  # conflicts with /var mount support in ignition because NFS tries to mount stuff
-  # in /var/ and then ignition can't cleanly unmount it. For example:
-  # https://github.com/dracutdevs/dracut/blob/1856ae95c873a6fe855b3dccd0144f1a96b9e71c/modules.d/95nfs/nfs-start-rpc.sh#L7
-  # See also discussion in https://github.com/coreos/fedora-coreos-config/pull/60
-  - --omit=nfs
-  # Omit these since we don't use them
-  - --omit=lvm
-  - --omit=iscsi
-
 # Be minimal
 recommends: false
 

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -8,10 +8,6 @@
 # Include rpm-ostree + kernel + bootloader
 include: bootable-rpm-ostree.yaml
 
-initramfs-args:
-  # make it a hard error if Ignition can't be included
-  - --add=ignition
-
 # Modern defaults we want
 boot-location: modules
 tmp-is-dir: true

--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-nohostonly.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-nohostonly.conf
@@ -1,0 +1,2 @@
+# Default rpm-ostree model is server-side generated initramfs
+hostonly=no

--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-omits.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-omits.conf
@@ -1,0 +1,7 @@
+# We don't support root on NFS, so we don't need it in the initramfs. It also
+# conflicts with /var mount support in ignition because NFS tries to mount stuff
+# in /var/ and then ignition can't cleanly unmount it. For example:
+# https://github.com/dracutdevs/dracut/blob/1856ae95c873a6fe855b3dccd0144f1a96b9e71c/modules.d/95nfs/nfs-start-rpc.sh#L7
+# See also discussion in https://github.com/coreos/fedora-coreos-config/pull/60
+# Further, we currently do not use LVM or iSCSI
+omit_dracutmodules+=" nfs lvm iscsi "


### PR DESCRIPTION
See https://github.com/coreos/rpm-ostree/issues/3799

This way when we run dracut in a container build, we naturally
pick up the same config we used for server side builds.