### PR TITLE
denylist: bump snooze for ext.config.kdump.crash on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,7 +31,7 @@
     - stable
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-03-22
+  snooze: 2023-04-12
   arches:
     - aarch64
   streams:


### PR DESCRIPTION
This is still a problem. See
https://github.com/coreos/fedora-coreos-tracker/issues/1430#issuecomment-1479842542