### PR TITLE
denylist: extend snooze for ext.config.platforms.aws.nvme test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,4 +33,8 @@
   - s390x
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306
-  snooze: 2022-10-21
+  snooze: 2022-11-05
+  streams:
+    - testing-devel
+    - testing
+    - stable


### PR DESCRIPTION
It looks like our F37+ streams pass this test now [1] so let's also only deny the test on streams where it's known to fail.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1289910315