### PR TITLE
[rawhide] overrides: grub2-ppc64le is not noarch

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -25,7 +25,7 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
       type: pin
   grub2-ppc64le:
-    evra: 1:2.06-78.fc38.noarch
+    evra: 1:2.06-78.fc38.ppc64le
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1403
       type: pin


### PR DESCRIPTION
Fixes 3008623