### PR TITLE
denylist: drop ext.config.files.file-directory-permissions denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -29,13 +29,6 @@
     - testing-devel
     - testing
     - stable
-- pattern: ext.config.files.file-directory-permissions
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1427
-  snooze: 2023-03-20
-  streams:
-    - branched
-    - next-devel
-    - next
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
   snooze: 2023-03-22


### PR DESCRIPTION
The new systemd made it into Fedora 38 now too.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1427