### PR TITLE
coreos-livepxe-rootfs: use `curl --fail`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh
@@ -59,6 +59,10 @@ elif [[ -n "${rootfs_url}" ]]; then
         echo "Couldn't fetch, verify, and unpack image specified by:" >&2
         echo "coreos.live.rootfs_url=${rootfs_url}" >&2
         echo "Check that the URL is correct and that the rootfs version matches the initramfs." >&2
+        source /etc/os-release
+        if [ -n "${OSTREE_VERSION:-}" ]; then
+            echo "The version of this initramfs is ${OSTREE_VERSION}." >&2
+        fi
         exit 1
     fi
 else

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh
@@ -37,7 +37,8 @@ elif [[ -n "${rootfs_url}" ]]; then
     # Doing this allows us to retry all errors (including transient
     # "no route to host" errors during startup). Note we can't use
     # curl's --retry-all-errors here because it's not in el8's curl yet.
-    # We retry forever, matching Ignition's semantics.
+    # We don't need to verify TLS certificates because we're checking the
+    # image hash. We retry forever, matching Ignition's semantics.
     curl_common_args="--silent --show-error --insecure --location"
     while ! curl --head $curl_common_args "${rootfs_url}" >/dev/null; do
         echo "Couldn't establish connectivity with the server specified by:" >&2
@@ -46,8 +47,6 @@ elif [[ -n "${rootfs_url}" ]]; then
         sleep 5
     done
 
-    # We don't need to verify TLS certificates because we're checking the
-    # image hash.
     # bsdtar can read cpio archives and we already depend on it for
     # coreos-liveiso-persist-osmet.service, so use it instead of cpio.
     # We shouldn't need a --retry here since we've just successfully HEADed the


### PR DESCRIPTION
Currently, if the server returns a 404 when fetching the rootfs, we
still try to hash the server's HTML response and compare it, which
leads to a confusing error message about mismatched hashes.

Do a single `HEAD` after establishing server connectivity, but before
the pipeline. Use `--fail` so that `curl` exits with a nonzero code and
clearly prints out the erroring HTTP code it got. Also use `--fail`
during the pipeline invocation for the same reason.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1390