### PR TITLE
manifests: add zstd

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1223,6 +1223,9 @@
     },
     "zram-generator": {
       "evra": "1.1.2-1.fc36.aarch64"
+    },
+    "zstd": {
+      "evra": "1.5.2-2.fc36.aarch64"
     }
   },
   "metadata": {

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1151,6 +1151,9 @@
     },
     "zram-generator": {
       "evra": "1.1.2-1.fc36.s390x"
+    },
+    "zstd": {
+      "evra": "1.5.2-2.fc36.s390x"
     }
   },
   "metadata": {

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1232,6 +1232,9 @@
     },
     "zram-generator": {
       "evra": "1.1.2-1.fc36.x86_64"
+    },
+    "zstd": {
+      "evra": "1.5.2-2.fc36.x86_64"
     }
   },
   "metadata": {

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -26,6 +26,7 @@ packages:
   - gzip
   - tar
   - xz
+  - zstd
   # Improved MOTD experience
   - console-login-helper-messages-issuegen
   - console-login-helper-messages-profile


### PR DESCRIPTION
We'll soon use this to compress our initrds.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1251.