### PR TITLE
manifests/fedora-coreos-base: Add lsof to rhcos

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -146,7 +146,6 @@ packages:
   # Used by admins interactively
   - attr
   - openssl
-  - lsof
   # Provides terminal tools like clear, reset, tput, and tset
   - ncurses
   # file-transfer: note fuse-sshfs is not in RHEL

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -44,3 +44,5 @@ packages:
   - toolbox
   # nvme-cli for managing nvme disks
   - nvme-cli
+  # Used by admins interactively
+  - lsof


### PR DESCRIPTION
Remove lsof from fedora-coreos-base and move it to user-experience
Reference : https://github.com/coreos/fedora-coreos-config/pull/284

See: https://issues.redhat.com/browse/COS-1877