### PR TITLE
[rawhide] overrides: drop systemd-252.4-4.fc38 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,33 +24,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
       type: pin
-  systemd:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin
-  systemd-container:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin
-  systemd-libs:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin
-  systemd-pam:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin
-  systemd-resolved:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin
-  systemd-udev:
-    evr: 252.4-4.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1402
-      type: pin


### PR DESCRIPTION
The feature that caused us to pin systemd has been temporarily reverted in systemd [1]. We still need to fix our coreos-platform-chrony generator but we can unpin systemd for now so we get more test coverage on the latest bits.

[1] https://src.fedoraproject.org/rpms/systemd/c/4bdd16eba5c409a5aa0afcc16f6e284f20793e06?branch=rawhide