### PR TITLE
kola/validate-symlinks: Add qcom/LENOVO/21BX.xz to broken symlink list

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -21,6 +21,7 @@ list_broken_symlinks_skip=(
     '/etc/xdg/systemd/user'
     '/usr/lib/.build-id/'
     '/usr/lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt.xz'
+    '/usr/lib/firmware/qcom/LENOVO/21BX.xz'
     '/usr/lib/modules/'
     '/usr/share/rhel/secrets/etc-pki-entitlement'
     '/usr/share/rhel/secrets/redhat.repo'


### PR DESCRIPTION
Add `qcom/LENOVO/21BX.xz` to the broken symlinks list.
Ref issue: https://github.com/coreos/fedora-coreos-tracker/issues/1310