### PR TITLE
[rawhide] image: Switch to oci-chunked-v1

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -4,4 +4,4 @@
 include: image-base.yaml
 
 # Plan to move this to all streams soon
-ostree-format: "oci-chunked"
+ostree-format: "oci-chunked-v1"


### PR DESCRIPTION
Deploying/parsing this requires rpm-ostree v2022.12, which
is already in coreos-assembler and is on track for F36 stable.

Let's shake out any other bugs before changing all streams.