### PR TITLE
overrides: fast-track kernel-5.19.12-200.fc36

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,8 +31,3 @@
   snooze: 2022-10-27
   arches:
   - s390x
-- pattern: coreos.boot-mirror*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1282
-  snooze: 2022-09-27
-  streams:
-  - rawhide

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,12 +23,12 @@
   - s390x
 - pattern: ext.config.ignition.resource.remote
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  snooze: 2022-09-27
+  snooze: 2022-10-27
   arches:
   - s390x
 - pattern: rpmostree.install-uninstall
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  snooze: 2022-09-27
+  snooze: 2022-10-27
   arches:
   - s390x
 - pattern: coreos.boot-mirror*

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 5.19.12-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-ee88ba9ed6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: fast-track
+  kernel-core:
+    evr: 5.19.12-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-ee88ba9ed6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: fast-track
+  kernel-modules:
+    evr: 5.19.12-200.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-ee88ba9ed6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1282
+      type: fast-track


### PR DESCRIPTION
Also extend snooze for systemd-tmpfiles issue tests.