### PR TITLE
overrides: fast-track libxml2-2.10.3-2.fc36

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -27,6 +27,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-658b2dbea2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1327
       type: fast-track
+  libxml2:
+    evr: 2.10.3-2.fc36
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-d7349a124a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1336
+      type: fast-track
   netavark:
     evr: 1.2.0-5.fc36
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).