### PR TITLE
manifests: drop workaround for 'tss' user/group

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -140,8 +140,6 @@ remove-from-packages:
   # Drop some buggy sysusers fragments which do not match static IDs allocation:
   # https://bugzilla.redhat.com/show_bug.cgi?id=2105177
   - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2103683
-  - [tpm2-tss, /usr/lib/sysusers.d/tpm2-tss.conf]
 
 remove-files:
   # We don't ship man(1) or info(1)

--- a/manifests/passwd
+++ b/manifests/passwd
@@ -30,4 +30,3 @@ systemd-network:x:991:990:systemd Network Management:/:/usr/sbin/nologin
 systemd-resolve:x:990:989:systemd Resolver:/:/usr/sbin/nologin
 systemd-timesync:x:993:991:systemd Time Synchronization:/:/usr/sbin/nologin
 tcpdump:x:72:72::/:/usr/sbin/nologin
-tss:x:59:59:Account used for TPM access:/:/usr/sbin/nologin

--- a/overlay.d/15fcos/usr/lib/sysusers.d/10-static-extra.conf
+++ b/overlay.d/15fcos/usr/lib/sysusers.d/10-static-extra.conf
@@ -11,7 +11,6 @@ g rpcuser 29
 g sshd 74
 g systemd-journal 190
 g tcpdump 72
-g tss 59
 g utempter 35
 g utmp 22
 
@@ -23,4 +22,3 @@ u rpc           32:32       "Rpcbind Daemon"              /var/lib/rpcbind      
 u rpcuser       29:29       "RPC Service User"            /var/lib/nfs           -
 u sshd          74:74       "Privilege-separated SSH"     /var/empty/sshd        -
 u tcpdump       72:72       -                             -                      -
-u tss           59:59       "Account used for TPM access" -                      -


### PR DESCRIPTION
The `tss` user/group entries have been fixed in `tpm2-tss-3.2.0-3`,
so this drops all existing workarounds.
Both are static entries and are already covered by kola tests.