### PR TITLE
denylist: drop denial and extend a couple of snoozes 

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -54,6 +54,3 @@
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
   snooze: 2023-02-05
-- pattern: ext.config.ntp.timesyncd.dhcp-propagation
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1359
-  snooze: 2023-01-15

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -53,7 +53,7 @@
   snooze: 2023-01-10
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
-  snooze: 2023-01-05
+  snooze: 2023-02-05
 - pattern: ext.config.ntp.timesyncd.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1359
   snooze: 2023-01-15

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/coreos-assembler/issues/2725#issuecomment-1292616121
-  snooze: 2023-01-04
+  snooze: 2023-02-04
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
```
commit 68dc5c4829003e2c82eba5f0d15b2621c01f3fd3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 3 20:48:04 2023 -0500

    denylist: extend snooze for default-network-behavior-change test
    
    No one has looked at the root cause of
    https://github.com/coreos/fedora-coreos-tracker/issues/1341 yet so
    this one is going to start failing if we don't extend the snooze.

commit 9cbcd50e5fc24c8ce4fe99129be78edcae952c93
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 3 20:45:32 2023 -0500

    denylist: extend snooze for ext.config.kdump.crash on ppc64le
    
    We still don't have a 6.1+ kernel yet in anything other than rawhide
    so we need to snooze for longer.

```