### PR TITLE
commonlib: add func to check unit is started

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -71,3 +71,14 @@ cmdline_arg() {
     done
     echo "${value}"
 }
+
+# wait for 20s when in activating status
+is_service_active() {
+    local service="$1"
+    for x in {0..20}; do
+        [ $(systemctl is-active "${service}") != "activating" ] && break
+        sleep 1
+    done
+    # return actual result
+    systemctl is-active "${service}"
+}

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -16,7 +16,7 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-      if [ $(systemctl show -p Result kdump.service) != "Result=success" ]; then
+      if ! is_service_active kdump.service; then
           fatal "kdump.service failed to start"
       fi
       # Verify that the crashkernel reserved memory is large enough


### PR DESCRIPTION
The code in tests will always return true if the unit does not exist: 
`if [ $(systemctl show -p Result kdump.service) != "Result=success" ]; then` 
See https://github.com/coreos/fedora-coreos-config/issues/1743

Make sure service is active, and wait for 20s if service is activating