### PR TITLE
tests/kola: test Ignition spec 3.4.0 LUKS `discard` and `openOptions` fields

### DIFF
--- a/tests/kola/root-reprovision/luks/config.ign
+++ b/tests/kola/root-reprovision/luks/config.ign
@@ -1,6 +1,6 @@
 {
   "ignition": {
-    "version": "3.2.0"
+    "version": "3.4.0"
   },
   "storage": {
     "luks": [
@@ -10,6 +10,8 @@
         "clevis": {
           "tpm2": true
         },
+        "discard": true,
+        "openOptions": ["--perf-no_read_workqueue"],
         "label": "root",
         "wipeVolume": true
       }

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -30,6 +30,15 @@ if ! grep prjquota <<< "${rootflags}"; then
 fi
 ok "root mounted with prjquota"
 
+table=$(dmsetup table myluksdev)
+if ! grep -q allow_discards <<< "${table}"; then
+    fatal "missing allow_discards in root DM table: ${table}"
+fi
+if ! grep -q no_read_workqueue <<< "${table}"; then
+    fatal "missing no_read_workqueue in root DM table: ${table}"
+fi
+ok "discard and custom option enabled for root LUKS"
+
 # while we're here, sanity-check that boot is mounted by UUID
 if ! systemctl cat boot.mount | grep -q What=/dev/disk/by-uuid; then
   systemctl cat boot.mount

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -27,6 +27,15 @@ blktype=$(lsblk -o TYPE "${src}" --noheadings)
 fstype=$(findmnt -nvr /var/log -o FSTYPE)
 [[ $fstype == ext4 ]]
 
+table=$(dmsetup table varlog)
+if grep -q allow_discards <<< "${table}"; then
+    fatal "found allow_discards in /var/log DM table: ${table}"
+fi
+if grep -q no_read_workqueue <<< "${table}"; then
+    fatal "found no_read_workqueue in /var/log DM table: ${table}"
+fi
+ok "discard and custom option not enabled for /var/log"
+
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
       ok "mounted on first boot"


### PR DESCRIPTION
Rather than adding a dedicated test for relatively obscure options, change the rootfs test to enable them, check that it does so, and check that the existing LUKS `/var/log` test doesn't do so.  In each case, check both the first and second boots.

The rootfs is the important case, since its mount flow doesn't read `/etc/crypttab`.