### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -153,12 +153,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0195fb6f72
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
-  libksba:
-    evr: 1.6.2-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0002284730
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
-      type: fast-track
   libxml2:
     evr: 2.10.3-1.fc37
     metadata:
@@ -194,18 +188,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-5c25a19c97
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
-      type: fast-track
-  openssl:
-    evr: 1:3.0.5-3.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
-      type: fast-track
-  openssl-libs:
-    evr: 1:3.0.5-3.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-0f1d2e0537
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1329
       type: fast-track
   podman:
     evr: 4:4.3.0-2.fc37


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).