### PR TITLE
[next-devel] overrides: fast-track nmstate-2.2.9-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -27,3 +27,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
       type: fast-track
+  nmstate:
+    evr: 2.2.9-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a226c4298d
+      reason: https://github.com/coreos/coreos-assembler/pull/3397
+      type: fast-track


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).