### PR TITLE
networking/tests: add no-persist-ip and rd-net-timeout-carrier cases

### DIFF
--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This test verifies that the coreos.no_persist_ip kernel argument will
+# prevent propagating kernel argument based networking configuration into
+# the real root. It does this by providing karg static networking config
+# for eth1 and then verifying that DHCP is used in the real root.
+
+## kola:
+##   # This test should pass everywhere if it passes anywhere.
+##   platforms: qemu
+##   # Add 1 NIC for this test
+##   additionalNics: 1
+##   # The functionality we're testing here and the configuration for the NIC.
+##   # We use net.ifnames=0 to disable consistent network naming here because on
+##   # different firmwares (BIOS vs UEFI) the NIC names are different.
+##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
+##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none net.ifnames=0 coreos.no_persist_ip"
+##   # appendKernelArgs doesn't work on s390x, see https://github.com/coreos/coreos-assembler/issues/2776
+##   architectures: !s390x
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Verify eth1 gets ip address via dhcp
+nic_name="eth1"
+nic_ip=$(get_ipv4_for_nic ${nic_name})
+if [ ${nic_ip} != "10.0.2.31" ]; then
+    fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is 10.0.2.31"
+fi
+ok "get ${nic_name} ip is 10.0.2.31"
+
+if ! journalctl -b -u coreos-teardown-initramfs | grep -q "info: skipping propagating initramfs settings"; then
+    fatal "Error: can not get log: (info: skipping propagating initramfs settings)"
+fi
+ok "test coreos.no_persist_ip disable initramfs network propagation"

--- a/tests/kola/networking/rd-net-timeout-carrier/config.bu
+++ b/tests/kola/networking/rd-net-timeout-carrier/config.bu
@@ -1,0 +1,6 @@
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_exist:
+    - rd.net.timeout.carrier=15
+    - rd.neednet=1

--- a/tests/kola/networking/rd-net-timeout-carrier/data/commonlib.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/networking/rd-net-timeout-carrier/test.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This test verifies that NetworkManager supports configuring the
+# carrier timeout via the `rd.net.timeout.carrier=` karg. Without
+# recreating an environment that requires this setting to be set
+# (which would be hard to do), we'll test this by just making sure
+# that setting the kernel argument ensures the runtime configuration
+# file /run/NetworkManager/conf.d/15-carrier-timeout.conf gets created.
+# 
+# Checking that this file gets created is also tricky because we
+# `rm -rf /run/NetworkManager` in coreos-teardown-initramfs on first boot,
+# so we'll workaround that by setting the karg permanently and then
+# performing a reboot so we can check on the second boot if the file exists.
+#
+# See:
+# - https://bugzilla.redhat.com/show_bug.cgi?id=1917773
+# - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/e300138892ee0fc3824d38b527b60103a01758ab#
+
+## kola:
+##   # This test should pass everywhere if it passes anywhere.
+##   platforms: qemu-unpriv
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      ok "first boot"
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+  
+  rebooted)
+      ok "second boot"
+      grep rd.net.timeout.carrier=15 /proc/cmdline
+      
+      generator_conf="/run/NetworkManager/conf.d/15-carrier-timeout.conf"
+      if [ ! -f ${generator_conf} ]; then
+        fatal "Error: can not generate ${generator_conf} with karg rd.net.timeout.carrier"
+      fi
+      ok "NM generated rd.net.timeout.carrier configuration in the initramfs"
+      ;;
+
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac


### PR DESCRIPTION
- Verify `coreos.no_persist_ip` karg will disable initramfs network propagation
- Verify nm-initrd-generator supports `rd.net.timeout.carrier=`