### PR TITLE
ignition-ostree-firstboot-uuid: nuke libblkid cache after UUID restamp

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -62,6 +62,10 @@ if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
     *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
   esac
   udevadm settle || :
+  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2162151.
+  # We nuke the blkid cache containing stale UUIDs so that future blkid calls
+  # (or tools leveraging libblkid) will be forced to re-probe.
+  rm -rf /run/blkid
   echo "Regenerated UUID for ${target}"
 else
   echo "No changes required for ${target} TYPE=${TYPE} UUID=${UUID}"


### PR DESCRIPTION
We're hitting an issue right now where
`coreos-ignition-unique-boot.service` (backed by `rdcore`) is failing on multipath with:

```
Error: System has 2 devices with a filesystem labeled 'boot': ["/dev/sdb3", "/dev/mapper/mpatha3"]
```

The unique label detection code in `rdcore` determines whether multiple lower-level devices actually refer to the same higher-level device (e.g. multipath or RAID1) by looking at the filesystem UUID. It uses blkid to query device UUIDs.

libblkid maintains a cache of devices to avoid reprobing all devices all the time. This cache normally gets updated (I *think* via udev, but I'm not sure) when changes occur. But something changed recently at least in the multipath case where the cache is only updated for the multipathed device, but not the underlying backing paths.

This then leads `rdcore` to think that they're separate devices. We probably should make `rdcore` smarter here in how it handles multipath devices, but still we don't want to have this stale cache around for the sake of other tools relying on it.

We started hitting this more frequently starting with kernel v6.0.17, but the issue triggers equally as easily on v6.0.16 when reproduced artificially. So I think we've just been lucky so far that this hasn't bit us (possibly we raced with another service that helped refresh the cache).

There's likely a bug here either in the kernel, or multipath or blkid. This is tracked by https://bugzilla.redhat.com/show_bug.cgi?id=2162151. Until then, nuke the blkid cache to force a reprobe on the next call.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1373