### PR TITLE
[rawhide] move to F38; various cleanups

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  coreos-installer:
+    evr: 0.15.0-5.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-16d040e55b
+      reason: https://src.fedoraproject.org/rpms/rust-coreos-installer/pull-request/42
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.15.0-5.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-16d040e55b
+      reason: https://src.fedoraproject.org/rpms/rust-coreos-installer/pull-request/42
+      type: fast-track
   fedora-release-common:
     evra: 38-0.3.noarch
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  fedora-release-common:
+    evra: 38-0.3.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7efe395d87
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/902
+      type: fast-track
+  fedora-release-coreos:
+    evra: 38-0.3.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7efe395d87
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/902
+      type: fast-track
+  fedora-release-identity-coreos:
+    evra: 38-0.3.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-7efe395d87
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/902
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,14 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  cryptsetup:
-    evr: 2.5.0~rc1-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
-      type: pin
-  cryptsetup-libs:
-    evr: 2.5.0~rc1-2.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
-      type: pin
+packages: {}

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,18 +19,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1268
       type: pin
-  kernel:
-    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
-      type: pin
-  kernel-core:
-    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
-      type: pin
-  kernel-modules:
-    evr: 5.19.0-0.rc8.20220727git39c3c396f813.60.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1275
-      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: rawhide
   prod: false
 
-releasever: 37
+releasever: 38
 
 repos:
   - fedora-rawhide


### PR DESCRIPTION
```
commit a22890ed3f9b37c461bbedadb8417ec88fc8af01
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 22 16:55:52 2022 -0400

    manifest: rawhide is now F38

commit 83da73a4a333adc8b7da0df7680a35288b7fcbd7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 22 16:53:43 2022 -0400

    overrides: fast-track fedora-release-38-0.3.noarch
    
    It has a fix for the os-release DEFAULT_HOSTNAME change.
    
    See https://src.fedoraproject.org/rpms/fedora-release/pull-request/227#

commit 83f2b92012759069c1111e256a63db9d4a4e250f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 22 16:33:12 2022 -0400

    overrides: drop cryptsetup-2.5.0~rc1-2.fc37 pin
    
    I suspect the failures we were seeing for coreos.boot-mirror.luks were
    related to some changes we made in the pipelines rather than due to the
    cryptsetup package [1]. A local test passes. Let's unpin it to see if
    the problem shows up in the pipeline again.
    
    [1] https://github.com/coreos/fedora-coreos-tracker/issues/1268#issuecomment-1208854314

commit 1adf1aea5425b9ee804a8490c49ca47bfeffba63
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 22 16:32:02 2022 -0400

    overrides: drop kernel-5.19.0-0.rc8.20220727git39c3c396f813.60.fc37 pin
    
    I tested with the latest kernel in rawhide and the miniso-install-nm
    testiso scenario seems to be working again. Let's drop the pin for
    now and see if the problem surfaces again.

```
