### PR TITLE
WIP test rpm-ostree remove-from-packages

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -39,4 +39,5 @@ packages-x86_64:
 # Temporary workaround to remove the SetGID binary from liblockfile that is
 # pulled by the s390utils but not needed for /usr/sbin/zipl.
 remove-from-packages:
-  - ["liblockfile", "/usr/bin/dotlockfile"]
+  - [liblockfile, /usr/bin/dotlockfile]
+  - [util-linux, /usr/bin/write]


### PR DESCRIPTION
Do not merge this one.

This is a test PR to try understanding why https://github.com/coreos/fedora-coreos-config/pull/1887 fails.