### PR TITLE
fixes/workarounds for NetworkManager 1.41.3+

### DIFF
--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -93,13 +93,41 @@ method=auto
 [user]
 org.freedesktop.NetworkManager.origin=nm-initrd-generator"
 # EXPECTED_INITRD_NETWORK_CFG4
-#   - used on Fedora 37+ and scos
+#   - used on Fedora 37+
 EXPECTED_INITRD_NETWORK_CFG4="# Created by nm-initrd-generator
 
 [connection]
 id=Wired Connection
 uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 type=ethernet
+autoconnect-retries=1
+multi-connect=3
+
+[ethernet]
+
+[ipv4]
+dhcp-timeout=90
+method=auto
+required-timeout=20000
+
+[ipv6]
+dhcp-timeout=90
+method=auto
+
+[proxy]
+
+[user]
+org.freedesktop.NetworkManager.origin=nm-initrd-generator"
+
+# EXPECTED_INITRD_NETWORK_CFG5
+#   - used on Fedora 38+ and scos
+EXPECTED_INITRD_NETWORK_CFG5="# Created by nm-initrd-generator
+
+[connection]
+id=Wired Connection
+uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+type=ethernet
+autoconnect-priority=-100
 autoconnect-retries=1
 multi-connect=3
 
@@ -202,10 +230,11 @@ normalize_connection_file() {
 }
 
 source /etc/os-release
-# All current FCOS releases use the same config
-# https://github.com/coreos/fedora-coreos-config/pull/1533
 if [ "$ID" == "fedora" ]; then
-    if [ "$VERSION_ID" -ge "37" ]; then
+    if [ "$VERSION_ID" -ge "38" ]; then
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG5
+        EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG3
+    elif [ "$VERSION_ID" -eq "37" ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG4
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG3
     elif [ "$VERSION_ID" -eq "36" ]; then
@@ -218,13 +247,9 @@ elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
     # For the version comparison use string substitution to remove the
     # '.` from the version so we can use integer comparison
 
-    # scos includes NetworkManager-1.39.10-1.el9.x86_64, update scripts
-    # according to F37
     if is_scos; then
-        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG4
+        EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG5
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG3
-    # RHEL8.6 includes NetworkManager-1.36.0-1.el8.x86_64, update scripts
-    # according to F36
     elif [ "${RHEL_VERSION/\./}" -ge 86 ]; then
         EXPECTED_INITRD_NETWORK_CFG=$EXPECTED_INITRD_NETWORK_CFG3
         EXPECTED_REALROOT_NETWORK_CFG=$EXPECTED_REALROOT_NETWORK_CFG2

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -12,35 +12,6 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# EXPECTED_INITRD_NETWORK_CFG1
-#   - used on RHEL 8.5 release
-EXPECTED_INITRD_NETWORK_CFG1="[connection]
-id=Wired Connection
-uuid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-type=ethernet
-autoconnect-retries=1
-multi-connect=3
-permissions=
-
-[ethernet]
-mac-address-blacklist=
-
-[ipv4]
-dhcp-timeout=90
-dns-search=
-method=auto
-required-timeout=20000
-
-[ipv6]
-addr-gen-mode=eui64
-dhcp-timeout=90
-dns-search=
-method=auto
-
-[proxy]
-
-[user]
-org.freedesktop.NetworkManager.origin=nm-initrd-generator"
 # EXPECTED_INITRD_NETWORK_CFG2
 #   - used on older RHEL 8.4 release
 EXPECTED_INITRD_NETWORK_CFG2="[connection]


### PR DESCRIPTION
```
commit c7b45d6028f6f99dfd533a790cc89b5232fe9170
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 2 16:57:31 2022 -0400

    denylist: snooze ext.config.networking.mtu-on-bond-ignition on rawhide
    
    It's failing because of a regression in newer NetworkManager 1.41.3 [1].
    We've identified the issue and reported it upstream [2]. Let's snooze the
    test for now so we can unpin NetworkManager in rawhide.
    
    [1] https://github.com/coreos/fedora-coreos-tracker/issues/1325
    [2] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1130

commit bdd34fd99af1e23ab8dedab406fc5b2345958d83
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 2 16:52:55 2022 -0400

    tests/default-network-behavior-change: drop unused EXPECTED_INITRD_NETWORK_CFG1
    
    Nothing we test on still uses that profile so let's drop it from
    the code.

commit 7cdf1be06f148e7779a9a6c644a10976e760292e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Nov 2 16:47:23 2022 -0400

    tests/default-network-behavior-change: update for NM 1.41.3+
    
    Looks like there was a slight change upstream [1] to add
    `autoconnect-priority=-100` to the generated NM connection file.
    I think this should be harmless for our uses.
    
    SCOS and Rawhide are both affected by this.
    
    Also dropped some out of date comments.
    
    [1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1376/diffs?commit_id=98575bd5138afdb61a3837a2a73436eb05490f4a

```
