### PR TITLE
Prepare for 'qemu-unpriv' removal

### DIFF
--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # This test doesn't make meaningful changes to the system and should
 ##   # be able to be combined with other tests.
 ##   exclusive: false

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,7 +1,4 @@
 #!/bin/bash
-# Test the x86_64 emulator on non-x86_64 instances.
-# https://github.com/coreos/fedora-coreos-tracker/issues/1237
-#
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -14,6 +11,9 @@
 ##   distros: fcos
 ##   # We ship the x86_64 on all non-x86_64 arches.
 ##   architectures: "! x86_64"
+#
+# Test the x86_64 emulator on non-x86_64 instances.
+# https://github.com/coreos/fedora-coreos-tracker/issues/1237
 
 set -xeuo pipefail
 

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # This is just a basic sanity check; at some point we
 # will implement "project-owned tests run in the pipeline"
 # and be able to run the existing bootupd tests:

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2
 ##   architectures: "!aarch64 s390x"

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -1,17 +1,17 @@
 #!/bin/bash
-
-# Verify to install BIOS/PReP bootloader using grub2-install from 
-# the target system.
-# See:
-#  - https://github.com/coreos/coreos-assembler/pull/3190
-#  - https://github.com/coreos/coreos-assembler/issues/3148
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2
 ##   architectures: "!aarch64 s390x"
+#
+# Verify to install BIOS/PReP bootloader using grub2-install from
+# the target system.
+# See:
+#  - https://github.com/coreos/coreos-assembler/pull/3190
+#  - https://github.com/coreos/coreos-assembler/issues/3148
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
@@ -21,20 +21,20 @@ arch=$(arch)
 case ${arch} in
   x86_64)
     target=i386-pc
-    core="${boot_dev}/grub2/${target}/core.img"   
+    core="${boot_dev}/grub2/${target}/core.img"
     partition=$(findmnt -no SOURCE ${boot_dev})
     device=$(lsblk --paths -no PKNAME ${partition})
     # sync grub2-install parameter according to image build script
     # https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
     grub_install_args="--modules mdraid1x"
     ;;
-  
+
   ppc64le)
     target=powerpc-ieee1275
     core="${boot_dev}/grub2/${target}/core.elf"
     device=$(realpath /dev/disk/by-partlabel/PowerPC-PReP-boot)
     # sync grub2-install parameter according to image build script
-    # https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh    
+    # https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
     grub_install_args="--no-nvram"   
     ;;
 

--- a/tests/kola/butane/grub-users/test.sh
+++ b/tests/kola/butane/grub-users/test.sh
@@ -6,7 +6,7 @@
 ##  # ppc64le and s390x
 ##  architectures: "!ppc64le s390x"
 ##  # Running on multiple platforms won't prove anything further
-##  platforms: qemu
+##  platforms: platform-independent
 #
 # Check Butane GRUB sugar as best we can from inside the OS.
 

--- a/tests/kola/clhm/ignition-warnings/test.sh
+++ b/tests/kola/clhm/ignition-warnings/test.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# This test ensures that Ignition warnings are displayed on the console.
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu-unpriv
 ##   # We intentionally exclude the Install section from a systemd unit.
 ##   # This is valid but not ideal, so Butane warns about it.
 ##   allowConfigWarnings: true
+#
+# This test ensures that Ignition warnings are displayed on the console.
 
 set -xeuo pipefail
 

--- a/tests/kola/clhm/ignition-warnings/test.sh
+++ b/tests/kola/clhm/ignition-warnings/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 ##   # We intentionally exclude the Install section from a systemd unit.
 ##   # This is valid but not ideal, so Butane warns about it.
 ##   allowConfigWarnings: true

--- a/tests/kola/clhm/network-device-info
+++ b/tests/kola/clhm/network-device-info
@@ -2,6 +2,7 @@
 ## kola:
 ##   # This is a read-only test that can be run with other tests.
 ##   exclusive: false
+#
 # This test makes sure CLHM wrote a snippet for the NIC IP info.
 # See - https://github.com/coreos/fedora-coreos-tracker/issues/1153
 

--- a/tests/kola/content-origins/test.sh
+++ b/tests/kola/content-origins/test.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Verify the RPM %{vendor} flag for everything installed matches what we expect.
 ## kola:
 ##   tags: "platform-independent"
 ##   # This is a read-only, nondestructive test.
 ##   exclusive: false
 ##   # May support e.g. centos in the future
 ##   distros: "fcos rhcos"
+#
+# Verify the RPM %{vendor} flag for everything installed matches what we expect.
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -1,7 +1,4 @@
 #!/bin/bash
-# This test ensures that we can install some common tools as OS extensions.
-set -xeuo pipefail
-
 ## kola:
 ##   # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
 ##   distros: fcos
@@ -12,6 +9,10 @@ set -xeuo pipefail
 ##   # test take longer than 10 minutes in our aarch64 qemu tests.
 ##   timeoutMin: 15
 ##   minMemory: 1536
+#
+# This test ensures that we can install some common tools as OS extensions.
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -1,10 +1,10 @@
 #!/bin/bash
 ## kola:
+##   # Should pass on all platforms if it passes on one
+##   platforms: platform-independent
 ##   # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
 ##   distros: fcos
 ##   tags: needs-internet
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
 ##   # This is dependent on network and disk speed but we've seen the
 ##   # test take longer than 10 minutes in our aarch64 qemu tests.
 ##   timeoutMin: 15

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -4,7 +4,7 @@
 ##   distros: fcos
 ##   tags: needs-internet
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # This is dependent on network and disk speed but we've seen the
 ##   # test take longer than 10 minutes in our aarch64 qemu tests.
 ##   timeoutMin: 15

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
 ## kola:
 ##   # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
 ##   distros: fcos
@@ -11,8 +9,10 @@ set -xeuo pipefail
 ##   # test take longer than 10 minutes in our aarch64 qemu tests.
 ##   timeoutMin: 15
 ##   minMemory: 1536
-
+#
 # This test ensures that we can install some common tools as OS extensions.
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/files/check-symlink
+++ b/tests/kola/files/check-symlink
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # Verify /etc release symlinks are valid
 # See:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2068148

--- a/tests/kola/files/kernel-headers
+++ b/tests/kola/files/kernel-headers
@@ -1,7 +1,8 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-# check that we are not including the kernel headers on the host
+#
+# Check that we are not including the kernel headers on the host.
 # See:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1814719
 # - https://gitlab.cee.redhat.com/coreos/redhat-coreos/-/merge_requests/1116

--- a/tests/kola/files/logrotate-service
+++ b/tests/kola/files/logrotate-service
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # Test some services are enabled or disabled appropriately
 
 set -xeuo pipefail

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -3,7 +3,7 @@
 ##   # This is a read-only test that can be run with other tests.
 ##   exclusive: false
 ##   # This test should pass everywhere if it passes anywhere
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 #
 # Check if there are broken symlinks in /etc/ and /usr/.
 # See: https://github.com/coreos/fedora-coreos-config/issues/1782

--- a/tests/kola/firewall/iptables-legacy/test.sh
+++ b/tests/kola/firewall/iptables-legacy/test.sh
@@ -4,6 +4,7 @@
 ##   # backend. It is scoped to only FCOS because RHCOS only supports nft.
 ##   distros: fcos
 ##   exclusive: true
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/firewall/iptables/test.sh
+++ b/tests/kola/firewall/iptables/test.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # Verifies that the expected iptables backend is configured.
 # https://github.com/coreos/fedora-coreos-tracker/issues/676
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/gshadow
+++ b/tests/kola/gshadow
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
 # Verify that glibc's parsing of /etc/gshadow does not cause systemd-sysusers
 # to segfault on specially constructed lines.
 #
@@ -13,6 +12,9 @@ set -xeuo pipefail
 # causing segfaults when those pointers are dereferenced.
 #
 # Tests: https://github.com/coreos/bugs/issues/1394
+
+set -xeuo pipefail
+
 echo 'grp0:*::root' >> /etc/gshadow
 echo 'grp1:*::somebody.a1,somebody.a2,somebody.a3,somebody.a4,somebody.a5,somebody.a6,somebody.a7,somebody.a8,somebody.a9,somebody.a10,somebody.a11,somebody.a12,somebody.a13,somebody.a14,somebody.a15,somebody.a16,somebody.a17,somebody.a18,somebody.a19,somebody.a20,somebody.a21,somebody.a22,somebody.a23,somebody.a24,somebody.a25,somebody.a26,somebody.a27,somebody.a28,somebody.a29,somebody.a30,somebody.a31,somebody.a32,somebody.a33,somebody.a34,somebody.a35,somebody.a36,somebody.a37,somebody.a38,somebody.a39,somebody.a40,somebody.a41,somebody.a42,somebody.a43,somebody.a44,somebody.a45,somebody.a46,somebody.a47,a1234' >> /etc/gshadow
 echo 'grp2:*::root' >> /etc/gshadow

--- a/tests/kola/ignition/delete-config/test.sh
+++ b/tests/kola/ignition/delete-config/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   # Ideally we'd test on virtualbox and vmware, but we don't have tests
 ##   # there, so we mock specifically for ignition.platform.id=qemu
-##   platforms: qemu-unpriv
+##   platforms: qemu
 
 set -xeuo pipefail
 

--- a/tests/kola/ignition/remote/test.sh
+++ b/tests/kola/ignition/remote/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   tags: needs-internet
+#
 # To test https://bugzilla.redhat.com/show_bug.cgi?id=1980679
 # remote.ign on github: inject kernelArguments and write something to /etc/testfile
 # config.ign to include remote kargsfile.ign

--- a/tests/kola/ignition/stable-boot/test.sh
+++ b/tests/kola/ignition/stable-boot/test.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 ## kola:
-##   # This test makes sure that ignition is able to use `coreos-boot-disk` symlink.
-##   # We don't need to test this on every platform. If it passes in one place it
-##   # will pass everywhere.
-##   platforms: qemu-unpriv
+##   # We don't need to test this on every platform. If it passes in one place
+##   # it will pass everywhere.
+##   platforms: platform-independent
+#
+# This test makes sure that ignition is able to use `coreos-boot-disk` symlink.
 
 set -xeuo pipefail
 

--- a/tests/kola/ignition/systemd-disable/test.sh
+++ b/tests/kola/ignition/systemd-disable/test.sh
@@ -6,7 +6,7 @@
 ##   distros: fcos
 ##   # We don't need to test this on every platform. If it passes in
 ##   # one place it will pass everywhere.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to disable units
 # https://github.com/coreos/fedora-coreos-tracker/issues/392

--- a/tests/kola/ignition/systemd-disable/test.sh
+++ b/tests/kola/ignition/systemd-disable/test.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 ## kola:
-##   # This test is currently scoped to FCOS because `zincati` is only available on
-##   # FCOS.
+##   # This test is currently scoped to FCOS because `zincati` is only available
+##   # on FCOS.
 ##   # TODO-RHCOS: Determine if any services on RHCOS may be disabled and adapt test
 ##   distros: fcos
 ##   # We don't need to test this on every platform. If it passes in
 ##   # one place it will pass everywhere.
 ##   platforms: qemu-unpriv
+#
 # This test makes sure that ignition is able to disable units
 # https://github.com/coreos/fedora-coreos-tracker/issues/392
 

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -3,6 +3,7 @@
 ##   # We don't need to test this on every platform. If it passes in
 ##   # one place it will pass everywhere.
 ##   platforms: qemu-unpriv
+#
 # This test makes sure that ignition is able to enable systemd units of
 # different types.
 # https://github.com/coreos/ignition/issues/586

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   # We don't need to test this on every platform. If it passes in
 ##   # one place it will pass everywhere.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to enable systemd units of
 # different types.

--- a/tests/kola/ignition/systemd-unmasking/test.sh
+++ b/tests/kola/ignition/systemd-unmasking/test.sh
@@ -6,7 +6,7 @@
 ##   distros: fcos
 ##   # We don't need to test this on every platform. If it passes in one place it
 ##   # will pass everywhere.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to unmask units It just so happens
 # we have masked dnsmasq in FCOS so we can test this by unmasking it.

--- a/tests/kola/ignition/systemd-unmasking/test.sh
+++ b/tests/kola/ignition/systemd-unmasking/test.sh
@@ -7,16 +7,15 @@
 ##   # We don't need to test this on every platform. If it passes in one place it
 ##   # will pass everywhere.
 ##   platforms: qemu-unpriv
-
-# This test makes sure that ignition is able to unmask units
-# It just so happens we have masked dnsmasq in FCOS so we can
-# test this by unmasking it.
+#
+# This test makes sure that ignition is able to unmask units It just so happens
+# we have masked dnsmasq in FCOS so we can test this by unmasking it.
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# make sure the systemd unit (dnsmasq) is unmasked and enabled
+# Make sure the systemd unit (dnsmasq) is unmasked and enabled
 if [ "$(systemctl is-enabled dnsmasq.service)" != 'enabled' ]; then
     fatal "dnsmasq.service systemd unit should be unmasked and enabled"
 fi

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
 ## kola:
 ##   # Testing kdump requires some reserved memory for the crashkernel.
 ##   minMemory: 4096
@@ -9,6 +8,8 @@
 ##   # This test includes a few reboots and the generation of a vmcore,
 ##   # which can take longer than the default 10 minute timeout.
 ##   timeoutMin: 15
+#
+# https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
 
 set -xeuo pipefail
 

--- a/tests/kola/kdump/service
+++ b/tests/kola/kdump/service
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # Make sure that kdump didn't start (it's either disabled, or enabled but
 # conditional on crashkernel= karg, which we don't bake).
 

--- a/tests/kola/kubernetes/kube-watch/test.sh
+++ b/tests/kola/kubernetes/kube-watch/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # This is for verifying that `kubernetes_file_t` labeled files can be
 # watched by systemd
 # See: https://github.com/coreos/fedora-coreos-tracker/issues/861

--- a/tests/kola/logging/printk
+++ b/tests/kola/logging/printk
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # Verify default console log level; xref https://github.com/coreos/fedora-coreos-tracker/issues/1244
 
 set -xeuo pipefail

--- a/tests/kola/multipath/multipathd-service-fix
+++ b/tests/kola/multipath/multipathd-service-fix
@@ -2,7 +2,7 @@
 ## kola:
 ##   exclusive: false
 ##   # Just run on qemu since the answer is the same everywhere
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/bridge-static-via-kargs
+++ b/tests/kola/networking/bridge-static-via-kargs
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-# Verify bridge networks works via kernel arguments.
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -14,7 +12,8 @@
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
+# Verify bridge networks works via kernel arguments.
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/bridge-static-via-kargs
+++ b/tests/kola/networking/bridge-static-via-kargs
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # Configuration of the 2 NICs for this test

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -3,14 +3,14 @@
 ##   exclusive: false
 ##   # No need to run on any other platform than QEMU.
 ##   platforms: qemu-unpriv
-
-set -xeuo pipefail
-
+#
 # Since we depend so much on the default networking configurations let's
 # alert ourselves when any default networking configuration changes in
 # NetworkManager. This allows us to react and adjust to the changes
 # (if needed) instead of finding out later that problems were introduced.
 # some context in: https://github.com/coreos/fedora-coreos-tracker/issues/1000
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   exclusive: false
 ##   # No need to run on any other platform than QEMU.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 #
 # Since we depend so much on the default networking configurations let's
 # alert ourselves when any default networking configuration changes in

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 1 NIC for this test
 ##   additionalNics: 1
 ##   # The functionality we're testing here and the configuration for the NIC

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -1,15 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
-# Setup configuration for a single NIC with two different ways:
-# - kargs provide static network config for eth1 and also coreos.force_persist_ip
-# - ignition provides dhcp network config for eth1
-# Expected result:
-# - with coreos.force_persist_ip ip=kargs win, verify that
-#   eth1 has the static IP address via kargs
-
-# https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -23,6 +12,17 @@ set -xeuo pipefail
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
+#
+# Setup configuration for a single NIC with two different ways:
+# - kargs provide static network config for eth1 and also coreos.force_persist_ip
+# - ignition provides dhcp network config for eth1
+# Expected result:
+# - with coreos.force_persist_ip ip=kargs win, verify that
+#   eth1 has the static IP address via kargs
+#
+# https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## kola:
-##   platforms: qemu
+##   platforms: platform-independent
 #
 # Test that the fallback hostname is `localhost`. This test
 # validates that the fallback hostname is set to `localhost`

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
 ## kola:
 ##   platforms: qemu
 #
@@ -11,11 +9,6 @@ set -xeuo pipefail
 # hostname is set from the fallback hostname and is `localhost`.
 # https://github.com/coreos/fedora-coreos-tracker/issues/902
 #
-# - platforms: qemu
-#   - This test should pass everywhere if it passes anywhere.
-
-. $KOLA_EXT_DATA/commonlib.sh
-
 # Use the output of hostnamectl to gather information about how
 # the hostname is/was set. We're expecting something like this:
 #   {
@@ -38,8 +31,8 @@ set -xeuo pipefail
 #       "HardwareModel" : "Standard PC _i440FX + PIIX, 1996_",
 #       "ProductUUID" : null
 #   }
-
-# "hostnamectl --json=pretty" is not supported on rhel8 yet, the 
+#
+# "hostnamectl --json=pretty" is not supported on rhel8 yet, the
 # expected output like this:
 #    Static hostname: n/a
 # Transient hostname: localhost
@@ -53,6 +46,9 @@ set -xeuo pipefail
 #             Kernel: Linux 4.18.0-372.19.1.el8_6.x86_64
 #       Architecture: x86-64
 
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
 
 if is_rhcos8; then
     if [ $(hostnamectl --transient) != 'localhost' ]; then

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -7,7 +7,7 @@
 ##   # appendFirstbootKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
 # Verify rd.net.timeout.dhcp and rd.net.dhcp.retry are supported
 # by NetworkManager. Append them to kernel parameter when boot,
 # get total timeout is `timeout * retry`, 30*8(240) seconds

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # The functionality we're testing here.
 ##   appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
 ##   # appendFirstbootKernelArgs doesn't work on s390x

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # We use net.ifnames=0 to disable consistent network naming here because on

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -11,19 +11,19 @@
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
 # Set MTU on a VLAN subinterface for the bond using ignition config and check
 # - verify MTU on the bond matches config
 # - verify MTU on the VLAN subinterface for the bond matches config
 # - verify ip address on the VLAN subinterface for the bond matches config
-
+#
 # The ignition config is generated using nm-initrd-generator according to
 # https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/
 # kargs="bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 \
 #        ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000: \
 #        vlan=bond0.100:bond0"
 # $/usr/libexec/nm-initrd-generator -s -- $kargs
-
+#
 # Using kernel args to `configure MTU on a VLAN subinterface for the bond` refer to
 # https://github.com/coreos/fedora-coreos-config/pull/1401
 

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -12,7 +12,7 @@
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
 # Configuring MTU on a VLAN subinterface for the bond,
 # - verify MTU on the bond matches config
 # - verify MTU on the VLAN subinterface for the bond matches config

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # Configuration of the 2 NICs for this test

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   appendKernelArgs: "nameserver=8.8.8.8 nameserver=1.1.1.1"
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -6,7 +6,7 @@
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
 # Verify multiple nameservers config via kernel arguments work well
 # RHCOS: need to check /etc/resolv.conf and nmconnection
 # FCOS:  using systemd-resolved which needs to run resolvectl to check
@@ -30,7 +30,7 @@ elif is_rhcos; then
         grep -q "nameserver 1.1.1.1" ${resolv}); then
         fatal "Error: can not find nameserver in ${resolv}"
     fi
-fi 
+fi
 
 # check nameserver in config file
 conf=/etc/NetworkManager/system-connections/default_connection.nmconnection

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -8,7 +8,7 @@
 ##   # Add rd.neednet=1 so we can force networking to be brought up on
 ##   # qemu to test that doing so doesn't materially change things.
 ##   appendFirstbootKernelArgs: "BOOTIF=52:54:00:12:34:56 rd.neednet=1"
-
+#
 # In addition to the pure network defaults case we should also make
 # sure that when BOOTIF= or rd.bootif= are provided on the kernel
 # command line (typically from PXE servers) that we don't propagate

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # appendFirstbootKernelArgs is only supported on qemu
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Append BOOTIF kernel argument so we can test how nm-initrd-generator
 ##   # and the coreos-teardown-initramfs interact. The MAC address is from:
 ##   # https://github.com/coreos/coreos-assembler/blob/d5f1623aad6d133b2c7c00e784c04ab6828450c1/mantle/platform/metal.go#L468

--- a/tests/kola/networking/no-default-initramfs-net-propagation/default
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/default
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # With pure network defaults no networking should have been propagated
 # from the initramfs. This test tries to verify that is the case.
 # https://github.com/coreos/fedora-coreos-tracker/issues/696

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -1,10 +1,4 @@
 #!/bin/bash
-
-# This test verifies that the coreos.no_persist_ip kernel argument will
-# prevent propagating kernel argument based networking configuration into
-# the real root. It does this by providing karg static networking config
-# for eth1 and then verifying that DHCP is used in the real root.
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -17,6 +11,11 @@
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none net.ifnames=0 coreos.no_persist_ip"
 ##   # appendKernelArgs doesn't work on s390x, see https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
+#
+# This test verifies that the coreos.no_persist_ip kernel argument will
+# prevent propagating kernel argument based networking configuration into
+# the real root. It does this by providing karg static networking config
+# for eth1 and then verifying that DHCP is used in the real root.
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 1 NIC for this test
 ##   additionalNics: 1
 ##   # The functionality we're testing here and the configuration for the NIC.

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -14,15 +12,17 @@ set -xeuo pipefail
 ##   # appendKernelArgs doesn't work on s390x so skip there
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
-
+#
 # Setup configuration for a single NIC with two different ways:
 # - kargs provide static network config for eth1 without coreos.force_persist_ip
 # - ignition provides dhcp network config for eth1
 # Expected result:
 # - without coreos.force_persist_ip Ignition networking
 #   configuration wins, verify that eth1 gets ip via dhcp
-
+#
 # https://bugzilla.redhat.com/show_bug.cgi?id=1958930#c29
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Add 1 additional NIC for this test
 ##   additionalNics: 1
 ##   # Set the kernel arguments so that we can set the configuration for the NIC.

--- a/tests/kola/networking/rd-net-timeout-carrier/test.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-qemu-unpriv
+##   platforms: platform-independent
 #
 # This test verifies that NetworkManager supports configuring the
 # carrier timeout via the `rd.net.timeout.carrier=` karg. Without

--- a/tests/kola/networking/rd-net-timeout-carrier/test.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/test.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-
+## kola:
+##   # This test should pass everywhere if it passes anywhere.
+##   platforms: platform-qemu-unpriv
+#
 # This test verifies that NetworkManager supports configuring the
 # carrier timeout via the `rd.net.timeout.carrier=` karg. Without
 # recreating an environment that requires this setting to be set
 # (which would be hard to do), we'll test this by just making sure
 # that setting the kernel argument ensures the runtime configuration
 # file /run/NetworkManager/conf.d/15-carrier-timeout.conf gets created.
-# 
+#
 # Checking that this file gets created is also tricky because we
 # `rm -rf /run/NetworkManager` in coreos-teardown-initramfs on first boot,
 # so we'll workaround that by setting the karg permanently and then
@@ -15,10 +18,6 @@
 # See:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1917773
 # - https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/e300138892ee0fc3824d38b527b60103a01758ab#
-
-## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu-unpriv
 
 set -xeuo pipefail
 
@@ -29,11 +28,11 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       ok "first boot"
       /tmp/autopkgtest-reboot rebooted
       ;;
-  
+
   rebooted)
       ok "second boot"
       grep rd.net.timeout.carrier=15 /proc/cmdline
-      
+
       generator_conf="/run/NetworkManager/conf.d/15-carrier-timeout.conf"
       if [ ! -f ${generator_conf} ]; then
         fatal "Error: can not generate ${generator_conf} with karg rd.net.timeout.carrier"

--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-# Verify team networking using ignition config works.
-# The ignition config refers to
-# https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -15,6 +11,10 @@
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776
 ##   architectures: "!s390x"
+#
+# Verify team networking using ignition config works.
+# The ignition config refers to
+# https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/
 
 set -xeuo pipefail
 

--- a/tests/kola/ntp/chrony/coreos-platform-chrony-generator
+++ b/tests/kola/ntp/chrony/coreos-platform-chrony-generator
@@ -2,6 +2,7 @@
 ## kola:
 ##   exclusive: false
 ##   platforms: "aws azure gce"
+#
 # Test the coreos-platform-chrony generator.
 
 set -xeuo pipefail

--- a/tests/kola/ntp/chrony/dhcp-propagation
+++ b/tests/kola/ntp/chrony/dhcp-propagation
@@ -1,11 +1,4 @@
 #!/bin/bash
-#
-# This script creates two veth interfaces i.e. one for the host machine
-# and other for the container(dnsmasq server). This setup will be helpful
-# to verify the DHCP propagation of NTP servers. This will also avoid any
-# regression that might cause in RHCOS or FCOS when the upstream changes
-# come down and obsolete the temporary work (https://github.com/coreos/fedora-coreos-config/pull/412)
-#
 ## kola:
 ##   # Add the needs-internet tag. This test builds a container from remote
 ##   # sources and uses a remote NTP server.
@@ -20,6 +13,12 @@
 ##   # https://bugzilla.redhat.com/show_bug.cgi?id=1907030
 ##   # https://pagure.io/releng/issue/10935#comment-808601
 ##   minMemory: 1536
+#
+# This script creates two veth interfaces i.e. one for the host machine
+# and other for the container(dnsmasq server). This setup will be helpful
+# to verify the DHCP propagation of NTP servers. This will also avoid any
+# regression that might cause in RHCOS or FCOS when the upstream changes
+# come down and obsolete the temporary work (https://github.com/coreos/fedora-coreos-config/pull/412)
 
 set -xeuo pipefail
 

--- a/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
+++ b/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-#
-# This script creates two veth interfaces i.e. one for the host machine
-# and other for the container(dnsmasq server). This setup will be helpful
-# to verify the DHCP propagation of NTP servers. This will also avoid any
-# regression that might cause in RHCOS or FCOS when the upstream changes
-# come down and obsolete the temporary work (https://github.com/coreos/fedora-coreos-config/pull/412)
-#
 ## kola:
 ##   # Add the needs-internet tag. This test builds a container from remote
 ##   # sources and uses a remote NTP server.
@@ -22,6 +15,12 @@
 ##   minMemory: 1536
 ##   # We only care about timesyncd in Fedora. It's not available elsewhere.
 ##   distros: fcos
+#
+# This script creates two veth interfaces i.e. one for the host machine
+# and other for the container(dnsmasq server). This setup will be helpful
+# to verify the DHCP propagation of NTP servers. This will also avoid any
+# regression that might cause in RHCOS or FCOS when the upstream changes
+# come down and obsolete the temporary work (https://github.com/coreos/fedora-coreos-config/pull/412)
 
 set -xeuo pipefail
 

--- a/tests/kola/platforms/aws/assert-xen
+++ b/tests/kola/platforms/aws/assert-xen
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Test to make sure the booted AWS instance is XEN based
-#
 ## kola:
 ##   # This is a read-only test and can be run with other tests
 ##   exclusive: false
@@ -12,6 +10,7 @@
 ##   # the test.
 ##   requiredTag: aws-xen-test
 #
+# Test to make sure the booted AWS instance is XEN based
 
 set -xeuo pipefail
 

--- a/tests/kola/platforms/aws/nvme
+++ b/tests/kola/platforms/aws/nvme
@@ -1,21 +1,16 @@
 #!/bin/bash
-# Test to make sure AWS instances with nvme storage get a device
-# properly created for it. See https://github.com/coreos/fedora-coreos-tracker/issues/1306
-#
 ## kola:
 ##   # This is a read-only test and can be run with other tests
 ##   exclusive: false
 ##   # This test is targeted at AWS
 ##   platforms: aws
-
-
-set -xeuo pipefail
-
-. $KOLA_EXT_DATA/commonlib.sh
-
+#
+# Test to make sure AWS instances with nvme storage get a device
+# properly created for it. See https://github.com/coreos/fedora-coreos-tracker/issues/1306
+#
 # We'll check to see if anything is listed in `nvme list-subsys`
 # and then run the test based on that. Example output:
-# 
+#
 # [core@ip-10-0-1-155 ~]$ nvme list-subsys -o json
 # [
 #   {
@@ -37,6 +32,11 @@ set -xeuo pipefail
 #     ]
 #   }
 # ]
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
 nvme_info=$(nvme list-subsys -o json || true)
 has_nvme=$(jq -r ".[].Subsystems[].Paths[] | select(.Name == \"nvme0\").Name" <<< "$nvme_info")
 if [ -n "${has_nvme}" ]; then

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # This test pulls a container from a registry.
 ##   tags: needs-internet
 ##   # This test doesn't make meaningful changes to the system and

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: qemu
@@ -12,9 +10,11 @@ set -xeuo pipefail
 ##   # This test reaches out to the internet and it could take more
 ##   # time to pull down the container.
 ##   timeoutMin: 3
-
+#
 # Tests that rootless podman containers can DNS resolve external domains.
 # https://github.com/coreos/fedora-coreos-tracker/issues/923
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -4,7 +4,7 @@
 ##   # This test uses a remote NTP server.
 ##   tags: needs-internet
 ##   # If the test works anywhere it should work everywhere.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 ##   # Pulling and building the container can take a long time if a
 ##   # slow mirror gets chosen.
 ##   timeoutMin: 15

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -12,7 +12,7 @@
 ##   # https://bugzilla.redhat.com/show_bug.cgi?id=1907030
 ##   # https://pagure.io/releng/issue/10935#comment-808601
 ##   minMemory: 1536
-
+#
 # This script runs a rootless podman container (rootless because it's
 # run as the `core` user) with systemd inside that brings up httpd.
 # It tests that rootless+systemd works. See issue:

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   platforms: qemu
+#
 # These are read-only not-necessarily-related checks that verify default system
 # configuration both on first and subsequent boots.
 

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # This test should pass everywhere if it passes anywhere.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # A TPM backend device is not available on s390x to suport TPM.

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -4,7 +4,7 @@
 ##   # RHCOS. See: https://github.com/openshift/os/issues/665
 ##   distros: fcos
 ##   # additionalDisks is only supported on qemu.
-##   platforms: qemu
+##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher

--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -4,7 +4,7 @@
 ##   distros: fcos
 ##   tags: needs-internet
 ##   # No need to run on any other platform than QEMU.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 
 set -xeuo pipefail
 

--- a/tests/kola/rpm-ostree/container-deps
+++ b/tests/kola/rpm-ostree/container-deps
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Verify some dependencies of the rpm-ostree container stack.
 ## kola:
 ##   exclusive: false
+#
+# Verify some dependencies of the rpm-ostree container stack.
 
 set -xeuo pipefail
 

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -87,7 +87,7 @@ FROM localhost/fcos
 RUN rpm-ostree cliwrap install-to-root /
 ADD dracut_call.sh dracut_call.sh
 RUN cat dracut_call.sh
-RUN chmod +x dracut_call.sh && rpm-ostree override replace \ 
+RUN chmod +x dracut_call.sh && rpm-ostree override replace \
     https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352 && \
     ./dracut_call.sh && \
     ostree container commit

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -76,7 +76,7 @@ if [[ "$version" == *"2023"* ]] || [[ "$version" == *"2022.19"* ]]; then
     echo "Running rpm-ostree 2022.19 or newer.";
 else
     echo "Running rpm-ostree 2022.18 or older, rebuilding the initramfs.";
-    echo "Building initramfs for Kernel: $kver" 
+    echo "Building initramfs for Kernel: $kver"
     /usr/libexec/rpm-ostree/wrapped/dracut --tmpdir /tmp/ --no-hostonly --kver $kver --reproducible \
     -v --add ostree -f /tmp/initramfs2.img
     mv /tmp/initramfs2.img /lib/modules/$kver/initramfs.img

--- a/tests/kola/selinux/default
+++ b/tests/kola/selinux/default
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Verify that the SELinux policy isn't marked as modified.
-# See: https://github.com/openshift/os/issues/1036.
 ## kola:
 ##   exclusive: false
 ##   tags: "platform-independent"
+#
+# Verify that the SELinux policy isn't marked as modified.
+# See: https://github.com/openshift/os/issues/1036.
 
 set -xeuo pipefail
 

--- a/tests/kola/swap/zram-default
+++ b/tests/kola/swap/zram-default
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+#
 # We can run this on both FCOS and RHCOS as neither should have a zram device
 # enabled by default. (In RHCOS, there is no zram support at all)
 

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -10,7 +10,7 @@
 ##   platforms: qemu-unpriv
 ##   # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
 ##   architectures: x86_64 aarch64
-
+#
 # Make sure that basic toolbox functionnality is working:
 # - Creating a toolbox
 # - Running a command in a toolbox

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -7,7 +7,7 @@
 ##   distros: fcos
 ##   tags: needs-internet
 ##   # Only run on QEMU to reduce CI costs as nothing is platform specific here.
-##   platforms: qemu-unpriv
+##   platforms: platform-independent
 ##   # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
 ##   architectures: x86_64 aarch64
 #

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -xeuo pipefail
-
 ## kola:
 ##   # restrict to qemu for now because the primary disk path is platform-dependent
 ##   platforms: qemu
 ##   architectures: "!s390x"
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # restrict to qemu for now because the primary disk path is platform-dependent
-##   platforms: qemu
+##   platforms: platform-independent
 ##   architectures: "!s390x"
 
 set -xeuo pipefail

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-set -xeuo pipefail
+## kola:
+##   platforms: qemu
+##   additionalDisks: ["5G:mpath"]
+#
 # This is to verify udev rules /dev/disk/by-id/scsi-*
 # symlinks present in initramfs
 # https://bugzilla.redhat.com/show_bug.cgi?id=1990506
 
-## kola:
-##   platforms: qemu
-##   additionalDisks: ["5G:mpath"]
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/kola/var-mount/simple/test.sh
+++ b/tests/kola/var-mount/simple/test.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -xeuo pipefail
-
-# restrict to qemu for now because the primary disk path is platform-dependent
 ## kola:
 ##   platforms: qemu
+#
+# Restrict to qemu for now because the primary disk path is platform-dependent
+
+set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 

--- a/tests/manual/coreos-docs-net-testing.sh
+++ b/tests/manual/coreos-docs-net-testing.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/bash
-set -eu -o pipefail
-
 # This script attempts to test the configurations in our documentation
 # at https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/.
 # All it does is test the various documented scenarios via both the
@@ -32,6 +30,8 @@ set -eu -o pipefail
 #     systemctl enable dnsmasq --now
 #
 # - Dusty Mabe - dusty@dustymabe.com
+
+set -eu -o pipefail
 
 vmname="coreos-docs-nettest"
 

--- a/tests/manual/coreos-network-testing.sh
+++ b/tests/manual/coreos-network-testing.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/bash
-set -eu -o pipefail
-#set -x
-
 # This script attempts to test networking configuration in various
 # scenarios/configurations. It tries to test what should happen
 # when initramfs networking is passed and/or networking config is
@@ -9,7 +6,11 @@ set -eu -o pipefail
 # configured network is passed properly to the real root when it
 # should be and not when it shouldn't be. See the following issue
 # for more details: https://github.com/coreos/fedora-coreos-tracker/issues/394
+#
 # - Dusty Mabe - dusty@dustymabe.com
+
+set -eu -o pipefail
+#set -x
 
 vmname="coreos-nettest"
 


### PR DESCRIPTION
tests: Use a unified format and layout

Unify test layout based on the format described in the README and fix
whitespace.

---

tests: Use 'platform-independent' as much as possible

Mark test indentified as idependent from the platform as such with the
'platform-independent' platform.

---

tests/delete-config: Use qemu platform

We're going to remove support for the qemu-unpriv platform.

---

tests/kola/rpm-ostree/kernel-replace: Significant whitespace change

---

See: https://github.com/coreos/fedora-coreos-config/pull/2130
See: https://github.com/coreos/coreos-assembler/pull/3280
See: https://github.com/coreos/coreos-assembler/issues/3279

This is preparation work for https://github.com/coreos/coreos-assembler/pull/3285