### PR TITLE
denylist: extend snooze for ext.config.binfmt.qemu

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -43,7 +43,7 @@
   - stable
 - pattern: ext.config.binfmt.qemu
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
-  snooze: 2022-08-10
+  snooze: 2022-09-10
   arches:
   - aarch64
   streams:


### PR DESCRIPTION
Still working with kernel team to get this one figured out. See
https://github.com/coreos/fedora-coreos-tracker/issues/1241