### PR TITLE
tests: Bump RAM allocation for tests that install packages

### DIFF
--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -2,7 +2,7 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15, "minMemory": 1536 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -2,7 +2,7 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15, "minMemory": 1536 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #


### PR DESCRIPTION
This is similar to
https://github.com/coreos/fedora-coreos-config/commit/3dee27d except for rpm-ostree on the host system.