### PR TITLE
denylist: extend snooze for ext.config.binfmt.qemu on rawhide/aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -54,7 +54,7 @@
   - stable
 - pattern: ext.config.binfmt.qemu
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
-  snooze: 2022-07-21
+  snooze: 2022-08-10
   arches:
   - aarch64
   streams:


### PR DESCRIPTION
See coreos/fedora-coreos-tracker#1241