### PR TITLE
denylist: extend snooze for ext.config.binfmt.qemu on rawhide/aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -47,7 +47,7 @@
   - rawhide
 - pattern: ext.config.binfmt.qemu
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
-  snooze: 2022-07-14
+  snooze: 2022-07-21
   arches:
   - aarch64
   streams:


### PR DESCRIPTION
See coreos/fedora-coreos-tracker#1241