### PR TITLE
overlay: disable dracut stripping

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-nostrip.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/fcos-nostrip.conf
@@ -1,0 +1,3 @@
+# We don't ship `strip` or `eu-strip` today, and even if we did, it doesn't
+# save much space. So let's disable it to avoid the error-looking message.
+do_strip=no


### PR DESCRIPTION
While looking at the boot space issue[1], I tested whether stripping
binaries saved anything. Currently, dracut tries to strip binaries if
`strip` (or `eu-strip`) are available, which isn't the case in FCOS.

Adding it as a test, it turns out stripping barely saves anything
because we've already split out debug symbols into separate RPMs, and
the remaining symbols don't take much space.

So let's just tell dracut to stop trying to opportunistically strip
anything to be consistent. This then squashes a message emitted about
`strip` not being found.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1247