### PR TITLE
manifests/group: fix static GID for "tape" group

### DIFF
--- a/manifests/group
+++ b/manifests/group
@@ -16,7 +16,7 @@ sudo:x:16:
 dialout:x:18:
 floppy:x:19:
 games:x:20:
-tape:x:30:
+tape:x:33:
 video:x:39:
 ftp:x:50:
 lock:x:54:

--- a/tests/kola/files/fcos_groups
+++ b/tests/kola/files/fcos_groups
@@ -29,9 +29,7 @@ declare -A setup_groups=( \
     ["dialout"]="18" \
     ["floppy"]="19" \
     ["games"]="20" \
-# CoreOS mismatch: https://github.com/coreos/fedora-coreos-tracker/issues/1201
-#   ["tape"]="33" \
-    ["tape"]="30" \
+    ["tape"]="33" \
     ["video"]="39" \
     ["ftp"]="50" \
     ["lock"]="54" \


### PR DESCRIPTION
This moves the "tape" group to GID 33.
Apparently the old GID is a typo/bug coming from F20 times, and it
conflicts with the actual static GID allocated to group "gopher".

Ref: https://pagure.io/setup/blob/289bc53aa97c0758d8cf910b99f3515e21a34a40/f/group#_18
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1179585