### PR TITLE
coreos-teardown-initramfs: ignore lo.nmconnection

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -58,6 +58,9 @@ are_default_NM_configs() {
     # Copy over the previously generated connection(s) profiles
     cp  /run/NetworkManager/system-connections/* \
         /run/coreos-teardown-initramfs/connections-compare-1/
+    # Delete lo.nmconnection if it was created.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1385
+    rm -f /run/coreos-teardown-initramfs/connections-compare-1/lo.nmconnection
     # Do a new run with the default input
     /usr/libexec/nm-initrd-generator \
         -c /run/coreos-teardown-initramfs/connections-compare-2 \
@@ -127,6 +130,9 @@ propagate_initramfs_networking() {
             else
                 echo "info: propagating initramfs networking config to the real root"
                 cp -v /run/NetworkManager/system-connections/* /sysroot/etc/NetworkManager/system-connections/
+                # Delete lo.nmconnection if it was created.
+                # https://github.com/coreos/fedora-coreos-tracker/issues/1385
+                rm -vf /sysroot/etc/NetworkManager/system-connections/lo.nmconnection
                 coreos-relabel /etc/NetworkManager/system-connections/
             fi
         else

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -177,7 +177,7 @@ down_interface() {
 }
 
 # Iterate through the interfaces in the machine and take them down.
-# Note that in the futre we would like to possibly use `nmcli` networking off`
+# Note that in the future we would like to possibly use `nmcli` networking off`
 # for this. See the following two comments for details:
 # https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
 # https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599746049

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -5,7 +5,9 @@
 ##   # Append BOOTIF kernel argument so we can test how nm-initrd-generator
 ##   # and the coreos-teardown-initramfs interact. The MAC address is from:
 ##   # https://github.com/coreos/coreos-assembler/blob/d5f1623aad6d133b2c7c00e784c04ab6828450c1/mantle/platform/metal.go#L468
-##   appendFirstbootKernelArgs: BOOTIF=52:54:00:12:34:56
+##   # Add rd.neednet=1 so we can force networking to be brought up on
+##   # qemu to test that doing so doesn't materially change things.
+##   appendFirstbootKernelArgs: "BOOTIF=52:54:00:12:34:56 rd.neednet=1"
 
 # In addition to the pure network defaults case we should also make
 # sure that when BOOTIF= or rd.bootif= are provided on the kernel

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
+##   # appendFirstbootKernelArgs is only supported on qemu
 ##   platforms: qemu
 ##   # Append BOOTIF kernel argument so we can test how nm-initrd-generator
 ##   # and the coreos-teardown-initramfs interact. The MAC address is from:


### PR DESCRIPTION
There are a few commits in here, but the most important is the reworking of `coreos-teardown-initramfs` to ignore the `lo.nmconnection`, which should fix https://github.com/coreos/fedora-coreos-tracker/issues/1385.

```
commit 6b1923264cde0b1f38faa9432a7721fa7a99c46c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 17 17:02:21 2023 -0500

    tests: set rd.neednet=1 in bootif net propagation test
    
    Normally on qemu networking isn't brought up in the initramfs because
    it's not needed (the Ignition config is passed via fw_cfg, not network).
    This will force networking to be brought up to verify that bringing up
    NetworkManager doesn't materially change things.
    
    One case where it did materially change things and we needed to adapt
    is described in https://github.com/coreos/fedora-coreos-tracker/issues/1385

commit 6fb18ac9b3aa6a7531a14c660a425c4c2eab969d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 17 17:01:02 2023 -0500

    tests: update comment in bootif net propagation test
    
    This improves the accuracy of the comment since we're forced to
    use qemu because the features we need aren't available on other
    platforms.

commit 6d79119b741ab8601cca88413a93d6d7c8de0c3a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 17 16:57:33 2023 -0500

    coreos-teardown-initramfs: ignore lo.nmconnection
    
    Upstream NetworkManager now autogenerates a lo.nmconnection connection
    to manage the local loopback device. Let's ignore that connection for
    the purposes of our comparison and propagation here.
    
    Closes https://github.com/coreos/fedora-coreos-tracker/issues/1385

commit 737ca288d58a4b8d8756536270ac53584a78ed29
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jan 17 16:56:01 2023 -0500

    coreos-teardown-initramfs: fix spelling error

```