### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,9 +15,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2122902605
       reason: https://github.com/coreos/coreos-assembler/pull/3397
       type: fast-track
-  xfsprogs:
-    evr: 6.1.0-2.fc37
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-59700c9754
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1443
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).