### PR TITLE
denylist: drop next/next-devel streams for some tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,8 +18,6 @@
   arches:
     - s390x
   streams:
-    - next-devel
-    - next
     - testing-devel
     - testing
     - stable
@@ -28,8 +26,6 @@
   arches:
     - s390x
   streams:
-    - next-devel
-    - next
     - testing-devel
     - testing
     - stable


### PR DESCRIPTION
These tests pass on F38+ and `next`/`next-devel` have moved to F38.