### PR TITLE
s390x: not run ext.config.networking.nameserver

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,7 +41,3 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1300781645
   snooze: 2022-12-05
-- pattern: ext.config.networking.nameserver
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1332
-  arches:
-  - s390x

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "appendKernelArgs": "nameserver=8.8.8.8 nameserver=1.1.1.1"}
+# kola: { "platforms": "qemu", "appendKernelArgs": "nameserver=8.8.8.8 nameserver=1.1.1.1", "architectures": "!s390x"}
 
 # Verify multiple nameservers config via kernel arguments work well
 # RHCOS: need to check /etc/resolv.conf and nmconnection
@@ -8,6 +8,9 @@
 
 # - platforms: qemu
 #   - This test should pass everywhere if it passes anywhere.
+# - architectures: !s390x
+#   - appendKernelArgs doesn't work on s390x
+#   - https://github.com/coreos/coreos-assembler/issues/2776
 
 set -xeuo pipefail
 


### PR DESCRIPTION
The test is currently not working on s390x.
See https://github.com/coreos/coreos-assembler/issues/2776

Fix https://github.com/coreos/fedora-coreos-tracker/issues/1332