### PR TITLE
denylist: extend snooze for ext.config.kdump.crash on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/coreos-assembler/issues/2725#issuecomment-1292616121
-  snooze: 2022-12-01
+  snooze: 2023-01-04
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
The 6.1 kernel hasn't made it out yet so we'll wait another month for this test.