### PR TITLE
[rawhide] manifest: include fedora-rawhide-nodebug-kernel repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,5 +6,6 @@ releasever: 38
 
 repos:
   - fedora-rawhide
+  - fedora-rawhide-nodebug-kernel
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
The fedora-rawhide-nodebug-kernel repo was added in [1]
and is what we'll be using exclusively for our rawhide
kernels in the future because we've wasted too much time
with debug kernels.

[1] https://github.com/coreos/fedora-coreos-config/pull/1932