### PR TITLE
tests: New `ostree-containers/rpmdb` test

### DIFF
--- a/tests/kola/ostree-containers/data/commonlib.sh
+++ b/tests/kola/ostree-containers/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/ostree-containers/rpmdb
+++ b/tests/kola/ostree-containers/rpmdb
@@ -1,0 +1,12 @@
+#!/bin/bash
+# kola: { "injectContainer": true }
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+skopeo copy oci-archive:$KOLA_OSTREE_OCIARCHIVE containers-storage:localhost/os
+rm -v $KOLA_OSTREE_OCIARCHIVE
+podman run --rm -ti localhost/os rpm -q systemd
+
+


### PR DESCRIPTION
This builds on https://github.com/coreos/coreos-assembler/pull/2999
to test that `rpm -q` works inside the container, which would
have caught https://github.com/coreos/fedora-coreos-tracker/issues/1258