### PR TITLE
coreos-teardown-initramfs: teardown after NM has exited

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.service
@@ -18,6 +18,14 @@ DefaultDependencies=false
 Before=ignition-mount.service
 Before=ignition-complete.target
 
+# Since we are tearing down networking we need to make sure
+# NetworkManager has been stopped, otherwise it'll be trying
+# to react to our delete/down operations. Since the ordering
+# for ExecStop is the opposite of ExecStart we need to use
+# `Before=nm-initrd.service`.
+# https://issues.redhat.com/browse/OCPBUGS-11052
+Before=nm-initrd.service
+
 # Make sure ExecStop= runs before we switch root
 Conflicts=initrd-switch-root.target umount.target
 Before=initrd-switch-root.target


### PR DESCRIPTION
We haven't seen this before, but recently there was a case where in RHCOS based on RHEL 9 we saw the coreos-teardown-initramfs happening before the nm-initrd.service had been stopped during switch root. We need to guarantee that NetworkManager is stopped before we start the teardown.

Seen in https://issues.redhat.com/browse/OCPBUGS-11052