### PR TITLE
platform-chrony: Make /run/coreos dir so we can create platform-chrony.conf

### DIFF
--- a/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
+++ b/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
@@ -19,6 +19,7 @@ if ! cmp {/usr,}/etc/chrony.conf >/dev/null; then
     exit 0
 fi
 
+mkdir -p /run/coreos
 confpath=/run/coreos/platform-chrony.conf
 altenvfilepath=/run/coreos/sysconfig-chrony
 cmdline=( $(</proc/cmdline) )


### PR DESCRIPTION
We are hitting `/usr/libexec/coreos-platform-chrony-config: line 61: /run/coreos/platform-chrony.conf: No such file or directory` error for a few kola tests. To fix that, we will create the required directory(`/run/coreos/`) beforehand.