### PR TITLE
overrides: fast-track ignition-2.15.0-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,7 @@
 
 packages:
   ignition:
-    evr: 2.15.0-1.fc37
+    evr: 2.15.0-3.fc37
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bcd536e05c
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-5a7c2a5c5b
       type: fast-track


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).