### PR TITLE
Revert "ignition-ostree-firstboot-uuid: nuke libblkid cache after UUID restamp"

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -62,10 +62,6 @@ if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
     *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
   esac
   udevadm settle || :
-  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2162151.
-  # We nuke the blkid cache containing stale UUIDs so that future blkid calls
-  # (or tools leveraging libblkid) will be forced to re-probe.
-  rm -rf /run/blkid
   echo "Regenerated UUID for ${target}"
 else
   echo "No changes required for ${target} TYPE=${TYPE} UUID=${UUID}"


### PR DESCRIPTION
This reverts commit e41fd27e3e5dafe671be47c449358aaee984b143.

We shouldn't need this anymore now that we don't rely on the cache:
- https://github.com/coreos/fedora-coreos-config/pull/2184
- https://github.com/coreos/coreos-installer/pull/1094

See also: https://github.com/coreos/fedora-coreos-config/pull/2181