### PR TITLE
[rawhide] overrides: pin cryptsetup

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  cryptsetup:
+    evr: 2.5.0~rc1-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
+      type: pin
+  cryptsetup-libs:
+    evr: 2.5.0~rc1-2.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
+      type: pin


### PR DESCRIPTION
`coreos.boot-mirror.luks` is failing in rawhide due to `cryptsetup`.

related: https://github.com/coreos/fedora-coreos-tracker/issues/1268