### PR TITLE
denylist: exclude ext.config.networking.nameserver on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -45,3 +45,7 @@
     - testing-devel
     - testing
     - stable
+- pattern: ext.config.networking.nameserver
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1332
+  arches:
+  - s390x


### PR DESCRIPTION
This test was recently introduced and fails on s390x. See https://github.com/coreos/fedora-coreos-tracker/issues/1332