### PR TITLE
manifests: install the x86_64 emulator on ppc64le instances

### DIFF
--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1026,6 +1026,9 @@
     "publicsuffix-list-dafsa": {
       "evra": "20210518-5.fc37.noarch"
     },
+    "qemu-user-static-x86": {
+      "evra": "2:7.0.0-12.fc37.ppc64le"
+    },
     "readline": {
       "evra": "8.2-2.fc37.ppc64le"
     },

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -174,8 +174,8 @@ packages:
 # https://serverfault.com/questions/513807/is-there-still-a-use-for-irqbalance-on-modern-hardware
 # https://access.redhat.com/solutions/41535
 #
-# Include the qemu-user-static-x86 package on aarch64 and s390x FCOS images
-# to allow access to the large inventory of containers only built for x86_64.
+# Include the qemu-user-static-x86 package on non-x86_64 FCOS images to allow
+# access to the large inventory of containers only built for x86_64.
 # https://github.com/coreos/fedora-coreos-tracker/issues/1237
 packages-x86_64:
   - irqbalance
@@ -184,6 +184,7 @@ packages-ppc64le:
   - librtas
   - powerpc-utils-core
   - ppc64-diag-rtas
+  - qemu-user-static-x86
 packages-aarch64:
   - irqbalance
   - qemu-user-static-x86

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test the x86_64 emulator on aarch64 and s390x images for now
+# Test the x86_64 emulator on non-x86_64 instances.
 # https://github.com/coreos/fedora-coreos-tracker/issues/1237
 #
 ## kola:
@@ -12,15 +12,15 @@
 ##   tags: needs-internet
 ##   # Only run on fcos, as rhel does not support emulation
 ##   distros: fcos
-##   # We decided to ship x86_64 emulator to only these arches for now.
-##   architectures: aarch64 s390x
+##   # We ship the x86_64 on all non-x86_64 arches.
+##   architectures: "! x86_64"
 
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
 case "$(arch)" in
-    aarch64|s390x)
+    aarch64|ppc64le|s390x)
         containerArch=$(podman run --arch=amd64 --rm registry.fedoraproject.org/fedora:37 arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"


### PR DESCRIPTION
This gets ppc64le in line with the other non-x86_64 arches.