### PR TITLE
[rawhide] overrides: fast-track grub2-2.06-47.fc37

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,22 +10,26 @@
 
 packages:
   grub2-common:
-    evra: 1:2.06-43.fc37.noarch
+    evra: 1:2.06-47.fc37.noarch
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-tools-minimal:
-    evra: 1:2.06-43.fc37.aarch64
+    evra: 1:2.06-47.fc37.aarch64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-efi-aa64:
-    evra: 1:2.06-43.fc37.aarch64
+    evra: 1:2.06-47.fc37.aarch64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-tools:
-    evra: 1:2.06-43.fc37.aarch64
+    evra: 1:2.06-47.fc37.aarch64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,32 +10,38 @@
 
 packages:
   grub2-pc-modules:
-    evra: 1:2.06-43.fc37.noarch
+    evra: 1:2.06-47.fc37.noarch
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-common:
-    evra: 1:2.06-43.fc37.noarch
+    evra: 1:2.06-47.fc37.noarch
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-tools-minimal:
-    evra: 1:2.06-43.fc37.x86_64
+    evra: 1:2.06-47.fc37.x86_64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-efi-x64:
-    evra: 1:2.06-43.fc37.x86_64
+    evra: 1:2.06-47.fc37.x86_64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-pc:
-    evra: 1:2.06-43.fc37.x86_64
+    evra: 1:2.06-47.fc37.x86_64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116
   grub2-tools:
-    evra: 1:2.06-43.fc37.x86_64
+    evra: 1:2.06-47.fc37.x86_64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1271
-      type: pin
+      type: fast-track
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1199601116


### PR DESCRIPTION
This should fix
https://github.com/coreos/fedora-coreos-tracker/issues/1271