### PR TITLE
denylist: Changing tracker issues for coreos.boot-mirror and coreos-boot-mirror.luks

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,11 +6,11 @@
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.boot-mirror.luks
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
+  tracker: https://github.com/coreos/coreos-assembler/issues/3360
   arches:
     - ppc64le
 - pattern: coreos.boot-mirror
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
+  tracker: https://github.com/coreos/coreos-assembler/issues/3361
   arches:
     - ppc64le
 - pattern: ext.config.ignition.resource.remote


### PR DESCRIPTION
Changed tracker issues for  coreos.boot-mirror and coreos.boot-mirror.luks for ppc64le arch Updated the issues with latest kola runs
https://github.com/coreos/coreos-assembler/issues/3360 (coreos.boot-mirror.luks) https://github.com/coreos/coreos-assembler/issues/3361 (coreos.boot-mirror)
Signed-off-by: Shilpi Das <shdas@redhat.com>