### PR TITLE
manifests: Merge EL9 manifests and overlays

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -9,7 +9,6 @@ include:
   - networking-tools.yaml
   - user-experience.yaml
   - shared-workarounds.yaml
-  - shared-el9.yaml
 
 ostree-layers:
   - overlay/05core

--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -1,9 +1,0 @@
-# These are packages that are shared between FCOS and
-# RHCOS/SCOS 9+
-
-packages:
-  # SSH
-  - ssh-key-dir
-
-ostree-layers:
-  - overlay/06el9

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -37,6 +37,8 @@ packages:
   # Boost starving threads
   # https://github.com/coreos/fedora-coreos-tracker/issues/753
   - stalld
+  # Ignition aware SSH key management
+  - ssh-key-dir
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first

--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-zstd.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-zstd.conf
@@ -1,8 +1,4 @@
 # Compress initrd with zstd.  dracut defaults to -15, but we want the
 # maximum reasonable compression, so override the command line to use
 # dracut's defaults along with -19.
-#
-# We can't use this in RHCOS 8 because the kernel doesn't enable
-# CONFIG_RD_ZSTD.
-
 compress="zstd -19 -q -T0"

--- a/overlay.d/06el9/statoverride
+++ b/overlay.d/06el9/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -8,11 +8,7 @@ longer the case).
 
 This overlay matches `fedora-coreos-base.yaml`; core Ignition+ostree bits.
 
-06el9
------
-
-This overlay includes content shared between FCOS and RHCOS/SCOS 9, but not
-RHCOS 8.
+This overlay is shared with RHCOS/SCOS 9.
 
 08nouveau
 ---------


### PR DESCRIPTION
Now that we only have RHCOS based on RHEL 9 and SCOS based on C9S, we can merge the manifests again.