### PR TITLE
[testing] ci: migrate to new directory and method names

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -9,7 +9,7 @@ cosaPod {
     shwrap("cd config && ci/validate")
 
     shwrap("""
-        mkdir -p /srv/fcos && cd /srv/fcos
+        mkdir -p /srv/coreos && cd /srv/coreos
         cosa init ${env.WORKSPACE}/config
         curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/main/scripts/download-overrides.py
         python3 download-overrides.py
@@ -20,8 +20,8 @@ cosaPod {
     // use a --parent-build arg so we can diff later and it matches prod
     def parent_arg = ""
     def parent_commit = ""
-    if (shwrapRc("test -e /srv/fcos/builds/latest/${basearch}/meta.json") == 0) {
-        shwrap("cp /srv/fcos/builds/latest/${basearch}/meta.json .") // readJSON wants it in the WORKSPACE
+    if (shwrapRc("test -e /srv/coreos/builds/latest/${basearch}/meta.json") == 0) {
+        shwrap("cp /srv/coreos/builds/latest/${basearch}/meta.json .") // readJSON wants it in the WORKSPACE
         def meta = readJSON file: "meta.json"
         def version = meta["buildid"]
         parent_arg = "--parent-build ${version}"
@@ -35,24 +35,24 @@ cosaPod {
     if (env.CHANGE_TARGET in mechanical_streams) {
         no_strict_build = true
     }
-    fcosBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
+    cosaBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
 
     parallel metal: {
-        shwrap("cd /srv/fcos && cosa buildextend-metal")
+        shwrap("cd /srv/coreos && cosa buildextend-metal")
     }, metal4k: {
-        shwrap("cd /srv/fcos && cosa buildextend-metal4k")
+        shwrap("cd /srv/coreos && cosa buildextend-metal4k")
     }
 
     stage("Test ISO") {
-        shwrap("cd /srv/fcos && cosa buildextend-live")
-        fcosKolaTestIso(cosaDir: "/srv/fcos", extraArgs4k: "--no-pxe")
+        shwrap("cd /srv/coreos && cosa buildextend-live")
+        kolaTestIso(extraArgs4k: "--no-pxe")
     }
 
     // also print the pkgdiff as a separate stage to make it more visible
     if (parent_arg != "") {
         stage("RPM Diff") {
             shwrap("""
-                cd /srv/fcos
+                cd /srv/coreos
                 new_commit=\$(jq -r '.["ostree-commit"]' builds/latest/${basearch}/meta.json)
                 rpm-ostree db diff --repo tmp/repo ${parent_commit} \${new_commit} | tee tmp/diff.txt
                 if grep -q Downgraded tmp/diff.txt; then


### PR DESCRIPTION
The previous `fcos*` ones are deprecated.

This requires a forced cherry-pick rather than relying on promotions because `coreosbot-releng` is completely unprivileged and untrusted by CoreOS CI to modify the Jenkinsfile.

(cherry picked from commit 37866426cbec0c026c35aab9618717d51c13d881)