### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -111,35 +111,11 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-fb088df94c
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
       type: fast-track
-  glib2:
-    evr: 2.74.1-2.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-ce3b8fbd4d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1304857839
-      type: fast-track
   gnutls:
     evr: 3.7.8-2.fc37
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-bd6c888fd2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
-      type: fast-track
-  kernel:
-    evr: 6.0.7-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f3e83cad6f
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1304857839
-      type: fast-track
-  kernel-core:
-    evr: 6.0.7-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f3e83cad6f
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1304857839
-      type: fast-track
-  kernel-modules:
-    evr: 6.0.7-301.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-f3e83cad6f
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1304857839
       type: fast-track
   libidn2:
     evr: 2.3.4-1.fc37
@@ -170,12 +146,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-2c33bba286
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1242724431
-      type: fast-track
-  mozjs102:
-    evr: 102.4.0-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2022-a2e0a97b88
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1223#issuecomment-1296474889
       type: fast-track
   netavark:
     evr: 1.2.0-5.fc37


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).