### PR TITLE
overrides: pin kernel-6.1.18-200.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,3 +19,18 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d6f3402ea1
       type: fast-track
+  kernel:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin
+  kernel-core:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin
+  kernel-modules:
+    evr: 6.1.18-200.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).