### PR TITLE
[rhcos-4.12] Bug 10275: Lazily unmount /proc/cmdline

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/ostree-cmdline.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/ostree-cmdline.sh
@@ -15,7 +15,7 @@ case "${1:-unset}" in
         mount --bind /tmp/cmdline /proc/cmdline
         ;;
     stop)
-        umount /proc/cmdline
+        umount -l /proc/cmdline
         rm /tmp/cmdline
         ;;
     *)


### PR DESCRIPTION
See: https://issues.redhat.com/browse/OCPBUGS-10275

It's possible that some other process has a file descriptor open for `/proc/cmdline`; if so our unmount will fail.  Do the unmount lazily - it was designed for exactly this situation.

This was seen in an OCP installation on vSphere at least once.

(cherry picked from commit 342a91f506c26c21db0fe16a540ab91418a7f029)