### PR TITLE
denylist: re-enable kdump.crash test on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,9 +6,16 @@
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
+  tracker: https://github.com/coreos/coreos-assembler/issues/2725#issuecomment-1292616121
+  snooze: 2022-12-01
   arches:
     - ppc64le
+  streams:
+    - next-devel
+    - next
+    - testing-devel
+    - testing
+    - stable
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:

--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -3,9 +3,11 @@ version: 1.4.0
 kernel_arguments:
   should_exist:
     # We need to make sure we have a large enough crashkernel for FCOS
-    # and RHCOS here. Currently the worst case is aarch64 RHCOS where
-    # the `kdumpctl estimate` says "Recommended crashkernel: 448M"
-    - crashkernel=500M
+    # and RHCOS here. Currently the worst case output of `kdumpctl estimate`
+    # is aarch64 RHCOS where the it says "Recommended crashkernel: 448M".
+    # Though for some reason when we set crashkernel=448M ppc64le complains
+    # and wants 512M so let's set it to 512M here.
+    - crashkernel=512M
 systemd:
   units:
     - name: kdump.service


### PR DESCRIPTION
It's passing now with newer kernel on rawhide [1]. Let's start testing it again.

[1] https://github.com/coreos/coreos-assembler/issues/2725#issuecomment-1292616121