### PR TITLE
[next] overlay/15fcos: upgrade bootloader on aarch64 at boot

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -1,3 +1,6 @@
 enable coreos-check-ssh-keys.service
 # Check if cgroupsv1 is still being used
 enable coreos-check-cgroups.service
+# Upgrade aarch64 bootloader to avoid
+# https://github.com/coreos/fedora-coreos-tracker/issues/1441
+enable coreos-bootupctl-update-aarch64.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-bootupctl-update-aarch64.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-bootupctl-update-aarch64.service
@@ -1,0 +1,15 @@
+# Remove after the next barrier release
+# https://github.com/coreos/fedora-coreos-tracker/issues/1441
+
+[Unit]
+Description=Update aarch64 Bootloader
+ConditionArchitecture=arm64
+ConditionFirmware=uefi
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bootupctl update
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On aarch64, kernel 6.2 won't boot with older versions of GRUB.  In preparation for switching to the new kernel, add a systemd service that uses bootupd to update the bootloader on aarch64 systems.

Revert this after the next barrier release.

For https://github.com/coreos/fedora-coreos-tracker/issues/1441.  Not heavily tested.