### PR TITLE
overrides: fast-track NetworkManager-1.40.10-1.fc37

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -51,9 +51,6 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1378864963
   snooze: 2023-02-10
-- pattern: ext.config.networking.default-network-behavior-change
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1341#issuecomment-1309756265
-  snooze: 2023-02-05
 - pattern: ext.config.ntp.timesyncd.dhcp-propagation                                                                                                       
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1371727078
   snooze: 2023-02-05

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,27 +10,32 @@
 
 packages:
   NetworkManager:
-    evr: 1:1.40.0-1.fc37
+    evr: 1:1.40.10-1.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-cloud-setup:
-    evr: 1:1.40.0-1.fc37
+    evr: 1:1.40.10-1.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-libnm:
-    evr: 1:1.40.0-1.fc37
+    evr: 1:1.40.10-1.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-team:
-    evr: 1:1.40.0-1.fc37
+    evr: 1:1.40.10-1.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-tui:
-    evr: 1:1.40.0-1.fc37
+    evr: 1:1.40.10-1.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).