### PR TITLE
denylist: extend denials to `branched` stream, set snooze

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,9 +23,11 @@
   - s390x
 - pattern: ext.config.ignition.resource.remote
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  snooze: 2022-09-10
   arches:
   - s390x
   streams:
+  - branched
   - next
   - next-devel
   - testing
@@ -33,9 +35,11 @@
   - stable
 - pattern: rpmostree.install-uninstall
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  snooze: 2022-09-10
   arches:
   - s390x
   streams:
+  - branched
   - next
   - next-devel
   - testing


### PR DESCRIPTION
The denials related to [1] are now showing up in `branched` so
let's add it to the denylist and also convert to a snooze so we'll
follow up on this issue more regularly.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1215