### PR TITLE
tests/kola: add version comparison functions to commonlib.sh

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -86,3 +86,31 @@ is_service_active() {
     # return actual result
     systemctl is-active "${service}"
 }
+
+## Some functions to support version comparison
+# Returns true iff $1 is equal to $2
+vereq() {
+    [ "$1" == "$2" ]
+}
+
+# Returns true iff $1 is less than $2
+verlt() {
+    vereq $1 $2 && return 1
+    local lowest="$(echo -e "$1\n$2" | sort -V | head -n 1)"
+    [ "$1" == "$lowest" ]
+}
+
+# Returns true iff $1 is less than or equal to $2
+verlte() {
+    vereq $1 $2 || verlt $1 $2
+}
+
+# Returns true iff $1 is greater than to $2
+vergt() {
+    ! verlte $1 $2
+}
+
+# Returns true iff $1 is greater than or equal to $2
+vergte() {
+    vereq $1 $2 || vergt $1 $2
+}

--- a/tests/kola/systemd/default-unit-timeouts
+++ b/tests/kola/systemd/default-unit-timeouts
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
+##   tags: "platform-independent"
 #
 # Checks if default shutdown time is 1m 30s
 #

--- a/tests/kola/systemd/default-unit-timeouts
+++ b/tests/kola/systemd/default-unit-timeouts
@@ -41,7 +41,7 @@ else
     fatal $error
 fi
 
-if [[ "${systemd_version}" == "${required_version}" || "${systemd_version}" > "${required_version}" ]]; then
+if vergte "${systemd_version}" "${required_version}"; then
     if [[ $DefaultDeviceTimeoutUSec == "$timeout" ]]; then
         ok "The default device timeout is 1m 30 seconds."
     else

--- a/tests/kola/systemd/default-unit-timeouts
+++ b/tests/kola/systemd/default-unit-timeouts
@@ -16,7 +16,10 @@ DefaultTimeoutStopUSec=$(systemctl show --value --property=DefaultTimeoutStopUSe
 DefaultTimeoutAbortUSec=$(systemctl show --value --property=DefaultTimeoutAbortUSec)
 DefaultDeviceTimeoutUSec=$(systemctl show --value --property=DefaultDeviceTimeoutUSec)
 
-error="DefaultTimeoutStartUsec=$DefaultTimeoutStartUSec DefaultTimeoutStopUSec=$DefaultTimeoutStopUSec DefaultTimeoutAbortUSec=$DefaultTimeoutAbortUSec DefaultDeviceTimeoutUSec=$DefaultDeviceTimeoutUSec"
+error="DefaultTimeoutStartUsec=$DefaultTimeoutStartUSec "
+error+="DefaultTimeoutStopUSec=$DefaultTimeoutStopUSec "
+error+="DefaultTimeoutAbortUSec=$DefaultTimeoutAbortUSec "
+error+="DefaultDeviceTimeoutUSec=$DefaultDeviceTimeoutUSec"
 timeout="1min 30s"
 
 systemd_version=$(rpm -q --queryformat '%{VERSION}' systemd)


### PR DESCRIPTION
Leveraging these functions will make it easier to do comparision checks inside of our tests.

Specifically for RPM version comparisons something like /usr/bin/rpmdev-vercmp would be better but that would require having rpmdevtools installed in FCOS, which we don't have.