### PR TITLE
s390x: Remove SetGID dotlockfile from liblockfile

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -33,3 +33,10 @@ packages-x86_64:
   - microcode_ctl
   # firmware updates
   - fwupd
+
+# See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
+#      https://bugzilla.redhat.com/show_bug.cgi?id=2112857
+# Temporary workaround to remove the SetGID binary from liblockfile that is
+# pulled by the s390utils but not needed for /usr/sbin/zipl.
+remove-from-packages:
+  - ["liblockfile", "/usr/bin/dotlockfile"]

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -9,7 +9,6 @@ list_setgid_files=(
     '/usr/bin/write'
     '/usr/libexec/openssh/ssh-keysign'
     '/usr/libexec/utempter/utempter'
-    '/usr/bin/dotlockfile'
 )
 
 unknown_setgid_files=""


### PR DESCRIPTION
s390x: Remove SetGID dotlockfile from liblockfile

Adding a new SetUID/SetGID binary to FCOS must come with a security
review as well as a detailed and explicit purpose.

Remove the offending binaries until we confirm that this is really
needed.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
See: https://bugzilla.redhat.com/show_bug.cgi?id=2112857
Fixes: 3505072d modify ext.config.files.setgid test as per upstream change to liblockfile ; fcos.filesystem test is deleted by #2986