### PR TITLE
tests: drop per-stream conditional for `platforms.json` test

### DIFF
--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -36,34 +36,11 @@ check_platforms_json() {
     ok "platforms.json for $platform"
 }
 
-# Check whether platforms.json exists
-if is_fcos; then
-    # Schedule based on:
-    # https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/message/GHLXX4MXNHUEAXQLK6BZN45IQYHRVQB4/
-    case "$(get_fcos_stream)" in
-    next-devel) threshold=20220919 ;;
-    next) threshold=20220930 ;;
-    testing-devel|rawhide|branched) threshold=20221118 ;;
-    testing) threshold=20221125 ;;
-    stable) threshold=20221209 ;;
-    *) fatal "Unknown stream" ;;
-    esac
-    datecode=$(echo "$VERSION" | cut -f2 -d.)
-    expect_config=$([ $datecode -ge $threshold ] && echo 1 || echo 0)
-else
-    threshold=none
-    expect_config=1
+# Ensure that platforms.json exists
+if [ ! -e /boot/coreos/platforms.json ]; then
+    fatal "platforms.json does not exist"
 fi
-have_config=$([ -e /boot/coreos/platforms.json ] && echo 1 || echo 0)
-if [ "$have_config" != "$expect_config" ]; then
-    fatal "platforms.json exists=$have_config expected=$expect_config threshold=$threshold"
-fi
-ok "platforms.json exists=$have_config"
-if [ "$have_config" != 1 ]; then
-    # We don't automatically test whether the legacy code injects the
-    # correct parameters
-    exit 0
-fi
+ok "platforms.json exists"
 
 # Check that platforms.json matches grub.cfg and kargs
 platform=$(cmdline_arg ignition.platform.id)


### PR DESCRIPTION
Once `platforms.json` is deployed on all streams, drop the date-based conditions.

Followup to https://github.com/coreos/fedora-coreos-config/pull/1974.  Requires `platforms.json` to land in all streams.