### PR TITLE
tests/kola: upgrade.extended: get info about booted deployment

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -57,8 +57,11 @@ if [ -f /etc/zincati/config.d/90-disable-auto-updates.toml ]; then
     systemctl restart zincati
 fi
 
-version=$(rpm-ostree status  --json | jq -r '.deployments[0].version')
-stream=$(rpm-ostree status  --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]')
+get_booted_deployment_json() {
+    rpm-ostree status  --json | jq -r '.deployments[] | select(.booted == true)'
+}
+version=$(get_booted_deployment_json | jq -r '.version')
+stream=$(get_booted_deployment_json | jq -r '.["base-commit-meta"]["fedora-coreos.stream"]')
 
 # Pick up the last release for the current stream
 test -f /srv/releases.json || \


### PR DESCRIPTION
I've seen a case where zincati/rpm-ostree stage an update before the kola script even runs so the information we pick up from `rpm-ostree status  --json | jq -r '.deployments[0]` is actually from the staged (not booted) deployment, which leads to us thinking we're one step further than we need to be in the process and then hitting an error when the `rpm-ostree rebase` fails because there is an rpm-ostree operation already in progress.

Let's pick up the information from the booted deployment to get rid of this race condition.