### PR TITLE
ci/buildroot: Add +ShellCheck and file

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -52,3 +52,7 @@ clang-analyzer
 
 # We don't want zombies in our pods
 dumb-init
+
+# Used to check Bash scripts in CI
+ShellCheck
+file


### PR DESCRIPTION
Will be used to check Bash scripts in CI to catch common errors.

See: https://github.com/coreos/repo-templates/pull/39
See: https://github.com/openshift/os/pull/1001