### PR TITLE
[rawhide] overrides: pin openssh-9.0p1-9.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,21 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1355059716
       type: pin
+  openssh:
+    evr: 9.0p1-9.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
+      type: pin
+  openssh-clients:
+    evr: 9.0p1-9.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
+      type: pin
+  openssh-server:
+    evr: 9.0p1-9.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
+      type: pin
   selinux-policy:
     evra: 38.1-1.fc38.noarch
     metadata:


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1394