### PR TITLE
40ignition-ostree: fix minor secex-related nits

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.service
@@ -1,7 +1,7 @@
 # RHOCS 4.12.s390x has an old kernel with a known issue: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
 # Once we have kernel >= 4.18.0-387.el8.s390x we should drop this unit and copy config in coreos-diskful-generator
 [Unit]
-Description=Ignition OSTree: Inject secex config
+Description=Ignition OSTree: Inject Secure Execution Config
 DefaultDependencies=false
 ConditionArchitecture=s390x
 ConditionKernelCommandLine=ostree

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-secex-config.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ -f /run/coreos/secure-execution ]]; then
-    bootdev=$(blkid --list-one --output device --match-token PARTLABEL=boot | sed 's,[0-9]\+$,,')
-    sed "s,\${BOOTDEV},$bootdev," < /usr/lib/coreos/01-secex.ign > /usr/lib/ignition/base.d/01-secex.ign
-fi
+bootdev=$(blkid --list-one --output device --match-token PARTLABEL=boot | sed 's,[0-9]\+$,,')
+sed "s,\${BOOTDEV},$bootdev," < /usr/lib/coreos/01-secex.ign > /usr/lib/ignition/base.d/01-secex.ign


### PR DESCRIPTION
Follow-up to #1819.

Tweak the description of `ignition-ostree-secex-config.service` for
consistency and drop an unnecessary conditional in the associated
script.