### PR TITLE
[next-devel] Move to Fedora Linux 37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.19.7-300.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track
+  kernel-core:
+    evr: 5.19.7-300.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track
+  kernel-modules:
+    evr: 5.19.7-300.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
+      type: fast-track

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,163 +1,163 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.36.4-1.fc36.x86_64"
+      "evra": "1:1.39.90-1.fc37.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.36.4-1.fc36.x86_64"
+      "evra": "1:1.39.90-1.fc37.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.36.4-1.fc36.x86_64"
+      "evra": "1:1.39.90-1.fc37.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.36.4-1.fc36.x86_64"
+      "evra": "1:1.39.90-1.fc37.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.36.4-1.fc36.x86_64"
+      "evra": "1:1.39.90-1.fc37.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.5.0.2-2.fc36.noarch"
+      "evra": "2.7.3.0-1.fc37.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.0.2-1.fc36.x86_64"
+      "evra": "1.1.0-1.fc37.x86_64"
     },
     "acl": {
-      "evra": "2.3.1-3.fc36.x86_64"
+      "evra": "2.3.1-4.fc37.x86_64"
     },
     "adcli": {
-      "evra": "0.9.1-10.fc36.x86_64"
+      "evra": "0.9.1-11.fc37.x86_64"
     },
     "afterburn": {
-      "evra": "5.3.0-1.fc36.x86_64"
+      "evra": "5.3.0-3.fc37.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.3.0-1.fc36.x86_64"
+      "evra": "5.3.0-3.fc37.x86_64"
     },
     "alternatives": {
-      "evra": "1.19-2.fc36.x86_64"
+      "evra": "1.19-3.fc37.x86_64"
     },
     "attr": {
-      "evra": "2.5.1-4.fc36.x86_64"
+      "evra": "2.5.1-5.fc37.x86_64"
     },
     "audit-libs": {
-      "evra": "3.0.8-1.fc36.x86_64"
+      "evra": "3.0.8-3.fc37.x86_64"
     },
     "authselect": {
-      "evra": "1.3.0-10.fc36.x86_64"
+      "evra": "1.4.0-3.fc37.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.3.0-10.fc36.x86_64"
+      "evra": "1.4.0-3.fc37.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.8-15.fc36.x86_64"
+      "evra": "0.8-17.fc37.x86_64"
     },
     "basesystem": {
-      "evra": "11-13.fc36.noarch"
+      "evra": "11-14.fc37.noarch"
     },
     "bash": {
-      "evra": "5.1.16-2.fc36.x86_64"
+      "evra": "5.1.16-3.fc37.x86_64"
     },
     "bash-completion": {
-      "evra": "1:2.11-6.fc36.noarch"
+      "evra": "1:2.11-8.fc37.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.16.28-1.fc36.x86_64"
+      "evra": "32:9.18.5-2.fc37.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.16.28-1.fc36.noarch"
+      "evra": "32:9.18.5-2.fc37.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.16.28-1.fc36.x86_64"
+      "evra": "32:9.18.5-2.fc37.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.6-2.fc36.x86_64"
+      "evra": "0.2.7-2.fc37.x86_64"
     },
     "bsdtar": {
-      "evra": "3.5.3-1.fc36.x86_64"
+      "evra": "3.6.1-2.fc37.x86_64"
     },
     "btrfs-progs": {
-      "evra": "5.16.2-1.fc36.x86_64"
+      "evra": "5.18-3.fc37.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.5.0-2.fc36.x86_64"
+      "evra": "0.5.0-3.fc37.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-11.fc36.x86_64"
+      "evra": "1.0.8-12.fc37.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-11.fc36.x86_64"
+      "evra": "1.0.8-12.fc37.x86_64"
     },
     "c-ares": {
-      "evra": "1.17.2-2.fc36.x86_64"
+      "evra": "1.17.2-3.fc37.x86_64"
     },
     "ca-certificates": {
-      "evra": "2021.2.52-3.fc36.noarch"
+      "evra": "2022.2.54-5.fc37.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-5.fc36.x86_64"
+      "evra": "0.1.7-7.fc37.x86_64"
     },
     "chrony": {
-      "evra": "4.2-5.fc36.x86_64"
+      "evra": "4.3-0.1.pre1.fc37.x86_64"
     },
     "cifs-utils": {
-      "evra": "6.15-1.fc36.x86_64"
+      "evra": "6.15-2.fc37.x86_64"
     },
     "clevis": {
-      "evra": "18-6.fc36.x86_64"
+      "evra": "18-12.fc37.x86_64"
     },
     "clevis-dracut": {
-      "evra": "18-6.fc36.x86_64"
+      "evra": "18-12.fc37.x86_64"
     },
     "clevis-luks": {
-      "evra": "18-6.fc36.x86_64"
+      "evra": "18-12.fc37.x86_64"
     },
     "clevis-systemd": {
-      "evra": "18-6.fc36.x86_64"
+      "evra": "18-12.fc37.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-10.fc36.noarch"
+      "evra": "0.31-11.fc37.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.0-2.fc36.x86_64"
+      "evra": "2:2.1.2-3.fc37.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.2-4.fc36.noarch"
+      "evra": "0.21.3-2.fc37.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.2-4.fc36.noarch"
+      "evra": "0.21.3-2.fc37.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.2-4.fc36.noarch"
+      "evra": "0.21.3-2.fc37.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.2-4.fc36.noarch"
+      "evra": "0.21.3-2.fc37.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.183.0-1.fc36.noarch"
+      "evra": "2:2.189.0-2.fc37.noarch"
     },
     "containerd": {
-      "evra": "1.6.2-2.fc36.x86_64"
+      "evra": "1.6.6-6.fc37.x86_64"
     },
     "containernetworking-plugins": {
-      "evra": "1.1.0-1.fc36.x86_64"
+      "evra": "1.1.1-8.fc37.x86_64"
     },
     "containers-common": {
-      "evra": "4:1-56.fc36.noarch"
+      "evra": "4:1-66.fc37.noarch"
     },
     "coreos-installer": {
-      "evra": "0.14.0-1.fc36.x86_64"
+      "evra": "0.15.0-5.fc37.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.14.0-1.fc36.x86_64"
+      "evra": "0.15.0-5.fc37.x86_64"
     },
     "coreutils": {
-      "evra": "9.0-5.fc36.x86_64"
+      "evra": "9.1-6.fc37.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.0-5.fc36.x86_64"
+      "evra": "9.1-6.fc37.x86_64"
     },
     "cpio": {
-      "evra": "2.13-12.fc36.x86_64"
+      "evra": "2.13-13.fc37.x86_64"
     },
     "cracklib": {
       "evra": "2.9.6-28.fc36.x86_64"
@@ -166,1091 +166,1088 @@
       "evra": "2.9.6-28.fc36.x86_64"
     },
     "criu": {
-      "evra": "3.16.1-12.fc36.x86_64"
+      "evra": "3.17.1-3.fc37.x86_64"
     },
     "criu-libs": {
-      "evra": "3.16.1-12.fc36.x86_64"
+      "evra": "3.17.1-3.fc37.x86_64"
     },
     "crun": {
-      "evra": "1.4.4-1.fc36.x86_64"
+      "evra": "1.5-1.fc37.x86_64"
     },
     "crypto-policies": {
-      "evra": "20220203-2.git112f859.fc36.noarch"
+      "evra": "20220815-1.gite4ed860.fc37.noarch"
     },
     "cryptsetup": {
-      "evra": "2.4.3-2.fc36.x86_64"
+      "evra": "2.5.0-1.fc37.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.4.3-2.fc36.x86_64"
+      "evra": "2.5.0-1.fc37.x86_64"
     },
     "curl": {
-      "evra": "7.82.0-4.fc36.x86_64"
+      "evra": "7.84.0-2.fc37.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.27-18.fc36.x86_64"
+      "evra": "2.1.28-8.fc37.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.27-18.fc36.x86_64"
+      "evra": "2.1.28-8.fc37.x86_64"
     },
     "dbus": {
-      "evra": "1:1.14.0-1.fc36.x86_64"
+      "evra": "1:1.14.0-5.fc37.x86_64"
     },
     "dbus-broker": {
-      "evra": "29-5.fc36.x86_64"
+      "evra": "32-1.fc37.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.14.0-1.fc36.noarch"
+      "evra": "1:1.14.0-5.fc37.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.0-1.fc36.x86_64"
+      "evra": "1:1.14.0-5.fc37.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.175-7.fc36.x86_64"
+      "evra": "1.02.175-9.fc37.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-7.fc36.x86_64"
+      "evra": "1.02.175-9.fc37.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-7.fc36.x86_64"
+      "evra": "1.02.175-9.fc37.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-7.fc36.x86_64"
+      "evra": "1.02.175-9.fc37.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.8.7-8.fc36.x86_64"
+      "evra": "0.9.0-3.fc37.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.8.7-8.fc36.x86_64"
+      "evra": "0.9.0-3.fc37.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-7.fc36.x86_64"
+      "evra": "0.9.0-8.fc37.x86_64"
     },
     "diffutils": {
-      "evra": "3.8-2.fc36.x86_64"
+      "evra": "3.8-3.fc37.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.86-6.fc36.x86_64"
+      "evra": "2.86-11.fc37.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-3.fc36.x86_64"
+      "evra": "4.2-4.fc37.x86_64"
     },
     "dracut": {
-      "evra": "056-1.fc36.x86_64"
+      "evra": "057-2.fc37.x86_64"
     },
     "dracut-network": {
-      "evra": "056-1.fc36.x86_64"
+      "evra": "057-2.fc37.x86_64"
     },
     "dracut-squash": {
-      "evra": "056-1.fc36.x86_64"
+      "evra": "057-2.fc37.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-2.fc36.x86_64"
+      "evra": "1.46.5-3.fc37.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-2.fc36.x86_64"
+      "evra": "1.46.5-3.fc37.x86_64"
     },
     "efi-filesystem": {
-      "evra": "5-5.fc36.noarch"
+      "evra": "5-6.fc37.noarch"
     },
     "efibootmgr": {
-      "evra": "16-12.fc36.x86_64"
+      "evra": "18-2.fc37.x86_64"
     },
     "efivar-libs": {
-      "evra": "38-2.fc36.x86_64"
+      "evra": "38-5.fc37.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.187-2.fc36.noarch"
+      "evra": "0.187-6.fc37.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.187-2.fc36.x86_64"
+      "evra": "0.187-6.fc37.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.187-2.fc36.x86_64"
+      "evra": "0.187-6.fc37.x86_64"
     },
     "ethtool": {
-      "evra": "2:5.17-1.fc36.x86_64"
+      "evra": "2:5.18-2.fc37.x86_64"
     },
     "expat": {
-      "evra": "2.4.7-1.fc36.x86_64"
-    },
-    "fedora-coreos-pinger": {
-      "evra": "0.0.4-13.fc36.x86_64"
+      "evra": "2.4.8-2.fc37.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "36-1.noarch"
+      "evra": "37-0.6.noarch"
     },
     "fedora-release-common": {
-      "evra": "36-17.noarch"
+      "evra": "37-0.12.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "36-17.noarch"
+      "evra": "37-0.12.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "36-17.noarch"
+      "evra": "37-0.12.noarch"
     },
     "fedora-repos": {
-      "evra": "36-1.noarch"
+      "evra": "37-0.6.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "36-1.noarch"
+      "evra": "37-0.6.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "36-1.noarch"
+      "evra": "37-0.6.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "36-1.noarch"
+      "evra": "37-0.6.noarch"
     },
     "file": {
-      "evra": "5.41-4.fc36.x86_64"
+      "evra": "5.42-4.fc37.x86_64"
     },
     "file-libs": {
-      "evra": "5.41-4.fc36.x86_64"
+      "evra": "5.42-4.fc37.x86_64"
     },
     "filesystem": {
-      "evra": "3.16-2.fc36.x86_64"
+      "evra": "3.18-2.fc37.x86_64"
     },
     "findutils": {
-      "evra": "1:4.9.0-1.fc36.x86_64"
+      "evra": "1:4.9.0-2.fc37.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.12.7-2.fc36.x86_64"
+      "evra": "1.13.3-6.fc37.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-4.fc36.x86_64"
+      "evra": "0.6.1-5.fc37.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-14.fc36.x86_64"
+      "evra": "2.9.9-15.fc37.x86_64"
     },
     "fuse-common": {
-      "evra": "3.10.5-2.fc36.x86_64"
+      "evra": "3.10.5-5.fc37.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-14.fc36.x86_64"
+      "evra": "2.9.9-15.fc37.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.8.1-3.fc36.x86_64"
+      "evra": "1.9-3.fc37.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.2-3.fc36.x86_64"
+      "evra": "3.7.3-2.fc37.x86_64"
     },
     "fuse3": {
-      "evra": "3.10.5-2.fc36.x86_64"
+      "evra": "3.10.5-5.fc37.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-2.fc36.x86_64"
+      "evra": "3.10.5-5.fc37.x86_64"
     },
     "fwupd": {
-      "evra": "1.7.7-1.fc36.x86_64"
+      "evra": "1.8.3-1.fc37.x86_64"
     },
     "gawk": {
-      "evra": "5.1.1-2.fc36.x86_64"
+      "evra": "5.1.1-4.fc37.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.22-2.fc36.x86_64"
+      "evra": "1:1.23-2.fc37.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.9-1.fc36.x86_64"
+      "evra": "1.0.9-3.fc37.x86_64"
     },
     "gettext": {
-      "evra": "0.21-9.fc36.x86_64"
+      "evra": "0.21-18.fc37.0.20220203.x86_64"
+    },
+    "gettext-envsubst": {
+      "evra": "0.21-18.fc37.0.20220203.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.21-9.fc36.x86_64"
+      "evra": "0.21-18.fc37.0.20220203.x86_64"
+    },
+    "gettext-runtime": {
+      "evra": "0.21-18.fc37.0.20220203.x86_64"
     },
     "git-core": {
-      "evra": "2.36.0-1.fc36.x86_64"
+      "evra": "2.37.2-1.fc37.x86_64"
     },
     "glib2": {
-      "evra": "2.72.1-1.fc36.x86_64"
+      "evra": "2.73.2-8.fc37.x86_64"
     },
     "glibc": {
-      "evra": "2.35-5.fc36.x86_64"
+      "evra": "2.36-1.fc37.x86_64"
     },
     "glibc-common": {
-      "evra": "2.35-5.fc36.x86_64"
+      "evra": "2.36-1.fc37.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.35-5.fc36.x86_64"
+      "evra": "2.36-1.fc37.x86_64"
     },
     "gmp": {
-      "evra": "1:6.2.1-2.fc36.x86_64"
+      "evra": "1:6.2.1-3.fc37.x86_64"
     },
     "gnupg2": {
-      "evra": "2.3.6-1.fc36.x86_64"
+      "evra": "2.3.7-3.fc37.x86_64"
     },
     "gnutls": {
-      "evra": "3.7.4-1.fc36.x86_64"
+      "evra": "3.7.7-1.fc37.x86_64"
     },
     "gpgme": {
-      "evra": "1.15.1-6.fc36.x86_64"
+      "evra": "1.17.0-4.fc37.x86_64"
     },
     "grep": {
-      "evra": "3.7-2.fc36.x86_64"
+      "evra": "3.7-4.fc37.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.06-38.fc36.noarch"
+      "evra": "1:2.06-52.fc37.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-38.fc36.x86_64"
+      "evra": "1:2.06-52.fc37.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.06-38.fc36.x86_64"
+      "evra": "1:2.06-52.fc37.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-38.fc36.noarch"
+      "evra": "1:2.06-52.fc37.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-38.fc36.x86_64"
+      "evra": "1:2.06-52.fc37.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-38.fc36.x86_64"
+      "evra": "1:2.06-52.fc37.x86_64"
     },
     "gzip": {
-      "evra": "1.11-3.fc36.x86_64"
+      "evra": "1.12-2.fc37.x86_64"
     },
     "hostname": {
-      "evra": "3.23-6.fc36.x86_64"
+      "evra": "3.23-7.fc37.x86_64"
     },
     "ignition": {
-      "evra": "2.13.0-5.fc36.x86_64"
+      "evra": "2.14.0-4.fc37.x86_64"
     },
     "inih": {
-      "evra": "55-1.fc36.x86_64"
+      "evra": "56-2.fc37.x86_64"
     },
     "iproute": {
-      "evra": "5.15.0-2.fc36.x86_64"
+      "evra": "5.18.0-2.fc37.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.15.0-2.fc36.x86_64"
+      "evra": "5.18.0-2.fc37.x86_64"
     },
     "iptables-legacy": {
-      "evra": "1.8.7-15.fc36.x86_64"
+      "evra": "1.8.8-3.fc37.x86_64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.7-15.fc36.x86_64"
+      "evra": "1.8.8-3.fc37.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.7-15.fc36.x86_64"
+      "evra": "1.8.8-3.fc37.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.7-15.fc36.x86_64"
+      "evra": "1.8.8-3.fc37.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.7-15.fc36.noarch"
+      "evra": "1.8.8-3.fc37.noarch"
+    },
+    "iptables-utils": {
+      "evra": "1.8.8-3.fc37.x86_64"
     },
     "iputils": {
-      "evra": "20211215-2.fc36.x86_64"
+      "evra": "20211215-3.fc37.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.7.0-8.fc35.x86_64"
+      "evra": "2:1.9.0-1.fc37.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-4.git2a8f9d8.fc36.x86_64"
+      "evra": "6.2.1.4-6.git2a8f9d8.fc37.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-4.git2a8f9d8.fc36.x86_64"
+      "evra": "6.2.1.4-6.git2a8f9d8.fc37.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-4.fc36.x86_64"
+      "evra": "0.101-5.fc37.x86_64"
     },
     "jansson": {
-      "evra": "2.13.1-4.fc36.x86_64"
+      "evra": "2.13.1-5.fc37.x86_64"
+    },
+    "jemalloc": {
+      "evra": "5.3.0-2.fc37.x86_64"
     },
     "jose": {
-      "evra": "11-5.fc36.x86_64"
+      "evra": "11-6.fc37.x86_64"
     },
     "jq": {
-      "evra": "1.6-13.fc36.x86_64"
+      "evra": "1.6-14.fc37.x86_64"
     },
     "json-c": {
-      "evra": "0.15-3.fc36.x86_64"
+      "evra": "0.16-2.fc37.x86_64"
     },
     "json-glib": {
-      "evra": "1.6.6-2.fc36.x86_64"
+      "evra": "1.6.6-3.fc37.x86_64"
     },
     "kbd": {
-      "evra": "2.4.0-9.fc36.x86_64"
+      "evra": "2.5.1-2.fc37.x86_64"
     },
     "kbd-misc": {
-      "evra": "2.4.0-9.fc36.noarch"
+      "evra": "2.5.1-2.fc37.noarch"
     },
     "kernel": {
-      "evra": "5.17.5-300.fc36.x86_64"
+      "evra": "5.19.6-300.fc37.x86_64"
     },
     "kernel-core": {
-      "evra": "5.17.5-300.fc36.x86_64"
+      "evra": "5.19.6-300.fc37.x86_64"
     },
     "kernel-modules": {
-      "evra": "5.17.5-300.fc36.x86_64"
+      "evra": "5.19.6-300.fc37.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.23-6.fc36.x86_64"
+      "evra": "2.0.25-1.fc37.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.1-4.fc36.x86_64"
+      "evra": "1.6.1-5.fc37.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-4.fc36.x86_64"
+      "evra": "1.6.1-5.fc37.x86_64"
     },
     "kmod": {
-      "evra": "29-7.fc36.x86_64"
+      "evra": "30-2.fc37.x86_64"
     },
     "kmod-libs": {
-      "evra": "29-7.fc36.x86_64"
+      "evra": "30-2.fc37.x86_64"
     },
     "kpartx": {
-      "evra": "0.8.7-8.fc36.x86_64"
+      "evra": "0.9.0-3.fc37.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.19.2-9.fc36.x86_64"
+      "evra": "1.19.2-11.fc37.1.x86_64"
     },
     "less": {
-      "evra": "590-3.fc36.x86_64"
+      "evra": "590-5.fc37.x86_64"
     },
     "libacl": {
-      "evra": "2.3.1-3.fc36.x86_64"
+      "evra": "2.3.1-4.fc37.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-13.fc36.x86_64"
+      "evra": "0.3.111-14.fc37.x86_64"
     },
     "libarchive": {
-      "evra": "3.5.3-1.fc36.x86_64"
+      "evra": "3.6.1-2.fc37.x86_64"
     },
     "libargon2": {
-      "evra": "20171227-9.fc36.x86_64"
+      "evra": "20190702-1.fc37.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.5-4.fc36.x86_64"
+      "evra": "2.5.5-5.fc37.x86_64"
     },
     "libattr": {
-      "evra": "2.5.1-4.fc36.x86_64"
+      "evra": "2.5.1-5.fc37.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-50.fc36.x86_64"
+      "evra": "0.1.1-52.fc37.x86_64"
     },
     "libblkid": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "libbpf": {
-      "evra": "2:0.5.0-2.fc36.x86_64"
-    },
-    "libbrotli": {
-      "evra": "1.0.9-7.fc36.x86_64"
+      "evra": "2:0.8.0-2.fc37.x86_64"
     },
     "libbsd": {
-      "evra": "0.10.0-9.fc36.x86_64"
+      "evra": "0.10.0-10.fc37.x86_64"
     },
     "libcap": {
-      "evra": "2.48-4.fc36.x86_64"
+      "evra": "2.48-5.fc37.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.2-9.fc36.x86_64"
+      "evra": "0.8.3-3.fc37.x86_64"
     },
     "libcbor": {
-      "evra": "0.7.0-5.fc36.x86_64"
+      "evra": "0.7.0-7.fc37.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-50.fc36.x86_64"
+      "evra": "0.7.0-52.fc37.x86_64"
     },
     "libcom_err": {
-      "evra": "1.46.5-2.fc36.x86_64"
+      "evra": "1.46.5-3.fc37.x86_64"
     },
-    "libcurl": {
-      "evra": "7.82.0-4.fc36.x86_64"
+    "libcurl-minimal": {
+      "evra": "7.84.0-2.fc37.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-23.fc36.x86_64"
+      "evra": "0.14-24.fc37.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-51.fc36.x86_64"
+      "evra": "5.3.28-53.fc37.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-50.fc36.x86_64"
+      "evra": "0.5.0-52.fc37.x86_64"
     },
     "libeconf": {
-      "evra": "0.4.0-3.fc36.x86_64"
+      "evra": "0.4.0-4.fc37.x86_64"
     },
     "libedit": {
-      "evra": "3.1-41.20210910cvs.fc36.x86_64"
+      "evra": "3.1-42.20210910cvs.fc37.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-6.fc36.x86_64"
+      "evra": "2.1.12-7.fc37.x86_64"
     },
     "libfdisk": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "libffi": {
-      "evra": "3.4.2-8.fc36.x86_64"
+      "evra": "3.4.2-9.fc37.x86_64"
     },
     "libfido2": {
-      "evra": "1.10.0-3.fc36.x86_64"
+      "evra": "1.11.0-3.fc37.x86_64"
     },
     "libgcab1": {
-      "evra": "1.4-6.fc36.x86_64"
+      "evra": "1.5-1.fc37.x86_64"
     },
     "libgcc": {
-      "evra": "12.0.1-0.16.fc36.x86_64"
+      "evra": "12.2.1-1.fc37.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.10.1-2.fc36.x86_64"
+      "evra": "1.10.1-4.fc37.x86_64"
     },
     "libgomp": {
-      "evra": "12.0.1-0.16.fc36.x86_64"
+      "evra": "12.2.1-1.fc37.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.45-1.fc36.x86_64"
+      "evra": "1.45-2.fc37.x86_64"
     },
     "libgudev": {
-      "evra": "237-2.fc36.x86_64"
+      "evra": "237-3.fc37.x86_64"
     },
     "libgusb": {
-      "evra": "0.3.10-2.fc36.x86_64"
+      "evra": "0.3.10-3.fc37.x86_64"
     },
     "libibverbs": {
-      "evra": "39.0-1.fc36.x86_64"
+      "evra": "41.0-1.fc37.x86_64"
     },
     "libicu": {
-      "evra": "69.1-5.fc36.x86_64"
+      "evra": "71.1-1.fc37.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.2-4.fc36.x86_64"
+      "evra": "2.3.3-2.fc37.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-50.fc36.x86_64"
+      "evra": "1.3.1-52.fc37.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.10-1.fc36.x86_64"
+      "evra": "0.1.10-2.fc37.x86_64"
     },
     "libjose": {
-      "evra": "11-5.fc36.x86_64"
+      "evra": "11-6.fc37.x86_64"
     },
     "libkcapi": {
-      "evra": "1.3.1-4.fc36.x86_64"
+      "evra": "1.4.0-2.fc37.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.3.1-4.fc36.x86_64"
+      "evra": "1.4.0-2.fc37.x86_64"
     },
     "libksba": {
-      "evra": "1.6.0-3.fc36.x86_64"
+      "evra": "1.6.0-4.fc37.x86_64"
     },
     "libldb": {
-      "evra": "2.5.0-1.fc36.x86_64"
+      "evra": "2.6.1-1.fc37.x86_64"
     },
     "libluksmeta": {
-      "evra": "9-13.fc36.x86_64"
+      "evra": "9-14.fc37.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.6.0-2.fc36.x86_64"
+      "evra": "1.6.0-3.fc37.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.4-15.fc36.x86_64"
+      "evra": "1.0.4-16.fc37.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.14.0-2.fc36.x86_64"
+      "evra": "2.14.0-4.fc37.x86_64"
     },
     "libmount": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "libndp": {
-      "evra": "1.8-3.fc36.x86_64"
+      "evra": "1.8-4.fc37.x86_64"
     },
     "libnet": {
-      "evra": "1.2-5.fc36.x86_64"
+      "evra": "1.2-6.fc37.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-4.fc36.x86_64"
+      "evra": "1.0.8-5.fc37.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-21.fc36.x86_64"
+      "evra": "1.0.1-22.fc37.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.1-2.rc4.fc36.x86_64"
+      "evra": "1:2.6.2-0.fc37.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.1-2.fc36.x86_64"
+      "evra": "1.2.2-2.fc37.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.46.0-2.fc36.x86_64"
+      "evra": "1.48.0-2.fc37.x86_64"
     },
     "libnl3": {
-      "evra": "3.5.0-9.fc36.x86_64"
+      "evra": "3.7.0-2.fc37.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.5.0-9.fc36.x86_64"
+      "evra": "3.7.0-2.fc37.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.0-3.fc36.x86_64"
+      "evra": "2.0.0-4.fc37.x86_64"
     },
     "libnvme": {
-      "evra": "1.0-1.fc36.x86_64"
+      "evra": "1.1-1.fc37.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-50.fc36.x86_64"
+      "evra": "0.2.1-52.fc37.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.1-3.fc36.x86_64"
+      "evra": "14:1.10.1-4.fc37.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-2.fc36.x86_64"
+      "evra": "1.8.0-3.fc37.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.1-5.fc36.x86_64"
+      "evra": "0.21.1-6.fc37.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.4-7.fc36.x86_64"
+      "evra": "1.4.4-11.fc37.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-50.fc36.x86_64"
+      "evra": "0.1.5-52.fc37.x86_64"
     },
     "librepo": {
-      "evra": "1.14.2-2.fc36.x86_64"
+      "evra": "1.14.3-3.fc37.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.1-1.fc36.noarch"
+      "evra": "2.17.2-1.fc37.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-2.fc36.x86_64"
+      "evra": "2.5.3-3.fc37.x86_64"
     },
     "libselinux": {
-      "evra": "3.3-4.fc36.x86_64"
+      "evra": "3.4-5.fc37.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.3-4.fc36.x86_64"
+      "evra": "3.4-5.fc37.x86_64"
     },
     "libsemanage": {
-      "evra": "3.3-3.fc36.x86_64"
+      "evra": "3.4-5.fc37.x86_64"
     },
     "libsepol": {
-      "evra": "3.3-3.fc36.x86_64"
+      "evra": "3.4-3.fc37.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.14-2.fc36.x86_64"
+      "evra": "2.14-3.fc37.x86_64"
     },
     "libslirp": {
-      "evra": "4.6.1-3.fc36.x86_64"
+      "evra": "4.7.0-2.fc37.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.16.1-0.fc36.x86_64"
+      "evra": "2:4.17.0-0.3.rc2.fc37.x86_64"
     },
     "libsmbios": {
-      "evra": "2.4.3-5.fc36.x86_64"
+      "evra": "2.4.3-7.fc37.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.22-1.fc36.x86_64"
+      "evra": "0.7.22-3.fc37.x86_64"
     },
     "libss": {
-      "evra": "1.46.5-2.fc36.x86_64"
-    },
-    "libssh": {
-      "evra": "0.9.6-4.fc36.x86_64"
-    },
-    "libssh-config": {
-      "evra": "0.9.6-4.fc36.noarch"
+      "evra": "1.46.5-3.fc37.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "libstdc++": {
-      "evra": "12.0.1-0.16.fc36.x86_64"
+      "evra": "12.2.1-1.fc37.x86_64"
     },
     "libtalloc": {
-      "evra": "2.3.3-3.fc36.x86_64"
+      "evra": "2.3.4-3.fc37.x86_64"
     },
     "libtasn1": {
-      "evra": "4.18.0-2.fc36.x86_64"
+      "evra": "4.18.0-3.fc37.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.6-1.fc36.x86_64"
+      "evra": "1.4.7-3.fc37.x86_64"
     },
     "libteam": {
-      "evra": "1.31-5.fc36.x86_64"
+      "evra": "1.31-6.fc37.x86_64"
     },
     "libtevent": {
-      "evra": "0.12.0-0.fc36.x86_64"
+      "evra": "0.13.0-1.fc37.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.2-1.rc1.fc36.1.x86_64"
+      "evra": "1.3.3-0.fc37.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.6-50.fc36.x86_64"
+      "evra": "2.4.7-2.fc37.x86_64"
     },
     "libunistring": {
-      "evra": "1.0-1.fc36.x86_64"
+      "evra": "1.0-2.fc37.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.25-8.fc36.x86_64"
+      "evra": "1.0.25-9.fc37.x86_64"
     },
     "libuser": {
-      "evra": "0.63-10.fc36.x86_64"
+      "evra": "0.63-12.fc37.x86_64"
     },
     "libutempter": {
-      "evra": "1.2.1-6.fc36.x86_64"
+      "evra": "1.2.1-7.fc37.x86_64"
     },
     "libuuid": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "libuv": {
-      "evra": "1:1.44.1-1.fc36.x86_64"
+      "evra": "1:1.44.2-2.fc37.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-3.fc36.x86_64"
+      "evra": "0.3.2-4.fc37.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.16.1-0.fc36.x86_64"
+      "evra": "2:4.17.0-0.3.rc2.fc37.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.28-1.fc36.x86_64"
+      "evra": "4.4.28-3.fc37.x86_64"
     },
     "libxml2": {
-      "evra": "2.9.14-1.fc36.x86_64"
+      "evra": "2.9.14-3.fc37.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.7-1.fc36.x86_64"
+      "evra": "0.3.9-2.fc37.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-7.fc36.x86_64"
+      "evra": "0.2.5-8.fc37.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.2-1.fc36.x86_64"
+      "evra": "1.5.2-3.fc37.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-31.fc36.x86_64"
+      "evra": "2.5.1-33.fc37.x86_64"
     },
     "linux-firmware": {
-      "evra": "20220411-131.fc36.noarch"
+      "evra": "20220815-138.fc37.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20220411-131.fc36.noarch"
+      "evra": "20220815-138.fc37.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.29-3.fc36.x86_64"
+      "evra": "0.9.29-4.fc37.x86_64"
     },
     "logrotate": {
-      "evra": "3.19.0-2.fc36.x86_64"
+      "evra": "3.20.1-3.fc37.x86_64"
     },
     "lsof": {
-      "evra": "4.94.0-3.fc36.x86_64"
+      "evra": "4.94.0-4.fc37.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.4-1.fc36.x86_64"
+      "evra": "5.4.4-4.fc37.x86_64"
     },
     "luksmeta": {
-      "evra": "9-13.fc36.x86_64"
+      "evra": "9-14.fc37.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.11-7.fc36.x86_64"
+      "evra": "2.03.11-9.fc37.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-7.fc36.x86_64"
+      "evra": "2.03.11-9.fc37.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.3-4.fc36.x86_64"
+      "evra": "1.9.3-5.fc37.x86_64"
     },
     "lzo": {
-      "evra": "2.10-6.fc36.x86_64"
+      "evra": "2.10-7.fc37.x86_64"
     },
     "mdadm": {
-      "evra": "4.2-1.fc36.x86_64"
+      "evra": "4.2-2.fc37.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-49.fc36.x86_64"
+      "evra": "2:2.1-53.fc37.x86_64"
     },
     "moby-engine": {
-      "evra": "20.10.14-1.fc36.x86_64"
+      "evra": "20.10.17-7.fc37.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.5.0-2.fc36.x86_64"
+      "evra": "2:0.6.0-5.fc37.x86_64"
     },
-    "mozjs91": {
-      "evra": "91.8.0-1.fc36.x86_64"
+    "mozjs102": {
+      "evra": "102.2.0-1.fc37.x86_64"
     },
     "mpfr": {
-      "evra": "4.1.0-9.fc36.x86_64"
+      "evra": "4.1.0-10.fc37.x86_64"
     },
     "nano": {
-      "evra": "6.0-2.fc36.x86_64"
+      "evra": "6.4-1.fc37.x86_64"
     },
     "nano-default-editor": {
-      "evra": "6.0-2.fc36.noarch"
+      "evra": "6.4-1.fc37.noarch"
     },
     "ncurses": {
-      "evra": "6.2-9.20210508.fc36.x86_64"
+      "evra": "6.3-3.20220501.fc37.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.2-9.20210508.fc36.noarch"
+      "evra": "6.3-3.20220501.fc37.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.2-9.20210508.fc36.x86_64"
+      "evra": "6.3-3.20220501.fc37.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.61.20160912git.fc36.x86_64"
+      "evra": "2.0-0.63.20160912git.fc37.x86_64"
     },
     "netavark": {
-      "evra": "1.0.2-1.fc36.x86_64"
+      "evra": "1.1.0-1.fc37.x86_64"
     },
     "nettle": {
-      "evra": "3.7.3-3.fc36.x86_64"
+      "evra": "3.8-2.fc37.x86_64"
     },
     "newt": {
-      "evra": "0.52.21-12.fc36.x86_64"
+      "evra": "0.52.21-14.fc37.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.1-2.rc4.fc36.x86_64"
+      "evra": "1:2.6.2-0.fc37.x86_64"
     },
     "nftables": {
-      "evra": "1:1.0.1-3.fc36.x86_64"
+      "evra": "1:1.0.4-3.fc37.x86_64"
     },
     "npth": {
-      "evra": "1.6-8.fc36.x86_64"
+      "evra": "1.6-9.fc37.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-20.fc36.x86_64"
+      "evra": "2.18.1-21.fc37.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.14-5.fc36.x86_64"
+      "evra": "2.0.14-6.fc37.x86_64"
     },
     "nvme-cli": {
-      "evra": "2.0-1.fc36.x86_64"
+      "evra": "2.1.2-1.fc37.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.8-1.fc36.x86_64"
+      "evra": "6.9.8-1.fc37.1.x86_64"
     },
     "openldap": {
-      "evra": "2.6.1-2.fc36.x86_64"
-    },
-    "openldap-compat": {
-      "evra": "2.6.1-2.fc36.x86_64"
+      "evra": "2.6.3-1.fc37.x86_64"
     },
     "openssh": {
-      "evra": "8.8p1-1.fc36.1.x86_64"
+      "evra": "8.8p1-6.fc37.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.8p1-1.fc36.1.x86_64"
+      "evra": "8.8p1-6.fc37.x86_64"
     },
     "openssh-server": {
-      "evra": "8.8p1-1.fc36.1.x86_64"
+      "evra": "8.8p1-6.fc37.x86_64"
     },
     "openssl": {
-      "evra": "1:3.0.2-5.fc36.x86_64"
+      "evra": "1:3.0.5-2.fc37.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.0.2-5.fc36.x86_64"
+      "evra": "1:3.0.5-2.fc37.x86_64"
     },
     "os-prober": {
-      "evra": "1.77-9.fc36.x86_64"
+      "evra": "1.81-1.fc37.x86_64"
     },
     "ostree": {
-      "evra": "2022.2-1.fc36.x86_64"
+      "evra": "2022.5-2.fc37.x86_64"
     },
     "ostree-libs": {
-      "evra": "2022.2-1.fc36.x86_64"
+      "evra": "2022.5-2.fc37.x86_64"
     },
     "p11-kit": {
-      "evra": "0.24.1-2.fc36.x86_64"
+      "evra": "0.24.1-3.fc37.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.24.1-2.fc36.x86_64"
+      "evra": "0.24.1-3.fc37.x86_64"
     },
     "pam": {
-      "evra": "1.5.2-12.fc36.x86_64"
+      "evra": "1.5.2-14.fc37.x86_64"
     },
     "pam-libs": {
-      "evra": "1.5.2-12.fc36.x86_64"
+      "evra": "1.5.2-14.fc37.x86_64"
     },
     "passwd": {
-      "evra": "0.80-12.fc36.x86_64"
+      "evra": "0.80-13.fc37.x86_64"
     },
     "pcre": {
-      "evra": "8.45-1.fc36.1.x86_64"
+      "evra": "8.45-1.fc37.2.x86_64"
     },
     "pcre2": {
-      "evra": "10.39-1.fc36.1.x86_64"
+      "evra": "10.40-1.fc37.1.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.39-1.fc36.1.noarch"
+      "evra": "10.40-1.fc37.1.noarch"
     },
     "pigz": {
-      "evra": "2.7-1.fc36.x86_64"
+      "evra": "2.7-2.fc37.x86_64"
     },
     "pkgconf": {
-      "evra": "1.8.0-2.fc36.x86_64"
+      "evra": "1.8.0-3.fc37.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-2.fc36.noarch"
+      "evra": "1.8.0-3.fc37.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-2.fc36.x86_64"
+      "evra": "1.8.0-3.fc37.x86_64"
     },
     "podman": {
-      "evra": "3:4.0.3-1.fc36.x86_64"
+      "evra": "4:4.2.0-2.fc37.x86_64"
     },
     "podman-plugins": {
-      "evra": "3:4.0.3-1.fc36.x86_64"
+      "evra": "4:4.2.0-2.fc37.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.3-4.fc36.x86_64"
+      "evra": "3.4-6.fc37.x86_64"
     },
     "polkit": {
-      "evra": "0.120-5.fc36.x86_64"
+      "evra": "121-4.fc37.x86_64"
     },
     "polkit-libs": {
-      "evra": "0.120-5.fc36.x86_64"
+      "evra": "121-4.fc37.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-21.fc36.x86_64"
+      "evra": "0.1-22.fc37.x86_64"
     },
     "popt": {
-      "evra": "1.18-7.fc36.x86_64"
+      "evra": "1.19~rc1-3.fc37.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.17-4.fc36.x86_64"
+      "evra": "3.3.17-6.fc37.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.4.0-4.fc36.x86_64"
+      "evra": "1.4.0-6.fc37.x86_64"
     },
     "psmisc": {
-      "evra": "23.4-3.fc36.x86_64"
+      "evra": "23.4-4.fc37.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20210518-4.fc36.noarch"
+      "evra": "20210518-5.fc37.noarch"
     },
     "readline": {
-      "evra": "8.1-6.fc36.x86_64"
+      "evra": "8.1-7.fc37.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.6-2.fc36.x86_64"
+      "evra": "1.2.6-3.fc37.x86_64"
     },
     "rpm": {
-      "evra": "4.17.0-10.fc36.x86_64"
+      "evra": "4.18.0-0.beta1.4.fc37.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.17.0-10.fc36.x86_64"
+      "evra": "4.18.0-0.beta1.4.fc37.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2022.8-1.fc36.x86_64"
+      "evra": "2022.12-4.fc37.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2022.8-1.fc36.x86_64"
+      "evra": "2022.12-4.fc37.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.17.0-10.fc36.x86_64"
+      "evra": "4.18.0-0.beta1.4.fc37.x86_64"
     },
     "rsync": {
-      "evra": "3.2.3-15.fc36.x86_64"
+      "evra": "3.2.5-1.fc37.x86_64"
     },
     "runc": {
-      "evra": "2:1.1.1-1.fc36.x86_64"
+      "evra": "2:1.1.3-1.fc37.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.16.1-0.fc36.x86_64"
+      "evra": "2:4.17.0-0.3.rc2.fc37.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.16.1-0.fc36.noarch"
+      "evra": "2:4.17.0-0.3.rc2.fc37.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.16.1-0.fc36.x86_64"
+      "evra": "2:4.17.0-0.3.rc2.fc37.x86_64"
     },
     "sed": {
-      "evra": "4.8-10.fc36.x86_64"
+      "evra": "4.8-11.fc37.x86_64"
     },
     "selinux-policy": {
-      "evra": "36.8-1.fc36.noarch"
+      "evra": "37.8-1.fc37.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "36.8-1.fc36.noarch"
+      "evra": "37.8-1.fc37.noarch"
     },
     "setup": {
-      "evra": "2.13.9.1-3.fc36.noarch"
+      "evra": "2.14.1-2.fc37.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-3.fc36.x86_64"
+      "evra": "1.46-4.fc37.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-3.fc36.x86_64"
+      "evra": "1.46-4.fc37.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.11.1-2.fc36.x86_64"
+      "evra": "2:4.11.1-4.fc37.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.11.1-2.fc36.x86_64"
+      "evra": "2:4.11.1-4.fc37.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.1-3.fc35.x86_64"
+      "evra": "2.2-2.fc37.x86_64"
     },
     "shim-x64": {
-      "evra": "15.4-5.x86_64"
+      "evra": "15.6-2.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.7.0-1.fc36.x86_64"
+      "evra": "1:1.9.2-1.fc37.x86_64"
     },
     "slang": {
-      "evra": "2.3.2-11.fc36.x86_64"
+      "evra": "2.3.3-1.fc37.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.2.0-0.2.beta.0.fc36.x86_64"
+      "evra": "1.2.0-5.fc37.x86_64"
     },
     "snappy": {
-      "evra": "1.1.9-4.fc36.x86_64"
+      "evra": "1.1.9-5.fc37.x86_64"
     },
     "socat": {
-      "evra": "1.7.4.2-2.fc36.x86_64"
+      "evra": "1.7.4.2-3.fc37.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.36.0-5.fc36.x86_64"
+      "evra": "3.39.2-2.fc37.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-1.fc36.x86_64"
+      "evra": "4.5.1-2.fc37.x86_64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.3-2.fc36.x86_64"
+      "evra": "0.1.3-4.fc37.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-client": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-common": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.7.0-1.fc36.x86_64"
-    },
-    "sssd-idp": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.7.0-1.fc36.x86_64"
+      "evra": "2.7.3-3.fc37.x86_64"
     },
     "stalld": {
-      "evra": "1.15-2.fc36.x86_64"
+      "evra": "1.16-2.fc37.x86_64"
     },
     "sudo": {
-      "evra": "1.9.8-5.p2.fc36.x86_64"
+      "evra": "1.9.11-4.p3.fc37.x86_64"
     },
     "systemd": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "systemd-container": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "systemd-libs": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "systemd-pam": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "systemd-resolved": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "systemd-udev": {
-      "evra": "250.3-8.fc36.x86_64"
+      "evra": "251.4-53.fc37.x86_64"
     },
     "tar": {
       "evra": "2:1.34-3.fc36.x86_64"
     },
     "teamd": {
-      "evra": "1.31-5.fc36.x86_64"
+      "evra": "1.31-6.fc37.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.99.3-4.fc36.x86_64"
+      "evra": "0.0.99.3-7.fc37.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.2-2.fc36.x86_64"
+      "evra": "5.2-3.fc37.x86_64"
     },
     "tpm2-tss": {
-      "evra": "3.2.0-1.fc36.x86_64"
+      "evra": "3.2.0-3.fc37.x86_64"
     },
     "tzdata": {
-      "evra": "2022a-2.fc36.noarch"
+      "evra": "2022c-1.fc37.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-4.fc36.x86_64"
+      "evra": "0.13.0-5.fc37.x86_64"
     },
     "util-linux": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.38-0.2.fc36.x86_64"
+      "evra": "2.38.1-1.fc37.x86_64"
     },
     "vim-data": {
-      "evra": "2:8.2.4845-1.fc36.noarch"
+      "evra": "2:9.0.213-1.fc37.noarch"
     },
     "vim-minimal": {
-      "evra": "2:8.2.4845-1.fc36.x86_64"
+      "evra": "2:9.0.213-1.fc37.x86_64"
     },
     "which": {
-      "evra": "2.21-32.fc36.x86_64"
+      "evra": "2.21-35.fc37.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-2.fc36.x86_64"
+      "evra": "1.0.20210914-3.fc37.x86_64"
     },
     "xfsprogs": {
-      "evra": "5.14.2-2.fc36.x86_64"
+      "evra": "5.18.0-3.fc37.x86_64"
     },
     "xxhash-libs": {
-      "evra": "0.8.1-2.fc36.x86_64"
+      "evra": "0.8.1-3.fc37.x86_64"
     },
     "xz": {
-      "evra": "5.2.5-9.fc36.x86_64"
+      "evra": "5.2.5-10.fc37.x86_64"
     },
     "xz-libs": {
-      "evra": "5.2.5-9.fc36.x86_64"
+      "evra": "5.2.5-10.fc37.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-18.fc36.x86_64"
+      "evra": "2.1.0-19.fc37.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.2.2-1.fc36.x86_64"
+      "evra": "1.2.2-2.fc37.x86_64"
     },
     "zincati": {
-      "evra": "0.0.24-3.fc36.x86_64"
+      "evra": "0.0.24-5.fc37.x86_64"
     },
     "zlib": {
-      "evra": "1.2.11-31.fc36.x86_64"
+      "evra": "1.2.12-4.fc37.x86_64"
     },
     "zram-generator": {
-      "evra": "1.1.2-1.fc36.x86_64"
+      "evra": "1.1.2-2.fc37.x86_64"
+    },
+    "zstd": {
+      "evra": "1.5.2-3.fc37.x86_64"
     }
   },
   "metadata": {
-    "generated": "2022-05-09T20:52:26Z",
+    "generated": "2022-09-09T18:54:17Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2022-05-08T22:06:23Z"
+        "generated": "2022-09-07T04:22:12Z"
       },
       "fedora-next": {
-        "generated": "2022-05-06T10:02:00Z"
+        "generated": "2022-09-09T09:55:55Z"
       },
       "fedora-next-updates": {
-        "generated": "2022-05-09T01:28:41Z"
+        "generated": "2022-08-09T18:08:15Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: next-devel
   prod: false
 
-releasever: 36
+releasever: 37
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to


### PR DESCRIPTION
The Fedora Linux 37 beta is shipping next week. Let's switch next-devel so we can ship it next week along with beta.