### PR TITLE
tests: var-mount.scsi-id and default-network-behavior-change add support for scos

### DIFF
--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -93,7 +93,7 @@ method=auto
 [user]
 org.freedesktop.NetworkManager.origin=nm-initrd-generator"
 # EXPECTED_INITRD_NETWORK_CFG4
-#   - used on Fedora 37+
+#   - used on Fedora 37+ and scos
 EXPECTED_INITRD_NETWORK_CFG4="# Created by nm-initrd-generator
 
 [connection]
@@ -170,7 +170,7 @@ method=auto
 [.nmmeta]
 nm-generated=true"
 # EXPECTED_REALROOT_NETWORK_CFG3:
-#   - used on all Fedora 37+
+#   - used on all Fedora 37+ and scos
 EXPECTED_REALROOT_NETWORK_CFG3="[connection]
 id=Wired connection 1
 uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -214,17 +214,24 @@ if [ "$ID" == "fedora" ]; then
     else
         fatal "fail: not operating on expected OS version"
     fi
-elif [ "$ID" == "rhcos" ]; then
+elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
     # For the version comparison use string substitution to remove the
     # '.` from the version so we can use integer comparison
+    
+    # scos does not have RHEL_VERSION variable in /etc/os-release
+    if [[ ${RHEL_VERSION:-} == "" ]]; then
+        RHEL_VERSION=$(echo $OSTREE_VERSION | cut -f2 -d.)
+    fi    
+    # scos includes NetworkManager-1.39.10-1.el9.x86_64, update scripts
+    # according to F37
+    if [ "${RHEL_VERSION/\./}" -ge 91 ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG4
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG3
     # RHEL8.6 includes NetworkManager-1.36.0-1.el8.x86_64, update scripts
     # according to F36
-    if [ "${RHEL_VERSION/\./}" -ge 86 ]; then
+    elif [ "${RHEL_VERSION/\./}" -ge 86 ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG3
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG2
-    elif [ "${RHEL_VERSION/\./}" -eq 85 ]; then
-        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG1
-        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1
     elif [ "${RHEL_VERSION/\./}" -eq 84 ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG2
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG1

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -17,8 +17,8 @@ source /etc/os-release
 ostree_conf=""
 if [ "$ID" == "fedora" ]; then
     ostree_conf="/boot/loader.1/entries/ostree-1-fedora-coreos.conf"
-elif [ "$ID" == "rhcos" ]; then
-    ostree_conf="/boot/loader.1/entries/ostree-1-rhcos.conf"
+elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
+    ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"
 else
     fatal "fail: not operating on expected OS"
 fi


### PR DESCRIPTION
Add scos support for var-mount.scsi-id

```
[coreos-assembler]$ kola run ext.config.shared.var-mount.scsi-id
⚠️  Skipping kola test pattern "coreos.ignition.journald-log":
  👉 https://github.com/coreos/coreos-assembler/issues/1173
=== RUN   ext.config.shared.var-mount.scsi-id
--- PASS: ext.config.shared.var-mount.scsi-id (76.63s)
PASS, output in tmp/kola/qemu-unpriv-2022-08-01-0731-187
```

Also add scos support for tests/default-network-behavior-change