### PR TITLE
Remove the fedora-rawhide-nodebug-kernel repo from fedora-rawhide.repo

### DIFF
--- a/fedora-rawhide.repo
+++ b/fedora-rawhide.repo
@@ -14,25 +14,3 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 skip_if_unavailable=False
-excludepkgs=kernel kernel-core kernel-modules kernel-modules-core
-
-# We are choosing to use only nodebug kernels in Fedora CoreOS
-# for our testing. We've seen too many issues where an issue either
-# shows up only on the debug kernels OR a debug kernel gives us a
-# false positive or negative when trying to root cause a failure.
-# Thus we use the nodebug kernel repo [1] and includepkgs=kernel
-# here and excludepkgs=kernel above.
-#
-# [1] https://fedoraproject.org/wiki/RawhideKernelNodebug
-[fedora-rawhide-nodebug-kernel]
-name=nodebug kernels for Rawhide
-baseurl=https://dl.fedoraproject.org/pub/alt/rawhide-kernel-nodebug/$basearch/
-enabled=1
-countme=1
-metadata_expire=6h
-repo_gpgcheck=0
-type=rpm
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
-skip_if_unavailable=False
-includepkgs=kernel kernel-core kernel-modules kernel-modules-core


### PR DESCRIPTION
This was originally added in ff9bf0e. There is no longer any need to pull from the separate repo because the policy has changed [1] and now forced debug won't be on for any kernels built and submitted to rawhide.

[1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/MDJUE324EVG7CVG5UCTZCXPCOMOWMX5M/