### PR TITLE
tests: Switch one test to use platform-independent + YAML

### DIFF
--- a/tests/kola/content-origins/test.sh
+++ b/tests/kola/content-origins/test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "exclusive": false, "distros": "fcos rhcos" }
 # Verify the RPM %{vendor} flag for everything installed matches what we expect.
-#
-# - platforms: qemu
-#   - This test should pass everywhere if it passes anywhere.
-# - distros: This only handles Fedora and RHEL today.
-
+## kola:
+##   tags: "platform-independent"
+##   # This is a read-only, nondestructive test.
+##   exclusive: false
+##   # May support e.g. centos in the future
+##   distros: "fcos rhcos"
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh


### PR DESCRIPTION
Since these two PRs

- https://github.com/coreos/coreos-assembler/pull/3064/commits/242e7149b8d57b5837238366bfcd70bd99b455a5
- https://github.com/coreos/coreos-assembler/pull/3059/commits/302130ec171d3d501310c40bd28db49c21459519

we support YAML for kola metadata, and there's a new `platform-independent`
tag.

Use both in a test I added recently to demonstrate.

Motivation: I think semantic tags and inline comments are far
superior to duplicating the test metadata and I don't want to
have to do that again in a test I write.