### PR TITLE
denylist: bump snooze for files.file-directory-permissions

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -51,11 +51,11 @@
     - rawhide
 - pattern: ext.config.files.file-directory-permissions
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1427
-  snooze: 2023-03-08
+  snooze: 2023-03-20
   streams:
-    - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
   snooze: 2023-03-08


### PR DESCRIPTION
The systemd package in F38 (next-devel/branched) is frozen right now so we won't get the fix for this until after beta is released. Let's snooze again for now.