### PR TITLE
manifests: drop explicit add of kernel-{core,modules}

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -5,9 +5,8 @@
 # We expect most people though using coreos-assembler to inherit from
 # fedora-coreos-base.yaml.
 packages:
- # Kernel + systemd.  Note we explicitly specify kernel-{core,modules}
- # because otherwise depsolving could bring in kernel-debug.
- - kernel kernel-core kernel-modules systemd
+ # Kernel + systemd.
+ - kernel systemd
  # linux-firmware now a recommends so let's explicitly include it
  # https://gitlab.com/cki-project/kernel-ark/-/commit/32271d0cd9bd52d386eb35497c4876a8f041f70b
  # https://src.fedoraproject.org/rpms/kernel/c/f55c3e9ed8605ff28cb9a922efbab1055947e213?branch=rawhide
@@ -44,3 +43,9 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     rm -f /usr/bin/dotlockfile
+
+exclude-packages:
+  # Exclude kernel-debug-core to make sure that it doesn't somehow get
+  # chosen as the package to satisfy the `kernel-core` dependency from
+  # the kernel package.
+  - kernel-debug-core


### PR DESCRIPTION
kernel-{core,modules} get pulled in by the `kernel` meta package.
We previously named these explicitly because we saw some issues where
the `kernel-debug-core` RPM was getting chosen instead (see )

Let's solve the problem a different way by just naming `kernel` like we
did in the past, but include `kernel-debug-core` in the list of packages
we explicitly exclude. This has the benefit of making it simpler to run
kernel regression git bisect with the kernel rpm generated from
`make binrpm-pkg` in upstream kernle git, which just creates a single
RPM named `kernel`.

This has the benefits of simplifying our steps for how to build/test
an RPM from upstream kernel git [1] (permalink for example [2]) by
allowing us to not have to edit any manifest files as part of the process.

[1] https://github.com/coreos/fedora-coreos-tracker/blob/main/docs/fedora-coreos-kernel-bisect.md
[1] https://github.com/coreos/fedora-coreos-tracker/blob/e0a4c4fbec14248b4771ce30e0639996a2100153/docs/fedora-coreos-kernel-bisect.md#doing-a-build-with-cosa