### PR TITLE
manifests/group: drop well-known static ID for "tss" group

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -94,9 +94,11 @@ remove-from-packages:
   # Drop NetworkManager support for ifcfg files, see also corresponding
   # overlay.d/14NetworkManager-plugins
   - [NetworkManager, /usr/lib64/NetworkManager/.*/libnm-settings-plugin-ifcfg-rh.so]
-  # Drop a buggy configuration fragment which does not match static ID allocation:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2090397
+  # Drop some buggy sysusers fragments which do not match static IDs allocation:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2105177
   - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2103683
+  - [tpm2-tss, /usr/lib/sysusers.d/tpm2-tss.conf]
 
 remove-files:
   # We don't ship man(1) or info(1)

--- a/manifests/group
+++ b/manifests/group
@@ -29,7 +29,6 @@ polkitd:x:998:
 etcd:x:997:
 dip:x:40:
 cgred:x:996:
-tss:x:59:
 avahi-autoipd:x:170:
 sssd:x:993:
 dockerroot:x:986:


### PR DESCRIPTION
This drops a redundant override for the "tss" group.
The group is created by the "tpm2-tss" package and has a static
group ID (GID) allocated in the `uidgid` table.
Out of an abundance of caution, it also temporarily removes a
buggy sysusers fragment which does not match Fedora allocation.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2103683