### PR TITLE
manifest & tests: Test if a symlink is broken first

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -66,7 +66,7 @@ postprocess:
   # https://github.com/coreos/fedora-coreos-tracker/issues/212
   - |
     #!/usr/bin/env bash
-    set -xeuo pipefail
+    set -euo pipefail
     source /etc/os-release
     if [[ $OSTREE_VERSION = *.dev* ]]; then
       mkdir -p /etc/zincati/config.d
@@ -101,7 +101,7 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-  
+
     list_broken_symlinks_folders=(
       '/etc/alternatives/'
       '/usr/lib/.build-id/'
@@ -118,12 +118,14 @@ postprocess:
       '/usr/share/info/'
       '/usr/share/man/'
       )
-    for folder in "${list_broken_symlinks_folders[@]}"
-    do
+    for folder in "${list_broken_symlinks_folders[@]}"; do
         find "${folder}" -type l | while read -r file_name; do
             real_path=$(realpath -m "${file_name}");
+            if [[ -e "${real_path}" ]]; then
+              continue
+            fi
             for element in "${list_known_removed_folders[@]}"; do
-              if [[ ! -e "${real_path}" ]] && [[ "${real_path}" == "${element}"* ]]; then
+              if [[ "${real_path}" == "${element}"* ]]; then
                   rm -r "${file_name}"
               fi
             done

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -20,7 +20,12 @@ list_broken_symlinks_skip=(
     '/usr/share/rhel/secrets/redhat.repo'
     '/usr/share/rhel/secrets/rhsm'
 )
+
 find /usr/ /etc/ -type l -not -path "/usr/etc*"| while read -r file_name; do
+    real_path=$(realpath -m "${file_name}");
+    if [[ -e "${real_path}" ]]; then
+        continue
+    fi
     found="false"
     for search_element in "${list_broken_symlinks_skip[@]}"; do
         if [[ "${file_name}" == "${search_element}"* || "${file_name}" == "${search_element}" ]]; then
@@ -28,8 +33,7 @@ find /usr/ /etc/ -type l -not -path "/usr/etc*"| while read -r file_name; do
             break
         fi
     done
-    real_path=$(realpath -m "${file_name}");
-    if [[ ! -e "${real_path}" ]] && [[ "${found}" == "false" ]];  then
+    if [[ "${found}" == "false" ]];  then
         fatal "Error: ${file_name} symlink to ${real_path} which does not exist"
     fi
 done


### PR DESCRIPTION
When looking for broken symlinks, test first if it is broken before
looking at the list of known broken links to skip.

Fixes: https://github.com/coreos/fedora-coreos-config/pull/1841