### PR TITLE
[rawhide] overrides: pin glib2-2.74.1-3.fc38 in rawhide

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  glib2:
+    evr: 2.74.1-3.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1418
+      type: pin
   openssh:
     evr: 9.0p1-9.fc38
     metadata:


### PR DESCRIPTION
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1418