### PR TITLE
[rhcos-4.9] tests/kola/root-reprovision: add `reprovision` tag

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096}
+# kola: { "platforms": "qemu", "minMemory": 4096, "tags": "reprovision" }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "architectures": "!s390x"}
+# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x", "tags": "reprovision" }
 set -xeuo pipefail
 
 ok() {

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"]}
+# kola: { "platforms": "qemu", "minMemory": 4096, "additionalDisks": ["5G", "5G"], "tags": "reprovision" }
 set -xeuo pipefail
 
 ok() {


### PR DESCRIPTION
This can be used to conveniently skip those tests by tag.

(cherry picked from commit c9849728f40aa763bf44ad6497f9811ecc396391)
(cherry picked from commit 4664a23a53594586864ba9c81ae2972ba18c466a)

dustymabe: This required manual merge conflict resolution. We needed
           to surgically add the reprovision tag here because the
           timeoutMin and other tags didn't exist in 4.9.
