### PR TITLE
manifests: exclude `perl-interpreter`

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -117,6 +117,7 @@ exclude-packages:
   - python3
   - python3-libs
   - perl
+  - perl-interpreter
   - nodejs
   - dnf
   - grubby


### PR DESCRIPTION
We were excluding `perl`, but that's just a metapackage. The actual
interpreter is in `perl-interpreter`. Let's add that to the list to make
sure no package can pull it in.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/1217