### PR TITLE
05core: fix `coreos-boot-edit.service` race with switch-root

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
@@ -16,6 +16,12 @@ After=dev-disk-by\x2dlabel-boot.device
 After=ignition-files.service
 # As above, this isn't strictly necessary, but on principle.
 After=coreos-multipath-wait.target
+# Finish before systemd starts tearing down services
+Before=initrd.target
+# initrd-parse-etc.service starts initrd-cleanup.service which will race
+# with us completing before we get nuked.  Need to get to the bottom of it,
+# but for now we need this.
+Before=initrd-parse-etc.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
`coreos-boot-edit.service` wasn't sequenced `Before` anything, so under heavy I/O contention it could race with services being terminated prior to switching to the real root.  `Before=initrd.target` should fix this, so we specify it, but it isn't enough for the same unknown reason as in 8b804863c64c3df4f34384019de019c48d18ad5e.  Also specify `Before=initrd-parse-etc.service` to avoid that problem.

Fixes occasional `multipath.day1` flakes in https://github.com/coreos/fedora-coreos-tracker/issues/1105, which became more frequent after https://github.com/coreos/coreos-ci-lib/pull/112 landed.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1105.