### PR TITLE
overlay.d/20platform-chrony: use generator-lib.sh for generator

### DIFF
--- a/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system-generators/coreos-platform-chrony
@@ -11,16 +11,12 @@ set -euo pipefail
 #
 # Originally spawned from discussion in https://github.com/openshift/installer/pull/3513
 
-# Generators don't have logging right now
-# https://github.com/systemd/systemd/issues/15638
-exec 1>/dev/kmsg; exec 2>&1
+. /usr/lib/coreos/generator-lib.sh
 
 self=$(basename $0)
 confpath=/run/coreos-platform-chrony.conf
 
-# Yeah this isn't a completely accurate kernel argument parser but
-# we don't have one shared across shell services at the moment.
-platform="$(grep -Eo ' ignition.platform.id=[a-z]+' /proc/cmdline | cut -f 2 -d =)"
+platform=$(karg ignition.platform.id)
 case "${platform}" in
     azure|azurestack|aws|gcp) ;;  # OK, this is a platform we know how to support
     *) exit 0 ;;


### PR DESCRIPTION
In this case the generator-lib.sh handles the logging setup and also offers a karg helper that we can use instead of the grep.