### PR TITLE
kola/rpm-ostree/kernel-replace: add path for kernel-modules-core

### DIFF
--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -85,7 +85,9 @@ FROM localhost/fcos
 RUN rpm-ostree cliwrap install-to-root /
 ADD dracut_call.sh dracut_call.sh
 RUN cat dracut_call.sh
-RUN chmod +x dracut_call.sh && rpm-ostree override replace \
+# Once kernel-modules-core is in all supported releases, we can remove this conditional.
+RUN if rpm -q kernel-modules-core; then echo "kernel-modules-core installed.. removing"; remove="--remove kernel-modules-core"; fi && \
+    chmod +x dracut_call.sh && rpm-ostree override replace \$remove \
     https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352 && \
     ./dracut_call.sh && \
     ostree container commit


### PR DESCRIPTION
rawhide adds a new kernel-modules-core package, this PR adds a conditional path to detect if the package is installed and remove it when replacing the kernel in the test. When we update the kernel version in all tested releases to a kernel that includes this package, the conditional can be removed and code amended.