### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,28 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  console-login-helper-messages:
-    evra: 0.21.3-1.fc36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-8b6af15c3b
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1153
-      type: fast-track
-  console-login-helper-messages-issuegen:
-    evra: 0.21.3-1.fc36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-8b6af15c3b
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1153
-      type: fast-track
-  console-login-helper-messages-motdgen:
-    evra: 0.21.3-1.fc36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-8b6af15c3b
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1153
-      type: fast-track
-  console-login-helper-messages-profile:
-    evra: 0.21.3-1.fc36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-8b6af15c3b
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1153
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).