### PR TITLE
denylist: re-snooze tests using Butane experimental spec

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -14,13 +14,21 @@
   arches:
     - ppc64le
 - pattern: ext.config.ignition.resource.remote
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  arches:
-    - s390x
-  streams:
-    - testing-devel
-    - testing
-    - stable
+  tracker: https://github.com/coreos/butane/issues/430
+  snooze: 2023-03-31
+  #tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
+  #arches:
+  #  - s390x
+  #streams:
+  #  - testing-devel
+  #  - testing
+  #  - stable
+- pattern: ext.config.ignition.resource.authenticated-s3
+  tracker: https://github.com/coreos/butane/issues/430
+  snooze: 2023-03-31
+- pattern: ext.config.butane.grub-users
+  tracker: https://github.com/coreos/butane/issues/430
+  snooze: 2023-03-31
 - pattern: rpmostree.install-uninstall
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
   arches:


### PR DESCRIPTION
Allow ratcheting the Butane spec stabilization into coreos-assembler.