### PR TITLE
[rawhide] Revert "manifest: include fedora-rawhide-nodebug-kernel repo"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,6 +6,5 @@ releasever: 39
 
 repos:
   - fedora-rawhide
-  - fedora-rawhide-nodebug-kernel
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
This reverts commit e54a2747ba0c1c573f40e56a76c76e82a80400bc.

There is no longer any need to pull from the separate repo because the policy has changed [1] and now forced debug won't be on for any kernels built and submitted to rawhide.

[1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/MDJUE324EVG7CVG5UCTZCXPCOMOWMX5M/