### PR TITLE
denylist: bump snooze for kdump.crash and drop extensions.module

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -44,11 +44,6 @@
 - pattern: ext.config.platforms.aws.nvme
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1426106534
   snooze: 2023-03-10
-- pattern: ext.config.extensions.module
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1420
-  snooze: 2023-03-08
-  streams:
-    - rawhide
 - pattern: ext.config.files.file-directory-permissions
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1427
   snooze: 2023-03-20

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -58,10 +58,11 @@
     - next
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-03-08
+  snooze: 2023-03-22
   arches:
     - aarch64
   streams:
     - rawhide
     - branched
     - next-devel
+    - next


### PR DESCRIPTION
We are still waiting on updates for [#1430 ](https://github.com/coreos/fedora-coreos-tracker/issues/1430) so bumping the snooze for `kdump.crash for now. Also dropping `ext.config.extensions.module` from denylist as the test passes in rawhide now.
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1420