### PR TITLE
manifests/passwd: re-sync user entries with Fedora and sort them

### DIFF
--- a/manifests/passwd
+++ b/manifests/passwd
@@ -10,11 +10,11 @@ mail:x:8:12:mail:/var/spool/mail:/usr/sbin/nologin
 operator:x:11:0:operator:/root:/usr/sbin/nologin
 games:x:12:100:games:/usr/games:/usr/sbin/nologin
 ftp:x:14:50:FTP User:/var/ftp:/usr/sbin/nologin
-nobody:x:99:99:Nobody:/:/usr/sbin/nologin
-dbus:x:81:81:System message bus:/:/usr/sbin/nologin
+nobody:x:99:99:Kernel Overflow User:/:/usr/sbin/nologin
+dbus:x:81:81:System Message Bus:/:/usr/sbin/nologin
 polkitd:x:999:998:User for polkitd:/:/usr/sbin/nologin
 etcd:x:998:997:etcd user:/var/lib/etcd:/usr/sbin/nologin
-tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/usr/sbin/nologin
+tss:x:59:59:Account used for TPM access:/:/usr/sbin/nologin
 avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/usr/sbin/nologin
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/sbin/nologin
 sssd:x:995:993:User for sssd:/:/usr/sbin/nologin

--- a/manifests/passwd
+++ b/manifests/passwd
@@ -18,7 +18,7 @@ nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/usr/sbin/nologin
 nobody:x:99:99:Kernel Overflow User:/:/usr/sbin/nologin
 operator:x:11:0:operator:/root:/usr/sbin/nologin
 polkitd:x:999:998:User for polkitd:/:/usr/sbin/nologin
-root:x:0:0:root:/root:/bin/bash
+root:x:0:0:Super User:/root:/bin/bash
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/sbin/nologin
 rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/usr/sbin/nologin
 shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown

--- a/manifests/passwd
+++ b/manifests/passwd
@@ -1,33 +1,33 @@
-root:x:0:0:root:/root:/bin/bash
-bin:x:1:1:bin:/bin:/usr/sbin/nologin
-daemon:x:2:2:daemon:/sbin:/usr/sbin/nologin
 adm:x:3:4:adm:/var/adm:/usr/sbin/nologin
-lp:x:4:7:lp:/var/spool/lpd:/usr/sbin/nologin
-sync:x:5:0:sync:/sbin:/bin/sync
-shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-halt:x:7:0:halt:/sbin:/sbin/halt
-mail:x:8:12:mail:/var/spool/mail:/usr/sbin/nologin
-operator:x:11:0:operator:/root:/usr/sbin/nologin
-games:x:12:100:games:/usr/games:/usr/sbin/nologin
-ftp:x:14:50:FTP User:/var/ftp:/usr/sbin/nologin
-nobody:x:99:99:Kernel Overflow User:/:/usr/sbin/nologin
-dbus:x:81:81:System Message Bus:/:/usr/sbin/nologin
-polkitd:x:999:998:User for polkitd:/:/usr/sbin/nologin
-etcd:x:998:997:etcd user:/var/lib/etcd:/usr/sbin/nologin
-tss:x:59:59:Account used for TPM access:/:/usr/sbin/nologin
 avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/usr/sbin/nologin
-rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/sbin/nologin
-sssd:x:995:993:User for sssd:/:/usr/sbin/nologin
-dockerroot:x:997:986:Docker User:/var/lib/docker:/usr/sbin/nologin
-rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/usr/sbin/nologin
-nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/usr/sbin/nologin
-kube:x:996:994:Kubernetes user:/:/usr/sbin/nologin
-sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/usr/sbin/nologin
-chrony:x:994:992::/var/lib/chrony:/usr/sbin/nologin
-tcpdump:x:72:72::/:/usr/sbin/nologin
+bin:x:1:1:bin:/bin:/usr/sbin/nologin
 ceph:x:167:167:Ceph daemons:/var/lib/ceph:/usr/sbin/nologin
-systemd-timesync:x:993:991:systemd Time Synchronization:/:/usr/sbin/nologin
+chrony:x:994:992::/var/lib/chrony:/usr/sbin/nologin
+cockpit-ws:x:988:987:User for cockpit-ws:/:/usr/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/usr/sbin/nologin
+dbus:x:81:81:System Message Bus:/:/usr/sbin/nologin
+dockerroot:x:997:986:Docker User:/var/lib/docker:/usr/sbin/nologin
+etcd:x:998:997:etcd user:/var/lib/etcd:/usr/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/usr/sbin/nologin
+games:x:12:100:games:/usr/games:/usr/sbin/nologin
+halt:x:7:0:halt:/sbin:/sbin/halt
+kube:x:996:994:Kubernetes user:/:/usr/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:12:mail:/var/spool/mail:/usr/sbin/nologin
+nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/usr/sbin/nologin
+nobody:x:99:99:Kernel Overflow User:/:/usr/sbin/nologin
+operator:x:11:0:operator:/root:/usr/sbin/nologin
+polkitd:x:999:998:User for polkitd:/:/usr/sbin/nologin
+root:x:0:0:root:/root:/bin/bash
+rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/usr/sbin/nologin
+rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/usr/sbin/nologin
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/usr/sbin/nologin
+sssd:x:995:993:User for sssd:/:/usr/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+systemd-bus-proxy:x:989:988:systemd Bus Proxy:/:/usr/sbin/nologin
 systemd-network:x:991:990:systemd Network Management:/:/usr/sbin/nologin
 systemd-resolve:x:990:989:systemd Resolver:/:/usr/sbin/nologin
-systemd-bus-proxy:x:989:988:systemd Bus Proxy:/:/usr/sbin/nologin
-cockpit-ws:x:988:987:User for cockpit-ws:/:/usr/sbin/nologin
+systemd-timesync:x:993:991:systemd Time Synchronization:/:/usr/sbin/nologin
+tcpdump:x:72:72::/:/usr/sbin/nologin
+tss:x:59:59:Account used for TPM access:/:/usr/sbin/nologin


### PR DESCRIPTION
This updates users details in order to re-sync with the ones from Fedora packages.
It also sort all users by name, so that it is easier to diff against systemd-sysusers
output.