### PR TITLE
kola/files/validate-symlinks: Update broken symlinks list

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -20,7 +20,6 @@ list_broken_symlinks_skip=(
     '/etc/swid/swidtags.d/fedoraproject.org'
     '/etc/xdg/systemd/user'
     '/usr/lib/.build-id/'
-    '/usr/lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt.xz'
     '/usr/lib/firmware/qcom/LENOVO/21BX.xz'
     '/usr/lib/modules/'
     '/usr/share/rhel/secrets/etc-pki-entitlement'


### PR DESCRIPTION
The `/usr/lib/firmware/brcm/brcmfmac43455-sdio.AW-CM256SM.txt.xz` is fixed and can be dropped from the broken symlinks list