### PR TITLE
overlay.d/14NetworkManager-plugins: Explicitly disable ifcfg-rh plugin

### DIFF
--- a/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
+++ b/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
@@ -1,9 +1,0 @@
-# Stop NetworkManager from trying to load the ifcfg-rh plugin by default,
-# which we don't ship.  This actually disables all default plugins, of which
-# ifcfg-rh is currently the only one.
-#
-# Note that we must do this for now because `-=` syntax doesn't work
-# with compiled-in defaults. Proposed upstream fix:
-# https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/491
-[main]
-plugins=

--- a/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-ifcfg-rh-plugin.conf
+++ b/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-ifcfg-rh-plugin.conf
@@ -1,0 +1,4 @@
+# Stop NetworkManager from trying to load the ifcfg-rh plugin by default,
+# which we don't ship.
+[main]
+plugins-=ifcfg-rh


### PR DESCRIPTION
The NM issue [1] where compiled-in default plugins could not be disabled with the `-=`  syntax has been fixed upstream, so move to explicitly disabling the ifcfg-rh plugin.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/491