### PR TITLE
tests: Lift `exclusive: false` on tests that actually mutate system

### DIFF
--- a/tests/kola/kubernetes/kube-watch/test.sh
+++ b/tests/kola/kubernetes/kube-watch/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# kola: { "exclusive": false }
 # This is for verifying that `kubernetes_file_t` labeled files can be
 # watched by systemd
 # See: https://github.com/coreos/fedora-coreos-tracker/issues/861

--- a/tests/kola/security/passwd/test.sh
+++ b/tests/kola/security/passwd/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "distros": "fcos", "exclusive": false }
+# kola: { "distros": "fcos" }
 # This test only runs on FCOS because RHCOS does not support `yescrypt`
 # TODO-RHCOS: adapt to use different `crypt` scheme for RHCOS
 


### PR DESCRIPTION
I'm planning a PR to coreos-assembler to inject
`ProtectSystem=strict` on tests that say `exclusive: false`
to *actively enforce* their read only nature.

These tests do mutate the system, and are hence not exclusive.