### PR TITLE
overlay: always use `-p` with `blkid`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
@@ -20,7 +20,7 @@ else
         # Get the PKNAME
         eval $(lsblk --output PKNAME --pairs --paths --nodeps "$1")
         # Get the PTUUID
-        eval $(blkid -o export $PKNAME)
+        eval $(blkid -p -o export $PKNAME)
     else
         # PTUUID is the disk guid, PKNAME is the parent kernel name
         eval $(lsblk --output PTUUID,PKNAME --pairs --paths --nodeps "$1")

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-rootflags.sh
@@ -21,7 +21,7 @@ if [ -d /run/ignition-ostree-transposefs/root ]; then
     fi
 fi
 
-eval $(blkid -o export ${rootpath})
+eval $(blkid -p -o export ${rootpath})
 if [ "${TYPE}" == "xfs" ]; then
     # We use prjquota on XFS by default to aid multi-tenant Kubernetes (and
     # other container) clusters.  See

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -18,7 +18,7 @@ if ! [ -b "${target}" ]; then
   exit 1
 fi
 
-eval $(blkid -o export ${target})
+eval $(blkid -p -o export ${target})
 case "${label}" in
   root) orig_uuid="${rootfs_uuid}"; orig_type=xfs ;;
   boot) orig_uuid="${bootfs_uuid}"; orig_type=ext4 ;;

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-growfs.sh
@@ -58,7 +58,7 @@ done
 # because the partition, once extended, might include leftover superblocks
 # from the previous contents of the disk (notably ZFS), causing blkid to
 # refuse to return any filesystem type at all.
-eval $(blkid -o export "${src}")
+eval $(blkid -p -o export "${src}")
 ROOTFS_TYPE=${TYPE:-}
 case "${ROOTFS_TYPE}" in
     xfs|ext4|btrfs) ;;

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -56,7 +56,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       ok "found root karg"
 
       bootsrc=$(findmnt -nvr /boot -o SOURCE)
-      eval $(blkid -o export "${bootsrc}")
+      eval $(blkid -p -o export "${bootsrc}")
       grep boot=UUID="${UUID}" /proc/cmdline
       ok "found boot karg"
 


### PR DESCRIPTION
By default, `blkid` will return cached data, which we don't want because it might be stale. Add `-p` to make sure we always bypass the cache. Some of these callsites could probably be changed to use `lsblk`, which uses the udev database, but it's safer to keep using `blkid`.

See also: https://github.com/coreos/fedora-coreos-config/pull/2181#issuecomment-1397386896