### PR TITLE
tests/kola/butane/grub-users: correctly skip on s390x

### DIFF
--- a/tests/kola/butane/grub-users-fix
+++ b/tests/kola/butane/grub-users-fix
@@ -6,6 +6,8 @@
 ##  architectures: "!s390x"
 ##  # Running on multiple platforms won't prove anything further
 ##  platforms: qemu
+##  # 10 minutes is not quite enough on ppc64le runners
+##  timeoutMin: 15
 #
 # Test coreos-fix-grub-users.service.
 

--- a/tests/kola/butane/grub-users/test.sh
+++ b/tests/kola/butane/grub-users/test.sh
@@ -4,7 +4,7 @@
 ##  distros: fcos
 ##  # coreos-post-ignition-checks.service forbids GRUB passwords on
 ##  # ppc64le and s390x
-##  architectures: "!ppc64le !s390x"
+##  architectures: "!ppc64le s390x"
 ##  # Running on multiple platforms won't prove anything further
 ##  platforms: qemu
 #


### PR DESCRIPTION
The correct negation syntax is one exclamation mark followed by one or more items to exclude.