### PR TITLE
denylist: drop multipath.day2

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,10 +13,6 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
     - ppc64le
-- pattern: multipath.day2
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1206
-  arches:
-    - s390x
 - pattern: ext.config.ignition.resource.remote
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
   arches:


### PR DESCRIPTION
This is fixed now as per [1] and following.

[1]  https://github.com/coreos/fedora-coreos-tracker/issues/1206#issuecomment-1424249539