### PR TITLE
denylist: snooze coreos.boot-mirror* tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -48,3 +48,8 @@
   - aarch64
   streams:
   - rawhide
+- pattern: coreos.boot-mirror*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+  snooze: 2022-09-01
+  streams:
+  - branched


### PR DESCRIPTION
They are failing because of a kernel regression and we are actively
working on getting a fix upstream and backported. Let's snooze these
tests for now.

See https://github.com/coreos/fedora-coreos-tracker/issues/1282