### PR TITLE
update fallback hostname handling; add test

### DIFF
--- a/manifests/fallback-hostname.yaml
+++ b/manifests/fallback-hostname.yaml
@@ -1,0 +1,11 @@
+postprocess:
+  # Set the fallback hostname to `localhost`. This can be removed
+  # once we are based on Fedora 37+.
+  # See https://github.com/coreos/fedora-coreos-tracker/issues/902
+  - |
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    source /etc/os-release
+    if [ -z "${DEFAULT_HOSTNAME:-}" ]; then
+      echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
+    fi

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -11,6 +11,10 @@ include:
   - shared-workarounds.yaml
   - shared-el9.yaml
 
+conditional-include:
+  - if: releasever <= 36
+    include: fallback-hostname.yaml
+
 ostree-layers:
   - overlay/05core
   - overlay/08nouveau
@@ -67,19 +71,6 @@ postprocess:
   - |
     #!/usr/bin/env bash
     systemctl mask systemd-repart.service
-
-  # Set the fallback hostname to `localhost`. This was needed in F33/F34
-  # because a fallback hostname of `fedora` + systemd-resolved broke
-  # rDNS. It's now fixed in F35+ NetworkManager to handle the corner cases
-  # around synthetized hostnames and systemd-resolved, but the question
-  # remains on what is a more appropriate default hostname for a server like
-  # host. https://github.com/coreos/fedora-coreos-tracker/issues/902
-  - |
-    #!/usr/bin/env bash
-    source /etc/os-release
-    if [ -z "${DEFAULT_HOSTNAME:-}" ]; then
-      echo 'DEFAULT_HOSTNAME=localhost' >> /usr/lib/os-release
-    fi
 
   # Fedora 37 adds the nvmf dracut module to the initrd, causing
   # ext.config.files.dracut-executable to notice that the module puts a

--- a/tests/kola/networking/hostname/fallback-hostname/config.bu
+++ b/tests/kola/networking/hostname/fallback-hostname/config.bu
@@ -1,0 +1,10 @@
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/NetworkManager/conf.d/90-no-dhcp-dns-hostname.conf
+      mode: 0600
+      contents:
+        inline: |
+          [main]
+          hostname-mode=none

--- a/tests/kola/networking/hostname/fallback-hostname/data/commonlib.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# kola: { "platforms": "qemu" }
+#
+# Test that the fallback hostname is `localhost`. This test
+# validates that the fallback hostname is set to `localhost`
+# by first disabling NetworkManager from setting the hostname
+# via DHCP or DNS (see config.bu) and then verifying that the
+# hostname is set from the fallback hostname and is `localhost`.
+# https://github.com/coreos/fedora-coreos-tracker/issues/902
+#
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Use the output of hostnamectl to gather information about how
+# the hostname is/was set. We're expecting something like this:
+#   {
+#       "Hostname" : "localhost",
+#       "StaticHostname" : null,
+#       "PrettyHostname" : null,
+#       "DefaultHostname" : "localhost",
+#       "HostnameSource" : "default",
+#       "IconName" : "computer-vm",
+#       "Chassis" : "vm",
+#       "Deployment" : null,
+#       "Location" : null,
+#       "KernelName" : "Linux",
+#       "KernelRelease" : "5.18.17-200.fc36.x86_64",
+#       "KernelVersion" : "#1 SMP PREEMPT_DYNAMIC Thu Aug 11 14:36:06 UTC 2022",
+#       "OperatingSystemPrettyName" : "Fedora CoreOS 36.20220814.20.0",
+#       "OperatingSystemCPEName" : "cpe:/o:fedoraproject:fedora:36",
+#       "OperatingSystemHomeURL" : "https://getfedora.org/coreos/",
+#       "HardwareVendor" : "QEMU",
+#       "HardwareModel" : "Standard PC _i440FX + PIIX, 1996_",
+#       "ProductUUID" : null
+#   }
+
+
+output=$(hostnamectl --json=pretty)
+hostname=$(echo "$output" | jq -r '.Hostname')
+fallback=$(echo "$output" | jq -r '.DefaultHostname')
+static=$(echo "$output" | jq -r '.StaticHostname')
+namesource=$(echo "$output" | jq -r '.HostnameSource')
+
+if [ "$hostname" != 'localhost' ]; then
+    fatal "hostname was not expected"
+fi
+if [ "$fallback" != 'localhost' ]; then
+    fatal "fallback hostname was not expected"
+fi
+if [ "$static" != 'null' ]; then
+    fatal "static hostname not expected to be set"
+fi
+if [ "$namesource" != 'default' ]; then
+    # For this test since we disabled NM setting the hostname we
+    # expect the hostname to have been set via the fallback/default
+    fatal "hostname was set from non-default/fallback source"
+fi
+
+ok "fallback hostname wired up correctly"


### PR DESCRIPTION
In Fedora 37+ the fallback hostname provided at compile time to systemd
has been changed back to `localhost`. Let's update our modification of
/etc/os-release to insert DEFAULT_HOSTNAME to be F36 only and also add
a test to verify the fallback hostname is `localhost` everywhere.