### PR TITLE
denylist: deny ext.config.ntp.timesyncd.dhcp-propagation on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -54,3 +54,8 @@
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
   snooze: 2023-02-05
+- pattern: ext.config.ntp.timesyncd.dhcp-propagation                                                                                                       
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1371727078
+  snooze: 2023-02-05
+  streams:
+    - rawhide


### PR DESCRIPTION
We recently removed the denial for this but it turns out `selinux-policy` is pinned in `rawhide` so we need to still deny the test on that stream for a period of time.

See https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1371727078