### PR TITLE
tests/kola: update threshold for `next-devel` console switch

### DIFF
--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -41,7 +41,7 @@ if is_fcos; then
     # Schedule based on:
     # https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/message/GHLXX4MXNHUEAXQLK6BZN45IQYHRVQB4/
     case "$(get_fcos_stream)" in
-    next-devel) threshold=20220923 ;;
+    next-devel) threshold=20220919 ;;
     next) threshold=20220930 ;;
     testing-devel|rawhide|branched) threshold=20221118 ;;
     testing) threshold=20221125 ;;


### PR DESCRIPTION
The console change has landed now, so update the threshold to keep tests green.