### PR TITLE
overrides: pin container-selinux-2.193.0-1.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,3 +34,8 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
       type: pin
+  container-selinux:
+    evra: 2:2.193.0-1.fc37.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1366
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).