### PR TITLE
[branched] manifest: bump to F38

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 37
+releasever: 38
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 38 has now been branched from rawhide