### PR TITLE
denylist: drop ext.config.binfmt.qemu on aarch64+rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,13 +41,6 @@
   - testing
   - testing-devel
   - stable
-- pattern: ext.config.binfmt.qemu
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1241
-  snooze: 2022-09-10
-  arches:
-  - aarch64
-  streams:
-  - rawhide
 - pattern: coreos.boot-mirror*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1282
   snooze: 2022-09-01


### PR DESCRIPTION
The issue appears to be resolved. See
https://bugzilla.redhat.com/show_bug.cgi?id=2105623#c7