### PR TITLE
s390x: drop 's390utils-base'

### DIFF
--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -285,9 +285,6 @@
     "fedora-repos-ostree": {
       "evra": "36-1.noarch"
     },
-    "file": {
-      "evra": "5.41-4.fc36.s390x"
-    },
     "file-libs": {
       "evra": "5.41-4.fc36.s390x"
     },
@@ -362,9 +359,6 @@
     },
     "grep": {
       "evra": "3.7-2.fc36.s390x"
-    },
-    "groff-base": {
-      "evra": "1.22.4-9.fc36.s390x"
     },
     "gzip": {
       "evra": "1.11-3.fc36.s390x"
@@ -906,141 +900,6 @@
     "pcre2-syntax": {
       "evra": "10.40-1.fc36.noarch"
     },
-    "perl-Carp": {
-      "evra": "1.52-479.fc36.noarch"
-    },
-    "perl-Class-Struct": {
-      "evra": "0.66-486.fc36.noarch"
-    },
-    "perl-DynaLoader": {
-      "evra": "1.50-486.fc36.s390x"
-    },
-    "perl-Encode": {
-      "evra": "4:3.17-485.fc36.s390x"
-    },
-    "perl-English": {
-      "evra": "1.11-486.fc36.noarch"
-    },
-    "perl-Errno": {
-      "evra": "1.33-486.fc36.s390x"
-    },
-    "perl-Exporter": {
-      "evra": "5.76-480.fc36.noarch"
-    },
-    "perl-Fcntl": {
-      "evra": "1.14-486.fc36.s390x"
-    },
-    "perl-File-Basename": {
-      "evra": "2.85-486.fc36.noarch"
-    },
-    "perl-File-Path": {
-      "evra": "2.18-479.fc36.noarch"
-    },
-    "perl-File-Temp": {
-      "evra": "1:0.231.100-479.fc36.noarch"
-    },
-    "perl-File-stat": {
-      "evra": "1.09-486.fc36.noarch"
-    },
-    "perl-Getopt-Long": {
-      "evra": "1:2.52-479.fc36.noarch"
-    },
-    "perl-Getopt-Std": {
-      "evra": "1.13-486.fc36.noarch"
-    },
-    "perl-HTTP-Tiny": {
-      "evra": "0.080-2.fc36.noarch"
-    },
-    "perl-IO": {
-      "evra": "1.46-486.fc36.s390x"
-    },
-    "perl-IPC-Open3": {
-      "evra": "1.21-486.fc36.noarch"
-    },
-    "perl-MIME-Base64": {
-      "evra": "3.16-479.fc36.s390x"
-    },
-    "perl-POSIX": {
-      "evra": "1.97-486.fc36.s390x"
-    },
-    "perl-PathTools": {
-      "evra": "3.80-479.fc36.s390x"
-    },
-    "perl-Pod-Escapes": {
-      "evra": "1:1.07-479.fc36.noarch"
-    },
-    "perl-Pod-Perldoc": {
-      "evra": "3.28.01-480.fc36.noarch"
-    },
-    "perl-Pod-Simple": {
-      "evra": "1:3.43-3.fc36.noarch"
-    },
-    "perl-Pod-Usage": {
-      "evra": "4:2.01-479.fc36.noarch"
-    },
-    "perl-Scalar-List-Utils": {
-      "evra": "5:1.62-464.fc36.s390x"
-    },
-    "perl-SelectSaver": {
-      "evra": "1.02-486.fc36.noarch"
-    },
-    "perl-Socket": {
-      "evra": "4:2.034-1.fc36.s390x"
-    },
-    "perl-Storable": {
-      "evra": "1:3.25-2.fc36.s390x"
-    },
-    "perl-Symbol": {
-      "evra": "1.09-486.fc36.noarch"
-    },
-    "perl-Term-ANSIColor": {
-      "evra": "5.01-480.fc36.noarch"
-    },
-    "perl-Term-Cap": {
-      "evra": "1.17-479.fc36.noarch"
-    },
-    "perl-Text-ParseWords": {
-      "evra": "3.31-1.fc36.noarch"
-    },
-    "perl-Text-Tabs+Wrap": {
-      "evra": "2021.0814-2.fc36.noarch"
-    },
-    "perl-Time-Local": {
-      "evra": "2:1.300-479.fc36.noarch"
-    },
-    "perl-constant": {
-      "evra": "1.33-480.fc36.noarch"
-    },
-    "perl-if": {
-      "evra": "0.60.900-486.fc36.noarch"
-    },
-    "perl-interpreter": {
-      "evra": "4:5.34.1-486.fc36.s390x"
-    },
-    "perl-libs": {
-      "evra": "4:5.34.1-486.fc36.s390x"
-    },
-    "perl-mro": {
-      "evra": "1.25-486.fc36.s390x"
-    },
-    "perl-overload": {
-      "evra": "1.33-486.fc36.noarch"
-    },
-    "perl-overloading": {
-      "evra": "0.02-486.fc36.noarch"
-    },
-    "perl-parent": {
-      "evra": "1:0.238-479.fc36.noarch"
-    },
-    "perl-podlators": {
-      "evra": "1:4.14-479.fc36.noarch"
-    },
-    "perl-subs": {
-      "evra": "1.04-486.fc36.noarch"
-    },
-    "perl-vars": {
-      "evra": "1.05-486.fc36.noarch"
-    },
     "pigz": {
       "evra": "2.7-1.fc36.s390x"
     },
@@ -1115,9 +974,6 @@
     },
     "runc": {
       "evra": "2:1.1.1-1.fc36.s390x"
-    },
-    "s390utils-base": {
-      "evra": "2:2.20.0-1.fc36.s390x"
     },
     "s390utils-core": {
       "evra": "2:2.20.0-1.fc36.s390x"

--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -28,7 +28,6 @@ packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
   - /usr/sbin/zipl
-  - /usr/bin/genprotimg
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl


### PR DESCRIPTION
This package provides the `genprotimg` tool, but also depends on `perl-*` rpms, which we don't want 
to be part of the image. As long as IBM Secure Execution is targeted for RHCOS we can drop its support
in FCOS for now.
RHCOS comes with a lot of `perl-*` rpms, so there `s390utils-base` wouldn't bring new unwanted dependencies. 
For custom FCOS builds it's easier to:
```
$ mkdir -p overrides/rootfs/usr/bin/
$ mkdir -p overrides/rootfs/usr/share/s390-tools/genprotimg
$ cp /path/to/genprotimg overrides/rootfs/usr/bin/
$ cp /path/to/stage3a.bin overrides/rootfs/usr/share/s390-tools/genprotimg/
$ cp /path/to/stage3b_reloc.bin overrides/rootfs/usr/share/s390-tools/genprotimg/
```

https://github.com/coreos/fedora-coreos-tracker/issues/1217

