### PR TITLE
[rawhide] overrides: pin on popt-1.19~rc1-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,22 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  kernel:
-    evr: 6.0.0-0.rc2.20220824gitc40e8341e3b3.23.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d0aea4fc07
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
-      type: fast-track
-  kernel-core:
-    evr: 6.0.0-0.rc2.20220824gitc40e8341e3b3.23.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d0aea4fc07
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
-      type: fast-track
-  kernel-modules:
-    evr: 6.0.0-0.rc2.20220824gitc40e8341e3b3.23.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d0aea4fc07
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
-      type: fast-track
+packages: {}

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  popt:
+    evr: 1.19~rc1-3.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1283
+      type: pin


### PR DESCRIPTION
With the new popt-1.19~rc1-4.fc38 our systems won't even boot.

See https://github.com/coreos/fedora-coreos-tracker/issues/1283
