### PR TITLE
manifests/fedora-coreos-base: surgically remove qcom dtb files on aarch64

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -101,6 +101,13 @@ postprocess:
     ln -sf /usr/sbin/iptables-nft-restore  /etc/alternatives/iptables-restore
     ln -sf /usr/sbin/iptables-nft-save     /etc/alternatives/iptables-save
 
+  # Short term hack to avoid running out of space on aarch64. This should
+  # save us about 14M. https://github.com/coreos/fedora-coreos-tracker/issues/1464
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.


### PR DESCRIPTION
This will save us some space while we work on longer term solutions for limited space in the /boot partition.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1464