### PR TITLE
overrides: pin rust-coreos-installer-0.16.0-1.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,13 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1366
       type: pin
+  coreos-installer:
+    evr: 0.16.0-1.fc37
+    metadata:
+      reason: https://example.com/dnm-ci-test
+      type: pin
+  coreos-installer-bootinfra:
+    evr: 0.16.0-1.fc37
+    metadata:
+      reason: https://example.com/dnm-ci-test
+      type: pin


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).