### PR TITLE
overlay/live-generator: Allow 50% of RAM for /etc and /var

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -168,9 +168,22 @@ EOF
     add_requires workaround-stalled-media-iso-mount.service basic.target
 fi
 
-# It turns out that `tmpfs` currently munches all SELinux labels
+# The systemd default for /run is 20% of RAM, but we want to use basically all of RAM,
+# so we make a distinct tmpfs that allows more.  Note the file we create there is
+# "thinly provisioned", so we're not actually allocating all of that.
+cat >>"${UNIT_DIR}/run-ephemeral_base.mount" <<EOF
+[Unit]
+DefaultDependencies=false
+[Mount]
+What=tmpfs
+Where=/run/ephemeral_base
+Type=tmpfs
+Options=size=50%%
+EOF
+
+# But it turns out that `tmpfs` currently munches all SELinux labels
 # we set before policy is loaded, so we make an XFS filesystem
-# loopback mounted that's sized the same as /run.
+# loopback mounted on top of the base tmpfs.
 # https://github.com/coreos/fedora-coreos-config/pull/499
 cat >"${UNIT_DIR}/sysroot-xfs-ephemeral-mkfs.service" <<'EOF'
 [Unit]
@@ -179,14 +192,15 @@ DefaultDependencies=false
 # can run really early.
 After=systemd-tmpfiles-setup-dev.service
 ConditionPathExists=/usr/lib/initrd-release
+RequiresMountsFor=/run/ephemeral_base
 # Something seems to be causing us to rerun?
-ConditionPathExists=!/run/ephemeral
+ConditionPathExists=!/run/ephemeral_base/loopfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/sh -c 'set -euo pipefail; mem=$$(($$(stat -f -c "%%b * %%s / 1024" /run))) && /bin/truncate -s $${mem}k /run/ephemeral.xfsloop'
-ExecStart=/sbin/mkfs.xfs /run/ephemeral.xfsloop
+ExecStart=/bin/sh -c 'set -euo pipefail; mem=$$(($$(stat -f -c "%%b * %%s / 1024" /run/ephemeral_base))) && /bin/truncate -s $${mem}k /run/ephemeral_base/loopfs'
+ExecStart=/sbin/mkfs.xfs /run/ephemeral_base/loopfs
 ExecStart=/bin/mkdir /run/ephemeral
 EOF
 add_requires sysroot-xfs-ephemeral-mkfs.service initrd-root-fs.target
@@ -197,7 +211,7 @@ DefaultDependencies=false
 Requires=sysroot-xfs-ephemeral-mkfs.service
 After=sysroot-xfs-ephemeral-mkfs.service
 [Mount]
-What=/run/ephemeral.xfsloop
+What=/run/ephemeral_base/loopfs
 Where=/run/ephemeral
 Type=xfs
 Options=loop,discard


### PR DESCRIPTION


Today we default to sizing the ephemeral storage at the tmpfs default
of only 20%, but the goal here is to be able to run fully from RAM,
so there's no reason not to allow more.

(We should also likely enable zram here, but that's another topic)

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1344

---

