### PR TITLE
[rhcos-4.11] tests: bump memory for tests because of DNF issue

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
@@ -16,6 +16,12 @@ After=dev-disk-by\x2dlabel-boot.device
 After=ignition-files.service
 # As above, this isn't strictly necessary, but on principle.
 After=coreos-multipath-wait.target
+# Finish before systemd starts tearing down services
+Before=initrd.target
+# initrd-parse-etc.service starts initrd-cleanup.service which will race
+# with us completing before we get nuked.  Need to get to the bottom of it,
+# but for now we need this.
+Before=initrd-parse-etc.service
 
 [Service]
 Type=oneshot

--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15 }
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
 # This script creates two veth interfaces i.e. one for the host machine 
 # and other for the container(dnsmasq server). This setup will be helpful
 # to verify the DHCP propagation of NTP servers. This will also avoid any 
@@ -16,6 +16,10 @@
 # - timeoutMin: 15
 #   - Pulling and building the container can take a long time if a
 #     slow mirror gets chosen.
+# - minMemory: 1536
+#   - There's a bug in dnf that is causing OOM on low memory systems:
+#     https://bugzilla.redhat.com/show_bug.cgi?id=1907030
+#     https://pagure.io/releng/issue/10935#comment-808601
 
 set -xeuo pipefail
 

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
 # This script runs a rootless podman container (rootless because it's
 # run as the `core` user) with systemd inside that brings up httpd.
 # It tests that rootless+systemd works. See issue:
@@ -21,6 +21,10 @@
 # - timeoutMin: 15
 #   - Pulling and building the container can take a long time if a
 #     slow mirror gets chosen.
+# - minMemory: 1536
+#   - There's a bug in dnf that is causing OOM on low memory systems:
+#     https://bugzilla.redhat.com/show_bug.cgi?id=1907030
+#     https://pagure.io/releng/issue/10935#comment-808601
 
 set -xeuo pipefail
 


### PR DESCRIPTION
It appears there is some issue where DNF is getting OOM killed
with the current versions of DNF and the current updates repo.
Not sure what the issue is entirely, but let's bump the memory
required for the tests that run DNF inside a container.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1907030
xref: https://pagure.io/releng/issue/10935
(cherry picked from commit 3dee27d4487ee0a484858fe60e3c5b1a792d48b9)