### PR TITLE
[rawhide] overrides: pin linux-firmware 20220815-139.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  linux-firmware:
+    evra: 20220815-139.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1310
+      type: pin
+  linux-firmware-whence:
+    evra: 20220815-139.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1310
+      type: pin


### PR DESCRIPTION
pin `linux-firmware 20220815-139.fc38` till we find a solution for https://github.com/coreos/fedora-coreos-tracker/issues/1310