### PR TITLE
overrides: fast-track kernel-5.19.7-200.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.19.7-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-85445af488
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track
+  kernel-core:
+    evr: 5.19.7-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-85445af488
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track
+  kernel-modules:
+    evr: 5.19.7-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-85445af488
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).