### PR TITLE
denylist: drop one denial, extend snooze for another

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -52,7 +52,3 @@
   - aarch64
   streams:
   - rawhide
-- pattern: ext.config.files.file-directory-permissions
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
-  arches:
-  - s390x

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -47,7 +47,7 @@
   - rawhide
 - pattern: ext.config.binfmt.qemu
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
-  snooze: 2022-07-06
+  snooze: 2022-07-14
   arches:
   - aarch64
   streams:


### PR DESCRIPTION
```
commit 6e9aee2d073d42981ad3b1a078fd7929c736b92e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 11:34:17 2022 -0400

    denylist: remove ext.config.files.file-directory-permissions denial
    
    We temporarily reverted the inclusion of s390utils-base in f3cbb35
    while we work on fixing up the packaging so we don't get a bunch of
    extra things we don't want/need.
    
    That means we should be able to drop this denial as well.

commit e1911da27284ebc2d9a6828e2f4e3472816ed6c6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 11:30:01 2022 -0400

    denylist: extend snooze for ext.config.binfmt.qemu on rawhide/aarch64
    
    It's still failing. Will try to followup with upstream.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/1241
```
