### PR TITLE
[rhcos-4.13] Add 30gcp-udev-rules overlay to the manifest

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -21,6 +21,7 @@ ostree-layers:
   - overlay/09misc
   - overlay/20platform-chrony
   - overlay/25azure-udev-rules
+  - overlay/30gcp-udev-rules
 
 # Be minimal
 recommends: false


### PR DESCRIPTION
- Add the new 30gcp-udev-rules overlay into the manifest

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit 1236c033b7e224fab833ba6f5d302f96e4d5ddf0)