### PR TITLE
tests: Use qemu-unpriv as much as possible

### DIFF
--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,9 +1,9 @@
 #!/bin/bash
-# kola: {"platforms": "qemu", "exclusive": false, "tags": "needs-internet", "distros": "fcos", "architectures": "aarch64 s390x"}
+# kola: {"platforms": "qemu-unpriv", "exclusive": false, "tags": "needs-internet", "distros": "fcos", "architectures": "aarch64 s390x"}
 # Test the x86_64 emulator on aarch64 and s390x images for now
 # https://github.com/coreos/fedora-coreos-tracker/issues/1237
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - exclusive: false
 #   - This test doesn't make meaningful changes to the system and

--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -2,11 +2,11 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15, "minMemory": 1536 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - timeoutMin: 15
 #   - This is dependent on network and disk speed but we've seen the

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -2,14 +2,14 @@
 set -xeuo pipefail
 
 # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
-# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu", "timeoutMin": 15, "minMemory": 1536 }
+# kola: { "distros": "fcos", "tags": "needs-internet", "platforms": "qemu-unpriv", "timeoutMin": 15, "minMemory": 1536 }
 #
 # This test ensures that we can install some common tools as OS extensions.
 #
 # - timeoutMin: 15
 #   - This is dependent on network and disk speed but we've seen the
 #     test take longer than 10 minutes in our aarch64 qemu tests.
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -1,12 +1,12 @@
 #!/bin/bash
-# kola: { "exclusive": false, "platforms": "qemu" }
+# kola: { "exclusive": false, "platforms": "qemu-unpriv" }
 #
 # Check if there are broken symlinks in /etc/ and /usr/.
 # See: https://github.com/coreos/fedora-coreos-config/issues/1782
 #
 # - distros: fcos
 #   - Only run on FCOS until we've tested it on RHCOS.
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 
 set -xeuo pipefail

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -10,9 +10,9 @@ set -xeuo pipefail
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
 
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip", "architectures": "!s390x" }
+# kola: { "platforms": "qemu-unpriv", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip", "architectures": "!s390x" }
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - additionalNics: 1
 #   - Add 1 NIC for this test

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# kola: { "platforms": "qemu" }
+# kola: { "platforms": "qemu-unpriv" }
 #
 # Test that the fallback hostname is `localhost`. This test
 # validates that the fallback hostname is set to `localhost`
@@ -10,7 +10,7 @@ set -xeuo pipefail
 # hostname is set from the fallback hostname and is `localhost`.
 # https://github.com/coreos/fedora-coreos-tracker/issues/902
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8", "architectures": "!s390x"}
+# kola: { "platforms": "qemu-unpriv", "appendFirstbootKernelArgs": "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8", "architectures": "!s390x"}
 #
 # Veirfy rd.net.timeout.dhcp and rd.net.dhcp.retry are supported
 # by NetworkManager. Append them to kernel parameter when boot,
@@ -10,7 +10,7 @@
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1879094#c10
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1877740
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
 #   - The functionality we're testing here.

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "net.ifnames=0", "architectures": "!s390x"}
+# kola: { "platforms": "qemu-unpriv", "additionalNics": 2, "appendKernelArgs": "net.ifnames=0", "architectures": "!s390x"}
 
 # Set MTU on a VLAN subinterface for the bond using ignition config and check
 # - verify MTU on the bond matches config
@@ -16,7 +16,7 @@
 # Using kernel args to `configure MTU on a VLAN subinterface for the bond` refer to
 # https://github.com/coreos/fedora-coreos-config/pull/1401
 
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - additionalNics: 2
 #   - Add 2 NIC for this test

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0", "architectures": "!s390x"}
+# kola: { "platforms": "qemu-unpriv", "additionalNics": 2, "appendKernelArgs": "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0", "architectures": "!s390x"}
 
 # Configuring MTU on a VLAN subinterface for the bond,
 # - verify MTU on the bond matches config
@@ -7,7 +7,7 @@
 # - verify ip address on the VLAN subinterface for the bond matches config
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1932502#c9
 
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - additionalNics: 2
 #   - Add 2 NIC for this test

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -1,12 +1,12 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "appendKernelArgs": "nameserver=8.8.8.8 nameserver=1.1.1.1", "architectures": "!s390x"}
+# kola: { "platforms": "qemu-unpriv", "appendKernelArgs": "nameserver=8.8.8.8 nameserver=1.1.1.1", "architectures": "!s390x"}
 
 # Verify multiple nameservers config via kernel arguments work well
 # RHCOS: need to check /etc/resolv.conf and nmconnection
 # FCOS:  using systemd-resolved which needs to run resolvectl to check
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1763341
 
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - architectures: !s390x
 #   - appendKernelArgs doesn't work on s390x

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -1,12 +1,12 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "appendFirstbootKernelArgs": "BOOTIF=52:54:00:12:34:56" }
+# kola: { "platforms": "qemu-unpriv", "appendFirstbootKernelArgs": "BOOTIF=52:54:00:12:34:56" }
 #
 # In addition to the pure network defaults case we should also make
 # sure that when BOOTIF= or rd.bootif= are provided on the kernel
 # command line (typically from PXE servers) that we don't propagate
 # networking configs either. See https://github.com/coreos/fedora-coreos-tracker/issues/1048
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - appendFirstbootKernelArgs: "BOOTIF=52:54:00:12:34:56"
 #   - Append BOOTIF kernel argument so we can test how nm-initrd-generator

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -12,8 +12,8 @@ set -xeuo pipefail
 
 # https://github.com/coreos/fedora-coreos-config/issues/1499
 # - Disable the test on s390x
-# kola: { "platforms": "qemu", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0", "architectures": "!s390x" }
-# - platforms: qemu
+# kola: { "platforms": "qemu-unpriv", "additionalNics": 1, "appendKernelArgs": "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0", "architectures": "!s390x" }
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - additionalNics: 1
 #   - Add 1 NIC for this test

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# kola: { "platforms": "qemu", "tags": "needs-internet", "exclusive": false, "timeoutMin": 3 }
+# kola: { "platforms": "qemu-unpriv", "tags": "needs-internet", "exclusive": false, "timeoutMin": 3 }
 # Tests that rootless podman containers can DNS resolve external domains.
 # https://github.com/coreos/fedora-coreos-tracker/issues/923
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - tags: needs-internet
 #   - This test pulls a container from a registry.

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: {"platforms": "qemu"}
+# kola: {"platforms": "qemu-unpriv"}
 # These are read-only not-necessarily-related checks that verify default system
 # configuration both on first and subsequent boots.
 

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15, "tags": "reprovision" }
+# kola: { "platforms": "qemu-unpriv", "minMemory": 4096, "timeoutMin": 15, "tags": "reprovision" }
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - tags: reprovision
 #   - This test reprovisions the rootfs.

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# kola: { "platforms": "qemu", "minMemory": 4096, "architectures": "!s390x", "timeoutMin": 15, "tags": "reprovision" }
+# kola: { "platforms": "qemu-unpriv", "minMemory": 4096, "architectures": "!s390x", "timeoutMin": 15, "tags": "reprovision" }
 #
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - tags: reprovision
 #   - This test reprovisions the rootfs.

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# kola: { "distros": "fcos", "platforms": "qemu", "minMemory": 4096, "timeoutMin": 15, "allowConfigWarnings": true, "tags": "reprovision" }
+# kola: { "distros": "fcos", "platforms": "qemu-unpriv", "minMemory": 4096, "timeoutMin": 15, "allowConfigWarnings": true, "tags": "reprovision" }
 #
 # - distros: fcos
 #   - This test only runs on FCOS due to a problem enabling a swap partition on
 #     RHCOS. See: https://github.com/openshift/os/issues/665
-# - platforms: qemu
+# - platforms: qemu-unpriv
 #   - This test should pass everywhere if it passes anywhere.
 # - tags: reprovision
 #   - This test reprovisions the rootfs.

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# restrict to qemu for now because the primary disk path is platform-dependent
-# kola: {"platforms": "qemu", "architectures": "!s390x"}
+# restrict to qemu-unpriv for now because the primary disk path is platform-dependent
+# kola: {"platforms": "qemu-unpriv", "architectures": "!s390x"}
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 # symlinks present in initramfs
 # https://bugzilla.redhat.com/show_bug.cgi?id=1990506
 
-# kola: {"platforms": "qemu", "additionalDisks": ["5G:mpath"]}
+# kola: {"platforms": "qemu-unpriv", "additionalDisks": ["5G:mpath"]}
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/var-mount/simple/test.sh
+++ b/tests/kola/var-mount/simple/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# restrict to qemu for now because the primary disk path is platform-dependent
-# kola: {"platforms": "qemu"}
+# restrict to qemu-unpriv for now because the primary disk path is platform-dependent
+# kola: {"platforms": "qemu-unpriv"}
 
 . $KOLA_EXT_DATA/commonlib.sh
 


### PR DESCRIPTION
Tests that are run locally in an unprivileged container will run under the `qemu-unpriv` platform by default. We should try to run as many tests as possible under this platform and only keep the test requiring privileged `qemu` using this platform.