### PR TITLE
ci: add a cpu and memory request

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,7 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
 
-cosaPod {
+// We run `kolaTestIso` which requires at least 8Gi. Add 512M for overhead.
+cosaPod(cpus: 4, memory: "8704Mi") {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")


### PR DESCRIPTION
We're not currently requesting anything, which means we're at the mercy of any default limit set on the cluster we're running on. Let's add an explicit request.

Also bump the CPU request to 4 from the default of 2.