### PR TITLE
overrides: drop kernel-6.1.18-200.fc37 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,21 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 6.1.18-200.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
-      type: pin
-  kernel-core:
-    evr: 6.1.18-200.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
-      type: pin
-  kernel-modules:
-    evr: 6.1.18-200.fc37
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1441
-      type: pin
   xfsprogs:
     evr: 5.18.0-3.fc37
     metadata:


### PR DESCRIPTION
Since the barrier release for [1] shipped in 37.20230322.2.0 we can now unpin and ship the 6.2 kernel.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1441