### PR TITLE
modify ext.config.files.setgid test as per upstream change to liblockfile

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -48,15 +48,3 @@
   - aarch64
   streams:
   - rawhide
-- pattern: ext.config.files.setgid
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1253
-  arches:
-  - s390x
-  streams:
-  - rawhide
-- pattern: fcos.filesystem
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1253
-  arches:
-  - s390x
-  streams:
-  - rawhide

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -9,6 +9,7 @@ list_setgid_files=(
     '/usr/bin/write'
     '/usr/libexec/openssh/ssh-keysign'
     '/usr/libexec/utempter/utempter'
+    '/usr/bin/dotlockfile'
 )
 
 unknown_setgid_files=""


### PR DESCRIPTION
fix: https://github.com/coreos/fedora-coreos-tracker/issues/1253

- modify `ext.config.files.setgid` test as per upstream change to liblockfile https://github.com/miquels/liblockfile/blob/9389848f70d5b1f242ffffe1ebf7865011f9026f/Makefile.in#L80-L83 which tries too set a special groupId.

- since `fcos.filesystem` test is deleted by https://github.com/coreos/coreos-assembler/pull/2986 thereby removing it from the denylist