### PR TITLE
[branched] manifest: bump to F37

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 36
+releasever: 37
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 37 has now been branched from rawhide.