### PR TITLE
[rawhide] overrides: drop pin for popt 1.19~rc1-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  popt:
-    evr: 1.19~rc1-3.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1283
-      type: pin
+packages: {}


### PR DESCRIPTION
Dropping the pin for popt 1.19~rc1-3.fc37. The issue got fixed when gdisk [was rebuilt](https://bodhi.fedoraproject.org/updates/FEDORA-2022-23ef6d2496) for [BZ#2100391](https://bugzilla.redhat.com/show_bug.cgi?id=2100391).

Fixes:https://github.com/coreos/fedora-coreos-tracker/issues/1283