### PR TITLE
overrides: drop filesystem pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  filesystem:
-    evr: 3.16-2.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1273
-      type: pin
+packages: {}


### PR DESCRIPTION
A new rpm-ostree has been tagged that can handle the new lua
scriptlet in the filesystem package.

This reverts commit b7dd545536aa7f13f17dd87490aca25f06f569dd.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1273