### PR TITLE
[next-devel] overrides: fast-track openssl-3.0.5-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -195,6 +195,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5c25a19c97
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
+  openssl:
+    evr: 1:3.0.5-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
+  openssl-libs:
+    evr: 1:3.0.5-3.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
   podman:
     evr: 4:4.3.0-2.fc37
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).