### PR TITLE
Revert "denylist: Snooze ext.config.toolbox until 2023-02-21 for rawide"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -36,11 +36,6 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1426106534
   snooze: 2023-03-10
-- pattern: ext.config.toolbox
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1416
-  snooze: 2023-02-21
-  streams:
-    - rawhide
 - pattern: ext.config.extensions.module
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1420
   snooze: 2023-03-08


### PR DESCRIPTION
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1416

This reverts commit 0551699b3cd512a77c65dff7041cbee7241f47dd.

---

Tested that the following commands work:

```
$ podman pull registry.fedoraproject.org/fedora-toolbox:39
$ toolbox create -d fedora -r 39
$ toolbox enter fedora-toolbox-39
$ cat /etc/os-release | grep 39
...
VERSION_ID=39
...
```