### PR TITLE
tests/kola/ntp: use different server for NTP for DHCP propagation tests

### DIFF
--- a/tests/kola/ntp/chrony/dhcp-propagation
+++ b/tests/kola/ntp/chrony/dhcp-propagation
@@ -28,7 +28,10 @@ set -xeuo pipefail
 
 main() {
 
-    ntp_host_ip=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
+    # Choose a host from https://tf.nist.gov/tf-cgi/servers.cgi
+    # that can get DNS over DNSSEC since the environment our OpenShift
+    # runs in requires DNSSEC validation. Test with https://dnsviz.net/
+    ntp_host_ip=$(getent hosts utcnist.colorado.edu | cut -d ' ' -f 1)
 
     ntp_test_setup $ntp_host_ip
 

--- a/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
+++ b/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
@@ -30,7 +30,10 @@ set -xeuo pipefail
 
 main() {
 
-    ntp_host_ip=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
+    # Choose a host from https://tf.nist.gov/tf-cgi/servers.cgi
+    # that can get DNS over DNSSEC since the environment our OpenShift
+    # runs in requires DNSSEC validation. Test with https://dnsviz.net/
+    ntp_host_ip=$(getent hosts utcnist.colorado.edu | cut -d ' ' -f 1)
 
     ntp_test_setup $ntp_host_ip
 


### PR DESCRIPTION
The time-c-g.nist.gov can't resolve in our Fedora OpenShift because they require DNSSEC validation and that server started failing. I picked another server on the https://tf.nist.gov/tf-cgi/servers.cgi page that is passing validation and also added some commentary.