### PR TITLE
tests/validate-symlinks: QEMU & FCOS only

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,16 +160,28 @@ Tests should follow the following format:
 
 ```bash
 #!/bin/bash
-# kola: { "exclusive": false }    <-- kola option comment. See all options in <https://coreos.github.io/coreos-assembler/kola/external-tests/#kolajson>
+# kola: { "exclusive": false, ... }
+# ^^----- kola option comment
+# ^^----- See all options in <https://coreos.github.io/coreos-assembler/kola/external-tests/#kolajson>
+#
 # Short summary of what the test does, why we need it, etc.
-# Should also explain the reasons behind the non-obvious options selected above.
-# Optional: Link to corresponding issue or PR
+#
+# Recommended: Link to corresponding issue or PR
+#
+# Explain the reasons behind all the kola options:
+# - distros: fcos
+#   - This test only runs on FCOS due to ...
+# - platforms: qemu
+#   - This test should ...
+# - etc.
 
 set -euxo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-foo_bar()    <-- Other function definitions
+foo_bar() <-- Other function definitions
 
-if ...    <-- Actual test code. Errors must be raised with `fatal()`. Does not need to end with a call to `ok()`
+if ...    <-- Actual test code
+          <-- Errors must be raised with `fatal()`
+          <-- Does not need to end with a call to `ok()`
 ```

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -1,13 +1,19 @@
 #!/bin/bash
-# kola: { "exclusive": false }
-# Checking if there are no broken symlinks from from /etc/ and /usr/ .
-# https://github.com/coreos/fedora-coreos-config/issues/1782
+# kola: { "exclusive": false, "distros": "fcos", "platforms": "qemu" }
+#
+# Check if there are broken symlinks in /etc/ and /usr/.
+# See: https://github.com/coreos/fedora-coreos-config/issues/1782
+#
+# - distros: fcos
+#   - Only run on FCOS until we've tested it on RHCOS.
+# - platforms: qemu
+#   - This test should pass everywhere if it passes anywhere.
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# Here is the list of known broken symlinks that need to be investigated further:
+# List of known broken symlinks that require further investigation:
 list_broken_symlinks_skip=(
     '/etc/mtab'
     '/etc/ssl/'


### PR DESCRIPTION
Let's resttrict this test to:
- QEMU only as we don't expect the result to be different on another
  platform
- FCOS only until we've tested it for RHCOS & SCOS