### PR TITLE
[rawhide] overrides: pin kernel-5.19.0-0.rc8.20220727git39c3c396f813.60.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,3 +19,18 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
       type: pin
+  kernel:
+    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
+      type: pin
+  kernel-core:
+    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
+      type: pin
+  kernel-modules:
+    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).