### PR TITLE
denylist: aws.nvme: extend snooze and re-apply to all streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,8 +39,8 @@
   arches:
   - s390x
 - pattern: ext.config.platforms.aws.nvme
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1300781645
-  snooze: 2022-12-05
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1337660156
+  snooze: 2023-01-10
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
   snooze: 2023-01-05


### PR DESCRIPTION
It seems as if the fix that AWS had applied is no longer working.
See: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1337660156