### PR TITLE
denylist: bump snooze for ext.config.kdump.crash on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,6 +31,6 @@
     - stable
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-04-12
+  snooze: 2023-05-03
   arches:
     - aarch64


### PR DESCRIPTION
This is still causing issues. See:
https://github.com/coreos/fedora-coreos-tracker/issues/1430