### PR TITLE
overlay.d/35coreos-live: pull in coreos-enable-network.service on live boots

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -30,6 +30,9 @@ fi
 add_requires sysroot.mount     initrd-root-fs.target
 add_requires sysroot-etc.mount initrd-root-fs.target
 add_requires sysroot-var.mount initrd-root-fs.target
+# make sure we enable network if required for coreos-livepxe-rootfs
+# https://github.com/coreos/fedora-coreos-tracker/issues/1423
+add_requires coreos-enable-network.service initrd-root-fs.target
 
 mkdir -p "${UNIT_DIR}/ostree-prepare-root.service.d"
 cat > "${UNIT_DIR}/ostree-prepare-root.service.d/10-live.conf" <<EOF


### PR DESCRIPTION
After 937d329 coreos-enable-network.service is load bearing for coreos-livepxe-rootfs.service if ignition.firstboot isn't provided on the kernel command line. Let's pull it back in for live boots.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1423