### PR TITLE
35coreos-multipath: enter emergency.target if multipathd bootfs times out

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
@@ -8,6 +8,9 @@ After=dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device
 Requires=multipathd.service
 After=multipathd.service
 
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
 # This is already enforced transitively by coreos-gpt-setup.service, but
 # let's be more explicit and list it directly here too.
 Before=coreos-ignition-setup-user.service


### PR DESCRIPTION
This should be the default in almost all our initramfs systemd units.
Otherwise we'll keep limping on and other spurious errors might mislead
users.