### PR TITLE
denylist: snooze tests that use Butane 1.5.0-experimental

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -14,15 +14,20 @@
   arches:
     - ppc64le
 - pattern: ext.config.ignition.resource.remote
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  arches:
-    - s390x
-  streams:
-    - next-devel
-    - next
-    - testing-devel
-    - testing
-    - stable
+  tracker: https://github.com/coreos/ignition/pull/1558
+  snooze: 2023-03-06
+  #tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  #arches:
+  #  - s390x
+  #streams:
+  #  - next-devel
+  #  - next
+  #  - testing-devel
+  #  - testing
+  #  - stable
+- pattern: ext.config.butane.grub-users
+  tracker: https://github.com/coreos/ignition/pull/1558
+  snooze: 2023-03-06
 - pattern: rpmostree.install-uninstall
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
   arches:


### PR DESCRIPTION
We're ratcheting in a spec stabilization.  The Ignition repo has a workaround for ratcheting Ignition configs using the experimental spec, but we've started using Butane configs in tests, and that requires a double ratchet.  For now, just snooze the affected tests.

cc @prestist