### PR TITLE
manifests/passwd: align 'nologin' shell path with systemd defaults

### DIFF
--- a/manifests/passwd
+++ b/manifests/passwd
@@ -1,33 +1,33 @@
 root:x:0:0:root:/root:/bin/bash
-bin:x:1:1:bin:/bin:/sbin/nologin
-daemon:x:2:2:daemon:/sbin:/sbin/nologin
-adm:x:3:4:adm:/var/adm:/sbin/nologin
-lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+bin:x:1:1:bin:/bin:/usr/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/usr/sbin/nologin
+adm:x:3:4:adm:/var/adm:/usr/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/usr/sbin/nologin
 sync:x:5:0:sync:/sbin:/bin/sync
 shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
 halt:x:7:0:halt:/sbin:/sbin/halt
-mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-operator:x:11:0:operator:/root:/sbin/nologin
-games:x:12:100:games:/usr/games:/sbin/nologin
-ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
-nobody:x:99:99:Nobody:/:/sbin/nologin
-dbus:x:81:81:System message bus:/:/sbin/nologin
-polkitd:x:999:998:User for polkitd:/:/sbin/nologin
-etcd:x:998:997:etcd user:/var/lib/etcd:/sbin/nologin
-tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
-avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/sbin/nologin
-rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin
-sssd:x:995:993:User for sssd:/:/sbin/nologin
-dockerroot:x:997:986:Docker User:/var/lib/docker:/sbin/nologin
-rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin
-nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/sbin/nologin
-kube:x:996:994:Kubernetes user:/:/sbin/nologin
-sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin
-chrony:x:994:992::/var/lib/chrony:/sbin/nologin
-tcpdump:x:72:72::/:/sbin/nologin
-ceph:x:167:167:Ceph daemons:/var/lib/ceph:/sbin/nologin
-systemd-timesync:x:993:991:systemd Time Synchronization:/:/sbin/nologin
-systemd-network:x:991:990:systemd Network Management:/:/sbin/nologin
-systemd-resolve:x:990:989:systemd Resolver:/:/sbin/nologin
-systemd-bus-proxy:x:989:988:systemd Bus Proxy:/:/sbin/nologin
-cockpit-ws:x:988:987:User for cockpit-ws:/:/sbin/nologin
+mail:x:8:12:mail:/var/spool/mail:/usr/sbin/nologin
+operator:x:11:0:operator:/root:/usr/sbin/nologin
+games:x:12:100:games:/usr/games:/usr/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/usr/sbin/nologin
+nobody:x:99:99:Nobody:/:/usr/sbin/nologin
+dbus:x:81:81:System message bus:/:/usr/sbin/nologin
+polkitd:x:999:998:User for polkitd:/:/usr/sbin/nologin
+etcd:x:998:997:etcd user:/var/lib/etcd:/usr/sbin/nologin
+tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/usr/sbin/nologin
+avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/usr/sbin/nologin
+rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/sbin/nologin
+sssd:x:995:993:User for sssd:/:/usr/sbin/nologin
+dockerroot:x:997:986:Docker User:/var/lib/docker:/usr/sbin/nologin
+rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/usr/sbin/nologin
+nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/usr/sbin/nologin
+kube:x:996:994:Kubernetes user:/:/usr/sbin/nologin
+sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/usr/sbin/nologin
+chrony:x:994:992::/var/lib/chrony:/usr/sbin/nologin
+tcpdump:x:72:72::/:/usr/sbin/nologin
+ceph:x:167:167:Ceph daemons:/var/lib/ceph:/usr/sbin/nologin
+systemd-timesync:x:993:991:systemd Time Synchronization:/:/usr/sbin/nologin
+systemd-network:x:991:990:systemd Network Management:/:/usr/sbin/nologin
+systemd-resolve:x:990:989:systemd Resolver:/:/usr/sbin/nologin
+systemd-bus-proxy:x:989:988:systemd Bus Proxy:/:/usr/sbin/nologin
+cockpit-ws:x:988:987:User for cockpit-ws:/:/usr/sbin/nologin


### PR DESCRIPTION
This updates all relevant shell fields to use `/usr/sbin/nologin`.
After the `/usr` hierarchy merge that happened in Fedora 17, the
`nologin` binary is now effectively located under `/usr/sbin/`.
For this reason, `systemd-sysusers` directly uses the latter path
as the default shell for system users.
While semantically equivalent, updating all entries to the new
location ensures that defaults are matching across all components.
In turn, that allows packages to avoid specifying a custom `nologin`
shell in sysusers.d fragment, and just rely on systemd defaults.

Refs:
 * https://fedoraproject.org/wiki/Features/UsrMove
 * https://github.com/systemd/systemd/blob/v251/meson.build#L633
 * https://pagure.io/setup/pull-request/40