### PR TITLE
overrides: pin xfsprogs-5.18.0-3.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,8 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-59543876eb
       type: fast-track
+  xfsprogs:
+    evr: 5.18.0-3.fc37
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1443
+      type: pin


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).