### PR TITLE
[rhcos-4.10] tests: set min memory for chrony dhcp propagation

### DIFF
--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -10,7 +10,7 @@ set -xeuo pipefail
 
 # Just run on QEMU; it should work theoretically on cloud platforms, but many
 # of those have platform-specific sources which take precedence.
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "minMemory": 2048 }
 
 test_setup() {
 


### PR DESCRIPTION
RHCOS 4.10 builds were failing because the qemu instance was running out
of memory. The test was failing as exit code 125 from the dockerfile
build but with exit code 137 when run manually. It was only running out
of memory downloading the repodata on the Fedora 35 container. The
Fedora 36 container did not have any issues.

Fixes: https://github.com/openshift/os/issues/899