### PR TITLE
denylist: expand kdump.crash denial to all streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,8 +34,3 @@
   snooze: 2023-04-12
   arches:
     - aarch64
-  streams:
-    - rawhide
-    - branched
-    - next-devel
-    - next


### PR DESCRIPTION
The 6.2 kernel is now heading towards our production streams so the failure will propagate there.

See https://github.com/coreos/fedora-coreos-tracker/issues/1430