### PR TITLE
overrides: pin kernel-5.18.19-200.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.18.19-200.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: pin
+  kernel-core:
+    evr: 5.18.19-200.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: pin
+  kernel-modules:
+    evr: 5.18.19-200.fc36
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).