### PR TITLE
s390x: Remove SetGID dotlockfile from liblockfile (postprocess)

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -34,9 +34,13 @@ packages-x86_64:
   # firmware updates
   - fwupd
 
-# See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
-#      https://bugzilla.redhat.com/show_bug.cgi?id=2112857
-# Temporary workaround to remove the SetGID binary from liblockfile that is
-# pulled by the s390utils but not needed for /usr/sbin/zipl.
-remove-from-packages:
-  - ["liblockfile", "/usr/bin/dotlockfile"]
+postprocess:
+  # See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
+  #      https://bugzilla.redhat.com/show_bug.cgi?id=2112857
+  #      https://github.com/coreos/rpm-ostree/issues/3918
+  # Temporary workaround to remove the SetGID binary from liblockfile that is
+  # pulled by the s390utils but not needed for /usr/sbin/zipl.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rm -f /usr/bin/dotlockfile


### PR DESCRIPTION
Moved from `remove-from-packages` to post-process due to a bug in
rpm-ostree.

See: https://github.com/coreos/rpm-ostree/issues/3918
See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
See: https://bugzilla.redhat.com/show_bug.cgi?id=2112857
Fixes: 5053bc7d s390x: Remove SetGID dotlockfile from liblockfile
Fixes: 3505072d modify ext.config.files.setgid test as per upstream change to liblockfile ; fcos.filesystem test is deleted by #2986