### PR TITLE
denylist: extend snooze for tests affected by tmpfiles issue

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -30,12 +30,12 @@
   - s390x
 - pattern: ext.config.ignition.resource.remote
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  snooze: 2022-10-27
+  snooze: 2022-11-10
   arches:
   - s390x
 - pattern: rpmostree.install-uninstall
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  snooze: 2022-10-27
+  snooze: 2022-11-10
   arches:
   - s390x
 - pattern: ext.config.platforms.aws.nvme


### PR DESCRIPTION
The systemd fix has landed but we've got it pinned right now for another issue so we still need to snooze this one. See
https://github.com/coreos/fedora-coreos-tracker/issues/1215#issuecomment-1295021109