### PR TITLE
denylist: Snooze ext.config.toolbox until 2023-02-21 for rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -36,3 +36,8 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1426106534
   snooze: 2023-03-10
+- pattern: ext.config.toolbox
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1416
+  snooze: 2023-02-21
+  streams:
+    - rawhide


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/1416
See: https://github.com/containers/toolbox/issues/1233