### PR TITLE
05core: fix permissions of `/etc/sudoers.d/coreos-sudo-group`

### DIFF
--- a/overlay.d/05core/statoverride
+++ b/overlay.d/05core/statoverride
@@ -1,6 +1,7 @@
 # Config file for overriding permission bits on overlay files/dirs
 # Format: =<file mode in decimal> <absolute path to a file or directory>
 
-# Some security scanners complain if /etc/sudoers.d files have 0044 mode bits
+# sudo prefers its config files to be mode 440, and some security scanners
+# complain if /etc/sudoers.d files are world-readable.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1981979
-=384 /etc/sudoers.d/coreos-sudo-group
+=288 /etc/sudoers.d/coreos-sudo-group

--- a/tests/kola/files/sudoers
+++ b/tests/kola/files/sudoers
@@ -6,9 +6,7 @@ set -xeuo pipefail
 . $KOLA_EXT_DATA/commonlib.sh
 
 # Security scanners complain about world-readable files in /etc/sudoers.d.
-# Check that there aren't any.
+# Check file permissions and syntax of /etc/sudoers and /etc/sudoers.d/*.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1981979
-sudoers_files="$(find /etc/sudoers.d -type f ! -perm 600 2>&1)"
-if [ -n "$sudoers_files" ]; then
-    fatal "Found files in /etc/sudoers.d with unexpected permissions: $sudoers_files"
-fi
+visudo -c
+ok "sudoers files are valid"


### PR DESCRIPTION
sudo wants them to be 440, not 600.

Also update the kola test to run `visudo -c` rather than checking the perms ourselves.  This not only checks perms, but also ensures that the files are syntactically valid.

Fixes https://github.com/coreos/fedora-coreos-config/issues/1872.