### PR TITLE
test luks with custom clevis configuration

### DIFF
--- a/tests/kola/var-mount/lukspcr/config.bu
+++ b/tests/kola/var-mount/lukspcr/config.bu
@@ -4,10 +4,8 @@ storage:
   disks:
     - device: /dev/vda
       partitions:
-        - label: var
-          size_mib: 1000
-          start_mib: 5000
-        - label: publicdata
+        - start_mib: 6000
+          label: publicdata
       wipe_table: false
   luks:
     - name: data
@@ -18,10 +16,6 @@ storage:
           pin: tpm2
           config: '{"pcr_bank":"sha1","pcr_ids":"0,7"}'
   filesystems:
-    - device: /dev/disk/by-partlabel/var
-      format: xfs
-      path: /var
-      with_mount_unit: true
     - device: /dev/mapper/data
       format: ext4
       path: /var/publicdata

--- a/tests/kola/var-mount/lukspcr/config.bu
+++ b/tests/kola/var-mount/lukspcr/config.bu
@@ -1,0 +1,29 @@
+variant: fcos
+version: 1.3.0
+storage:
+  disks:
+    - device: /dev/vda
+      partitions:
+        - label: var
+          size_mib: 1000
+          start_mib: 5000
+        - label: publicdata
+      wipe_table: false
+  luks:
+    - name: data
+      device: /dev/disk/by-partlabel/publicdata
+      clevis:
+        custom:
+          needs_network: false
+          pin: tpm2
+          config: '{"pcr_bank":"sha1","pcr_ids":"0,7"}'
+  filesystems:
+    - device: /dev/disk/by-partlabel/var
+      format: xfs
+      path: /var
+      with_mount_unit: true
+    - device: /dev/mapper/data
+      format: ext4
+      path: /var/publicdata
+      with_mount_unit: true
+

--- a/tests/kola/var-mount/lukspcr/data/commonlib.sh
+++ b/tests/kola/var-mount/lukspcr/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/var-mount/lukspcr/test.sh
+++ b/tests/kola/var-mount/lukspcr/test.sh
@@ -16,7 +16,7 @@ umount /var/publicdata
 cryptsetup close data
 
 # we validate we can still unlock the drive
-clevis luks unlock -d /dev/vda6 -n data
+clevis luks unlock -d /dev/disk/by-partlabel/publicdata -n data
 mount /dev/mapper/data /var/publicdata
 umount /var/publicdata
 cryptsetup close data
@@ -26,7 +26,7 @@ cryptsetup close data
 tpm2_pcrextend 7:sha1=0x1234567890123456789012345678901234567890
 
 # we validate we cannot unbind anymore
-if clevis luks unlock -d /dev/vda6 -n data ; then
+if clevis luks unlock -d /dev/disk/by-partlabel/publicdata -n data ; then
   fatal "could decrypt the device: the pcr pinning was not applied"
 fi
 

--- a/tests/kola/var-mount/lukspcr/test.sh
+++ b/tests/kola/var-mount/lukspcr/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# restrict to qemu for now because the primary disk path is platform-dependent
+# kola: {"platforms": "qemu", "architectures": "!s390x"}
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# /var/publicdata
+
+src=$(findmnt -nvr /var/publicdata -o SOURCE)
+[[ $(realpath "$src") == $(realpath /dev/mapper/data) ]]
+
+# we close the drive
+umount /var/publicdata
+cryptsetup close data
+
+# we validate we can still unlock the drive
+clevis luks unlock -d /dev/vda6 -n data
+mount /dev/mapper/data /var/publicdata
+umount /var/publicdata
+cryptsetup close data
+
+# we change the pcr value, that is used to bind the encryption key.
+# It will be resetted on reboot.
+tpm2_pcrextend 7:sha1=0x1234567890123456789012345678901234567890
+
+# we validate we cannot unbind anymore
+if clevis luks unlock -d /dev/vda6 -n data ; then
+  fatal "could decrypt the device: the pcr pinning was not applied"
+fi
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      ok "mounted on first boot"
+
+      # reboot once to sanity-check we can mount on second boot
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      ok "mounted on reboot"
+      ;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac


### PR DESCRIPTION
we bind the luks decryption key to pcr 0 and 7 using custom options

tests coreos/fedora-coreos-tracker#1255