### PR TITLE
overrides: fast-track xfsprogs-6.1.0-2.fc37

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -16,7 +16,8 @@ packages:
       reason: https://github.com/coreos/coreos-assembler/pull/3397
       type: fast-track
   xfsprogs:
-    evr: 5.18.0-3.fc37
+    evr: 6.1.0-2.fc37
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-59700c9754
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1443
-      type: pin
+      type: fast-track


### PR DESCRIPTION
Requested by @bgilbert via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).