### PR TITLE
tests/kola/butane/grub-users-fix: increase timeout again

### DIFF
--- a/tests/kola/butane/grub-users-fix
+++ b/tests/kola/butane/grub-users-fix
@@ -6,8 +6,8 @@
 ##  architectures: "!s390x"
 ##  # Running on multiple platforms won't prove anything further
 ##  platforms: qemu
-##  # 10 minutes is not quite enough on ppc64le runners
-##  timeoutMin: 15
+##  # 15 minutes is not quite enough on ppc64le runners
+##  timeoutMin: 20
 #
 # Test coreos-fix-grub-users.service.
 


### PR DESCRIPTION
15 minutes still isn't reliably enough for ppc64le.