### PR TITLE
overrides: fast-track openssl-3.0.5-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,6 +33,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-658b2dbea2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1327
       type: fast-track
+  openssl:
+    evr: 1:3.0.5-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
+  openssl-libs:
+    evr: 1:3.0.5-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
   podman:
     evr: 4:4.3.0-2.fc36
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).