### PR TITLE
manifests/group: fix ID for "input" group

### DIFF
--- a/manifests/group
+++ b/manifests/group
@@ -38,7 +38,7 @@ kube:x:994:
 chrony:x:992:
 tcpdump:x:72:
 ceph:x:167:
-input:x:995:
+input:x:104:
 systemd-timesync:x:991:
 systemd-network:x:990:
 systemd-resolve:x:989:

--- a/tests/kola/files/fcos_groups
+++ b/tests/kola/files/fcos_groups
@@ -35,6 +35,7 @@ declare -A setup_groups=( \
     ["lock"]="54" \
     ["audio"]="63" \
     ["users"]="100" \
+    ["input"]="104" \
 # CoreOS mismatch: https://github.com/coreos/fedora-coreos-tracker/issues/1201
 #   ["nobody"]="65534" \
     ["nobody"]="99" \
@@ -84,7 +85,6 @@ declare -A coreos_groups_static=( \
     ["chrony"]="992" \
     ["sssd"]="993" \
     ["kube"]="994" \
-    ["input"]="995" \
     ["cgred"]="996" \
     ["etcd"]="997" \
     ["polkitd"]="998" \


### PR DESCRIPTION
This fixes the static GID for the `input` group, properly using the
Fedora-wide reserved ID `104`.
This group is mostly used as the owner of ephemeral entries under
`/dev`, thus it should be safe to update (upon booting into the new
deployment, devices will get created from scratch with the new GID).

Ref: https://pagure.io/setup/blob/108f62338e57652bb3a37e9028572704f3f28c29/f/uidgid#_113
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1201#issuecomment-1192522908