### PR TITLE
workflows: normalize the denylist in the promotion-diff workflow

### DIFF
--- a/.github/workflows/promotion-diff.yml
+++ b/.github/workflows/promotion-diff.yml
@@ -37,6 +37,12 @@ jobs:
           # manifest.yaml is per-branch, so we care about changes vs. the
           # one in the base, not the one from the origin
           cp base/manifest.yaml origin/
+      - name: Normalize kola-denylist.yaml
+        run: |
+          # When we promote to a production branch we strip out the
+          # snooze lines. Let's do the same here so we don't get warnings.
+          # See https://github.com/coreos/fedora-coreos-releng-automation/pull/165
+          sed -E -i 's/^(\s+)(snooze:\s+.*)/\1# \2 (disabled on promotion)/' origin/kola-denylist.yaml
       - name: Compare trees
         uses: coreos/actions-lib/check-diff@main
         with:


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-releng-automation/pull/165 we started stripping out the snooze lines so we need to do the same here in the origin path to make it so we don't get unwanted warnings.