### PR TITLE
overlay.d/35coreos-live: add workaround for stalled iso-live-login boot

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -118,6 +118,20 @@ Type=squashfs
 # is checked by coreos-assembler cmd-buildextend-live at build time.
 Options=loop,offset=124
 EOF
+
+    # And one more unit to workaround what we think is a systemd bug.
+    # We've found the system can stall waiting for run-media-iso.mount
+    # and apparently any operation seems to be effective at reviving
+    # the system.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1233#issuecomment-1238814171
+    cat >"${UNIT_DIR}/workaround-stalled-media-iso-mount.service" <<EOF
+[Service]
+Type=simple
+StandardOutput=journal
+StandardError=journal
+ExecStart=bash -c "sleep 10; echo 'warn: tracker issue workaround engaged for https://github.com/coreos/fedora-coreos-tracker/issues/1233'"
+EOF
+    add_requires workaround-stalled-media-iso-mount.service basic.target
 fi
 
 # It turns out that `tmpfs` currently munches all SELinux labels


### PR DESCRIPTION
We've found the system can stall waiting for run-media-iso.mount and apparently any operation seems to be effective at reviving the system. Let's add a workaround that will kick in after 10 seconds and try to revive the boot.

A lot more context over in
https://github.com/coreos/fedora-coreos-tracker/issues/1233#issuecomment-1238814171

Here's an example of this working:

```
[    2.749303] systemd[1]: ignition-ostree-transposefs-restore.service - Ignition OSTree: Restore Partitions was skipped because of a failed condition check (ConditionPathIsDire
ctory=/run/ignition-ostree-transposefs).
[    2.750547] ignition[591]: disks: disks passed
[    2.750882] ignition[591]: Ignition finished successfully
[   12.645801] kauditd_printk_skb: 19 callbacks suppressed
[   12.645804] audit: type=1131 audit(1662520856.021:30): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=kernel msg='unit=workaround-stalled-media-iso-mount comm="systemd" exe=
"/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
[   12.647774] bash[564]: warn: tracker issue workaround engaged for https://github.com/coreos/fedora-coreos-tracker/issues/1233
[   12.648646] systemd[1]: workaround-stalled-media-iso-mount.service: Deactivated successfully.
[   12.649281] systemd[1]: Mounting run-media-iso.mount - /run/media/iso...
```