### PR TITLE
manifest: Exclude support for NM legacy ifcfg config format

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -19,7 +19,6 @@ ostree-layers:
   - overlay/05core
   - overlay/08nouveau
   - overlay/09misc
-  - overlay/14NetworkManager-plugins
   - overlay/20platform-chrony
 
 # Be minimal

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -134,9 +134,6 @@ postprocess:
 
 
 remove-from-packages:
-  # Drop NetworkManager support for ifcfg files, see also corresponding
-  # overlay.d/14NetworkManager-plugins
-  - [NetworkManager, /usr/lib64/NetworkManager/.*/libnm-settings-plugin-ifcfg-rh.so]
   # Drop some buggy sysusers fragments which do not match static IDs allocation:
   # https://bugzilla.redhat.com/show_bug.cgi?id=2105177
   - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
@@ -169,3 +166,6 @@ exclude-packages:
   # For (datacenter/cloud oriented) servers, we want to see the details by default.
   # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
   - plymouth
+  # Do not use legacy ifcfg config format in NetworkManager
+  # See https://github.com/coreos/fedora-coreos-config/pull/1991
+  - NetworkManager-initscripts-ifcfg-rh

--- a/overlay.d/14NetworkManager-plugins/statoverride
+++ b/overlay.d/14NetworkManager-plugins/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
+++ b/overlay.d/14NetworkManager-plugins/usr/lib/NetworkManager/conf.d/10-disable-default-plugins.conf
@@ -1,9 +1,0 @@
-# Stop NetworkManager from trying to load the ifcfg-rh plugin by default,
-# which we don't ship.  This actually disables all default plugins, of which
-# ifcfg-rh is currently the only one.
-#
-# Note that we must do this for now because `-=` syntax doesn't work
-# with compiled-in defaults. Proposed upstream fix:
-# https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/491
-[main]
-plugins=

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -28,11 +28,6 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1700056
 
 Warning about `/etc/sysconfig`.
 
-14NetworkManager-plugins
-------------------------
-
-Disables the Red Hat Linux legacy `ifcfg` format.
-
 15fcos
 ------
 


### PR DESCRIPTION
Since Fedora 36, the ifcfg-rh plugin implementing support for reading network configuration files in the legacy ifcfg format has been split out into its own RPM subpackage.

We can now remove our configuration workaround and instead ensure that we do not ship this plugin at all.

See: https://github.com/coreos/fedora-coreos-config/pull/1991