### PR TITLE
[rawhide] Revert "Enable cliwrap (rawhide only for now)"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,6 +8,3 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
-
-# Only enabled on rawhide right now
-cliwrap: true


### PR DESCRIPTION
This reverts commit 35661f93f2ffc441da4a66f353d5c6b460c77aa8.  We
will work to gain more consensus before enabling this by default
anywhere.

Having it merged for a while was useful to shake out issues, of which we only found one (the kdump one), but I don't think we'll get any more real testing just in rawhide.