### PR TITLE
[rhcos-4.11] Revert "05core: fix coreos-boot-edit.service race with switch-root"

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.service
@@ -16,12 +16,6 @@ After=dev-disk-by\x2dlabel-boot.device
 After=ignition-files.service
 # As above, this isn't strictly necessary, but on principle.
 After=coreos-multipath-wait.target
-# Finish before systemd starts tearing down services
-Before=initrd.target
-# initrd-parse-etc.service starts initrd-cleanup.service which will race
-# with us completing before we get nuked.  Need to get to the bottom of it,
-# but for now we need this.
-Before=initrd-parse-etc.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This reverts commit 539f342b78478360c1939c2547a343107bb79849.

The test change and the race condition should be split so we can
independently evaluate the changes and avoid unnecessary changes near
release time.