### PR TITLE
Add workaround for dhcp-propagation(scos and rhcos9)

### DIFF
--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -23,6 +23,8 @@
 
 set -xeuo pipefail
 
+. $KOLA_EXT_DATA/commonlib.sh
+
 # Just run on QEMU; it should work theoretically on cloud platforms, but many
 # of those have platform-specific sources which take precedence.
 
@@ -53,7 +55,15 @@ RUN dnf -y install systemd dnsmasq iproute iputils \
 RUN echo -e 'dhcp-range=172.16.0.10,172.16.0.20,12h\nbind-interfaces\ninterface=veth-container\ndhcp-option=option:ntp-server,$NTPHOSTIP' > /etc/dnsmasq.d/dhcp
 CMD [ "/sbin/init" ]
 EOF
-    podman build -t dnsmasq .
+
+    if is_fcos || is_rhcos8; then
+        podman build -t dnsmasq .
+    else
+        # only workaround for scos and rhel9
+        # https://github.com/openshift/os/issues/964
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2123246 (revert PR when bug is fixed)
+        podman build --security-opt seccomp=/usr/share/containers/seccomp.json -t dnsmasq .
+    fi
     popd
     podman run -d --rm --name dnsmasq --privileged --network ns:/var/run/netns/container dnsmasq
 

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -48,3 +48,9 @@ get_rhel_maj_ver() {
     source /etc/os-release
     echo "${RHEL_VERSION%%.*}"
 }
+
+# rhcos8
+is_rhcos8() (
+    source /etc/os-release
+    [ "${ID}" == "rhcos" ] && [ "${RHEL_VERSION%%.*}" -eq 8 ]
+)

--- a/tests/kola/podman/data/commonlib.sh
+++ b/tests/kola/podman/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
 # This script runs a rootless podman container (rootless because it's
 # run as the `core` user) with systemd inside that brings up httpd.
 # It tests that rootless+systemd works. See issue:
@@ -8,11 +8,6 @@
 # If it gets easy to change the kargs in the future we should try this
 # both on cgroups v1 and cgroups v2.
 #
-# - distros: fcos
-#   - The test is scoped to only FCOS because the `--retry-all-errors`
-#     flag passed to `curl` is not avaiable on RHEL8.
-#     TODO-RHCOS: adapt test to conditionally use the `-retry-all-errors`
-#     flag on only FCOS
 # - tags: needs-internet
 #   - This test builds a container from remote sources.
 #   - This test uses a remote NTP server.
@@ -27,6 +22,7 @@
 #     https://pagure.io/releng/issue/10935#comment-808601
 
 set -xeuo pipefail
+. $KOLA_EXT_DATA/commonlib.sh
 
 runascoreuserscript='
 #!/bin/bash
@@ -68,13 +64,18 @@ main() {
 
     sleep 5
 
-    # Try to grab the web page. Retry as it might not be up fully yet.
-    if ! curl --silent --show-error --retry 5 --retry-all-errors http://localhost:8080 >/dev/null; then
-        echo TEST FAILED 1>&2
-        runascoreuser podman logs httpd
-        return 1
+    retryflag="--retry-all-errors"
+    # --retry-all-errors flag passed to curl is not available on RHEL8
+    if is_rhcos8; then
+        retryflag="--retry-connrefused"
     fi
+    # Try to grab the web page. Retry as it might not be up fully yet.
+    if ! curl --silent --show-error --retry 5 ${retryflag} http://localhost:8080 >/dev/null; then
+        runascoreuser podman logs httpd
+        fatal "setup http server container failed"
+    fi
+
+    ok "setup http server container successfully"
 }
 
 main
-exit $?


### PR DESCRIPTION
This has no effect for fcos and rhcos8 (refer to https://github.com/openshift/os/issues/964), revert this when [bug#2123246](https://bugzilla.redhat.com/show_bug.cgi?id=2123246) is fixed.

Also makes podman.rootless-systemd works on rhcos.