### PR TITLE
kola: Add ignition.journald-log test

### DIFF
--- a/tests/kola/ignition/data/commonlib.sh
+++ b/tests/kola/ignition/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/ignition/journald-log
+++ b/tests/kola/ignition/journald-log
@@ -1,0 +1,19 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+ignitionJournalMsgId="57124006b5c94805b77ce473e92a8aeb"
+
+# See https://github.com/coreos/ignition/pull/958
+# for the MESSAGE_ID source. It will track the
+# journal messages related to an ignition config
+# provided by the user.
+num=$(journalctl -o json-pretty MESSAGE_ID=$ignitionJournalMsgId | jq -s ".[] | select(.IGNITION_CONFIG_TYPE == \"user\")" | wc -l)
+
+if [ "$num" -eq 0 ]; then
+  fatal "Ignition didn't write $ignitionJournalMsgId"
+fi
+ok "ignition successfully wrote $ignitionJournalMsgId"


### PR DESCRIPTION
Converting `coreos.ignition.journald-log` test to an external one.
Ref: https://github.com/coreos/coreos-assembler/pull/3391#pullrequestreview-1339641509