### PR TITLE
denylist: snooze `ext.config.extensions.module` for now

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,3 +41,8 @@
   snooze: 2023-02-21
   streams:
     - rawhide
+- pattern: ext.config.extensions.module
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1420
+  snooze: 2023-03-08
+  streams:
+    - rawhide


### PR DESCRIPTION
Issue: coreos/fedora-coreos-tracker#1420