### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -63,59 +63,11 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d4be764cf4
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
-  kernel:
-    evr: 5.19.16-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1c6a1ca835
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288196776
-      type: fast-track
-  kernel-core:
-    evr: 5.19.16-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1c6a1ca835
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288196776
-      type: fast-track
-  kernel-modules:
-    evr: 5.19.16-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1c6a1ca835
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288196776
-      type: fast-track
-  libsmbclient:
-    evr: 2:4.17.1-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
-      type: fast-track
-  libwbclient:
-    evr: 2:4.17.1-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
-      type: fast-track
   readline:
     evr: 8.2-2.fc37
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bde0600efe
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
-      type: fast-track
-  samba-client-libs:
-    evr: 2:4.17.1-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
-      type: fast-track
-  samba-common:
-    evra: 2:4.17.1-1.fc37.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
-      type: fast-track
-  samba-common-libs:
-    evr: 2:4.17.1-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
       type: fast-track
   skopeo:
     evr: 1:1.10.0-3.fc37


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).