### PR TITLE
[rawhide] overrides: fast-track fedora-release to 38-0.18

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,20 +15,23 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1355059716
       type: pin
   fedora-release-common:
-    evra: 38-0.8.noarch
+    evra: 38-0.18.noarch
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-db60a723ab
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380#issuecomment-1398571821
+      type: fast-track
   fedora-release-coreos:
-    evra: 38-0.8.noarch
+    evra: 38-0.18.noarch
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-db60a723ab
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380#issuecomment-1398571821
+      type: fast-track
   fedora-release-identity-coreos:
-    evra: 38-0.8.noarch
+    evra: 38-0.18.noarch
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-db60a723ab
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1380#issuecomment-1398571821
+      type: fast-track
   selinux-policy:
     evra: 38.1-1.fc38.noarch
     metadata:


### PR DESCRIPTION
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1380