### PR TITLE
40ignition-ostree: give filesystem type when mounting zram-based XFS

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -176,7 +176,7 @@ ensure_zram_dev() {
     echo $(( mem_available * 90 / 100 ))K > /sys/block/zram"${dev}"/mem_limit
     mkfs.xfs -q /dev/zram"${dev}"
     mkdir "${saved_data}"
-    mount /dev/zram"${dev}" "${saved_data}"
+    mount -t xfs /dev/zram"${dev}" "${saved_data}"
     # save the zram device number created for when called to cleanup
     echo "${dev}" > "${zram_dev}"
 }


### PR DESCRIPTION
We should do this anyway to be more explicit, but it also happens to satisfy util-linux v2.39 in rawhide. (But likely we've exposed a bug in that new code.)

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1462