### PR TITLE
[testing] overrides: fast-track openssl-3.0.5-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,15 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1313
       type: pin
+  openssl:
+    evr: 1:3.0.5-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track
+  openssl-libs:
+    evr: 1:3.0.5-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
+      type: fast-track


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).