### PR TITLE
denylist: snooze another test that uses Butane 1.5.0-experimental

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,6 +25,9 @@
   #  - testing-devel
   #  - testing
   #  - stable
+- pattern: ext.config.ignition.resource.authenticated-s3
+  tracker: https://github.com/coreos/ignition/pull/1558
+  snooze: 2023-03-06
 - pattern: ext.config.butane.grub-users
   tracker: https://github.com/coreos/ignition/pull/1558
   snooze: 2023-03-06


### PR DESCRIPTION
This one only runs on AWS, so we missed it before.

Fixes #2252.