### PR TITLE
[rawhide] overrides: pin systemd-252.4-4.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,33 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364
       type: pin
+  systemd:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin
+  systemd-container:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin
+  systemd-libs:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin
+  systemd-pam:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin
+  systemd-resolved:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin
+  systemd-udev:
+    evr: 252.4-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).