### PR TITLE
[next-devel] overrides: fast-track rust-coreos-installer-0.17.0-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,6 +33,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f7a298ee7d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1356#issuecomment-1463962490
       type: fast-track
+  coreos-installer:
+    evr: 0.17.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-8c9cfc425e
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.17.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-8c9cfc425e
+      type: fast-track
   gnutls:
     evr: 3.8.0-2.fc38
     metadata:


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).