### PR TITLE
[next-devel] overrides: fast-track dracut-059-2.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  dracut:
+    evr: 059-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
+      type: fast-track
+  dracut-network:
+    evr: 059-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
+      type: fast-track
+  dracut-squash:
+    evr: 059-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).