### PR TITLE
manifests: Add postprocess script to remove broken symlinks

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -91,6 +91,47 @@ postprocess:
     cat /usr/etc/rpm-ostreed.conf >> /tmp/rpm-ostreed.conf
     cp /tmp/rpm-ostreed.conf /usr/etc/rpm-ostreed.conf
     rm /tmp/rpm-ostreed.conf
+  # Make sure that we do not ship broken symlinks:
+  # https://github.com/coreos/fedora-coreos-config/issues/1782
+  # Remove known broken symlinks that point to non-existing files or directories:
+  # - Remove `.build-id` for binaries that we remove in other parts of the FCOS manifest
+  # - Remove links to man pages that we remove in FCOS
+  # Man pages are removed in FCOS thus the links in alternatives pointing to those are left there broken.
+  # Docs removal comes from manifests/fedora-coreos.yaml
+  # - systemd-firstboot comes from manifests/ignition-and-ostree.yaml
+  # - systemd-gpt-auto-generator comes from ignition-and-ostree.yaml
+  # - dotlockfile comes from bootable-rpm-ostree.yaml
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+  
+    list_broken_symlinks_folders=(
+      '/etc/alternatives/'
+      '/usr/lib/.build-id/'
+    )
+
+    # It is not possible to remove files from usr after first boot so that is 
+    # why we are removing them in the postprocess scripts here.
+    # The .build-id links are pointing to binaries that we remove in other parts of the FCOS manifest.
+    list_known_removed_folders=(
+      '/usr/bin/dotlockfile'
+      '/usr/bin/systemd-firstboot'
+      '/usr/lib/systemd/system-generators/systemd-gpt-auto-generator'
+      '/usr/share/doc/'
+      '/usr/share/info/'
+      '/usr/share/man/'
+      )
+    for folder in "${list_broken_symlinks_folders[@]}"
+    do
+        find "${folder}" -type l | while read -r file_name; do
+            real_path=$(realpath -m "${file_name}");
+            for element in "${list_known_removed_folders[@]}"; do
+              if [[ ! -e "${real_path}" ]] && [[ "${real_path}" == "${element}"* ]]; then
+                  rm -r "${file_name}"
+              fi
+            done
+        done
+    done
 
 
 remove-from-packages:

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -1,0 +1,35 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+# Checking if there are no broken symlinks from from /etc/ and /usr/ .
+# https://github.com/coreos/fedora-coreos-config/issues/1782
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Here is the list of known broken symlinks that need to be investigated further:
+list_broken_symlinks_skip=(
+    '/etc/mtab'
+    '/etc/ssl/'
+    '/etc/swid/swidtags.d/fedoraproject.org'
+    '/etc/xdg/systemd/user'
+    '/usr/lib/.build-id/'
+    '/usr/lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt.xz'
+    '/usr/lib/modules/'
+    '/usr/share/rhel/secrets/etc-pki-entitlement'
+    '/usr/share/rhel/secrets/redhat.repo'
+    '/usr/share/rhel/secrets/rhsm'
+)
+find /usr/ /etc/ -type l -not -path "/usr/etc*"| while read -r file_name; do
+    found="false"
+    for search_element in "${list_broken_symlinks_skip[@]}"; do
+        if [[ "${file_name}" == "${search_element}"* || "${file_name}" == "${search_element}" ]]; then
+            found="true"
+            break
+        fi
+    done
+    real_path=$(realpath -m "${file_name}");
+    if [[ ! -e "${real_path}" ]] && [[ "${found}" == "false" ]];  then
+        fatal "Error: ${file_name} symlink to ${real_path} which does not exist"
+    fi
+done


### PR DESCRIPTION
Add postprocess script to remove specific broken symlinks
from /etc/alternatives/ and /usr/lib/.build-id/.

Fix: https://github.com/coreos/fedora-coreos-config/issues/1782