### PR TITLE
denylist: deny default-network-behavior-change on all streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -44,5 +44,3 @@
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
   snooze: 2023-01-05
-  streams:
-    - rawhide


### PR DESCRIPTION
Similar to fb3b09d (for rawhide) this problem is now affecting F37 so we are going to pin NetworkManager there too so we need to denylist this test on all streams for now.

See https://github.com/coreos/fedora-coreos-tracker/issues/1341