### PR TITLE
tests/kola: a few updates for the upgrade test

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -32,14 +32,16 @@ set -eux -o pipefail
 #       - tail -f tmp/kola/ext.config.upgrade.extended/*/journal.txt | grep --color -i 'ok reached version'
 #
 # For convenience, here is a list of the earliest releases on each
-# stream/architecture:
+# stream/architecture. x86_64 minimum version has to be 32.x because
+# of https://github.com/coreos/fedora-coreos-tracker/issues/1448
 #
 # stable
-#   - x86_64  31.20200108.3.0
+#   - x86_64  31.20200108.3.0 -> works for BIOS, not UEFI
+#             32.20200601.3.0
 #   - aarch64 34.20210821.3.0
 #   - s390x   36.20220618.3.1
 # testing
-#   - x86_64  30.20190716.1
+#   - x86_64  32.20200601.2.1
 #   - aarch64 34.20210904.2.0
 #   - s390x   36.20220618.2.0
 # next

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -101,7 +101,8 @@ ok "Reached version: $version"
 # If so then we can exit with success!
 if vereq $version $target_version; then
     ok "Fully upgraded to $target_version"
-    bootupctl status
+    # log bootupctl information for inspection where available
+    [ -f /usr/bin/bootupctl ] && /usr/bin/bootupctl status
     exit 0
 fi
 


### PR DESCRIPTION
```
commit 56c038edab6e856dd8fa2aae0519396991114b6d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Mar 28 21:48:46 2023 -0400

    tests/kola: support injecting target stream for extended upgrade test
    
    This will allow someone to inject (via --append-butane) an
    /etc/target_stream file into the node used for the upgrade test.
    
    ```
    $ cat stream.bu
    variant: fcos
    version: 1.4.0
    storage:
      files:
        - path: /etc/target_stream
          mode: 0644
          contents:
            inline: |
              rawhide
    $ cosa kola run --tag extended-upgrade --build=37.20230303.1.1 --append-butane=stream.bu
    ```

commit cda732602e37c7fc8a576f3038bba250b4204c91
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Mar 24 23:56:00 2023 -0400

    tests/kola: only print bootupctl info if exists in upgrade test
    
    This won't exist on ppc64le and s390x. Let's avoice the failure
    there.

commit 7a651d63f26346b4be06aa46c681fabf43f564cf
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Mar 24 23:54:56 2023 -0400

    tests/kola: update info about starting versions for upgrade test
    
    We can't really perform the test for <F31 because of a bootloader
    incompatibility. See https://github.com/coreos/fedora-coreos-tracker/issues/1448

```
