### PR TITLE
denylist: drop denials for clhm.network-device-info

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -36,10 +36,3 @@
   snooze: 2022-09-27
   streams:
   - rawhide
-- pattern: ext.config.clhm.network-device-info
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1153
-  snooze: 2022-10-04
-  streams:
-  - testing-devel
-  - testing
-  - stable


### PR DESCRIPTION
Drop denial as the test no longer fails because of
selinux-policy-36.13-3.fc36 update.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1153