### PR TITLE
tests: Enable rpmdb-sqlite for EL9

### DIFF
--- a/tests/kola/files/rpmdb-sqlite
+++ b/tests/kola/files/rpmdb-sqlite
@@ -1,13 +1,16 @@
 #!/bin/bash
 ## kola:
-##   # This test only runs on FCOS as the RHCOS rpmdb has not migrated to sqlite yet.
-##   # TODO-RHCOS: drop the "fcos" tag when RHCOS migrates to using sqlite
-##   distros: fcos
+##   # Read only test thus safe to run in parallel
 ##   exclusive: false
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
+
+if is_rhcos8; then
+    ok "nothing to check for RHCOS 8"
+    exit 0
+fi
 
 # make sure we're using the sqlite rpmdb backend
 # https://github.com/coreos/fedora-coreos-tracker/issues/623


### PR DESCRIPTION
From https://github.com/coreos/fedora-coreos-config/pull/2131/files#r1050151417

Will conflict with https://github.com/coreos/fedora-coreos-config/pull/2131 so I'll rebase when its merged.