### PR TITLE
boot/grub2-install: fix `skip s390x` issue

### DIFF
--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -11,7 +11,7 @@
 ##   platforms: qemu
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2
-##   architectures: "!aarch64 !s390x"
+##   architectures: "!aarch64 s390x"
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh


### PR DESCRIPTION
Fix `fatal 'grub2-install testing is not supported on s390x'`