### PR TITLE
05core: create top-level user symlinks on first boot

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -32,3 +32,4 @@ enable rtas_errd.service
 enable clevis-luks-askpass.path
 # Provide status information about the Ignition run
 enable coreos-ignition-write-issues.service
+enable coreos-create-toplevel-symlinks.service

--- a/overlay.d/05core/usr/lib/systemd/system/coreos-create-toplevel-symlinks.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-create-toplevel-symlinks.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=CoreOS Create Top-Level User Symlinks
+Documentation=https://docs.fedoraproject.org/en-US/fedora-coreos/
+ConditionPathExists=!/run/ostree-live
+DefaultDependencies=false
+RequiresMountsFor=/boot
+
+# We run on first boot only
+ConditionFirstBoot=true
+Before=first-boot-complete.target systemd-machine-id-commit.service
+Wants=first-boot-complete.target
+
+# We run before anything gets mounted
+Before=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ostree admin create-toplevel-user-links
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
With this, users can specify an Ignition config like

```yaml
variant: fcos
version: 1.4.0
storage:
  files:
    - path: /etc/ostree/config.d/01-foobar.conf
      contents:
        inline: |
          [toplevel-links]
          foobar=/var/foobar
```

and on first boot, a `/foobar` symlink will be created.

Requires: https://github.com/ostreedev/ostree/pull/2681
Related: https://github.com/coreos/rpm-ostree/issues/337