### PR TITLE
overlay.d/20platform-chrony: additional skip of platform chrony config

### DIFF
--- a/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
+++ b/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
@@ -18,6 +18,10 @@ if ! cmp {/usr,}/etc/chrony.conf >/dev/null; then
     echo "$self: /etc/chrony.conf is modified; not changing the default"
     exit 0
 fi
+if ! cmp {/usr,}/etc/sysconfig/chronyd >/dev/null; then
+    echo "$self: /etc/sysconfig/chronyd is modified; not changing the default"
+    exit 0
+fi
 
 mkdir -p /run/coreos
 confpath=/run/coreos/platform-chrony.conf


### PR DESCRIPTION
Typically we'd think the user would only pass in optional arguments to chrony via OPTIONS in /etc/sysconfig/chronyd but we found a case where a user was providing actual config directives. Let's also exit early out of coreos-platform-chrony-config if /etc/sysconfig/chronyd has been touched. If either /etc/chrony.conf or /etc/sysconfig/chronyd has been touched we just consider the user to own the config and not do anything special based on the platform.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1449