### PR TITLE
kola-denylist.yaml: remove ext.config.extensions.module

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,10 +41,6 @@
   - testing
   - testing-devel
   - stable
-- pattern: ext.config.extensions.module
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1229
-  streams:
-  - rawhide
 - pattern: ext.config.binfmt.qemu
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
   snooze: 2022-07-21


### PR DESCRIPTION
The test is no longer failing as the issue has been fixed by Fedora Releng.
Let's start running the test in our CI again.

closes: https://github.com/coreos/fedora-coreos-tracker/issues/1229