### PR TITLE
overrides: fast-track container-selinux; add test for container tmpfs mount

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -35,7 +35,8 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
       type: pin
   container-selinux:
-    evra: 2:2.193.0-1.fc37.noarch
+    evra: 2:2.198.0-1.fc37.noarch
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d03c3d75ec
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1366
-      type: pin
+      type: fast-track

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -1,0 +1,21 @@
+#!/bin/bash
+## kola:
+##   # This test doesn't meaningfully change the system and
+##   # can be run with other tests.
+##   exclusive: false
+##   # - This test pulls a container image from the network.
+##   # - This test should pass everywhere if it passes anywhere.
+##   tags: "needs-internet platform-independent"
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# Make sure that tmpfs mounts inside a container have the `container_file_t` label.
+# https://github.com/coreos/fedora-coreos-tracker/issues/1366
+context=$(podman run --rm --privileged registry.fedoraproject.org/fedora:37 \
+            bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
+if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
+    fatal "SELinux context for files on a tmpfs inside a container is wrong"
+fi
+ok "SELinux context for files on a tmpfs inside a container is correct"


### PR DESCRIPTION
We have an update that now fixes the problem and a test to make sure that the problem doesn't come back in the future.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1366