### PR TITLE
tests/kola/root-reprovision: add `reprovision` tag

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15 }
+# kola: { "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15, "tags": "reprovision" }
 #
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
+# - tags: reprovision
+#   - This test reprovisions the rootfs.
 # - minMemory: 4096
 #   - Root reprovisioning requires at least 4GiB of memory.
 # - timeoutMin: 15

--- a/tests/kola/root-reprovision/linear/test.sh
+++ b/tests/kola/root-reprovision/linear/test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15 }
+# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15, "tags": "reprovision" }
 #
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
 #   - additionalDisks is only supported on qemu.
+# - tags: reprovision
+#   - This test reprovisions the rootfs.
 # - minMemory: 4096
 #   - Root reprovisioning requires at least 4GiB of memory.
 # - additionalDisks: ["5G", "5G"]

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x", "timeoutMin": 15 }
+# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x", "timeoutMin": 15, "tags": "reprovision" }
 #
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
+# - tags: reprovision
+#   - This test reprovisions the rootfs.
 # - minMemory: 4096
 #   - Root reprovisioning requires at least 4GiB of memory.
 # - architectures: !s390x

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15 }
+# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "timeoutMin": 15, "tags": "reprovision" }
 #
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
 #   - additionalDisks is only supported on qemu.
+# - tags: reprovision
+#   - This test reprovisions the rootfs.
 # - minMemory: 4096
 #   - Root reprovisioning requires at least 4GiB of memory.
 # - additionalDisks: ["5G", "5G"]

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15, "allowConfigWarnings": true }
+# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15, "allowConfigWarnings": true, "tags": "reprovision" }
 #
 # - distros: fcos
 #   - This test only runs on FCOS due to a problem enabling a swap partition on
 #     RHCOS. See: https://github.com/openshift/os/issues/665
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
+# - tags: reprovision
+#   - This test reprovisions the rootfs.
 # - minMemory: 4096
 #   - Root reprovisioning requires at least 4GiB of memory.
 # - timeoutMin: 15


### PR DESCRIPTION
This can be used to conveniently skip those tests by tag.