### PR TITLE
[next-devel] overrides: fast-track podman-4.4.4-3.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  podman:
+    evr: 5:4.4.4-3.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-c6f82ee005
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1455
+      type: fast-track
+  podman-plugins:
+    evr: 5:4.4.4-3.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-c6f82ee005
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1455
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).