### PR TITLE
kola/tests: add ext.config.platforms.aws.{nvme,assert-xen} tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,3 +31,6 @@
   snooze: 2022-10-27
   arches:
   - s390x
+- pattern: ext.config.platforms.aws.nvme
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306
+  snooze: 2022-10-21

--- a/tests/kola/platforms/aws/assert-xen
+++ b/tests/kola/platforms/aws/assert-xen
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test to make sure the booted AWS instance is XEN based
+#
+## kola:
+##   # This is a read-only test and can be run with other tests
+##   exclusive: false
+##   # This test is targeted at AWS
+##   platforms: aws
+##   # Force this test to not run by default unless named specifically
+##   # or `--tag aws-xen-test` is passed to `kola run`. i.e. this test
+##   # should only run on Xen instances and the caller should request
+##   # the test.
+##   requiredTag: aws-xen-test
+#
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+hypervisor=$(curl http://169.254.169.254/2022-09-24/meta-data/system || true)
+if [ "${hypervisor}" != "xen" ]; then
+    fatal "expected xen instance type"
+fi
+
+ok xen instance type

--- a/tests/kola/platforms/aws/data/commonlib.sh
+++ b/tests/kola/platforms/aws/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/platforms/aws/nvme
+++ b/tests/kola/platforms/aws/nvme
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Test to make sure AWS instances with nvme storage get a device
+# properly created for it. See https://github.com/coreos/fedora-coreos-tracker/issues/1306
+#
+## kola:
+##   # This is a read-only test and can be run with other tests
+##   exclusive: false
+##   # This test is targeted at AWS
+##   platforms: aws
+
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# We'll check to see if anything is listed in `nvme list-subsys`
+# and then run the test based on that. Example output:
+# 
+# [core@ip-10-0-1-155 ~]$ nvme list-subsys -o json
+# [
+#   {
+#     "HostNQN":"nqn.2014-08.org.nvmexpress:uuid:c2c16640-0d5c-472a-846c-2f981c5914db",
+#     "HostID":"c37c43ca-31a3-4015-8704-1f493081da36",
+#     "Subsystems":[
+#       {
+#         "Name":"nvme-subsys0",
+#         "NQN":"nqn.2014.08.org.nvmexpress:1d0f0000AWS2710D45D72D3C9D4AAmazon EC2 NVMe Instance Storage",
+#         "Paths":[
+#           {
+#             "Name":"nvme0",
+#             "Transport":"pcie",
+#             "Address":"0000:00:1e.0",
+#             "State":"live"
+#           }
+#         ]
+#       }
+#     ]
+#   }
+# ]
+nvme_info=$(nvme list-subsys -o json || true)
+has_nvme=$(jq -r ".[].Subsystems[].Paths[] | select(.Name == \"nvme0\").Name" <<< "$nvme_info")
+if [ -n "${has_nvme}" ]; then
+    if [ ! -e '/dev/nvme0n1' ]; then
+        fatal "instance has nvme device but no nvme0n1 accessible"
+    fi
+else
+    echo "it appears this system has no nvme devices. skipping"
+fi
+
+ok aws nvme device


### PR DESCRIPTION
```
commit 199a66ebe5e46e17e097aa742a873cd647d4697a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 4 10:57:35 2022 -0400

    tests/kola: add ext.config.platforms.aws.assert-xen test
    
    This is just an extra layer to make sure that when we run an AWS
    Xen test in our pipeline that the instance is legitimately a Xen
    instance. It will only be run if the caller requested the test
    by name or via the aws-xen-test tag.

commit c9decffd79a50c89b15e6dbd99b42caef78f4db5
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Oct 4 10:56:06 2022 -0400

    tests/kola: add ext.config.platforms.aws.nvme test
    
    This test ensures that if an nvme device exists it is accessible.
    See https://github.com/coreos/fedora-coreos-tracker/issues/1306
    
    This commit also denylists the test with a snooze for the next few
    weeks. The hope is that Amazon does the firmware rollout soon.

```
