### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,24 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  dracut:
-    evr: 059-2.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
-      type: fast-track
-  dracut-network:
-    evr: 059-2.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
-      type: fast-track
-  dracut-squash:
-    evr: 059-2.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e8ca690ff3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/919
-      type: fast-track
   nmstate:
     evr: 2.2.9-1.fc38
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).