### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,34 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  NetworkManager:
-    evr: 1:1.40.10-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: fast-track
-  NetworkManager-cloud-setup:
-    evr: 1:1.40.10-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: fast-track
-  NetworkManager-libnm:
-    evr: 1:1.40.10-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: fast-track
-  NetworkManager-team:
-    evr: 1:1.40.10-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: fast-track
-  NetworkManager-tui:
-    evr: 1:1.40.10-1.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7f92dd90a3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1341
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).