### PR TITLE
[rawhide] overrides: drop systemd-pin; pin grub2

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.06-64.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-64.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-efi-aa64:
+    evra: 1:2.06-64.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-64.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-pc-modules:
+    evra: 1:2.06-64.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-common:
+    evra: 1:2.06-64.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-64.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-efi-x64:
+    evra: 1:2.06-64.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-pc:
+    evra: 1:2.06-64.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-64.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,33 +34,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
       type: pin
-  systemd:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin
-  systemd-container:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin
-  systemd-libs:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin
-  systemd-pam:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin
-  systemd-resolved:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin
-  systemd-udev:
-    evr: 251.5-607.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1320
-      type: pin


### PR DESCRIPTION
```
commit 8428cfae1d9004b111afcb600d9d502ee08d9624
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 25 09:44:11 2022 -0500

    overrides: pin to grub2-2.06-64.fc38
    
    This causes a failure in our TestISO tests. See
    https://github.com/coreos/fedora-coreos-tracker/issues/1352

commit 90ac7eb046bb69e6c428a3c4a31a5e74a1777936
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 25 09:36:09 2022 -0500

    overrides: drop systemd-251.5-607.fc38 pin
    
    This was fixed in systemd-252.2-591.fc38 according to the BZ.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1320

```