### PR TITLE
denylist: drop ntp.timesyncd.dhcp-propagation from denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -40,8 +40,3 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1378864963
   snooze: 2023-02-10
-- pattern: ext.config.ntp.timesyncd.dhcp-propagation                                                                                                       
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1371727078
-  snooze: 2023-02-05
-  streams:
-    - rawhide


### PR DESCRIPTION
This test was denylisted for rawhide because the fix for [1],
which was an updated container-selinux RPM, was held back [2]
because it needed a newer selinux-policy RPM, which was pinned
because of [3]. Now that selinux-policy and container-selinux
are no longer pinned, we can start running this test in rawhide.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1359
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1364#issuecomment-1371727078
[3] https://github.com/coreos/fedora-coreos-tracker/issues/1364
