### PR TITLE
[rawhide] overrides: pin grub2 and filesystem

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -9,18 +9,23 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  cryptsetup:
-    evr: 2.5.0~rc1-2.fc37
+  grub2-common:
+    evra: 1:2.06-43.fc37.noarch
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
       type: pin
-  cryptsetup-libs:
-    evr: 2.5.0~rc1-2.fc37
+  grub2-tools-minimal:
+    evra: 1:2.06-43.fc37.aarch64
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
       type: pin
-  filesystem:
-    evr: 3.16-4.fc37
+  grub2-efi-aa64:
+    evra: 1:2.06-43.fc37.aarch64
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1273
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-43.fc37.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
       type: pin

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-pc-modules:
+    evra: 1:2.06-43.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-common:
+    evra: 1:2.06-43.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-43.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-efi-x64:
+    evra: 1:2.06-43.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-pc:
+    evra: 1:2.06-43.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-43.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
+      type: pin


### PR DESCRIPTION
kola basic tests aren't coming up and the machines aren't getting out of grub.
Also filesystem.posttrans fails with unsupported lua script
Relates to:
https://github.com/coreos/fedora-coreos-tracker/issues/1271
https://github.com/coreos/fedora-coreos-tracker/issues/1273