### PR TITLE
tests/default-network-behavior-change: update for NM 1.39.8+

### DIFF
--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -92,6 +92,32 @@ method=auto
 
 [user]
 org.freedesktop.NetworkManager.origin=nm-initrd-generator"
+# EXPECTED_INITRD_NETWORK_CFG4
+#   - used on Fedora 37+
+EXPECTED_INITRD_NETWORK_CFG4="# Created by nm-initrd-generator
+
+[connection]
+id=Wired Connection
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-retries=1
+multi-connect=3
+
+[ethernet]
+
+[ipv4]
+dhcp-timeout=90
+method=auto
+required-timeout=20000
+
+[ipv6]
+dhcp-timeout=90
+method=auto
+
+[proxy]
+
+[user]
+org.freedesktop.NetworkManager.origin=nm-initrd-generator"
 
 # EXPECTED_REALROOT_NETWORK_CFG1:
 #   - used on RHEL <= 8.5
@@ -143,6 +169,29 @@ method=auto
 
 [.nmmeta]
 nm-generated=true"
+# EXPECTED_REALROOT_NETWORK_CFG3:
+#   - used on all Fedora 37+
+EXPECTED_REALROOT_NETWORK_CFG3="[connection]
+id=Wired connection 1
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-priority=-999
+interface-name=xxxx
+timestamp=xxxxxxxxxx
+
+[ethernet]
+
+[ipv4]
+method=auto
+
+[ipv6]
+addr-gen-mode=default
+method=auto
+
+[proxy]
+
+[.nmmeta]
+nm-generated=true"
 
 # Function that will remove unique (per-run) data from a connection file
 normalize_connection_file() {
@@ -156,7 +205,10 @@ source /etc/os-release
 # All current FCOS releases use the same config
 # https://github.com/coreos/fedora-coreos-config/pull/1533
 if [ "$ID" == "fedora" ]; then
-    if [ "$VERSION_ID" -ge "36" ]; then
+    if [ "$VERSION_ID" -ge "37" ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG4
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG3
+    elif [ "$VERSION_ID" -eq "36" ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG3
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG2
     else


### PR DESCRIPTION
Upstream NM landed some rework [1] to the ipv6.addr-gen-mode
knob which changed slightly some of the generated NM keyfiles.
Let's update the test to account for that.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/e6a33c04ebe1ac84e31628911e25bdfd7534dd3c