### PR TITLE
[rhcos-4.13] tests/kola: stabilize Butane 1.5.0 spec

### DIFF
--- a/tests/kola/butane/grub-users/config.bu
+++ b/tests/kola/butane/grub-users/config.bu
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.5.0-experimental
+version: 1.5.0
 grub:
   users:
     - name: bovik

--- a/tests/kola/ignition/resource/authenticated-s3/config.bu
+++ b/tests/kola/ignition/resource/authenticated-s3/config.bu
@@ -2,7 +2,7 @@
 # associated with the instance
 
 variant: fcos
-version: 1.5.0-experimental
+version: 1.5.0
 ignition:
   config:
     merge:

--- a/tests/kola/ignition/resource/remote/config.bu
+++ b/tests/kola/ignition/resource/remote/config.bu
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.5.0-experimental
+version: 1.5.0
 storage:
   files:
     - path: /var/resource/http


### PR DESCRIPTION
(cherry picked from commit b0ffe7c29d74d2d520a816ee4e194be13ff9fcce)