### PR TITLE
tests/kola: bump `minDisk` in autosave-xfs tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,15 +34,3 @@
   snooze: 2023-04-12
   arches:
     - aarch64
-- pattern: ext.config.root-reprovision.autosave-xfs
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1458
-  snooze: 2023-04-21
-  arches:
-    - aarch64
-    - ppc64le
-- pattern: ext.config.root-reprovision.luks.autosave-xfs
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1458
-  snooze: 2023-04-21
-  arches:
-    - aarch64
-    - ppc64le

--- a/tests/kola/root-reprovision/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/autosave-xfs/test.sh
@@ -3,7 +3,7 @@
 ##   # This test reprovisions the rootfs automatically.
 ##   tags: "platform-independent reprovision"
 ##   # Trigger automatic XFS reprovisioning
-##   minDisk: 64
+##   minDisk: 100
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -10,7 +10,7 @@
 ##   # timeout value than the default.
 ##   timeoutMin: 15
 ##   # Trigger automatic XFS reprovisioning
-##   minDisk: 64
+##   minDisk: 100
 
 set -xeuo pipefail
 


### PR DESCRIPTION
The actual agcount on a 64G disk depends on the agsize baked in the image, which in turn depends on how large the rootfs was calculated to be (see `estimate-commit-disk-size` in cosa).

Since the starting rootfs size will differ on different arches (notably, be larger than x86_64) and minor variations are greatly amplified, the agcount may be lower than expected for a 64G disk and in turn the test can fail. Even on x86_64, the rootfs size can change e.g. in CI builds where we bake non-stripped binaries.

Bump the requested disk size to 100G in the test to make it more foolproof.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1458