### PR TITLE
[rawhide] overrides: pin util-linux-2.38.1-4.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,39 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  libblkid:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  libfdisk:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  libmount:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  libsmartcols:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  libuuid:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  util-linux:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  util-linux-core:
+    evr: 2.38.1-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin


### PR DESCRIPTION
The new util_linux-2.39-0.4.fc39 package causes kola reprovision tests to fail in rawhide. Pin on util-linux-2.38.1-4.fc38 so these tests pass.
see: https://github.com/coreos/fedora-coreos-tracker/issues/1462