### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,18 +33,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-658b2dbea2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1327
       type: fast-track
-  openssl:
-    evr: 1:3.0.5-2.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
-      type: fast-track
-  openssl-libs:
-    evr: 1:3.0.5-2.fc36
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-502f096dce
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
-      type: fast-track
   podman:
     evr: 4:4.3.0-2.fc36
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).