### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  ignition:
-    evr: 2.15.0-3.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-5a7c2a5c5b
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).