### PR TITLE
overlay.d/05core: don't omit dracut modules we don't ship anyway

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
@@ -12,4 +12,4 @@ omit_dracutmodules+=" systemd-networkd network-legacy network-wicked "
 # We use systemd network naming
 omit_dracutmodules+=" biosdevname "
 # Random stuff we don't want
-omit_dracutmodules+=" rngd busybox dbus-daemon memstrack pcsc bluetooth "
+omit_dracutmodules+=" dbus-daemon memstrack "


### PR DESCRIPTION
We don't ship rngd, busybox, pcscd, or bluetooth, so there's no point in listing them as modules to omit; the modules already know they can't be installed.

This allows users to more easily include them in the initrd if they do decide to overlay those packages and want them in the initrd (by enabling local initramfs regeneration). Another use case is kata- containers, which creates the guest OS using bits from the host and wants to be able to include busybox for debugging purposes.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1450