### PR TITLE
networking-tools: Add nmstate

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,3 +34,8 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
       type: pin
+  nmstate:
+    evr: 2.2.8-2.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-59543876eb
+      type: fast-track

--- a/manifests/networking-tools.yaml
+++ b/manifests/networking-tools.yaml
@@ -19,3 +19,6 @@ packages:
   - iptables nftables
   # Interactive network tools for admins
   - socat net-tools bind-utils
+  # Declarative network configuration
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1175
+  - nmstate

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -32,3 +32,6 @@ enable rtas_errd.service
 enable clevis-luks-askpass.path
 # Provide status information about the Ignition run
 enable coreos-ignition-write-issues.service
+# Apply network configuration from /etc/nmstate/*.yml
+# We can drop this after merging https://src.fedoraproject.org/rpms/fedora-release/pull-request/255
+enable nmstate.service

--- a/tests/kola/networking/nmstate/data/nmstate-common.sh
+++ b/tests/kola/networking/nmstate/data/nmstate-common.sh
@@ -1,0 +1,23 @@
+. $KOLA_EXT_DATA/commonlib.sh
+
+main() {
+    nmstatectl show
+    journalctl -u nmstate
+    
+    local prefix="first boot"
+    if [ "${AUTOPKGTEST_REBOOT_MARK:-}" == rebooted ]; then
+        prefix="second boot"
+    fi
+    
+    if ! nmcli c show br-ex; then
+        fatal "${prefix}: bridge not configured"
+    fi
+
+    if ! ls /etc/nmstate/*applied; then
+        fatal "${prefix}: nmstate yamls files not marked as applied"    
+    fi
+
+    if [ "${AUTOPKGTEST_REBOOT_MARK:-}" == "" ]; then
+        /tmp/autopkgtest-reboot rebooted
+    fi
+}

--- a/tests/kola/networking/nmstate/policy/config.bu
+++ b/tests/kola/networking/nmstate/policy/config.bu
@@ -1,0 +1,24 @@
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/nmstate/br-ex-policy.yml
+      contents:
+        inline: |
+          capture:
+            default-gw-route: routes.running.destination=="0.0.0.0/0"
+            default-gw-iface: interfaces.name==capture.default-gw-route.routes.running.0.next-hop-interface
+          desiredState:
+            interfaces:
+            - name: "{{ capture.default-gw-iface.interfaces.0.name }}"
+              type: ethernet
+              state: up
+            - name: br-ex
+              type: linux-bridge
+              copy-mac-from: "{{ capture.default-gw-iface.interfaces.0.name }}"
+              state: up
+              ipv4: "{{ capture.default-gw-iface.interfaces.0.ipv4 }}"
+              ipv6: "{{ capture.default-gw-iface.interfaces.0.ipv6 }}"
+              bridge:
+                port:
+                - name: "{{ capture.default-gw-iface.interfaces.0.name }}"

--- a/tests/kola/networking/nmstate/policy/data/commonlib.sh
+++ b/tests/kola/networking/nmstate/policy/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/networking/nmstate/policy/data/nmstate-common.sh
+++ b/tests/kola/networking/nmstate/policy/data/nmstate-common.sh
@@ -1,0 +1,1 @@
+../../data/nmstate-common.sh

--- a/tests/kola/networking/nmstate/policy/test.sh
+++ b/tests/kola/networking/nmstate/policy/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+## kola:
+##   tags: "platform-independent needs-internet"
+#
+# Configure a DHCP linux bridge using butane and nmstate service with policy
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/nmstate-common.sh
+
+main

--- a/tests/kola/networking/nmstate/state/config.bu
+++ b/tests/kola/networking/nmstate/state/config.bu
@@ -1,0 +1,17 @@
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+    - path: /etc/nmstate/br-ex.yml
+      contents:
+        inline: |
+          interfaces:
+           - name: br-ex
+             type: linux-bridge
+             state: up
+             ipv4:
+               enabled: false
+             ipv6:
+               enabled: false
+             bridge:
+               port: []

--- a/tests/kola/networking/nmstate/state/data/commonlib.sh
+++ b/tests/kola/networking/nmstate/state/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/networking/nmstate/state/data/nmstate-common.sh
+++ b/tests/kola/networking/nmstate/state/data/nmstate-common.sh
@@ -1,0 +1,1 @@
+../../data/nmstate-common.sh

--- a/tests/kola/networking/nmstate/state/test.sh
+++ b/tests/kola/networking/nmstate/state/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+## kola:
+##   tags: "platform-independent needs-internet"
+#
+# Configure a DHCP linux bridge using butane and nmstate service with state
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/nmstate-common.sh
+
+main


### PR DESCRIPTION
As [discussed](https://github.com/coreos/fedora-coreos-tracker/issues/1175) the nmstatectl tool is going to be added to FCOS, it will allow to declare the network configuration at boot time

