### PR TITLE
manifests/fedora-coreos-base: add GPU firmware packages

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -36,6 +36,9 @@
     "alternatives": {
       "evra": "1.21-1.fc37.aarch64"
     },
+    "amd-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
+    },
     "attr": {
       "evra": "2.5.1-5.fc37.aarch64"
     },
@@ -413,6 +416,9 @@
     },
     "inih": {
       "evra": "56-2.fc37.aarch64"
+    },
+    "intel-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "iproute": {
       "evra": "5.18.0-2.fc37.aarch64"
@@ -911,6 +917,9 @@
     },
     "numactl-libs": {
       "evra": "2.0.14-6.fc37.aarch64"
+    },
+    "nvidia-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "nvme-cli": {
       "evra": "2.2.1-1.fc37.aarch64"

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -36,6 +36,9 @@
     "alternatives": {
       "evra": "1.21-1.fc37.ppc64le"
     },
+    "amd-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
+    },
     "attr": {
       "evra": "2.5.1-5.fc37.ppc64le"
     },
@@ -407,6 +410,9 @@
     },
     "inih": {
       "evra": "56-2.fc37.ppc64le"
+    },
+    "intel-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "iproute": {
       "evra": "5.18.0-2.fc37.ppc64le"
@@ -908,6 +914,9 @@
     },
     "numactl-libs": {
       "evra": "2.0.14-6.fc37.ppc64le"
+    },
+    "nvidia-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "nvme-cli": {
       "evra": "2.2.1-1.fc37.ppc64le"

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -36,6 +36,9 @@
     "alternatives": {
       "evra": "1.21-1.fc37.s390x"
     },
+    "amd-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
+    },
     "attr": {
       "evra": "2.5.1-5.fc37.s390x"
     },
@@ -377,6 +380,9 @@
     },
     "inih": {
       "evra": "56-2.fc37.s390x"
+    },
+    "intel-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "iproute": {
       "evra": "5.18.0-2.fc37.s390x"
@@ -851,6 +857,9 @@
     },
     "nss-altfiles": {
       "evra": "2.18.1-21.fc37.s390x"
+    },
+    "nvidia-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "nvme-cli": {
       "evra": "2.2.1-1.fc37.s390x"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -36,6 +36,9 @@
     "alternatives": {
       "evra": "1.21-1.fc37.x86_64"
     },
+    "amd-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
+    },
     "attr": {
       "evra": "2.5.1-5.fc37.x86_64"
     },
@@ -419,6 +422,9 @@
     },
     "inih": {
       "evra": "56-2.fc37.x86_64"
+    },
+    "intel-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "iproute": {
       "evra": "5.18.0-2.fc37.x86_64"
@@ -923,6 +929,9 @@
     },
     "numactl-libs": {
       "evra": "2.0.14-6.fc37.x86_64"
+    },
+    "nvidia-gpu-firmware": {
+      "evra": "20221109-144.fc37.noarch"
     },
     "nvme-cli": {
       "evra": "2.2.1-1.fc37.x86_64"

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -163,6 +163,8 @@ packages:
   # In F35+ need `iptables-legacy` package
   # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
   - iptables-legacy
+  # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
+  - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
 
 
 # This thing is crying out to be pulled into systemd, but that hasn't happened


### PR DESCRIPTION
The files provided by these RPMs used to be included in the linux-firmware package, but were recently broken out into their own subpackages as recommends. Let's name them here so we get them back in Fedora CoreOS again.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1345