### PR TITLE
[rawhide] overrides: Drop filesystem pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,8 +19,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
       type: pin
-  filesystem:
-    evr: 3.16-4.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1273
-      type: pin


### PR DESCRIPTION
Partially reverts 9e6227328388915d68cee6d2c7e17eb48647c160
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1273