### PR TITLE
denylist: deny default-network-behavior-change on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,3 +41,8 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1300781645
   snooze: 2022-12-05
+- pattern: ext.config.networking.default-network-behavior-change
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
+  snooze: 2023-01-05
+  streams:
+    - rawhide


### PR DESCRIPTION
We need to revert to an older NetworkManager for a short period of time, but we already updated the test for the new NetworkManager. Let's just deny it for now.

See https://github.com/coreos/fedora-coreos-tracker/issues/1341