### PR TITLE
Adds mlx[45]_core to the udev rule for the Azure Accelerated Networking interfaces to exclude from the NetworkManager management

### DIFF
--- a/overlay.d/25-azure-udev-rules/usr/lib/udev/rules.d/68-azure-sriov-nm-unmanaged.rules
+++ b/overlay.d/25-azure-udev-rules/usr/lib/udev/rules.d/68-azure-sriov-nm-unmanaged.rules
@@ -2,3 +2,5 @@
 # This interface is transparently bonded to the synthetic interface,
 # so NetworkManager should just ignore any SRIOV interfaces.
 SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add|change|move", ENV{NM_UNMANAGED}="1"
+IMPORT{cmdline}=="ignition.platform.id=azure", SUBSYSTEM=="net", DRIVERS=="mlx[45]_core", ACTION=="add|change|move", ENV{NM_UNMANAGED}="1"
+


### PR DESCRIPTION
coreos/fedora-coreos-config#2176 introduced an udev rule to avoid the management of the SRIOV network accelerator interfaces on the Azure VMs. The aarch64 Azure VMs' network accelerators use the `mlx[45]_core` modules. This PR makes the introduced rule to also catch the interfaces backed by the `mlx[45]_core` modules.

Refers #1383 OCPBUGS-5569

cc @Prashanth684 