### PR TITLE
denylist: deny kdump.crash test on aarch64 for f38 streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -56,3 +56,12 @@
     - rawhide
     - branched
     - next-devel
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
+  snooze: 2023-03-08
+  arches:
+    - aarch64
+  streams:
+    - rawhide
+    - branched
+    - next-devel


### PR DESCRIPTION
It's failing with the latest kernel updates. See
https://github.com/coreos/fedora-coreos-tracker/issues/1430