### PR TITLE
[next-devel] overrides: pin on kernel-6.1.18-200.fc37 from F37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,3 +19,18 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-8c9cfc425e
       type: fast-track
+  kernel:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin
+  kernel-core:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin
+  kernel-modules:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin


### PR DESCRIPTION
The new 6.2 kernel can cause aarch64 systems originally installed on F36- to not boot. For now while we figure out the best path forward we'll ship the newest 6.1 kernel we can find, which just happens to be built against F37.

See https://github.com/coreos/fedora-coreos-tracker/issues/1441