### PR TITLE
[rawhide] overrides: pin grub2; drop pin for selinux-policy

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-78.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-78.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-efi-aa64:
+    evra: 1:2.06-78.fc38.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,36 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-78.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-78.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-ppc64le:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-ppc64le-modules:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools:
+    evra: 1:2.06-78.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.06-78.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-pc-modules:
+    evra: 1:2.06-78.fc38.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-efi-x64:
+    evra: 1:2.06-78.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin
+  grub2-pc:
+    evra: 1:2.06-78.fc38.x86_64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,11 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  container-selinux:
-    evra: 2:2.193.0-1.fc38.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1355059716
-      type: pin
   openssh:
     evr: 9.0p1-9.fc38
     metadata:
@@ -28,16 +23,6 @@ packages:
     evr: 9.0p1-9.fc38
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: pin
-  selinux-policy:
-    evra: 38.1-1.fc38.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364
-      type: pin
-  selinux-policy-targeted:
-    evra: 38.1-1.fc38.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1364
       type: pin
   systemd:
     evr: 252.4-4.fc38


### PR DESCRIPTION
```
commit e9d6d1acabe2e2d9a272c103cf3b41ea9d2d8090
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Feb 1 15:27:08 2023 -0500

    overrides: pin grub2-2.06-78.fc38
    
    We'll pin on grub2-2.06-78.fc38 since grub2-2.06-79.fc38 is causing our
    secureboot tests to fail [1].
    
    [1] https://github.com/coreos/fedora-coreos-tracker/issues/1403

commit 9473fbcdb9a75c145552953754b75ef0dab04cbc
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Feb 1 15:21:53 2023 -0500

    overrides: drop selinux-policy-38.1-1.fc38 pins
    
    The issue described in https://github.com/coreos/fedora-coreos-tracker/issues/1394
    has been fixed upstream in https://github.com/fedora-selinux/selinux-policy/pull/1574
    and landed in `selinux-policy-38.6-1.fc38`.

```