### PR TITLE
tests: Fix tests incorrectly marked as platform-independent

### DIFF
--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # This test doesn't make meaningful changes to the system and should
 ##   # be able to be combined with other tests.

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2

--- a/tests/kola/butane/grub-users/test.sh
+++ b/tests/kola/butane/grub-users/test.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 ## kola:
+##  platforms: platform-independent
 ##  # GRUB sugar currently only exists in FCOS
 ##  distros: fcos
 ##  # coreos-post-ignition-checks.service forbids GRUB passwords on
 ##  # ppc64le and s390x
 ##  architectures: "!ppc64le s390x"
-##  # Running on multiple platforms won't prove anything further
-##  platforms: platform-independent
 #
 # Check Butane GRUB sugar as best we can from inside the OS.
 

--- a/tests/kola/clhm/ignition-warnings/test.sh
+++ b/tests/kola/clhm/ignition-warnings/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # We intentionally exclude the Install section from a systemd unit.
 ##   # This is valid but not ideal, so Butane warns about it.

--- a/tests/kola/extensions/module
+++ b/tests/kola/extensions/module
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # Should pass on all platforms if it passes on one
 ##   platforms: platform-independent
 ##   # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
 ##   distros: fcos

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -1,10 +1,9 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test only runs on FCOS as OS extensions are implemented differently on RHCOS.
 ##   distros: fcos
 ##   tags: needs-internet
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
 ##   # This is dependent on network and disk speed but we've seen the
 ##   # test take longer than 10 minutes in our aarch64 qemu tests.
 ##   timeoutMin: 15

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -1,9 +1,8 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This is a read-only test that can be run with other tests.
 ##   exclusive: false
-##   # This test should pass everywhere if it passes anywhere
-##   platforms: platform-independent
 #
 # Check if there are broken symlinks in /etc/ and /usr/.
 # See: https://github.com/coreos/fedora-coreos-config/issues/1782

--- a/tests/kola/ignition/stable-boot/test.sh
+++ b/tests/kola/ignition/stable-boot/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # We don't need to test this on every platform. If it passes in one place
-##   # it will pass everywhere.
 ##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to use `coreos-boot-disk` symlink.

--- a/tests/kola/ignition/systemd-disable/test.sh
+++ b/tests/kola/ignition/systemd-disable/test.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test is currently scoped to FCOS because `zincati` is only available
 ##   # on FCOS.
 ##   # TODO-RHCOS: Determine if any services on RHCOS may be disabled and adapt test
 ##   distros: fcos
-##   # We don't need to test this on every platform. If it passes in
-##   # one place it will pass everywhere.
-##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to disable units
 # https://github.com/coreos/fedora-coreos-tracker/issues/392

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # We don't need to test this on every platform. If it passes in
-##   # one place it will pass everywhere.
 ##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to enable systemd units of

--- a/tests/kola/ignition/systemd-unmasking/test.sh
+++ b/tests/kola/ignition/systemd-unmasking/test.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test is currently scoped to FCOS because `dnsmasq` is not masked on
 ##   # RHCOS.
 ##   # TODO-RHCOS: determine if any services on RHCOS are masked and adapt test
 ##   distros: fcos
-##   # We don't need to test this on every platform. If it passes in one place it
-##   # will pass everywhere.
-##   platforms: platform-independent
 #
 # This test makes sure that ignition is able to unmask units It just so happens
 # we have masked dnsmasq in FCOS so we can test this by unmasking it.

--- a/tests/kola/multipath/multipathd-service-fix
+++ b/tests/kola/multipath/multipathd-service-fix
@@ -1,8 +1,7 @@
 #!/bin/bash
 ## kola:
-##   exclusive: false
-##   # Just run on qemu since the answer is the same everywhere
 ##   platforms: platform-independent
+##   exclusive: false
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/bridge-static-via-kargs
+++ b/tests/kola/networking/bridge-static-via-kargs
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # Configuration of the 2 NICs for this test

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 ## kola:
-##   exclusive: false
-##   # No need to run on any other platform than QEMU.
 ##   platforms: platform-independent
+##   exclusive: false
 #
 # Since we depend so much on the default networking configurations let's
 # alert ourselves when any default networking configuration changes in

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 1 NIC for this test
 ##   additionalNics: 1
 ##   # The functionality we're testing here and the configuration for the NIC

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # appendFirstbootKernelArgs is only supported on QEMU
+##   platforms: qemu
 ##   # The functionality we're testing here.
 ##   appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
 ##   # appendFirstbootKernelArgs doesn't work on s390x

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # We use net.ifnames=0 to disable consistent network naming here because on

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2
 ##   # Configuration of the 2 NICs for this test

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # appendKernelArgs is only supported on QEMU
+##   platforms: qemu
 ##   appendKernelArgs: "nameserver=8.8.8.8 nameserver=1.1.1.1"
 ##   # appendKernelArgs doesn't work on s390x
 ##   # https://github.com/coreos/coreos-assembler/issues/2776

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # appendFirstbootKernelArgs is only supported on qemu
-##   platforms: platform-independent
+##   platforms: qemu
 ##   # Append BOOTIF kernel argument so we can test how nm-initrd-generator
 ##   # and the coreos-teardown-initramfs interact. The MAC address is from:
 ##   # https://github.com/coreos/coreos-assembler/blob/d5f1623aad6d133b2c7c00e784c04ab6828450c1/mantle/platform/metal.go#L468

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 1 NIC for this test
 ##   additionalNics: 1
 ##   # The functionality we're testing here and the configuration for the NIC.

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
-##   platforms: platform-independent
+##   # additionalNics is only suppoorted on QEMU
+##   platforms: qemu
 ##   # Add 1 additional NIC for this test
 ##   additionalNics: 1
 ##   # Set the kernel arguments so that we can set the configuration for the NIC.

--- a/tests/kola/networking/rd-net-timeout-carrier/test.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 #
 # This test verifies that NetworkManager supports configuring the

--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
+##   # additionalNics is only suppoorted on QEMU
 ##   platforms: qemu
 ##   # Add 2 NIC for this test
 ##   additionalNics: 2

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # This test pulls a container from a registry.
 ##   tags: needs-internet

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -1,10 +1,9 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test builds a container from remote sources.
 ##   # This test uses a remote NTP server.
 ##   tags: needs-internet
-##   # If the test works anywhere it should work everywhere.
-##   platforms: platform-independent
 ##   # Pulling and building the container can take a long time if a
 ##   # slow mirror gets chosen.
 ##   timeoutMin: 15

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test should pass everywhere if it passes anywhere.
 ##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 ## kola:
+##   # This test's config manually references /dev/vda and is thus QEMU only
+##   platforms: qemu
 ##   # This test only runs on FCOS due to a problem enabling a swap partition on
 ##   # RHCOS. See: https://github.com/openshift/os/issues/665
 ##   distros: fcos
-##   # additionalDisks is only supported on qemu.
-##   platforms: platform-independent
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher

--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test only runs on FCOS because countme support is not available in RHCOS
 ##   distros: fcos
 ##   tags: needs-internet
-##   # No need to run on any other platform than QEMU.
-##   platforms: platform-independent
 
 set -xeuo pipefail
 

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -5,9 +5,7 @@
 ##   # This test only runs on FCOS due to a problem with skopeo copy on
 ##   # RHCOS. See: https://github.com/containers/skopeo/issues/1846
 ##   distros: fcos
-##   # tags:
-##   #   - needs-internet - we fetch files from koji
-##   #   - platform-independent - should pass everywhere if it passes anywhere
+##   # Needs internet access as we fetch files from koji
 ##   tags: "needs-internet platform-independent"
 #
 # Build container image with a new kernel and reboot into the new image.

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -3,8 +3,7 @@
 ##   # This test doesn't meaningfully change the system and
 ##   # can be run with other tests.
 ##   exclusive: false
-##   # - This test pulls a container image from the network.
-##   # - This test should pass everywhere if it passes anywhere.
+##   # This test pulls a container image from the network.
 ##   tags: "needs-internet platform-independent"
 
 set -xeuo pipefail

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 ## kola:
+##   platforms: platform-independent
 ##   # This test only runs on FCOS because RHCOS is missing the `machinectl` command.
 ##   # Additionally, there are some distro specific choices made for this test that
 ##   # should/could be adapted for RHCOS.
 ##   # TODO-RHCOS: adapt test for RHCOS specifics or create separate RHCOS toolbox test
 ##   distros: fcos
 ##   tags: needs-internet
-##   # Only run on QEMU to reduce CI costs as nothing is platform specific here.
-##   platforms: platform-independent
 ##   # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
 ##   architectures: x86_64 aarch64
 #

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##   # restrict to qemu for now because the primary disk path is platform-dependent
-##   platforms: platform-independent
+##   # Restrict to qemu for now because the primary disk path is platform-dependent
+##   platforms: qemu
 ##   architectures: "!s390x"
 
 set -xeuo pipefail

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 ## kola:
+##   # additionalDisks is only supported on QEMU
 ##   platforms: qemu
 ##   additionalDisks: ["5G:mpath"]
 #


### PR DESCRIPTION
tests: Fix tests incorrectly marked as platform-independent

Fixes: https://github.com/coreos/fedora-coreos-config/pull/2133

---

tests: Remove redundant comments for platform-independent tests

See: https://github.com/coreos/fedora-coreos-config/pull/2133