### PR TITLE
05core: add `Before=` to more Dracut services, and add CI check

### DIFF
--- a/ci/validate
+++ b/ci/validate
@@ -6,12 +6,36 @@ import stat
 import subprocess
 import yaml
 
+INITRD_SERVICES_WITHOUT_BEFORE = {
+    # Depended on by other services
+    'coreos-livepxe-rootfs.service',
+}
+
 validated=0
+
+def openat(dirfd, name, mode='r'):
+    def opener(path, flags):
+        return os.open(path, flags, dir_fd=dirfd)
+    return open(name, mode, opener=opener)
+
+
+def validate_initrd_service(rootfd, name):
+    with openat(rootfd, name) as fh:
+        if ([l for l in fh.readlines() if l.startswith('Before=')] or
+                name in INITRD_SERVICES_WITHOUT_BEFORE):
+            global validated
+            validated += 1
+        else:
+            raise Exception(
+                f'{name} has no Before= and may race with switch-root'
+            )
+
 
 def validate_shell(rootfd, name):
     subprocess.check_call(['bash', '-n', name], preexec_fn=lambda: os.fchdir(rootfd))
     global validated
     validated +=1
+
 
 for root, dirs, files, rootfd in os.fwalk('.'):
     # Skip .git
@@ -26,6 +50,8 @@ for root, dirs, files, rootfd in os.fwalk('.'):
         elif name.endswith('.sh'):
             validate_shell(rootfd, name)
             continue
+        elif 'dracut/modules.d' in root and name.endswith('.service'):
+            validate_initrd_service(rootfd, name)
         stbuf = os.lstat(name, dir_fd=rootfd)
         if not stat.S_ISREG(stbuf.st_mode):
             continue

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
@@ -6,6 +6,8 @@ ConditionKernelCommandLine=ostree
 ConditionPathExists=!/run/ostree-live
 After=ignition-ostree-growfs.service
 After=ostree-prepare-root.service
+# Allow Ignition config to blank out the warning
+Before=ignition-files.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/coreos-touch-run-agetty.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/60coreos-agetty-workaround/coreos-touch-run-agetty.service
@@ -5,6 +5,7 @@
 Description=CoreOS: Touch /run/agetty.reload
 Documentation=https://bugzilla.redhat.com/show_bug.cgi?id=1932053
 DefaultDependencies=false
+Before=initrd.target
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-shell-setup/ignition-virtio-dump-journal.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/99emergency-shell-setup/ignition-virtio-dump-journal.service
@@ -7,6 +7,7 @@ ConditionVirtualization=|qemu
 Requires=systemd-journald.service
 After=systemd-journald.service
 After=basic.target
+Before=initrd.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
If initrd services don't sequence themselves `Before` anything, it's possible that they won't be started before `initrd-cleanup.service` isolates to `initrd-switch-root.target` and kills them off.  Add at least `Before=initrd.target` to avoid this, plus a CI check to prevent a reoccurrence.