### PR TITLE
overrides: pin to grub2-2.06-63.fc37

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.06-63.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-63.fc37.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-efi-aa64:
+    evra: 1:2.06-63.fc37.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-63.fc37.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-pc-modules:
+    evra: 1:2.06-63.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-common:
+    evra: 1:2.06-63.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-63.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-efi-x64:
+    evra: 1:2.06-63.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-pc:
+    evra: 1:2.06-63.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-63.fc37.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1352
+      type: pin


### PR DESCRIPTION
Looks like https://github.com/coreos/fedora-coreos-tracker/issues/1352 has reached f37. Pin it for now to unblock lockfile bumps.