### PR TITLE
[next-devel] platforms: add secondary serial console on OpenStack, VirtualBox, VMware

### DIFF
--- a/platforms.yaml
+++ b/platforms.yaml
@@ -143,3 +143,23 @@ x86_64:
     kernel_arguments:
       - console=tty0
       - console=ttyS0,115200n8
+  virtualbox:
+    # Graphical console primary, serial console available for logging
+    # https://docs.fedoraproject.org/en-US/fedora-coreos/provisioning-virtualbox/#_troubleshooting_first_boot_problems
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0
+  vmware:
+    # Graphical console primary, serial console available for logging
+    # https://docs.fedoraproject.org/en-US/fedora-coreos/provisioning-vmware/#_troubleshooting_first_boot_problems
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -32,6 +32,17 @@ aarch64:
     kernel_arguments:
       - console=tty0
       - console=ttyAMA0,115200n8
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyAMA0,115200n8
+      - console=tty0
   packet:
     # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
     grub_commands:
@@ -48,6 +59,14 @@ aarch64:
       - terminal_input serial console
       - terminal_output serial console
 ppc64le:
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # petitboot doesn't understand GRUB console commands
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    kernel_arguments:
+      - console=hvc0
+      - console=tty0
   qemu:
     # petitboot doesn't understand GRUB console commands, but we need to
     # pass console kargs
@@ -96,6 +115,17 @@ x86_64:
     kernel_arguments:
       - console=tty0
       - console=ttyS0,115200n8
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0
   packet:
     # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
     grub_commands:


### PR DESCRIPTION
Previously, `openstack console log <server>` was useful for collecting console logs from OpenStack VMs, and FCOS docs included instructions on connecting to the VirtualBox/VMware serial console to get a console log.  However, we've disabled the serial console on all three platforms.  Re-enable it as a secondary console so those techniques continue to work while avoiding interfering with the primary graphical console.

The OpenStack change is untested.

Fixes: [OCPBUGS-2926](https://issues.redhat.com/browse/OCPBUGS-2926)
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/567#issuecomment-1271536899