### PR TITLE
overrides: fast-track nmstate-2.2.9-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,12 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  nmstate:
+    evr: 2.2.9-2.fc37
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2122902605
+      reason: https://github.com/coreos/coreos-assembler/pull/3397
+      type: fast-track
   xfsprogs:
     evr: 5.18.0-3.fc37
     metadata:


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).