### PR TITLE
overlay: compress initrd with `zstd -19` on FCOS and RHCOS/SCOS 9

### DIFF
--- a/overlay.d/06el9/usr/lib/dracut/dracut.conf.d/coreos-zstd.conf
+++ b/overlay.d/06el9/usr/lib/dracut/dracut.conf.d/coreos-zstd.conf
@@ -1,0 +1,8 @@
+# Compress initrd with zstd.  dracut defaults to -15, but we want the
+# maximum reasonable compression, so override the command line to use
+# dracut's defaults along with -19.
+#
+# We can't use this in RHCOS 8 because the kernel doesn't enable
+# CONFIG_RD_ZSTD.
+
+compress="zstd -19 -q -T0"

--- a/tests/kola/files/initrd/compression
+++ b/tests/kola/files/initrd/compression
@@ -1,0 +1,20 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+#
+# If dracut can't find the configured compressor, it warns and falls back to
+# gzip (!).  Fail if the initrd isn't compressed with zstd.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Check initrd for zstd magic number
+if is_rhcos8; then
+    ok "Skipping initrd zstd compression test on RHCOS 8"
+else
+    if ! LANG=C grep -aUPq "\x28\xb5\x2f\xfd" /boot/ostree/*/init*; then
+        fatal "Didn't find zstd compression in initrd"
+    fi
+    ok "Found zstd compression in initrd"
+fi

--- a/tests/kola/files/initrd/data/commonlib.sh
+++ b/tests/kola/files/initrd/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/files/initrd/executables
+++ b/tests/kola/files/initrd/executables
@@ -1,11 +1,14 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
+#
+# It's easy for dracut modules to accidentally ship scripts without +x set.
+# Check for those.
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# It's easy for dracut modules to accidentally ship scripts without +x set
 tmpd=$(mktemp -d)
 ( cd "${tmpd}" && lsinitrd --unpack /boot/ostree/*/init* )
 if find "${tmpd}/usr/"{bin,sbin,libexec} ! -perm -0111 | grep -v clevis-luks-common-functions; then

--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -1,9 +1,10 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
 
-# This test runs on both, FCOS&RHCOS. The initrd includes specific files which,
-# if omitted from the image will cause some failures with certain ingnition
-# configurations. This test doesnt assert the functionality of any files, it
+# This test runs on both FCOS & RHCOS. The initrd includes specific files which,
+# if omitted from the image, will cause some failures with certain Ignition
+# configs. This test doesn't assert the functionality of any files, it
 # simply gives a high level check to see if the files are available.
 # See https://github.com/coreos/fedora-coreos-config/issues/1775
 


### PR DESCRIPTION
On my system, relative to `gzip -9`, it roughly halves decompression time at boot while also [reducing initrd size](https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1179490347).

RHCOS 8 can't inherit this because the RHEL 8 kernel doesn't enable `CONFIG_RD_ZSTD`.

For https://github.com/coreos/fedora-coreos-tracker/issues/1247.