### PR TITLE
35coreos-multipath: propagate after Ignition `files` stage

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.service
@@ -5,6 +5,9 @@ Before=initrd.target
 # we write to the rootfs, so run after it's ready
 After=initrd-root-fs.target
 
+# we only propagate if multipath wasn't configured via Ignition
+After=ignition-files.service
+
 # That service starts initrd-cleanup.service which will race with us completing
 # before we get nuked. Need to get to the bottom of it, but for now we need
 # this (XXX: add link to systemd issue here).

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-propagate-multipath-conf.sh
@@ -20,6 +20,4 @@ fi
 
 echo "info: propagating initrd multipath configuration"
 cp -v /etc/multipath.conf /sysroot/etc/
-mkdir -p /sysroot/etc/multipath/multipath.conf.d
 coreos-relabel /etc/multipath.conf
-coreos-relabel /etc/multipath/multipath.conf.d


### PR DESCRIPTION
We didn't have a strong ordering between the propagation service and the
Ignition `files` stage. We need to run after it so that we only
propagate the multipath config if the Ignition config didn't create one.

In practice currently the propagation service runs before, which didn't
cause any issues because Ignition can still just clobber what we
propagated. But it could become racier in the future, and it's confusing
because the logic we run and messages we log assume the `files` stage
ran.