### PR TITLE
re-enable kdump.crash test on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -9,6 +9,17 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
   arches:
     - ppc64le
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
+  snooze: 2022-08-30
+  arches:
+    - s390x
+  streams:
+  - next
+  - next-devel
+  - testing
+  - testing-devel
+  - stable
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,7 +6,7 @@
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1075
+  tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
     - ppc64le
 - pattern: ext.config.kdump.crash

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -15,6 +15,7 @@ packages:
   ## jq - parsing/interacting with JSON data
   - bash-completion
   - coreutils
+  - file
   - jq
   - less
   - sudo

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
-# kola: {"minMemory": 4096, "tags": "skip-base-checks", "timeoutMin": 15, "architectures": "!s390x"}
+# kola: {"minMemory": 4096, "tags": "skip-base-checks", "timeoutMin": 15}
 # - minMemory: 4096
 #   - Testing kdump requires some reserved memory for the crashkernel.
 # - tags: skip-base-checks
 #   - Skip checks for things like kernel crashes in the console logs.
 #     For this test we trigger a kernel crash on purpose.
-# - architectures: !s390x
-#   - kdump.service is failing on s390x. See
-#     https://github.com/coreos/fedora-coreos-config/issues/1500
 # - timeoutMin: 15
 #   - This test includes a few reboots and the generation of a vmcore,
 #     which can take longer than the default 10 minute timeout.


### PR DESCRIPTION
```
commit 229724d97f931e3494a8306a2f513476f2743e2e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Jul 21 15:01:01 2022 -0400

    denylist: use more appropriate link for ppc64le kdump.crash denial
    
    The other issue was closed and this one looks more appropriate.

commit 32603e61b8483bd1e0e0f840d3556b985b707d23
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Jul 21 14:58:44 2022 -0400

    tests: enable kdump.crash test for rawhide on s390x
    
    The fix has landed in rawhide [1]. Let's re-enable the test for
    rawhide and set a snooze on the other branches to remind ourselves
    to followup for the other branches.
    
    [1] https://github.com/coreos/fedora-coreos-config/issues/1500#issuecomment-1191799541

commit a65c241feec507fe72b995f299156cfe311bba0e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Jul 21 14:15:03 2022 -0400

    manifests/user-experience: explicitly add file RPM
    
    This is pulled in by GRUB on platforms that use GRUB, but we want
    it even on platforms that don't use GRUB.
    
    I noticed this when trying to run the ext.config.kdump.crash test
    on s390x and it failed because `/usr/bin/file` didn't exist.

```
