### PR TITLE
overrides: drop NetworkManager-1.38.0-2.fc37 override

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,29 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  NetworkManager:
-    evr: 1:1.38.0-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
-      type: pin
-  NetworkManager-cloud-setup:
-    evr: 1:1.38.0-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
-      type: pin
-  NetworkManager-libnm:
-    evr: 1:1.38.0-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
-      type: pin
-  NetworkManager-team:
-    evr: 1:1.38.0-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
-      type: pin
-  NetworkManager-tui:
-    evr: 1:1.38.0-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1245
-      type: pin
+packages: {}


### PR DESCRIPTION
The test has been fixed now in https://github.com/coreos/fedora-coreos-config/pull/1870

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1245