### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,45 +9,9 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  fedora-release-common:
-    evra: 38-0.32.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: fast-track
-  fedora-release-coreos:
-    evra: 38-0.32.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: fast-track
-  fedora-release-identity-coreos:
-    evra: 38-0.32.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: fast-track
   nmstate:
     evr: 2.2.9-1.fc38
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a226c4298d
       reason: https://github.com/coreos/coreos-assembler/pull/3397
-      type: fast-track
-  openssh:
-    evr: 9.0p1-14.fc38.1
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: fast-track
-  openssh-clients:
-    evr: 9.0p1-14.fc38.1
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
-      type: fast-track
-  openssh-server:
-    evr: 9.0p1-14.fc38.1
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bb12d0efe6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1394
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).