### PR TITLE
overrides: drop bash pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  bash:
-    evr: 5.1.16-3.fc36
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1313
-      type: pin
+packages: {}


### PR DESCRIPTION
Unpin bash now that the issue https://github.com/coreos/fedora-coreos-tracker/issues/1313 is fixed in the latest package.