### PR TITLE
Move ssh-key-dir to shared manifest for EL9

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -9,6 +9,7 @@ include:
   - system-configuration.yaml
   - user-experience.yaml
   - shared-workarounds.yaml
+  - shared-el9.yaml
 
 ostree-layers:
   - overlay/05core
@@ -114,8 +115,6 @@ postprocess:
 packages:
   # Security
   - polkit
-  # SSH
-  - ssh-key-dir
   # Containers
   - systemd-container catatonit
   - fuse-overlayfs slirp4netns

--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -1,0 +1,6 @@
+# These are packages that are shared between FCOS and
+# RHCOS/SCOS 9+
+
+packages:
+  # SSH
+  - ssh-key-dir


### PR DESCRIPTION
The new `shared-el9.yaml` manifest is intended for packages that are
shared between FCOS and RHCOS/SCOS 9+.

Related to https://issues.redhat.com/browse/COS-1589

/cc @bgilbert
/cc @travier 