### PR TITLE
[rawhide] overrides: pin selinux-policy-38.1-1.fc38.noarch

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,3 +34,13 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
       type: pin
+  selinux-policy:
+    evra: 38.1-1.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364
+      type: pin
+  selinux-policy-targeted:
+    evra: 38.1-1.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364
+      type: pin


### PR DESCRIPTION
The SELinux is causing a test failure in the ostree.hotfix test. See https://github.com/coreos/fedora-coreos-tracker/issues/1364