### PR TITLE
ci: update for new kolaTestIso()

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -46,7 +46,7 @@ cosaPod(cpus: 4, memory: "9Gi") {
 
     stage("Test ISO") {
         shwrap("cd /srv/coreos && cosa buildextend-live")
-        kolaTestIso(extraArgs4k: "--no-pxe")
+        kolaTestIso()
     }
 
     // also print the pkgdiff as a separate stage to make it more visible


### PR DESCRIPTION
The `extraArgs4k` parameter no longer does anything. Just remove it so it's clear that we're accepting the default set of tests from `kola testiso`.

This will run more tests than before. We'll likely cut down tests we consider redundant soon, but that should be transparent to this code.