### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,24 +33,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-82b7a84be3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
-  kernel:
-    evr: 5.19.7-300.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
-      type: fast-track
-  kernel-core:
-    evr: 5.19.7-300.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
-      type: fast-track
-  kernel-modules:
-    evr: 5.19.7-300.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-c8ab7598fc
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1292
-      type: fast-track
   libipa_hbac:
     evr: 2.7.4-1.fc37
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).