### PR TITLE
ci: bump memory request to 9Gi

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,7 +1,7 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
 
-// We run `kolaTestIso` which requires at least 8Gi. Add 512M for overhead.
-cosaPod(cpus: 4, memory: "8704Mi") {
+// We run `kolaTestIso` which requires at least 8Gi. Add 1Gi for overhead.
+cosaPod(cpus: 4, memory: "9Gi") {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")


### PR DESCRIPTION
Noticed in https://github.com/coreos/fedora-coreos-config/pull/2031 that the `kola testiso` was killed:

    FAIL: iso-offline-install (bios + metal) (1m35.505s)
        signal: killed
    Error: signal: killed

This is likely due to hitting up against the memory limit. It seems like 512Mi of overhead isn't enough. Let's bump it to 1Gi.