### PR TITLE
overlay: add `06el9` overlay

### DIFF
--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -4,3 +4,6 @@
 packages:
   # SSH
   - ssh-key-dir
+
+ostree-layers:
+  - overlay/06el9

--- a/overlay.d/06el9/statoverride
+++ b/overlay.d/06el9/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/16disable-zincati/statoverride
+++ b/overlay.d/16disable-zincati/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -4,9 +4,15 @@ files via `ostree-layers` (this used to be done automatically, but that's no
 longer the case).
 
 05core
------
+------
 
 This overlay matches `fedora-coreos-base.yaml`; core Ignition+ostree bits.
+
+06el9
+-----
+
+This overlay includes content shared between FCOS and RHCOS/SCOS 9, but not
+RHCOS 8.
 
 08nouveau
 ---------


### PR DESCRIPTION
Add overlay for content shared between FCOS and RHCOS/SCOS 9.

Discussion in https://github.com/coreos/fedora-coreos-config/issues/1878.