### PR TITLE
denylist: extend snooze again for platforms.aws.nvme test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -49,8 +49,8 @@
     - testing
     - stable
 - pattern: ext.config.platforms.aws.nvme
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1337660156
-  snooze: 2023-01-10
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1378864963
+  snooze: 2023-02-10
 - pattern: ext.config.networking.default-network-behavior-change
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
   snooze: 2023-02-05


### PR DESCRIPTION
It's still failing. I'm hoping AWS get's it fixed on their end soon.