### PR TITLE
denylist: drop snooze for ext.config.platforms.aws.nvme

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,9 +33,6 @@
     - testing-devel
     - testing
     - stable
-- pattern: ext.config.platforms.aws.nvme
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1426106534
-  snooze: 2023-03-10
 - pattern: ext.config.files.file-directory-permissions
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1427
   snooze: 2023-03-20


### PR DESCRIPTION
Recent tests are passing. Hopefully the issue in the AWS environment is fully resolved now.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1306#issuecomment-1464560791