### PR TITLE
[rawhide] overrides: fast-track NetworkManager-1.41.4-2.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,30 +10,35 @@
 
 packages:
   NetworkManager:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.4-2.fc38
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f56af15452
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325#issuecomment-1302128665
+      type: fast-track
   NetworkManager-cloud-setup:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.4-2.fc38
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f56af15452
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325#issuecomment-1302128665
+      type: fast-track
   NetworkManager-libnm:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.4-2.fc38
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f56af15452
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325#issuecomment-1302128665
+      type: fast-track
   NetworkManager-team:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.4-2.fc38
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f56af15452
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325#issuecomment-1302128665
+      type: fast-track
   NetworkManager-tui:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.4-2.fc38
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f56af15452
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1325#issuecomment-1302128665
+      type: fast-track
   systemd:
     evr: 251.5-607.fc38
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).