### PR TITLE
[rawhide] overrides: fast-track NetworkManager-1.41.8-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,30 +10,35 @@
 
 packages:
   NetworkManager:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.8-1.fc38
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-6c11368023
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-cloud-setup:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.8-1.fc38
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-6c11368023
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-libnm:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.8-1.fc38
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-6c11368023
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-team:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.8-1.fc38
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-6c11368023
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   NetworkManager-tui:
-    evr: 1:1.40.0-1.fc38
+    evr: 1:1.41.8-1.fc38
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-6c11368023
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: pin
+      type: fast-track
   container-selinux:
     evra: 2:2.193.0-1.fc38.noarch
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).