### PR TITLE
denylist: aws.nvme: extend snooze and re-apply to all streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,12 +39,8 @@
   arches:
   - s390x
 - pattern: ext.config.platforms.aws.nvme
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306
-  snooze: 2022-11-05
-  streams:
-    - testing-devel
-    - testing
-    - stable
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1300781645
+  snooze: 2022-12-05
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1332
   arches:


### PR DESCRIPTION
It seems as if the fix that AWS had applied is no longer working. See https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1300781645