### PR TITLE
[next] overrides: fast-track openssl-3.0.5-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -93,6 +93,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-1b0ba70aca
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1288198630
       type: fast-track
+  openssl:
+    evr: 1:3.0.5-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
+  openssl-libs:
+    evr: 1:3.0.5-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
   readline:
     evr: 8.2-2.fc37
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).