### PR TITLE
Revert: "s390x: Remove SetGID dotlockfile from liblockfile"

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -35,17 +35,6 @@ packages-x86_64:
   # firmware updates
   - fwupd
 
-postprocess:
-  # See: https://github.com/coreos/fedora-coreos-tracker/issues/1253
-  #      https://bugzilla.redhat.com/show_bug.cgi?id=2112857
-  #      https://github.com/coreos/rpm-ostree/issues/3918
-  # Temporary workaround to remove the SetGID binary from liblockfile that is
-  # pulled by the s390utils but not needed for /usr/sbin/zipl.
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    rm -f /usr/bin/dotlockfile
-
 exclude-packages:
   # Exclude kernel-debug-core to make sure that it doesn't somehow get
   # chosen as the package to satisfy the `kernel-core` dependency from

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -97,7 +97,6 @@ postprocess:
   # Docs removal comes from manifests/fedora-coreos.yaml
   # - systemd-firstboot comes from manifests/ignition-and-ostree.yaml
   # - systemd-gpt-auto-generator comes from ignition-and-ostree.yaml
-  # - dotlockfile comes from bootable-rpm-ostree.yaml
   - |
     #!/usr/bin/env bash
     set -euo pipefail
@@ -111,7 +110,6 @@ postprocess:
     # why we are removing them in the postprocess scripts here.
     # The .build-id links are pointing to binaries that we remove in other parts of the FCOS manifest.
     list_known_removed_folders=(
-      '/usr/bin/dotlockfile'
       '/usr/bin/systemd-firstboot'
       '/usr/lib/systemd/system-generators/systemd-gpt-auto-generator'
       '/usr/share/doc/'


### PR DESCRIPTION
This reverts e79c4f1 and 5053bc7 (and a small part of 45434ed), which added an exclusion for dotlockfile. The liblockfile package, which provides dotlockfile, should no longer be getting used by s390utils so we can drop this.

See https://github.com/coreos/fedora-coreos-tracker/issues/1253#issuecomment-1313519008