### PR TITLE
[next] lockfiles: sync packages from Fedora 38 GA

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -280,28 +280,28 @@
       "evra": "2.5.0-2.fc38.aarch64"
     },
     "fedora-gpg-keys": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
       "evra": "5.44-3.fc38.aarch64"
@@ -325,7 +325,7 @@
       "evra": "2.9.9-16.fc38.aarch64"
     },
     "fuse-common": {
-      "evra": "3.13.1-1.fc38.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fuse-libs": {
       "evra": "2.9.9-16.fc38.aarch64"
@@ -337,10 +337,10 @@
       "evra": "3.7.3-3.fc38.aarch64"
     },
     "fuse3": {
-      "evra": "3.13.1-1.fc38.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fuse3-libs": {
-      "evra": "3.13.1-1.fc38.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fwupd": {
       "evra": "1.8.14-1.fc38.aarch64"
@@ -1253,13 +1253,13 @@
     }
   },
   "metadata": {
-    "generated": "2023-04-08T00:00:00Z",
+    "generated": "2023-04-14T00:00:00Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:19:34Z"
+        "generated": "2023-04-14T02:34:48Z"
       },
       "fedora-next": {
-        "generated": "2023-04-07T09:35:37Z"
+        "generated": "2023-04-13T09:32:17Z"
       },
       "fedora-next-updates": {
         "generated": "2018-02-20T19:13:29Z"

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  fuse-common:
+    evr: 3.13.1-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-37e142ea83
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1356#issuecomment-1507828970
+      type: fast-track
+  fuse3:
+    evr: 3.13.1-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-37e142ea83
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1356#issuecomment-1507828970
+      type: fast-track
+  fuse3-libs:
+    evr: 3.13.1-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-37e142ea83
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1356#issuecomment-1507828970
+      type: fast-track
   podman:
     evr: 5:4.4.4-3.fc38
     metadata:

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -271,28 +271,28 @@
       "evra": "2.5.0-2.fc38.ppc64le"
     },
     "fedora-gpg-keys": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
       "evra": "5.44-3.fc38.ppc64le"
@@ -316,7 +316,7 @@
       "evra": "2.9.9-16.fc38.ppc64le"
     },
     "fuse-common": {
-      "evra": "3.13.1-1.fc38.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fuse-libs": {
       "evra": "2.9.9-16.fc38.ppc64le"
@@ -328,10 +328,10 @@
       "evra": "3.7.3-3.fc38.ppc64le"
     },
     "fuse3": {
-      "evra": "3.13.1-1.fc38.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fuse3-libs": {
-      "evra": "3.13.1-1.fc38.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fwupd": {
       "evra": "1.8.14-1.fc38.ppc64le"
@@ -1259,13 +1259,13 @@
     }
   },
   "metadata": {
-    "generated": "2023-04-08T00:00:00Z",
+    "generated": "2023-04-14T00:00:00Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:20:08Z"
+        "generated": "2023-04-14T02:33:22Z"
       },
       "fedora-next": {
-        "generated": "2023-04-07T09:35:43Z"
+        "generated": "2023-04-13T09:32:11Z"
       },
       "fedora-next-updates": {
         "generated": "2018-02-28T16:06:00Z"

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -268,28 +268,28 @@
       "evra": "2.5.0-2.fc38.s390x"
     },
     "fedora-gpg-keys": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
       "evra": "5.44-3.fc38.s390x"
@@ -313,7 +313,7 @@
       "evra": "2.9.9-16.fc38.s390x"
     },
     "fuse-common": {
-      "evra": "3.13.1-1.fc38.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "fuse-libs": {
       "evra": "2.9.9-16.fc38.s390x"
@@ -325,10 +325,10 @@
       "evra": "3.7.3-3.fc38.s390x"
     },
     "fuse3": {
-      "evra": "3.13.1-1.fc38.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "fuse3-libs": {
-      "evra": "3.13.1-1.fc38.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "gawk": {
       "evra": "5.1.1-5.fc38.s390x"
@@ -1184,13 +1184,13 @@
     }
   },
   "metadata": {
-    "generated": "2023-04-08T00:00:00Z",
+    "generated": "2023-04-14T00:00:00Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:18:50Z"
+        "generated": "2023-04-14T02:32:05Z"
       },
       "fedora-next": {
-        "generated": "2023-04-07T09:35:26Z"
+        "generated": "2023-04-13T09:32:00Z"
       },
       "fedora-next-updates": {
         "generated": "2018-02-28T16:06:49Z"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -280,28 +280,28 @@
       "evra": "2.5.0-2.fc38.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-0.33.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-0.5.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
       "evra": "5.44-3.fc38.x86_64"
@@ -325,7 +325,7 @@
       "evra": "2.9.9-16.fc38.x86_64"
     },
     "fuse-common": {
-      "evra": "3.13.1-1.fc38.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fuse-libs": {
       "evra": "2.9.9-16.fc38.x86_64"
@@ -337,10 +337,10 @@
       "evra": "3.7.3-3.fc38.x86_64"
     },
     "fuse3": {
-      "evra": "3.13.1-1.fc38.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.13.1-1.fc38.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fwupd": {
       "evra": "1.8.14-1.fc38.x86_64"
@@ -1256,13 +1256,13 @@
     }
   },
   "metadata": {
-    "generated": "2023-04-08T00:00:00Z",
+    "generated": "2023-04-14T00:00:00Z",
     "rpmmd_repos": {
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:19:57Z"
+        "generated": "2023-04-14T02:33:15Z"
       },
       "fedora-next": {
-        "generated": "2023-04-07T09:36:00Z"
+        "generated": "2023-04-13T09:32:36Z"
       },
       "fedora-next-updates": {
         "generated": "2018-02-20T19:18:14Z"


### PR DESCRIPTION
This is a final push of packages that were recently pushed to stable for F38 GA. See https://pagure.io/releng/issue/11306