### PR TITLE
overlay: omit bluetooth dracut module

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-omits.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-omits.conf
@@ -12,4 +12,4 @@ omit_dracutmodules+=" systemd-networkd network-legacy network-wicked "
 # We use systemd network naming
 omit_dracutmodules+=" biosdevname "
 # Random stuff we don't want
-omit_dracutmodules+=" rngd busybox dbus-daemon memstrack pcsc "
+omit_dracutmodules+=" rngd busybox dbus-daemon memstrack pcsc bluetooth "


### PR DESCRIPTION
We don't ship Bluetooth support. Should squash:

    dracut: 62bluetooth: Could not find any command of
    '/usr/lib/bluetooth/bluetoothd /usr/libexec/bluetooth/bluetoothd'!

Follow-up to #1838.