### PR TITLE
[rawhide] overrides: drop openssh-9.0p1-9.fc38 override

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,19 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  openssh:
-    evr: 9.0p1-9.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: pin
-  openssh-clients:
-    evr: 9.0p1-9.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: pin
-  openssh-server:
-    evr: 9.0p1-9.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: pin
+packages: {}


### PR DESCRIPTION
This is handled now with https://src.fedoraproject.org/rpms/openssh/pull-request/40