### PR TITLE
[next-devel] overrides: fast-track libxml2-2.10.3-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -154,10 +154,10 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
   libxml2:
-    evr: 2.10.3-1.fc37
+    evr: 2.10.3-2.fc37
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a6812b0224
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1336
       type: fast-track
   linux-firmware:
     evra: 20221012-142.fc37.noarch


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).