### PR TITLE
tests/kola: remove date conditional from files.console-config test

### DIFF
--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -37,33 +37,10 @@ check_platforms_json() {
 }
 
 # Check whether platforms.json exists
-if is_fcos; then
-    # Schedule based on:
-    # https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/message/GHLXX4MXNHUEAXQLK6BZN45IQYHRVQB4/
-    case "$(get_fcos_stream)" in
-    next-devel) threshold=20220919 ;;
-    next) threshold=20220930 ;;
-    testing-devel|rawhide|branched) threshold=20221118 ;;
-    testing) threshold=20221125 ;;
-    stable) threshold=20221209 ;;
-    *) fatal "Unknown stream" ;;
-    esac
-    datecode=$(echo "$VERSION" | cut -f2 -d.)
-    expect_config=$([ $datecode -ge $threshold ] && echo 1 || echo 0)
-else
-    threshold=none
-    expect_config=1
+if [ ! -e /boot/coreos/platforms.json ]; then
+    fatal "platforms.json doesn't exist!"
 fi
-have_config=$([ -e /boot/coreos/platforms.json ] && echo 1 || echo 0)
-if [ "$have_config" != "$expect_config" ]; then
-    fatal "platforms.json exists=$have_config expected=$expect_config threshold=$threshold"
-fi
-ok "platforms.json exists=$have_config"
-if [ "$have_config" != 1 ]; then
-    # We don't automatically test whether the legacy code injects the
-    # correct parameters
-    exit 0
-fi
+ok "platforms.json exists!"
 
 # Check that platforms.json matches grub.cfg and kargs
 platform=$(cmdline_arg ignition.platform.id)


### PR DESCRIPTION
First, the dates mentioned in [1] have passed so we no longer need this check. Second, checking the date inspecting the value from $VERSION was actually not quite correct because `stable` lags behind so the actual date in its $VERSION string is the date from the timestamp of the yumrepos (which was two weeks in the past). This means the `stable` threshold=20221209 isn't checking correctly (the current `stable` build we are trying to build today has a version string of `37.20221127.3.0`).

Just dropping the check solves both of these problems. Once merged we'll forward port this to the `stable` branch too.

[1] https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/message/GHLXX4MXNHUEAXQLK6BZN45IQYHRVQB4/