### PR TITLE
denylist: snooze files.file-directory-permissions test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,3 +46,10 @@
   snooze: 2023-03-08
   streams:
     - rawhide
+- pattern: ext.config.files.file-directory-permissions
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1427
+  snooze: 2023-03-08
+  streams:
+    - rawhide
+    - branched
+    - next-devel


### PR DESCRIPTION
This is failing because the 98-default-mac-none.link  from systemd-udev has group write permissions. See
https://github.com/coreos/fedora-coreos-tracker/issues/1427