### PR TITLE
[rawhide] overrides: pin NetworkManager-1.40.0-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,31 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  NetworkManager:
+    evr: 1:1.40.0-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
+      type: pin
+  NetworkManager-cloud-setup:
+    evr: 1:1.40.0-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
+      type: pin
+  NetworkManager-libnm:
+    evr: 1:1.40.0-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
+      type: pin
+  NetworkManager-team:
+    evr: 1:1.40.0-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
+      type: pin
+  NetworkManager-tui:
+    evr: 1:1.40.0-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
+      type: pin
   systemd:
     evr: 251.5-607.fc38
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).