### PR TITLE
overrides: fast-track kexec-tools-2.0.24-4.fc36 for s390x kdump fix

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -9,17 +9,6 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
-  snooze: 2022-08-30
-  arches:
-    - s390x
-  streams:
-  - next
-  - next-devel
-  - testing
-  - testing-devel
-  - stable
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,10 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kexec-tools:
+    evr: 2.0.24-4.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-dc7dac9507
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1267
+      type: fast-track


### PR DESCRIPTION
Also drop the denylist entry.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1267