### PR TITLE
image-base: bump VMware hardware version to 17

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -30,4 +30,4 @@ vmware-os-type: fedora64Guest
 # VMware hardware versions: https://kb.vmware.com/s/article/1003746
 # We use the newest version allowed by the oldest non-EOL VMware
 # Workstation/Player/Fusion/ESXi release: https://lifecycle.vmware.com/
-vmware-hw-version: 13
+vmware-hw-version: 17

--- a/image-base.yaml
+++ b/image-base.yaml
@@ -31,7 +31,3 @@ vmware-os-type: fedora64Guest
 # We use the newest version allowed by the oldest non-EOL VMware
 # Workstation/Player/Fusion/ESXi release: https://lifecycle.vmware.com/
 vmware-hw-version: 13
-
-# After this, we plan to add support for the Ignition
-# storage/filesystems sections.  (Although one can do
-# that on boot as well)


### PR DESCRIPTION
The last VMware products requiring older hardware versions are now EOL.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1141.