### PR TITLE
Move to Fedora Linux 38

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,6 +5,6 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:38
 COPY . /src
 RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,22 +13,6 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/3361
   arches:
     - ppc64le
-- pattern: ext.config.ignition.resource.remote
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  arches:
-    - s390x
-  streams:
-    - testing-devel
-    - testing
-    - stable
-- pattern: rpmostree.install-uninstall
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1215
-  arches:
-    - s390x
-  streams:
-    - testing-devel
-    - testing
-    - stable
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
   snooze: 2023-05-03

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,1265 +1,1268 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.40.10-1.fc37.aarch64"
+      "evra": "1:1.42.0-1.fc38.aarch64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.40.10-1.fc37.aarch64"
+      "evra": "1:1.42.0-1.fc38.aarch64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.40.10-1.fc37.aarch64"
+      "evra": "1:1.42.0-1.fc38.aarch64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.40.10-1.fc37.aarch64"
+      "evra": "1:1.42.0-1.fc38.aarch64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.40.10-1.fc37.aarch64"
+      "evra": "1:1.42.0-1.fc38.aarch64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.8.0.11-1.fc37.noarch"
+      "evra": "2.9.0.4-1.fc38.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.5.0-4.fc37.aarch64"
+      "evra": "1.6.0-1.fc38.aarch64"
     },
     "acl": {
-      "evra": "2.3.1-4.fc37.aarch64"
+      "evra": "2.3.1-6.fc38.aarch64"
     },
     "adcli": {
-      "evra": "0.9.1-11.fc37.aarch64"
+      "evra": "0.9.2-2.fc38.aarch64"
     },
     "afterburn": {
-      "evra": "5.4.0-2.fc37.aarch64"
+      "evra": "5.4.0-2.fc38.aarch64"
     },
     "afterburn-dracut": {
-      "evra": "5.4.0-2.fc37.aarch64"
+      "evra": "5.4.0-2.fc38.aarch64"
     },
     "alternatives": {
-      "evra": "1.22-1.fc37.aarch64"
+      "evra": "1.22-1.fc38.aarch64"
     },
     "amd-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "attr": {
-      "evra": "2.5.1-5.fc37.aarch64"
+      "evra": "2.5.1-6.fc38.aarch64"
     },
     "audit-libs": {
-      "evra": "3.1-2.fc37.aarch64"
+      "evra": "3.1-2.fc38.aarch64"
     },
     "authselect": {
-      "evra": "1.4.2-1.fc37.aarch64"
+      "evra": "1.4.2-2.fc38.aarch64"
     },
     "authselect-libs": {
-      "evra": "1.4.2-1.fc37.aarch64"
+      "evra": "1.4.2-2.fc38.aarch64"
     },
     "avahi-libs": {
-      "evra": "0.8-18.fc37.aarch64"
+      "evra": "0.8-20.fc38.aarch64"
     },
     "basesystem": {
-      "evra": "11-14.fc37.noarch"
+      "evra": "11-15.fc38.noarch"
     },
     "bash": {
-      "evra": "5.2.15-1.fc37.aarch64"
+      "evra": "5.2.15-3.fc38.aarch64"
     },
     "bash-completion": {
-      "evra": "1:2.11-8.fc37.noarch"
+      "evra": "1:2.11-9.fc38.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.13-1.fc37.aarch64"
+      "evra": "32:9.18.13-1.fc38.aarch64"
     },
     "bind-license": {
-      "evra": "32:9.18.13-1.fc37.noarch"
+      "evra": "32:9.18.13-1.fc38.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.13-1.fc37.aarch64"
+      "evra": "32:9.18.13-1.fc38.aarch64"
     },
     "bootupd": {
-      "evra": "0.2.8-3.fc37.aarch64"
+      "evra": "0.2.9-1.fc38.aarch64"
     },
     "bsdtar": {
-      "evra": "3.6.1-3.fc37.aarch64"
+      "evra": "3.6.1-4.fc38.aarch64"
     },
     "btrfs-progs": {
-      "evra": "6.2.2-1.fc37.aarch64"
+      "evra": "6.2.2-1.fc38.aarch64"
     },
     "bubblewrap": {
-      "evra": "0.5.0-3.fc37.aarch64"
+      "evra": "0.7.0-1.fc38.aarch64"
     },
     "bzip2": {
-      "evra": "1.0.8-12.fc37.aarch64"
+      "evra": "1.0.8-13.fc38.aarch64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-12.fc37.aarch64"
+      "evra": "1.0.8-13.fc38.aarch64"
     },
     "c-ares": {
-      "evra": "1.19.0-1.fc37.aarch64"
+      "evra": "1.19.0-1.fc38.aarch64"
     },
     "ca-certificates": {
-      "evra": "2023.2.60-1.0.fc37.noarch"
+      "evra": "2023.2.60-2.fc38.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-10.fc37.aarch64"
+      "evra": "0.1.7-14.fc38.aarch64"
     },
     "chrony": {
-      "evra": "4.3-1.fc37.aarch64"
+      "evra": "4.3-3.fc38.aarch64"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc37.aarch64"
+      "evra": "7.0-1.fc38.aarch64"
     },
     "clevis": {
-      "evra": "19-2.fc37.aarch64"
+      "evra": "19-2.fc38.aarch64"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc37.aarch64"
+      "evra": "19-2.fc38.aarch64"
     },
     "clevis-luks": {
-      "evra": "19-2.fc37.aarch64"
+      "evra": "19-2.fc38.aarch64"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc37.aarch64"
+      "evra": "19-2.fc38.aarch64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-11.fc37.noarch"
+      "evra": "0.31-12.fc38.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc37.aarch64"
+      "evra": "2:2.1.7-2.fc38.aarch64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.209.0-1.fc37.noarch"
+      "evra": "2:2.209.0-1.fc38.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc37.aarch64"
+      "evra": "1.6.19-1.fc38.aarch64"
     },
     "containernetworking-plugins": {
-      "evra": "1.1.1-16.fc37.aarch64"
+      "evra": "1.1.1-16.fc38.aarch64"
     },
     "containers-common": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "coreos-installer": {
-      "evra": "0.17.0-1.fc37.aarch64"
+      "evra": "0.17.0-1.fc38.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.17.0-1.fc37.aarch64"
+      "evra": "0.17.0-1.fc38.aarch64"
     },
     "coreutils": {
-      "evra": "9.1-7.fc37.aarch64"
+      "evra": "9.1-11.fc38.aarch64"
     },
     "coreutils-common": {
-      "evra": "9.1-7.fc37.aarch64"
+      "evra": "9.1-11.fc38.aarch64"
     },
     "cpio": {
-      "evra": "2.13-13.fc37.aarch64"
+      "evra": "2.13-14.fc38.aarch64"
     },
     "cracklib": {
-      "evra": "2.9.7-30.fc37.aarch64"
+      "evra": "2.9.7-31.fc38.aarch64"
     },
     "criu": {
-      "evra": "3.17.1-3.fc37.aarch64"
+      "evra": "3.17.1-5.fc38.aarch64"
     },
     "criu-libs": {
-      "evra": "3.17.1-3.fc37.aarch64"
+      "evra": "3.17.1-5.fc38.aarch64"
     },
     "crun": {
-      "evra": "1.8.3-2.fc37.aarch64"
+      "evra": "1.8.3-2.fc38.aarch64"
     },
     "crypto-policies": {
-      "evra": "20220815-1.gite4ed860.fc37.noarch"
+      "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc37.aarch64"
+      "evra": "2.6.1-1.fc38.aarch64"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc37.aarch64"
+      "evra": "2.6.1-1.fc38.aarch64"
     },
     "curl": {
-      "evra": "7.85.0-8.fc37.aarch64"
+      "evra": "7.87.0-7.fc38.aarch64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-8.fc37.aarch64"
+      "evra": "2.1.28-9.fc38.aarch64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-8.fc37.aarch64"
+      "evra": "2.1.28-9.fc38.aarch64"
     },
     "dbus": {
-      "evra": "1:1.14.6-1.fc37.aarch64"
+      "evra": "1:1.14.6-1.fc38.aarch64"
     },
     "dbus-broker": {
-      "evra": "33-1.fc37.aarch64"
+      "evra": "33-1.fc38.aarch64"
     },
     "dbus-common": {
-      "evra": "1:1.14.6-1.fc37.noarch"
+      "evra": "1:1.14.6-1.fc38.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.6-1.fc37.aarch64"
+      "evra": "1:1.14.6-1.fc38.aarch64"
     },
     "device-mapper": {
-      "evra": "1.02.175-9.fc37.aarch64"
+      "evra": "1.02.189-2.fc38.aarch64"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-9.fc37.aarch64"
+      "evra": "1.02.189-2.fc38.aarch64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-9.fc37.aarch64"
+      "evra": "1.02.189-2.fc38.aarch64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-9.fc37.aarch64"
+      "evra": "1.02.189-2.fc38.aarch64"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.0-4.fc37.aarch64"
+      "evra": "0.9.4-2.fc38.aarch64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.0-4.fc37.aarch64"
+      "evra": "0.9.4-2.fc38.aarch64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-8.fc37.aarch64"
+      "evra": "0.9.0-10.fc38.aarch64"
     },
     "diffutils": {
-      "evra": "3.8-3.fc37.aarch64"
+      "evra": "3.9-1.fc38.aarch64"
     },
     "dnsmasq": {
-      "evra": "2.89-2.fc37.aarch64"
+      "evra": "2.89-1.fc38.aarch64"
     },
     "dosfstools": {
-      "evra": "4.2-4.fc37.aarch64"
+      "evra": "4.2-6.fc38.aarch64"
     },
     "dracut": {
-      "evra": "059-1.fc37.aarch64"
+      "evra": "059-2.fc38.aarch64"
     },
     "dracut-network": {
-      "evra": "059-1.fc37.aarch64"
+      "evra": "059-2.fc38.aarch64"
     },
     "dracut-squash": {
-      "evra": "059-1.fc37.aarch64"
+      "evra": "059-2.fc38.aarch64"
+    },
+    "duktape": {
+      "evra": "2.7.0-2.fc38.aarch64"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-3.fc37.aarch64"
+      "evra": "1.46.5-4.fc38.aarch64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-3.fc37.aarch64"
+      "evra": "1.46.5-4.fc38.aarch64"
     },
     "efi-filesystem": {
-      "evra": "5-6.fc37.noarch"
+      "evra": "5-7.fc38.noarch"
     },
     "efibootmgr": {
-      "evra": "18-2.fc37.aarch64"
+      "evra": "18-3.fc38.aarch64"
     },
     "efivar-libs": {
-      "evra": "38-6.fc37.aarch64"
+      "evra": "38-7.fc38.aarch64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-1.fc37.noarch"
+      "evra": "0.189-1.fc38.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-1.fc37.aarch64"
+      "evra": "0.189-1.fc38.aarch64"
     },
     "elfutils-libs": {
-      "evra": "0.189-1.fc37.aarch64"
+      "evra": "0.189-1.fc38.aarch64"
     },
     "ethtool": {
-      "evra": "2:6.2-1.fc37.aarch64"
+      "evra": "2:6.2-1.fc38.aarch64"
     },
     "expat": {
-      "evra": "2.5.0-1.fc37.aarch64"
+      "evra": "2.5.0-2.fc38.aarch64"
     },
     "fedora-gpg-keys": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
-      "evra": "5.42-4.fc37.aarch64"
+      "evra": "5.44-3.fc38.aarch64"
     },
     "file-libs": {
-      "evra": "5.42-4.fc37.aarch64"
+      "evra": "5.44-3.fc38.aarch64"
     },
     "filesystem": {
-      "evra": "3.18-2.fc37.aarch64"
+      "evra": "3.18-3.fc38.aarch64"
     },
     "findutils": {
-      "evra": "1:4.9.0-2.fc37.aarch64"
+      "evra": "1:4.9.0-3.fc38.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.14.4-1.fc37.aarch64"
+      "evra": "1.15.4-1.fc38.aarch64"
     },
     "fstrm": {
-      "evra": "0.6.1-5.fc37.aarch64"
+      "evra": "0.6.1-6.fc38.aarch64"
     },
     "fuse": {
-      "evra": "2.9.9-15.fc37.aarch64"
+      "evra": "2.9.9-16.fc38.aarch64"
     },
     "fuse-common": {
-      "evra": "3.10.5-5.fc37.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-15.fc37.aarch64"
+      "evra": "2.9.9-16.fc38.aarch64"
     },
     "fuse-overlayfs": {
-      "evra": "1.9-6.fc37.aarch64"
+      "evra": "1.10-3.fc38.aarch64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-2.fc37.aarch64"
+      "evra": "3.7.3-3.fc38.aarch64"
     },
     "fuse3": {
-      "evra": "3.10.5-5.fc37.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-5.fc37.aarch64"
+      "evra": "3.13.1-2.fc38.aarch64"
     },
     "fwupd": {
-      "evra": "1.8.14-1.fc37.aarch64"
+      "evra": "1.8.14-1.fc38.aarch64"
     },
     "gawk": {
-      "evra": "5.1.1-4.fc37.aarch64"
+      "evra": "5.1.1-5.fc38.aarch64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-2.fc37.aarch64"
+      "evra": "1:1.23-3.fc38.aarch64"
     },
     "gdisk": {
-      "evra": "1.0.9-4.fc37.aarch64"
+      "evra": "1.0.9-5.fc38.aarch64"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-1.fc37.aarch64"
+      "evra": "0.21.1-2.fc38.aarch64"
     },
     "gettext-libs": {
-      "evra": "0.21.1-1.fc37.aarch64"
+      "evra": "0.21.1-2.fc38.aarch64"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-1.fc37.aarch64"
+      "evra": "0.21.1-2.fc38.aarch64"
     },
     "git-core": {
-      "evra": "2.39.2-1.fc37.aarch64"
+      "evra": "2.40.0-1.fc38.aarch64"
     },
     "glib2": {
-      "evra": "2.74.6-1.fc37.aarch64"
+      "evra": "2.76.1-1.fc38.aarch64"
     },
     "glibc": {
-      "evra": "2.36-9.fc37.aarch64"
+      "evra": "2.37-1.fc38.aarch64"
     },
     "glibc-common": {
-      "evra": "2.36-9.fc37.aarch64"
+      "evra": "2.37-1.fc38.aarch64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.36-9.fc37.aarch64"
+      "evra": "2.37-1.fc38.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.36-9.fc37.aarch64"
+      "evra": "2.37-1.fc38.aarch64"
     },
     "gmp": {
-      "evra": "1:6.2.1-3.fc37.aarch64"
+      "evra": "1:6.2.1-4.fc38.aarch64"
     },
     "gnupg2": {
-      "evra": "2.3.8-1.fc37.aarch64"
+      "evra": "2.4.0-3.fc38.aarch64"
     },
     "gnutls": {
-      "evra": "3.8.0-2.fc37.aarch64"
+      "evra": "3.8.0-2.fc38.aarch64"
     },
     "gpgme": {
-      "evra": "1.17.0-4.fc37.aarch64"
+      "evra": "1.17.1-3.fc38.aarch64"
     },
     "grep": {
-      "evra": "3.7-4.fc37.aarch64"
+      "evra": "3.8-3.fc38.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.06-94.fc37.noarch"
+      "evra": "1:2.06-89.fc38.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-94.fc37.aarch64"
+      "evra": "1:2.06-89.fc38.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.06-94.fc37.aarch64"
+      "evra": "1:2.06-89.fc38.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-94.fc37.aarch64"
+      "evra": "1:2.06-89.fc38.aarch64"
     },
     "gzip": {
-      "evra": "1.12-2.fc37.aarch64"
+      "evra": "1.12-3.fc38.aarch64"
     },
     "hostname": {
-      "evra": "3.23-7.fc37.aarch64"
+      "evra": "3.23-8.fc38.aarch64"
     },
     "ignition": {
-      "evra": "2.15.0-3.fc37.aarch64"
+      "evra": "2.15.0-3.fc38.aarch64"
     },
     "inih": {
-      "evra": "56-2.fc37.aarch64"
+      "evra": "56-3.fc38.aarch64"
     },
     "intel-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "iproute": {
-      "evra": "5.18.0-2.fc37.aarch64"
+      "evra": "6.1.0-1.fc38.aarch64"
     },
     "iproute-tc": {
-      "evra": "5.18.0-2.fc37.aarch64"
+      "evra": "6.1.0-1.fc38.aarch64"
     },
     "iptables-legacy": {
-      "evra": "1.8.8-4.fc37.aarch64"
+      "evra": "1.8.9-2.fc38.aarch64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.8-4.fc37.aarch64"
+      "evra": "1.8.9-2.fc38.aarch64"
     },
     "iptables-libs": {
-      "evra": "1.8.8-4.fc37.aarch64"
+      "evra": "1.8.9-2.fc38.aarch64"
     },
     "iptables-nft": {
-      "evra": "1.8.8-4.fc37.aarch64"
+      "evra": "1.8.9-2.fc38.aarch64"
     },
     "iptables-services": {
-      "evra": "1.8.8-4.fc37.noarch"
+      "evra": "1.8.9-2.fc38.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.8-4.fc37.aarch64"
+      "evra": "1.8.9-2.fc38.aarch64"
     },
     "iputils": {
-      "evra": "20221126-1.fc37.aarch64"
+      "evra": "20221126-2.fc38.aarch64"
     },
     "irqbalance": {
-      "evra": "2:1.9.1-1.fc37.aarch64"
+      "evra": "2:1.9.1-2.fc38.aarch64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.aarch64"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.aarch64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.aarch64"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.aarch64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-5.fc37.aarch64"
+      "evra": "0.101-6.fc38.aarch64"
     },
     "jansson": {
-      "evra": "2.13.1-5.fc37.aarch64"
+      "evra": "2.13.1-6.fc38.aarch64"
     },
     "jemalloc": {
-      "evra": "5.3.0-2.fc37.aarch64"
+      "evra": "5.3.0-3.fc38.aarch64"
     },
     "jose": {
-      "evra": "11-6.fc37.aarch64"
+      "evra": "11-7.fc38.aarch64"
     },
     "jq": {
-      "evra": "1.6-14.fc37.aarch64"
+      "evra": "1.6-15.fc38.aarch64"
     },
     "json-c": {
-      "evra": "0.16-3.fc37.aarch64"
+      "evra": "0.16-4.fc38.aarch64"
     },
     "json-glib": {
-      "evra": "1.6.6-3.fc37.aarch64"
+      "evra": "1.6.6-4.fc38.aarch64"
     },
     "kbd": {
-      "evra": "2.5.1-3.fc37.aarch64"
+      "evra": "2.5.1-5.fc38.aarch64"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.2.9-200.fc37.aarch64"
+      "evra": "6.2.11-300.fc38.aarch64"
     },
     "kernel-core": {
-      "evra": "6.2.9-200.fc37.aarch64"
+      "evra": "6.2.11-300.fc38.aarch64"
     },
     "kernel-modules": {
-      "evra": "6.2.9-200.fc37.aarch64"
+      "evra": "6.2.11-300.fc38.aarch64"
     },
     "kernel-modules-core": {
-      "evra": "6.2.9-200.fc37.aarch64"
+      "evra": "6.2.11-300.fc38.aarch64"
     },
     "kexec-tools": {
-      "evra": "2.0.25-1.fc37.aarch64"
+      "evra": "2.0.26-3.fc38.aarch64"
     },
     "keyutils": {
-      "evra": "1.6.1-5.fc37.aarch64"
+      "evra": "1.6.1-6.fc38.aarch64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-5.fc37.aarch64"
+      "evra": "1.6.1-6.fc38.aarch64"
     },
     "kmod": {
-      "evra": "30-2.fc37.aarch64"
+      "evra": "30-4.fc38.aarch64"
     },
     "kmod-libs": {
-      "evra": "30-2.fc37.aarch64"
+      "evra": "30-4.fc38.aarch64"
     },
     "kpartx": {
-      "evra": "0.9.0-4.fc37.aarch64"
+      "evra": "0.9.4-2.fc38.aarch64"
     },
     "krb5-libs": {
-      "evra": "1.19.2-13.fc37.aarch64"
+      "evra": "1.20.1-8.fc38.aarch64"
     },
     "less": {
-      "evra": "590-5.fc37.aarch64"
+      "evra": "608-2.fc38.aarch64"
     },
     "libacl": {
-      "evra": "2.3.1-4.fc37.aarch64"
+      "evra": "2.3.1-6.fc38.aarch64"
     },
     "libaio": {
-      "evra": "0.3.111-14.fc37.aarch64"
+      "evra": "0.3.111-15.fc38.aarch64"
     },
     "libarchive": {
-      "evra": "3.6.1-3.fc37.aarch64"
+      "evra": "3.6.1-4.fc38.aarch64"
     },
     "libargon2": {
-      "evra": "20190702-1.fc37.aarch64"
+      "evra": "20190702-2.fc38.aarch64"
     },
     "libassuan": {
-      "evra": "2.5.5-5.fc37.aarch64"
+      "evra": "2.5.5-6.fc38.aarch64"
+    },
+    "libatomic": {
+      "evra": "13.0.1-0.12.fc38.aarch64"
     },
     "libattr": {
-      "evra": "2.5.1-5.fc37.aarch64"
+      "evra": "2.5.1-6.fc38.aarch64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-52.fc37.aarch64"
+      "evra": "0.1.1-53.fc38.aarch64"
     },
     "libblkid": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "libbpf": {
-      "evra": "2:0.8.0-2.fc37.aarch64"
+      "evra": "2:1.1.0-2.fc38.aarch64"
     },
     "libbsd": {
-      "evra": "0.11.7-2.fc37.aarch64"
+      "evra": "0.11.7-4.fc38.aarch64"
     },
     "libcap": {
-      "evra": "2.48-5.fc37.aarch64"
+      "evra": "2.48-6.fc38.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.8.3-3.fc37.aarch64"
+      "evra": "0.8.3-5.fc38.aarch64"
     },
     "libcbor": {
-      "evra": "0.7.0-7.fc37.aarch64"
+      "evra": "0.7.0-9.fc38.aarch64"
     },
     "libcollection": {
-      "evra": "0.7.0-52.fc37.aarch64"
+      "evra": "0.7.0-53.fc38.aarch64"
     },
     "libcom_err": {
-      "evra": "1.46.5-3.fc37.aarch64"
+      "evra": "1.46.5-4.fc38.aarch64"
     },
     "libcurl-minimal": {
-      "evra": "7.85.0-8.fc37.aarch64"
+      "evra": "7.87.0-7.fc38.aarch64"
     },
     "libdaemon": {
-      "evra": "0.14-24.fc37.aarch64"
+      "evra": "0.14-25.fc38.aarch64"
     },
     "libdb": {
-      "evra": "5.3.28-53.fc37.aarch64"
+      "evra": "5.3.28-55.fc38.aarch64"
     },
     "libdhash": {
-      "evra": "0.5.0-52.fc37.aarch64"
+      "evra": "0.5.0-53.fc38.aarch64"
     },
     "libeconf": {
-      "evra": "0.4.0-4.fc37.aarch64"
+      "evra": "0.4.0-5.fc38.aarch64"
     },
     "libedit": {
-      "evra": "3.1-43.20221009cvs.fc37.aarch64"
+      "evra": "3.1-45.20221030cvs.fc38.aarch64"
     },
     "libevent": {
-      "evra": "2.1.12-7.fc37.aarch64"
+      "evra": "2.1.12-8.fc38.aarch64"
     },
     "libfdisk": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "libffi": {
-      "evra": "3.4.4-1.fc37.aarch64"
+      "evra": "3.4.4-2.fc38.aarch64"
     },
     "libfido2": {
-      "evra": "1.11.0-3.fc37.aarch64"
+      "evra": "1.12.0-3.fc38.aarch64"
     },
     "libgcab1": {
-      "evra": "1.5-1.fc37.aarch64"
+      "evra": "1.5-2.fc38.aarch64"
     },
     "libgcc": {
-      "evra": "12.2.1-4.fc37.aarch64"
+      "evra": "13.0.1-0.12.fc38.aarch64"
     },
     "libgcrypt": {
-      "evra": "1.10.1-4.fc37.aarch64"
+      "evra": "1.10.1-7.fc38.aarch64"
     },
     "libgpg-error": {
-      "evra": "1.46-1.fc37.aarch64"
+      "evra": "1.46-2.fc38.aarch64"
     },
     "libgudev": {
-      "evra": "237-3.fc37.aarch64"
+      "evra": "237-4.fc38.aarch64"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc37.aarch64"
+      "evra": "0.4.5-1.fc38.aarch64"
     },
     "libibverbs": {
-      "evra": "41.0-1.fc37.aarch64"
+      "evra": "44.0-3.fc38.aarch64"
     },
     "libicu": {
-      "evra": "71.1-2.fc37.aarch64"
+      "evra": "72.1-2.fc38.aarch64"
     },
     "libidn2": {
-      "evra": "2.3.4-1.fc37.aarch64"
+      "evra": "2.3.4-2.fc38.aarch64"
     },
     "libini_config": {
-      "evra": "1.3.1-52.fc37.aarch64"
+      "evra": "1.3.1-53.fc38.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc37.aarch64"
+      "evra": "0.1.13-1.fc38.aarch64"
     },
     "libjose": {
-      "evra": "11-6.fc37.aarch64"
+      "evra": "11-7.fc38.aarch64"
     },
     "libkcapi": {
-      "evra": "1.4.0-2.fc37.aarch64"
+      "evra": "1.4.0-5.fc38.aarch64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-2.fc37.aarch64"
+      "evra": "1.4.0-5.fc38.aarch64"
     },
     "libksba": {
-      "evra": "1.6.3-1.fc37.aarch64"
+      "evra": "1.6.3-2.fc38.aarch64"
     },
     "libldb": {
-      "evra": "2.6.2-1.fc37.aarch64"
+      "evra": "2.7.2-1.fc38.aarch64"
     },
     "libluksmeta": {
-      "evra": "9-14.fc37.aarch64"
+      "evra": "9-15.fc38.aarch64"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-1.fc37.aarch64"
+      "evra": "1.7.1-2.fc38.aarch64"
     },
     "libmd": {
-      "evra": "1.0.4-2.fc37.aarch64"
+      "evra": "1.0.4-3.fc38.aarch64"
     },
     "libmnl": {
-      "evra": "1.0.5-1.fc37.aarch64"
+      "evra": "1.0.5-2.fc38.aarch64"
     },
     "libmodulemd": {
-      "evra": "2.14.0-4.fc37.aarch64"
+      "evra": "2.14.0-5.fc38.aarch64"
     },
     "libmount": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "libndp": {
-      "evra": "1.8-4.fc37.aarch64"
+      "evra": "1.8-5.fc38.aarch64"
     },
     "libnet": {
-      "evra": "1.2-6.fc37.aarch64"
+      "evra": "1.2-7.fc38.aarch64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-5.fc37.aarch64"
+      "evra": "1.0.8-7.fc38.aarch64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-22.fc37.aarch64"
+      "evra": "1.0.1-23.fc38.aarch64"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.2-2.rc6.fc37.aarch64"
+      "evra": "1:2.6.2-2.rc6.fc38.1.aarch64"
     },
     "libnftnl": {
-      "evra": "1.2.2-2.fc37.aarch64"
+      "evra": "1.2.4-2.fc38.aarch64"
     },
     "libnghttp2": {
-      "evra": "1.51.0-1.fc37.aarch64"
+      "evra": "1.52.0-1.fc38.aarch64"
     },
     "libnl3": {
-      "evra": "3.7.0-2.fc37.aarch64"
+      "evra": "3.7.0-3.fc38.aarch64"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-2.fc37.aarch64"
+      "evra": "3.7.0-3.fc38.aarch64"
     },
     "libnsl2": {
-      "evra": "2.0.0-4.fc37.aarch64"
+      "evra": "2.0.0-5.fc38.aarch64"
     },
     "libnvme": {
-      "evra": "1.2-1.fc37.aarch64"
+      "evra": "1.4-1.fc38.aarch64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-52.fc37.aarch64"
+      "evra": "0.2.1-53.fc38.aarch64"
     },
     "libpcap": {
-      "evra": "14:1.10.3-1.fc37.aarch64"
+      "evra": "14:1.10.3-2.fc38.aarch64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-3.fc37.aarch64"
+      "evra": "1.8.0-6.fc38.aarch64"
     },
     "libpsl": {
-      "evra": "0.21.1-6.fc37.aarch64"
+      "evra": "0.21.2-2.fc38.aarch64"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc37.aarch64"
+      "evra": "1.4.5-3.fc38.aarch64"
     },
     "libref_array": {
-      "evra": "0.1.5-52.fc37.aarch64"
+      "evra": "0.1.5-53.fc38.aarch64"
     },
     "librepo": {
-      "evra": "1.15.1-1.fc37.aarch64"
+      "evra": "1.15.1-2.fc38.aarch64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.4-1.fc37.noarch"
+      "evra": "2.17.9-1.fc38.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-3.fc37.aarch64"
+      "evra": "2.5.3-4.fc38.aarch64"
     },
     "libselinux": {
-      "evra": "3.5-1.fc37.aarch64"
+      "evra": "3.5-1.fc38.aarch64"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc37.aarch64"
+      "evra": "3.5-1.fc38.aarch64"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc37.aarch64"
+      "evra": "3.5-2.fc38.aarch64"
     },
     "libsepol": {
-      "evra": "3.5-1.fc37.aarch64"
+      "evra": "3.5-1.fc38.aarch64"
     },
     "libsigsegv": {
-      "evra": "2.14-3.fc37.aarch64"
+      "evra": "2.14-4.fc38.aarch64"
     },
     "libslirp": {
-      "evra": "4.7.0-2.fc37.aarch64"
+      "evra": "4.7.0-3.fc38.aarch64"
     },
     "libsmartcols": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.17.7-0.fc37.aarch64"
+      "evra": "2:4.18.1-0.fc38.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.22-3.fc37.aarch64"
+      "evra": "0.7.22-4.fc38.aarch64"
     },
     "libss": {
-      "evra": "1.46.5-3.fc37.aarch64"
+      "evra": "1.46.5-4.fc38.aarch64"
     },
     "libsss_certmap": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "libstdc++": {
-      "evra": "12.2.1-4.fc37.aarch64"
+      "evra": "13.0.1-0.12.fc38.aarch64"
     },
     "libtalloc": {
-      "evra": "2.3.4-3.fc37.aarch64"
+      "evra": "2.4.0-2.fc38.aarch64"
     },
     "libtasn1": {
-      "evra": "4.19.0-1.fc37.aarch64"
+      "evra": "4.19.0-2.fc38.aarch64"
     },
     "libtdb": {
-      "evra": "1.4.7-3.fc37.aarch64"
+      "evra": "1.4.8-1.fc38.aarch64"
     },
     "libteam": {
-      "evra": "1.31-6.fc37.aarch64"
+      "evra": "1.31-7.fc38.aarch64"
     },
     "libtevent": {
-      "evra": "0.13.0-1.fc37.aarch64"
+      "evra": "0.14.1-1.fc38.aarch64"
     },
     "libtirpc": {
-      "evra": "1.3.3-0.fc37.aarch64"
+      "evra": "1.3.3-1.fc38.aarch64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-2.fc37.aarch64"
+      "evra": "2.4.7-6.fc38.aarch64"
     },
     "libunistring": {
-      "evra": "1.0-2.fc37.aarch64"
+      "evra": "1.1-3.fc38.aarch64"
+    },
+    "libunistring1.0": {
+      "evra": "1.0-1.fc38.aarch64"
     },
     "libusb1": {
-      "evra": "1.0.25-9.fc37.aarch64"
+      "evra": "1.0.26-2.fc38.aarch64"
     },
     "libuser": {
-      "evra": "0.63-13.fc37.aarch64"
+      "evra": "0.64-2.fc38.aarch64"
     },
     "libutempter": {
-      "evra": "1.2.1-7.fc37.aarch64"
+      "evra": "1.2.1-8.fc38.aarch64"
     },
     "libuuid": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "libuv": {
-      "evra": "1:1.44.2-2.fc37.aarch64"
+      "evra": "1:1.44.2-3.fc38.aarch64"
     },
     "libverto": {
-      "evra": "0.3.2-4.fc37.aarch64"
+      "evra": "0.3.2-5.fc38.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.17.7-0.fc37.aarch64"
+      "evra": "2:4.18.1-0.fc38.aarch64"
     },
     "libxcrypt": {
-      "evra": "4.4.33-4.fc37.aarch64"
+      "evra": "4.4.33-7.fc38.aarch64"
     },
     "libxml2": {
-      "evra": "2.10.3-2.fc37.aarch64"
+      "evra": "2.10.3-3.fc38.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.11-1.fc37.aarch64"
+      "evra": "0.3.11-1.fc38.aarch64"
     },
     "libyaml": {
-      "evra": "0.2.5-8.fc37.aarch64"
+      "evra": "0.2.5-9.fc38.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc37.aarch64"
+      "evra": "1.5.5-1.fc38.aarch64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-33.fc37.aarch64"
+      "evra": "2.5.1-34.fc38.aarch64"
     },
     "linux-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.30-1.fc37.aarch64"
+      "evra": "0.9.30-1.fc38.aarch64"
     },
     "logrotate": {
-      "evra": "3.20.1-3.fc37.aarch64"
+      "evra": "3.21.0-2.fc38.aarch64"
     },
     "lsof": {
-      "evra": "4.94.0-4.fc37.aarch64"
+      "evra": "4.96.3-3.fc38.aarch64"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc37.aarch64"
+      "evra": "5.4.4-9.fc38.aarch64"
     },
     "luksmeta": {
-      "evra": "9-14.fc37.aarch64"
+      "evra": "9-15.fc38.aarch64"
     },
     "lvm2": {
-      "evra": "2.03.11-9.fc37.aarch64"
+      "evra": "2.03.18-2.fc38.aarch64"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-9.fc37.aarch64"
+      "evra": "2.03.18-2.fc38.aarch64"
     },
     "lz4-libs": {
-      "evra": "1.9.4-1.fc37.aarch64"
+      "evra": "1.9.4-2.fc38.aarch64"
     },
     "lzo": {
-      "evra": "2.10-7.fc37.aarch64"
+      "evra": "2.10-8.fc38.aarch64"
     },
     "mdadm": {
-      "evra": "4.2-2.fc37.aarch64"
+      "evra": "4.2-4.fc38.aarch64"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc37.aarch64"
+      "evra": "20.10.23-1.fc38.aarch64"
     },
     "mokutil": {
-      "evra": "2:0.6.0-5.fc37.aarch64"
-    },
-    "mozjs102": {
-      "evra": "102.9.0-1.fc37.aarch64"
+      "evra": "2:0.6.0-6.fc38.aarch64"
     },
     "mpfr": {
-      "evra": "4.1.0-10.fc37.aarch64"
+      "evra": "4.1.1-3.fc38.aarch64"
     },
     "nano": {
-      "evra": "6.4-1.fc37.aarch64"
+      "evra": "7.2-2.fc38.aarch64"
     },
     "nano-default-editor": {
-      "evra": "6.4-1.fc37.noarch"
+      "evra": "7.2-2.fc38.noarch"
     },
     "ncurses": {
-      "evra": "6.3-4.20220501.fc37.aarch64"
+      "evra": "6.4-3.20230114.fc38.aarch64"
     },
     "ncurses-base": {
-      "evra": "6.3-4.20220501.fc37.noarch"
+      "evra": "6.4-3.20230114.fc38.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.3-4.20220501.fc37.aarch64"
+      "evra": "6.4-3.20230114.fc38.aarch64"
     },
     "net-tools": {
-      "evra": "2.0-0.64.20160912git.fc37.aarch64"
+      "evra": "2.0-0.65.20160912git.fc38.aarch64"
     },
     "netavark": {
-      "evra": "1.5.0-4.fc37.aarch64"
+      "evra": "1.6.0-2.fc38.aarch64"
     },
     "nettle": {
-      "evra": "3.8-2.fc37.aarch64"
+      "evra": "3.8-3.fc38.aarch64"
     },
     "newt": {
-      "evra": "0.52.23-1.fc37.aarch64"
+      "evra": "0.52.23-2.fc38.aarch64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.2-2.rc6.fc37.aarch64"
+      "evra": "1:2.6.2-2.rc6.fc38.1.aarch64"
     },
     "nftables": {
-      "evra": "1:1.0.4-3.fc37.aarch64"
+      "evra": "1:1.0.5-2.fc38.aarch64"
     },
     "nmstate": {
-      "evra": "2.2.9-2.fc37.aarch64"
+      "evra": "2.2.9-1.fc38.aarch64"
     },
     "npth": {
-      "evra": "1.6-9.fc37.aarch64"
+      "evra": "1.6-12.fc38.aarch64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-21.fc37.aarch64"
+      "evra": "2.18.1-22.fc38.aarch64"
     },
     "numactl-libs": {
-      "evra": "2.0.14-6.fc37.aarch64"
+      "evra": "2.0.16-2.fc38.aarch64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "nvme-cli": {
-      "evra": "2.2.1-1.fc37.aarch64"
+      "evra": "2.4-1.fc38.aarch64"
     },
     "oniguruma": {
-      "evra": "6.9.8-2.D20220919gitb041f6d.fc37.aarch64"
+      "evra": "6.9.8-2.D20220919gitb041f6d.fc38.1.aarch64"
     },
     "openldap": {
-      "evra": "2.6.4-1.fc37.aarch64"
+      "evra": "2.6.4-1.fc38.aarch64"
     },
     "openssh": {
-      "evra": "8.8p1-9.fc37.aarch64"
+      "evra": "9.0p1-14.fc38.1.aarch64"
     },
     "openssh-clients": {
-      "evra": "8.8p1-9.fc37.aarch64"
+      "evra": "9.0p1-14.fc38.1.aarch64"
     },
     "openssh-server": {
-      "evra": "8.8p1-9.fc37.aarch64"
+      "evra": "9.0p1-14.fc38.1.aarch64"
     },
     "openssl": {
-      "evra": "1:3.0.8-1.fc37.aarch64"
+      "evra": "1:3.0.8-2.fc38.aarch64"
     },
     "openssl-libs": {
-      "evra": "1:3.0.8-1.fc37.aarch64"
+      "evra": "1:3.0.8-2.fc38.aarch64"
     },
     "os-prober": {
-      "evra": "1.81-1.fc37.aarch64"
+      "evra": "1.81-3.fc38.aarch64"
     },
     "ostree": {
-      "evra": "2022.7-2.fc37.aarch64"
+      "evra": "2023.1-2.fc38.aarch64"
     },
     "ostree-libs": {
-      "evra": "2022.7-2.fc37.aarch64"
+      "evra": "2023.1-2.fc38.aarch64"
     },
     "p11-kit": {
-      "evra": "0.24.1-3.fc37.aarch64"
+      "evra": "0.24.1-6.fc38.aarch64"
     },
     "p11-kit-trust": {
-      "evra": "0.24.1-3.fc37.aarch64"
+      "evra": "0.24.1-6.fc38.aarch64"
     },
     "pam": {
-      "evra": "1.5.2-14.fc37.aarch64"
+      "evra": "1.5.2-16.fc38.aarch64"
     },
     "pam-libs": {
-      "evra": "1.5.2-14.fc37.aarch64"
+      "evra": "1.5.2-16.fc38.aarch64"
     },
     "passwd": {
-      "evra": "0.80-13.fc37.aarch64"
-    },
-    "pcre": {
-      "evra": "8.45-1.fc37.2.aarch64"
+      "evra": "0.80-14.fc38.aarch64"
     },
     "pcre2": {
-      "evra": "10.40-1.fc37.1.aarch64"
+      "evra": "10.42-1.fc38.1.aarch64"
     },
     "pcre2-syntax": {
-      "evra": "10.40-1.fc37.1.noarch"
+      "evra": "10.42-1.fc38.1.noarch"
     },
     "pigz": {
-      "evra": "2.7-2.fc37.aarch64"
+      "evra": "2.7-3.fc38.aarch64"
     },
     "pkgconf": {
-      "evra": "1.8.0-3.fc37.aarch64"
+      "evra": "1.8.0-6.fc38.aarch64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-3.fc37.noarch"
+      "evra": "1.8.0-6.fc38.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-3.fc37.aarch64"
+      "evra": "1.8.0-6.fc38.aarch64"
     },
     "podman": {
-      "evra": "5:4.4.4-3.fc37.aarch64"
+      "evra": "5:4.5.0-1.fc38.aarch64"
     },
     "podman-plugins": {
-      "evra": "5:4.4.4-3.fc37.aarch64"
+      "evra": "5:4.5.0-1.fc38.aarch64"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc37.aarch64"
+      "evra": "3.5-1.fc38.aarch64"
     },
     "polkit": {
-      "evra": "121-4.fc37.2.aarch64"
+      "evra": "122-3.fc38.aarch64"
     },
     "polkit-libs": {
-      "evra": "121-4.fc37.2.aarch64"
+      "evra": "122-3.fc38.aarch64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-22.fc37.aarch64"
+      "evra": "0.1-23.fc38.aarch64"
     },
     "popt": {
-      "evra": "1.19-1.fc37.aarch64"
+      "evra": "1.19-2.fc38.aarch64"
     },
     "procps-ng": {
-      "evra": "3.3.17-6.fc37.2.aarch64"
+      "evra": "3.3.17-9.fc38.aarch64"
     },
     "protobuf-c": {
-      "evra": "1.4.1-2.fc37.aarch64"
+      "evra": "1.4.1-4.fc38.aarch64"
     },
     "psmisc": {
-      "evra": "23.4-4.fc37.aarch64"
+      "evra": "23.6-2.fc38.aarch64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230318-1.fc37.noarch"
+      "evra": "20230318-1.fc38.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.0.0-15.fc37.aarch64"
+      "evra": "2:7.2.0-6.fc38.aarch64"
     },
     "readline": {
-      "evra": "8.2-2.fc37.aarch64"
+      "evra": "8.2-3.fc38.aarch64"
     },
     "rpcbind": {
-      "evra": "1.2.6-3.rc2.fc37.aarch64"
+      "evra": "1.2.6-4.rc2.fc38.aarch64"
     },
     "rpm": {
-      "evra": "4.18.0-1.fc37.aarch64"
+      "evra": "4.18.1-1.fc38.aarch64"
     },
     "rpm-libs": {
-      "evra": "4.18.0-1.fc37.aarch64"
+      "evra": "4.18.1-1.fc38.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2023.2-1.fc37.aarch64"
+      "evra": "2023.2-1.fc38.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.2-1.fc37.aarch64"
+      "evra": "2023.2-1.fc38.aarch64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.0-1.fc37.aarch64"
+      "evra": "4.18.1-1.fc38.aarch64"
+    },
+    "rpm-sequoia": {
+      "evra": "1.3.0-1.fc38.aarch64"
     },
     "rsync": {
-      "evra": "3.2.7-1.fc37.aarch64"
+      "evra": "3.2.7-2.fc38.aarch64"
     },
     "runc": {
-      "evra": "2:1.1.4-1.fc37.aarch64"
+      "evra": "2:1.1.4-2.fc38.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.17.7-0.fc37.aarch64"
+      "evra": "2:4.18.1-0.fc38.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.17.7-0.fc37.noarch"
+      "evra": "2:4.18.1-0.fc38.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.17.7-0.fc37.aarch64"
+      "evra": "2:4.18.1-0.fc38.aarch64"
     },
     "sed": {
-      "evra": "4.8-11.fc37.aarch64"
+      "evra": "4.8-12.fc38.aarch64"
     },
     "selinux-policy": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "setup": {
-      "evra": "2.14.1-2.fc37.noarch"
+      "evra": "2.14.3-2.fc38.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-4.fc37.aarch64"
+      "evra": "1.46-5.fc38.aarch64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-4.fc37.aarch64"
+      "evra": "1.46-5.fc38.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.12.3-6.fc37.aarch64"
+      "evra": "2:4.13-6.fc38.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.12.3-6.fc37.aarch64"
+      "evra": "2:4.13-6.fc38.aarch64"
     },
     "shared-mime-info": {
-      "evra": "2.2-2.fc37.aarch64"
+      "evra": "2.2-3.fc38.aarch64"
     },
     "shim-aa64": {
       "evra": "15.6-2.aarch64"
     },
     "skopeo": {
-      "evra": "1:1.11.2-1.fc37.aarch64"
+      "evra": "1:1.11.2-1.fc38.aarch64"
     },
     "slang": {
-      "evra": "2.3.3-1.fc37.aarch64"
+      "evra": "2.3.3-3.fc38.aarch64"
     },
     "slirp4netns": {
-      "evra": "1.2.0-8.fc37.aarch64"
+      "evra": "1.2.0-12.fc38.aarch64"
     },
     "snappy": {
-      "evra": "1.1.9-5.fc37.aarch64"
+      "evra": "1.1.9-7.fc38.aarch64"
     },
     "socat": {
-      "evra": "1.7.4.2-3.fc37.aarch64"
+      "evra": "1.7.4.4-2.fc38.aarch64"
     },
     "sqlite-libs": {
-      "evra": "3.40.0-1.fc37.aarch64"
+      "evra": "3.40.1-2.fc38.aarch64"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-2.fc37.aarch64"
+      "evra": "4.5.1-3.fc38.aarch64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-1.fc37.aarch64"
+      "evra": "0.1.4-3.fc38.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-client": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-common": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.8.2-1.fc37.aarch64"
+      "evra": "2.8.2-4.fc38.aarch64"
     },
     "stalld": {
-      "evra": "1.16-2.fc37.aarch64"
+      "evra": "1.16-3.fc38.aarch64"
     },
     "sudo": {
-      "evra": "1.9.13-1.p2.fc37.aarch64"
+      "evra": "1.9.13-1.p2.fc38.aarch64"
     },
     "systemd": {
-      "evra": "251.14-2.fc37.aarch64"
-    },
-    "systemd-boot-unsigned": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "systemd-container": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "systemd-libs": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "systemd-pam": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "systemd-resolved": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "systemd-udev": {
-      "evra": "251.14-2.fc37.aarch64"
+      "evra": "253.2-1.fc38.aarch64"
     },
     "tar": {
-      "evra": "2:1.34-6.fc37.aarch64"
+      "evra": "2:1.34-8.fc38.aarch64"
     },
     "teamd": {
-      "evra": "1.31-6.fc37.aarch64"
+      "evra": "1.31-7.fc38.aarch64"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc37.aarch64"
+      "evra": "0.0.99.4-1.fc38.aarch64"
     },
     "tpm2-tools": {
-      "evra": "5.4-1.fc37.aarch64"
+      "evra": "5.5-1.fc38.aarch64"
     },
     "tpm2-tss": {
-      "evra": "3.2.2-1.fc37.aarch64"
+      "evra": "4.0.1-3.fc38.aarch64"
     },
     "tzdata": {
-      "evra": "2022g-1.fc37.noarch"
+      "evra": "2023c-1.fc38.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-5.fc37.aarch64"
+      "evra": "0.13.2-2.fc38.aarch64"
     },
     "util-linux": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "util-linux-core": {
-      "evra": "2.38.1-1.fc37.aarch64"
+      "evra": "2.38.1-4.fc38.aarch64"
     },
     "vim-data": {
-      "evra": "2:9.0.1440-1.fc37.noarch"
+      "evra": "2:9.0.1440-1.fc38.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.1440-1.fc37.aarch64"
+      "evra": "2:9.0.1440-1.fc38.aarch64"
     },
     "which": {
-      "evra": "2.21-39.fc37.aarch64"
+      "evra": "2.21-39.fc38.aarch64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-3.fc37.aarch64"
+      "evra": "1.0.20210914-4.fc38.aarch64"
     },
     "xfsprogs": {
-      "evra": "6.1.0-2.fc37.aarch64"
+      "evra": "6.1.0-3.fc38.aarch64"
     },
     "xxhash-libs": {
-      "evra": "0.8.1-3.fc37.aarch64"
+      "evra": "0.8.1-4.fc38.aarch64"
     },
     "xz": {
-      "evra": "5.4.1-1.fc37.aarch64"
+      "evra": "5.4.1-1.fc38.aarch64"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc37.aarch64"
+      "evra": "5.4.1-1.fc38.aarch64"
     },
     "yajl": {
-      "evra": "2.1.0-19.fc37.aarch64"
+      "evra": "2.1.0-20.fc38.aarch64"
     },
     "zchunk-libs": {
-      "evra": "1.3.1-1.fc37.aarch64"
+      "evra": "1.3.1-1.fc38.aarch64"
     },
     "zincati": {
-      "evra": "0.0.25-2.fc37.aarch64"
+      "evra": "0.0.25-4.fc38.aarch64"
     },
     "zlib": {
-      "evra": "1.2.12-5.fc37.aarch64"
+      "evra": "1.2.13-3.fc38.aarch64"
     },
     "zram-generator": {
-      "evra": "1.1.2-2.fc37.aarch64"
+      "evra": "1.1.2-4.fc38.aarch64"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc37.aarch64"
+      "evra": "1.5.5-1.fc38.aarch64"
     }
   },
   "metadata": {
-    "generated": "2023-04-13T00:00:00Z",
+    "generated": "2023-04-17T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2022-11-05T08:04:22Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:19:34Z"
+        "generated": "2023-04-17T00:31:04Z"
       },
-      "fedora-updates": {
-        "generated": "2023-04-13T01:45:05Z"
+      "fedora-next": {
+        "generated": "2023-04-14T09:32:18Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-04-16T01:55:02Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,40 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  aardvark-dns:
+    evr: 1.6.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  containers-common:
+    evra: 4:1-89.fc38.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  containers-common-extra:
+    evra: 4:1-89.fc38.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  netavark:
+    evr: 1.6.0-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  podman:
+    evr: 5:4.5.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  podman-plugins:
+    evr: 5:4.5.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,1268 +1,1274 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.40.10-1.fc37.ppc64le"
+      "evra": "1:1.42.0-1.fc38.ppc64le"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.40.10-1.fc37.ppc64le"
+      "evra": "1:1.42.0-1.fc38.ppc64le"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.40.10-1.fc37.ppc64le"
+      "evra": "1:1.42.0-1.fc38.ppc64le"
     },
     "NetworkManager-team": {
-      "evra": "1:1.40.10-1.fc37.ppc64le"
+      "evra": "1:1.42.0-1.fc38.ppc64le"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.40.10-1.fc37.ppc64le"
+      "evra": "1:1.42.0-1.fc38.ppc64le"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.8.0.11-1.fc37.noarch"
+      "evra": "2.9.0.4-1.fc38.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.5.0-4.fc37.ppc64le"
+      "evra": "1.6.0-1.fc38.ppc64le"
     },
     "acl": {
-      "evra": "2.3.1-4.fc37.ppc64le"
+      "evra": "2.3.1-6.fc38.ppc64le"
     },
     "adcli": {
-      "evra": "0.9.1-11.fc37.ppc64le"
+      "evra": "0.9.2-2.fc38.ppc64le"
     },
     "afterburn": {
-      "evra": "5.4.0-2.fc37.ppc64le"
+      "evra": "5.4.0-2.fc38.ppc64le"
     },
     "afterburn-dracut": {
-      "evra": "5.4.0-2.fc37.ppc64le"
+      "evra": "5.4.0-2.fc38.ppc64le"
     },
     "alternatives": {
-      "evra": "1.22-1.fc37.ppc64le"
+      "evra": "1.22-1.fc38.ppc64le"
     },
     "amd-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "attr": {
-      "evra": "2.5.1-5.fc37.ppc64le"
+      "evra": "2.5.1-6.fc38.ppc64le"
     },
     "audit-libs": {
-      "evra": "3.1-2.fc37.ppc64le"
+      "evra": "3.1-2.fc38.ppc64le"
     },
     "authselect": {
-      "evra": "1.4.2-1.fc37.ppc64le"
+      "evra": "1.4.2-2.fc38.ppc64le"
     },
     "authselect-libs": {
-      "evra": "1.4.2-1.fc37.ppc64le"
+      "evra": "1.4.2-2.fc38.ppc64le"
     },
     "avahi-libs": {
-      "evra": "0.8-18.fc37.ppc64le"
+      "evra": "0.8-20.fc38.ppc64le"
     },
     "basesystem": {
-      "evra": "11-14.fc37.noarch"
+      "evra": "11-15.fc38.noarch"
     },
     "bash": {
-      "evra": "5.2.15-1.fc37.ppc64le"
+      "evra": "5.2.15-3.fc38.ppc64le"
     },
     "bash-completion": {
-      "evra": "1:2.11-8.fc37.noarch"
+      "evra": "1:2.11-9.fc38.noarch"
     },
     "bc": {
-      "evra": "1.07.1-16.fc37.ppc64le"
+      "evra": "1.07.1-17.fc38.ppc64le"
     },
     "bind-libs": {
-      "evra": "32:9.18.13-1.fc37.ppc64le"
+      "evra": "32:9.18.13-1.fc38.ppc64le"
     },
     "bind-license": {
-      "evra": "32:9.18.13-1.fc37.noarch"
+      "evra": "32:9.18.13-1.fc38.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.13-1.fc37.ppc64le"
+      "evra": "32:9.18.13-1.fc38.ppc64le"
     },
     "bsdtar": {
-      "evra": "3.6.1-3.fc37.ppc64le"
+      "evra": "3.6.1-4.fc38.ppc64le"
     },
     "btrfs-progs": {
-      "evra": "6.2.2-1.fc37.ppc64le"
+      "evra": "6.2.2-1.fc38.ppc64le"
     },
     "bubblewrap": {
-      "evra": "0.5.0-3.fc37.ppc64le"
+      "evra": "0.7.0-1.fc38.ppc64le"
     },
     "bzip2": {
-      "evra": "1.0.8-12.fc37.ppc64le"
+      "evra": "1.0.8-13.fc38.ppc64le"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-12.fc37.ppc64le"
+      "evra": "1.0.8-13.fc38.ppc64le"
     },
     "c-ares": {
-      "evra": "1.19.0-1.fc37.ppc64le"
+      "evra": "1.19.0-1.fc38.ppc64le"
     },
     "ca-certificates": {
-      "evra": "2023.2.60-1.0.fc37.noarch"
+      "evra": "2023.2.60-2.fc38.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-10.fc37.ppc64le"
+      "evra": "0.1.7-14.fc38.ppc64le"
     },
     "chrony": {
-      "evra": "4.3-1.fc37.ppc64le"
+      "evra": "4.3-3.fc38.ppc64le"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc37.ppc64le"
+      "evra": "7.0-1.fc38.ppc64le"
     },
     "clevis": {
-      "evra": "19-2.fc37.ppc64le"
+      "evra": "19-2.fc38.ppc64le"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc37.ppc64le"
+      "evra": "19-2.fc38.ppc64le"
     },
     "clevis-luks": {
-      "evra": "19-2.fc37.ppc64le"
+      "evra": "19-2.fc38.ppc64le"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc37.ppc64le"
+      "evra": "19-2.fc38.ppc64le"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-11.fc37.noarch"
+      "evra": "0.31-12.fc38.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc37.ppc64le"
+      "evra": "2:2.1.7-2.fc38.ppc64le"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.209.0-1.fc37.noarch"
+      "evra": "2:2.209.0-1.fc38.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc37.ppc64le"
+      "evra": "1.6.19-1.fc38.ppc64le"
     },
     "containernetworking-plugins": {
-      "evra": "1.1.1-16.fc37.ppc64le"
+      "evra": "1.1.1-16.fc38.ppc64le"
     },
     "containers-common": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "coreos-installer": {
-      "evra": "0.17.0-1.fc37.ppc64le"
+      "evra": "0.17.0-1.fc38.ppc64le"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.17.0-1.fc37.ppc64le"
+      "evra": "0.17.0-1.fc38.ppc64le"
     },
     "coreutils": {
-      "evra": "9.1-7.fc37.ppc64le"
+      "evra": "9.1-11.fc38.ppc64le"
     },
     "coreutils-common": {
-      "evra": "9.1-7.fc37.ppc64le"
+      "evra": "9.1-11.fc38.ppc64le"
     },
     "cpio": {
-      "evra": "2.13-13.fc37.ppc64le"
+      "evra": "2.13-14.fc38.ppc64le"
     },
     "cracklib": {
-      "evra": "2.9.7-30.fc37.ppc64le"
+      "evra": "2.9.7-31.fc38.ppc64le"
     },
     "criu": {
-      "evra": "3.17.1-3.fc37.ppc64le"
+      "evra": "3.17.1-5.fc38.ppc64le"
     },
     "criu-libs": {
-      "evra": "3.17.1-3.fc37.ppc64le"
+      "evra": "3.17.1-5.fc38.ppc64le"
     },
     "crun": {
-      "evra": "1.8.3-2.fc37.ppc64le"
+      "evra": "1.8.3-2.fc38.ppc64le"
     },
     "crypto-policies": {
-      "evra": "20220815-1.gite4ed860.fc37.noarch"
+      "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc37.ppc64le"
+      "evra": "2.6.1-1.fc38.ppc64le"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc37.ppc64le"
+      "evra": "2.6.1-1.fc38.ppc64le"
     },
     "curl": {
-      "evra": "7.85.0-8.fc37.ppc64le"
+      "evra": "7.87.0-7.fc38.ppc64le"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-8.fc37.ppc64le"
+      "evra": "2.1.28-9.fc38.ppc64le"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-8.fc37.ppc64le"
+      "evra": "2.1.28-9.fc38.ppc64le"
     },
     "dbus": {
-      "evra": "1:1.14.6-1.fc37.ppc64le"
+      "evra": "1:1.14.6-1.fc38.ppc64le"
     },
     "dbus-broker": {
-      "evra": "33-1.fc37.ppc64le"
+      "evra": "33-1.fc38.ppc64le"
     },
     "dbus-common": {
-      "evra": "1:1.14.6-1.fc37.noarch"
+      "evra": "1:1.14.6-1.fc38.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.6-1.fc37.ppc64le"
+      "evra": "1:1.14.6-1.fc38.ppc64le"
     },
     "device-mapper": {
-      "evra": "1.02.175-9.fc37.ppc64le"
+      "evra": "1.02.189-2.fc38.ppc64le"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-9.fc37.ppc64le"
+      "evra": "1.02.189-2.fc38.ppc64le"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-9.fc37.ppc64le"
+      "evra": "1.02.189-2.fc38.ppc64le"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-9.fc37.ppc64le"
+      "evra": "1.02.189-2.fc38.ppc64le"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.0-4.fc37.ppc64le"
+      "evra": "0.9.4-2.fc38.ppc64le"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.0-4.fc37.ppc64le"
+      "evra": "0.9.4-2.fc38.ppc64le"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-8.fc37.ppc64le"
+      "evra": "0.9.0-10.fc38.ppc64le"
     },
     "diffutils": {
-      "evra": "3.8-3.fc37.ppc64le"
+      "evra": "3.9-1.fc38.ppc64le"
     },
     "dnsmasq": {
-      "evra": "2.89-2.fc37.ppc64le"
+      "evra": "2.89-1.fc38.ppc64le"
     },
     "dosfstools": {
-      "evra": "4.2-4.fc37.ppc64le"
+      "evra": "4.2-6.fc38.ppc64le"
     },
     "dracut": {
-      "evra": "059-1.fc37.ppc64le"
+      "evra": "059-2.fc38.ppc64le"
     },
     "dracut-network": {
-      "evra": "059-1.fc37.ppc64le"
+      "evra": "059-2.fc38.ppc64le"
     },
     "dracut-squash": {
-      "evra": "059-1.fc37.ppc64le"
+      "evra": "059-2.fc38.ppc64le"
+    },
+    "duktape": {
+      "evra": "2.7.0-2.fc38.ppc64le"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-3.fc37.ppc64le"
+      "evra": "1.46.5-4.fc38.ppc64le"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-3.fc37.ppc64le"
+      "evra": "1.46.5-4.fc38.ppc64le"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-1.fc37.noarch"
+      "evra": "0.189-1.fc38.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-1.fc37.ppc64le"
+      "evra": "0.189-1.fc38.ppc64le"
     },
     "elfutils-libs": {
-      "evra": "0.189-1.fc37.ppc64le"
+      "evra": "0.189-1.fc38.ppc64le"
     },
     "ethtool": {
-      "evra": "2:6.2-1.fc37.ppc64le"
+      "evra": "2:6.2-1.fc38.ppc64le"
     },
     "expat": {
-      "evra": "2.5.0-1.fc37.ppc64le"
+      "evra": "2.5.0-2.fc38.ppc64le"
     },
     "fedora-gpg-keys": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
-      "evra": "5.42-4.fc37.ppc64le"
+      "evra": "5.44-3.fc38.ppc64le"
     },
     "file-libs": {
-      "evra": "5.42-4.fc37.ppc64le"
+      "evra": "5.44-3.fc38.ppc64le"
     },
     "filesystem": {
-      "evra": "3.18-2.fc37.ppc64le"
+      "evra": "3.18-3.fc38.ppc64le"
     },
     "findutils": {
-      "evra": "1:4.9.0-2.fc37.ppc64le"
+      "evra": "1:4.9.0-3.fc38.ppc64le"
     },
     "flatpak-session-helper": {
-      "evra": "1.14.4-1.fc37.ppc64le"
+      "evra": "1.15.4-1.fc38.ppc64le"
     },
     "fstrm": {
-      "evra": "0.6.1-5.fc37.ppc64le"
+      "evra": "0.6.1-6.fc38.ppc64le"
     },
     "fuse": {
-      "evra": "2.9.9-15.fc37.ppc64le"
+      "evra": "2.9.9-16.fc38.ppc64le"
     },
     "fuse-common": {
-      "evra": "3.10.5-5.fc37.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fuse-libs": {
-      "evra": "2.9.9-15.fc37.ppc64le"
+      "evra": "2.9.9-16.fc38.ppc64le"
     },
     "fuse-overlayfs": {
-      "evra": "1.9-6.fc37.ppc64le"
+      "evra": "1.10-3.fc38.ppc64le"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-2.fc37.ppc64le"
+      "evra": "3.7.3-3.fc38.ppc64le"
     },
     "fuse3": {
-      "evra": "3.10.5-5.fc37.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-5.fc37.ppc64le"
+      "evra": "3.13.1-2.fc38.ppc64le"
     },
     "fwupd": {
-      "evra": "1.8.14-1.fc37.ppc64le"
+      "evra": "1.8.14-1.fc38.ppc64le"
     },
     "gawk": {
-      "evra": "5.1.1-4.fc37.ppc64le"
+      "evra": "5.1.1-5.fc38.ppc64le"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-2.fc37.ppc64le"
+      "evra": "1:1.23-3.fc38.ppc64le"
     },
     "gdisk": {
-      "evra": "1.0.9-4.fc37.ppc64le"
+      "evra": "1.0.9-5.fc38.ppc64le"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-1.fc37.ppc64le"
+      "evra": "0.21.1-2.fc38.ppc64le"
     },
     "gettext-libs": {
-      "evra": "0.21.1-1.fc37.ppc64le"
+      "evra": "0.21.1-2.fc38.ppc64le"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-1.fc37.ppc64le"
+      "evra": "0.21.1-2.fc38.ppc64le"
     },
     "git-core": {
-      "evra": "2.39.2-1.fc37.ppc64le"
+      "evra": "2.40.0-1.fc38.ppc64le"
     },
     "glib2": {
-      "evra": "2.74.6-1.fc37.ppc64le"
+      "evra": "2.76.1-1.fc38.ppc64le"
     },
     "glibc": {
-      "evra": "2.36-9.fc37.ppc64le"
+      "evra": "2.37-1.fc38.ppc64le"
     },
     "glibc-common": {
-      "evra": "2.36-9.fc37.ppc64le"
+      "evra": "2.37-1.fc38.ppc64le"
     },
     "glibc-gconv-extra": {
-      "evra": "2.36-9.fc37.ppc64le"
+      "evra": "2.37-1.fc38.ppc64le"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.36-9.fc37.ppc64le"
+      "evra": "2.37-1.fc38.ppc64le"
     },
     "gmp": {
-      "evra": "1:6.2.1-3.fc37.ppc64le"
+      "evra": "1:6.2.1-4.fc38.ppc64le"
     },
     "gnupg2": {
-      "evra": "2.3.8-1.fc37.ppc64le"
+      "evra": "2.4.0-3.fc38.ppc64le"
     },
     "gnutls": {
-      "evra": "3.8.0-2.fc37.ppc64le"
+      "evra": "3.8.0-2.fc38.ppc64le"
     },
     "gpgme": {
-      "evra": "1.17.0-4.fc37.ppc64le"
+      "evra": "1.17.1-3.fc38.ppc64le"
     },
     "grep": {
-      "evra": "3.7-4.fc37.ppc64le"
+      "evra": "3.8-3.fc38.ppc64le"
     },
     "grub2-common": {
-      "evra": "1:2.06-94.fc37.noarch"
+      "evra": "1:2.06-89.fc38.noarch"
     },
     "grub2-ppc64le": {
-      "evra": "1:2.06-94.fc37.ppc64le"
+      "evra": "1:2.06-89.fc38.ppc64le"
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.06-94.fc37.noarch"
+      "evra": "1:2.06-89.fc38.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-94.fc37.ppc64le"
+      "evra": "1:2.06-89.fc38.ppc64le"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-94.fc37.ppc64le"
+      "evra": "1:2.06-89.fc38.ppc64le"
     },
     "gzip": {
-      "evra": "1.12-2.fc37.ppc64le"
+      "evra": "1.12-3.fc38.ppc64le"
     },
     "hostname": {
-      "evra": "3.23-7.fc37.ppc64le"
+      "evra": "3.23-8.fc38.ppc64le"
     },
     "ignition": {
-      "evra": "2.15.0-3.fc37.ppc64le"
+      "evra": "2.15.0-3.fc38.ppc64le"
     },
     "inih": {
-      "evra": "56-2.fc37.ppc64le"
+      "evra": "56-3.fc38.ppc64le"
     },
     "intel-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "iproute": {
-      "evra": "5.18.0-2.fc37.ppc64le"
+      "evra": "6.1.0-1.fc38.ppc64le"
     },
     "iproute-tc": {
-      "evra": "5.18.0-2.fc37.ppc64le"
+      "evra": "6.1.0-1.fc38.ppc64le"
     },
     "iptables-legacy": {
-      "evra": "1.8.8-4.fc37.ppc64le"
+      "evra": "1.8.9-2.fc38.ppc64le"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.8-4.fc37.ppc64le"
+      "evra": "1.8.9-2.fc38.ppc64le"
     },
     "iptables-libs": {
-      "evra": "1.8.8-4.fc37.ppc64le"
+      "evra": "1.8.9-2.fc38.ppc64le"
     },
     "iptables-nft": {
-      "evra": "1.8.8-4.fc37.ppc64le"
+      "evra": "1.8.9-2.fc38.ppc64le"
     },
     "iptables-services": {
-      "evra": "1.8.8-4.fc37.noarch"
+      "evra": "1.8.9-2.fc38.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.8-4.fc37.ppc64le"
+      "evra": "1.8.9-2.fc38.ppc64le"
     },
     "iputils": {
-      "evra": "20221126-1.fc37.ppc64le"
+      "evra": "20221126-2.fc38.ppc64le"
     },
     "irqbalance": {
-      "evra": "2:1.9.1-1.fc37.ppc64le"
+      "evra": "2:1.9.1-2.fc38.ppc64le"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.ppc64le"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.ppc64le"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.ppc64le"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.ppc64le"
     },
     "isns-utils-libs": {
-      "evra": "0.101-5.fc37.ppc64le"
+      "evra": "0.101-6.fc38.ppc64le"
     },
     "jansson": {
-      "evra": "2.13.1-5.fc37.ppc64le"
+      "evra": "2.13.1-6.fc38.ppc64le"
     },
     "jemalloc": {
-      "evra": "5.3.0-2.fc37.ppc64le"
+      "evra": "5.3.0-3.fc38.ppc64le"
     },
     "jose": {
-      "evra": "11-6.fc37.ppc64le"
+      "evra": "11-7.fc38.ppc64le"
     },
     "jq": {
-      "evra": "1.6-14.fc37.ppc64le"
+      "evra": "1.6-15.fc38.ppc64le"
     },
     "json-c": {
-      "evra": "0.16-3.fc37.ppc64le"
+      "evra": "0.16-4.fc38.ppc64le"
     },
     "json-glib": {
-      "evra": "1.6.6-3.fc37.ppc64le"
+      "evra": "1.6.6-4.fc38.ppc64le"
     },
     "kbd": {
-      "evra": "2.5.1-3.fc37.ppc64le"
+      "evra": "2.5.1-5.fc38.ppc64le"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.2.9-200.fc37.ppc64le"
+      "evra": "6.2.11-300.fc38.ppc64le"
     },
     "kernel-core": {
-      "evra": "6.2.9-200.fc37.ppc64le"
+      "evra": "6.2.11-300.fc38.ppc64le"
     },
     "kernel-modules": {
-      "evra": "6.2.9-200.fc37.ppc64le"
+      "evra": "6.2.11-300.fc38.ppc64le"
     },
     "kernel-modules-core": {
-      "evra": "6.2.9-200.fc37.ppc64le"
+      "evra": "6.2.11-300.fc38.ppc64le"
     },
     "kexec-tools": {
-      "evra": "2.0.25-1.fc37.ppc64le"
+      "evra": "2.0.26-3.fc38.ppc64le"
     },
     "keyutils": {
-      "evra": "1.6.1-5.fc37.ppc64le"
+      "evra": "1.6.1-6.fc38.ppc64le"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-5.fc37.ppc64le"
+      "evra": "1.6.1-6.fc38.ppc64le"
     },
     "kmod": {
-      "evra": "30-2.fc37.ppc64le"
+      "evra": "30-4.fc38.ppc64le"
     },
     "kmod-libs": {
-      "evra": "30-2.fc37.ppc64le"
+      "evra": "30-4.fc38.ppc64le"
     },
     "kpartx": {
-      "evra": "0.9.0-4.fc37.ppc64le"
+      "evra": "0.9.4-2.fc38.ppc64le"
     },
     "krb5-libs": {
-      "evra": "1.19.2-13.fc37.ppc64le"
+      "evra": "1.20.1-8.fc38.ppc64le"
     },
     "less": {
-      "evra": "590-5.fc37.ppc64le"
+      "evra": "608-2.fc38.ppc64le"
     },
     "libacl": {
-      "evra": "2.3.1-4.fc37.ppc64le"
+      "evra": "2.3.1-6.fc38.ppc64le"
     },
     "libaio": {
-      "evra": "0.3.111-14.fc37.ppc64le"
+      "evra": "0.3.111-15.fc38.ppc64le"
     },
     "libarchive": {
-      "evra": "3.6.1-3.fc37.ppc64le"
+      "evra": "3.6.1-4.fc38.ppc64le"
     },
     "libargon2": {
-      "evra": "20190702-1.fc37.ppc64le"
+      "evra": "20190702-2.fc38.ppc64le"
     },
     "libassuan": {
-      "evra": "2.5.5-5.fc37.ppc64le"
+      "evra": "2.5.5-6.fc38.ppc64le"
+    },
+    "libatomic": {
+      "evra": "13.0.1-0.12.fc38.ppc64le"
     },
     "libattr": {
-      "evra": "2.5.1-5.fc37.ppc64le"
+      "evra": "2.5.1-6.fc38.ppc64le"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-52.fc37.ppc64le"
+      "evra": "0.1.1-53.fc38.ppc64le"
     },
     "libblkid": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "libbpf": {
-      "evra": "2:0.8.0-2.fc37.ppc64le"
+      "evra": "2:1.1.0-2.fc38.ppc64le"
     },
     "libbsd": {
-      "evra": "0.11.7-2.fc37.ppc64le"
+      "evra": "0.11.7-4.fc38.ppc64le"
     },
     "libcap": {
-      "evra": "2.48-5.fc37.ppc64le"
+      "evra": "2.48-6.fc38.ppc64le"
     },
     "libcap-ng": {
-      "evra": "0.8.3-3.fc37.ppc64le"
+      "evra": "0.8.3-5.fc38.ppc64le"
     },
     "libcbor": {
-      "evra": "0.7.0-7.fc37.ppc64le"
+      "evra": "0.7.0-9.fc38.ppc64le"
     },
     "libcollection": {
-      "evra": "0.7.0-52.fc37.ppc64le"
+      "evra": "0.7.0-53.fc38.ppc64le"
     },
     "libcom_err": {
-      "evra": "1.46.5-3.fc37.ppc64le"
+      "evra": "1.46.5-4.fc38.ppc64le"
     },
     "libcurl-minimal": {
-      "evra": "7.85.0-8.fc37.ppc64le"
+      "evra": "7.87.0-7.fc38.ppc64le"
     },
     "libdaemon": {
-      "evra": "0.14-24.fc37.ppc64le"
+      "evra": "0.14-25.fc38.ppc64le"
     },
     "libdb": {
-      "evra": "5.3.28-53.fc37.ppc64le"
+      "evra": "5.3.28-55.fc38.ppc64le"
     },
     "libdhash": {
-      "evra": "0.5.0-52.fc37.ppc64le"
+      "evra": "0.5.0-53.fc38.ppc64le"
     },
     "libeconf": {
-      "evra": "0.4.0-4.fc37.ppc64le"
+      "evra": "0.4.0-5.fc38.ppc64le"
     },
     "libedit": {
-      "evra": "3.1-43.20221009cvs.fc37.ppc64le"
+      "evra": "3.1-45.20221030cvs.fc38.ppc64le"
     },
     "libevent": {
-      "evra": "2.1.12-7.fc37.ppc64le"
+      "evra": "2.1.12-8.fc38.ppc64le"
     },
     "libfdisk": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "libffi": {
-      "evra": "3.4.4-1.fc37.ppc64le"
+      "evra": "3.4.4-2.fc38.ppc64le"
     },
     "libfido2": {
-      "evra": "1.11.0-3.fc37.ppc64le"
+      "evra": "1.12.0-3.fc38.ppc64le"
     },
     "libgcab1": {
-      "evra": "1.5-1.fc37.ppc64le"
+      "evra": "1.5-2.fc38.ppc64le"
     },
     "libgcc": {
-      "evra": "12.2.1-4.fc37.ppc64le"
+      "evra": "13.0.1-0.12.fc38.ppc64le"
     },
     "libgcrypt": {
-      "evra": "1.10.1-4.fc37.ppc64le"
+      "evra": "1.10.1-7.fc38.ppc64le"
     },
     "libgpg-error": {
-      "evra": "1.46-1.fc37.ppc64le"
+      "evra": "1.46-2.fc38.ppc64le"
     },
     "libgudev": {
-      "evra": "237-3.fc37.ppc64le"
+      "evra": "237-4.fc38.ppc64le"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc37.ppc64le"
+      "evra": "0.4.5-1.fc38.ppc64le"
     },
     "libibverbs": {
-      "evra": "41.0-1.fc37.ppc64le"
+      "evra": "44.0-3.fc38.ppc64le"
     },
     "libicu": {
-      "evra": "71.1-2.fc37.ppc64le"
+      "evra": "72.1-2.fc38.ppc64le"
     },
     "libidn2": {
-      "evra": "2.3.4-1.fc37.ppc64le"
+      "evra": "2.3.4-2.fc38.ppc64le"
     },
     "libini_config": {
-      "evra": "1.3.1-52.fc37.ppc64le"
+      "evra": "1.3.1-53.fc38.ppc64le"
     },
     "libipa_hbac": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc37.ppc64le"
+      "evra": "0.1.13-1.fc38.ppc64le"
     },
     "libjose": {
-      "evra": "11-6.fc37.ppc64le"
+      "evra": "11-7.fc38.ppc64le"
     },
     "libkcapi": {
-      "evra": "1.4.0-2.fc37.ppc64le"
+      "evra": "1.4.0-5.fc38.ppc64le"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-2.fc37.ppc64le"
+      "evra": "1.4.0-5.fc38.ppc64le"
     },
     "libksba": {
-      "evra": "1.6.3-1.fc37.ppc64le"
+      "evra": "1.6.3-2.fc38.ppc64le"
     },
     "libldb": {
-      "evra": "2.6.2-1.fc37.ppc64le"
+      "evra": "2.7.2-1.fc38.ppc64le"
     },
     "libluksmeta": {
-      "evra": "9-14.fc37.ppc64le"
+      "evra": "9-15.fc38.ppc64le"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-1.fc37.ppc64le"
+      "evra": "1.7.1-2.fc38.ppc64le"
     },
     "libmd": {
-      "evra": "1.0.4-2.fc37.ppc64le"
+      "evra": "1.0.4-3.fc38.ppc64le"
     },
     "libmnl": {
-      "evra": "1.0.5-1.fc37.ppc64le"
+      "evra": "1.0.5-2.fc38.ppc64le"
     },
     "libmodulemd": {
-      "evra": "2.14.0-4.fc37.ppc64le"
+      "evra": "2.14.0-5.fc38.ppc64le"
     },
     "libmount": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "libndp": {
-      "evra": "1.8-4.fc37.ppc64le"
+      "evra": "1.8-5.fc38.ppc64le"
     },
     "libnet": {
-      "evra": "1.2-6.fc37.ppc64le"
+      "evra": "1.2-7.fc38.ppc64le"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-5.fc37.ppc64le"
+      "evra": "1.0.8-7.fc38.ppc64le"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-22.fc37.ppc64le"
+      "evra": "1.0.1-23.fc38.ppc64le"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.2-2.rc6.fc37.ppc64le"
+      "evra": "1:2.6.2-2.rc6.fc38.1.ppc64le"
     },
     "libnftnl": {
-      "evra": "1.2.2-2.fc37.ppc64le"
+      "evra": "1.2.4-2.fc38.ppc64le"
     },
     "libnghttp2": {
-      "evra": "1.51.0-1.fc37.ppc64le"
+      "evra": "1.52.0-1.fc38.ppc64le"
     },
     "libnl3": {
-      "evra": "3.7.0-2.fc37.ppc64le"
+      "evra": "3.7.0-3.fc38.ppc64le"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-2.fc37.ppc64le"
+      "evra": "3.7.0-3.fc38.ppc64le"
     },
     "libnsl2": {
-      "evra": "2.0.0-4.fc37.ppc64le"
+      "evra": "2.0.0-5.fc38.ppc64le"
     },
     "libnvme": {
-      "evra": "1.2-1.fc37.ppc64le"
+      "evra": "1.4-1.fc38.ppc64le"
     },
     "libpath_utils": {
-      "evra": "0.2.1-52.fc37.ppc64le"
+      "evra": "0.2.1-53.fc38.ppc64le"
     },
     "libpcap": {
-      "evra": "14:1.10.3-1.fc37.ppc64le"
+      "evra": "14:1.10.3-2.fc38.ppc64le"
     },
     "libpkgconf": {
-      "evra": "1.8.0-3.fc37.ppc64le"
+      "evra": "1.8.0-6.fc38.ppc64le"
     },
     "libpsl": {
-      "evra": "0.21.1-6.fc37.ppc64le"
+      "evra": "0.21.2-2.fc38.ppc64le"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc37.ppc64le"
+      "evra": "1.4.5-3.fc38.ppc64le"
     },
     "libref_array": {
-      "evra": "0.1.5-52.fc37.ppc64le"
+      "evra": "0.1.5-53.fc38.ppc64le"
     },
     "librepo": {
-      "evra": "1.15.1-1.fc37.ppc64le"
+      "evra": "1.15.1-2.fc38.ppc64le"
     },
     "libreport-filesystem": {
-      "evra": "2.17.4-1.fc37.noarch"
+      "evra": "2.17.9-1.fc38.noarch"
     },
     "librtas": {
-      "evra": "2.0.2-13.fc37.ppc64le"
+      "evra": "2.0.4-1.fc38.ppc64le"
     },
     "libseccomp": {
-      "evra": "2.5.3-3.fc37.ppc64le"
+      "evra": "2.5.3-4.fc38.ppc64le"
     },
     "libselinux": {
-      "evra": "3.5-1.fc37.ppc64le"
+      "evra": "3.5-1.fc38.ppc64le"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc37.ppc64le"
+      "evra": "3.5-1.fc38.ppc64le"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc37.ppc64le"
+      "evra": "3.5-2.fc38.ppc64le"
     },
     "libsepol": {
-      "evra": "3.5-1.fc37.ppc64le"
+      "evra": "3.5-1.fc38.ppc64le"
     },
     "libservicelog": {
-      "evra": "1.1.19-4.fc37.ppc64le"
+      "evra": "1.1.19-5.fc38.ppc64le"
     },
     "libsigsegv": {
-      "evra": "2.14-3.fc37.ppc64le"
+      "evra": "2.14-4.fc38.ppc64le"
     },
     "libslirp": {
-      "evra": "4.7.0-2.fc37.ppc64le"
+      "evra": "4.7.0-3.fc38.ppc64le"
     },
     "libsmartcols": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "libsmbclient": {
-      "evra": "2:4.17.7-0.fc37.ppc64le"
+      "evra": "2:4.18.1-0.fc38.ppc64le"
     },
     "libsolv": {
-      "evra": "0.7.22-3.fc37.ppc64le"
+      "evra": "0.7.22-4.fc38.ppc64le"
     },
     "libss": {
-      "evra": "1.46.5-3.fc37.ppc64le"
+      "evra": "1.46.5-4.fc38.ppc64le"
     },
     "libsss_certmap": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "libsss_idmap": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "libsss_nss_idmap": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "libsss_sudo": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "libstdc++": {
-      "evra": "12.2.1-4.fc37.ppc64le"
+      "evra": "13.0.1-0.12.fc38.ppc64le"
     },
     "libtalloc": {
-      "evra": "2.3.4-3.fc37.ppc64le"
+      "evra": "2.4.0-2.fc38.ppc64le"
     },
     "libtasn1": {
-      "evra": "4.19.0-1.fc37.ppc64le"
+      "evra": "4.19.0-2.fc38.ppc64le"
     },
     "libtdb": {
-      "evra": "1.4.7-3.fc37.ppc64le"
+      "evra": "1.4.8-1.fc38.ppc64le"
     },
     "libteam": {
-      "evra": "1.31-6.fc37.ppc64le"
+      "evra": "1.31-7.fc38.ppc64le"
     },
     "libtevent": {
-      "evra": "0.13.0-1.fc37.ppc64le"
+      "evra": "0.14.1-1.fc38.ppc64le"
     },
     "libtirpc": {
-      "evra": "1.3.3-0.fc37.ppc64le"
+      "evra": "1.3.3-1.fc38.ppc64le"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-2.fc37.ppc64le"
+      "evra": "2.4.7-6.fc38.ppc64le"
     },
     "libunistring": {
-      "evra": "1.0-2.fc37.ppc64le"
+      "evra": "1.1-3.fc38.ppc64le"
+    },
+    "libunistring1.0": {
+      "evra": "1.0-1.fc38.ppc64le"
     },
     "libusb1": {
-      "evra": "1.0.25-9.fc37.ppc64le"
+      "evra": "1.0.26-2.fc38.ppc64le"
     },
     "libuser": {
-      "evra": "0.63-13.fc37.ppc64le"
+      "evra": "0.64-2.fc38.ppc64le"
     },
     "libutempter": {
-      "evra": "1.2.1-7.fc37.ppc64le"
+      "evra": "1.2.1-8.fc38.ppc64le"
     },
     "libuuid": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "libuv": {
-      "evra": "1:1.44.2-2.fc37.ppc64le"
+      "evra": "1:1.44.2-3.fc38.ppc64le"
     },
     "libverto": {
-      "evra": "0.3.2-4.fc37.ppc64le"
+      "evra": "0.3.2-5.fc38.ppc64le"
     },
     "libwbclient": {
-      "evra": "2:4.17.7-0.fc37.ppc64le"
+      "evra": "2:4.18.1-0.fc38.ppc64le"
     },
     "libxcrypt": {
-      "evra": "4.4.33-4.fc37.ppc64le"
+      "evra": "4.4.33-7.fc38.ppc64le"
     },
     "libxml2": {
-      "evra": "2.10.3-2.fc37.ppc64le"
+      "evra": "2.10.3-3.fc38.ppc64le"
     },
     "libxmlb": {
-      "evra": "0.3.11-1.fc37.ppc64le"
+      "evra": "0.3.11-1.fc38.ppc64le"
     },
     "libyaml": {
-      "evra": "0.2.5-8.fc37.ppc64le"
+      "evra": "0.2.5-9.fc38.ppc64le"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc37.ppc64le"
+      "evra": "1.5.5-1.fc38.ppc64le"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-33.fc37.ppc64le"
+      "evra": "2.5.1-34.fc38.ppc64le"
     },
     "linux-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.30-1.fc37.ppc64le"
+      "evra": "0.9.30-1.fc38.ppc64le"
     },
     "logrotate": {
-      "evra": "3.20.1-3.fc37.ppc64le"
+      "evra": "3.21.0-2.fc38.ppc64le"
     },
     "lsof": {
-      "evra": "4.94.0-4.fc37.ppc64le"
+      "evra": "4.96.3-3.fc38.ppc64le"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc37.ppc64le"
+      "evra": "5.4.4-9.fc38.ppc64le"
     },
     "luksmeta": {
-      "evra": "9-14.fc37.ppc64le"
+      "evra": "9-15.fc38.ppc64le"
     },
     "lvm2": {
-      "evra": "2.03.11-9.fc37.ppc64le"
+      "evra": "2.03.18-2.fc38.ppc64le"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-9.fc37.ppc64le"
+      "evra": "2.03.18-2.fc38.ppc64le"
     },
     "lz4-libs": {
-      "evra": "1.9.4-1.fc37.ppc64le"
+      "evra": "1.9.4-2.fc38.ppc64le"
     },
     "lzo": {
-      "evra": "2.10-7.fc37.ppc64le"
+      "evra": "2.10-8.fc38.ppc64le"
     },
     "mdadm": {
-      "evra": "4.2-2.fc37.ppc64le"
+      "evra": "4.2-4.fc38.ppc64le"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc37.ppc64le"
-    },
-    "mozjs102": {
-      "evra": "102.9.0-1.fc37.ppc64le"
+      "evra": "20.10.23-1.fc38.ppc64le"
     },
     "mpfr": {
-      "evra": "4.1.0-10.fc37.ppc64le"
+      "evra": "4.1.1-3.fc38.ppc64le"
     },
     "nano": {
-      "evra": "6.4-1.fc37.ppc64le"
+      "evra": "7.2-2.fc38.ppc64le"
     },
     "nano-default-editor": {
-      "evra": "6.4-1.fc37.noarch"
+      "evra": "7.2-2.fc38.noarch"
     },
     "ncurses": {
-      "evra": "6.3-4.20220501.fc37.ppc64le"
+      "evra": "6.4-3.20230114.fc38.ppc64le"
     },
     "ncurses-base": {
-      "evra": "6.3-4.20220501.fc37.noarch"
+      "evra": "6.4-3.20230114.fc38.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.3-4.20220501.fc37.ppc64le"
+      "evra": "6.4-3.20230114.fc38.ppc64le"
     },
     "net-tools": {
-      "evra": "2.0-0.64.20160912git.fc37.ppc64le"
+      "evra": "2.0-0.65.20160912git.fc38.ppc64le"
     },
     "netavark": {
-      "evra": "1.5.0-4.fc37.ppc64le"
+      "evra": "1.6.0-2.fc38.ppc64le"
     },
     "nettle": {
-      "evra": "3.8-2.fc37.ppc64le"
+      "evra": "3.8-3.fc38.ppc64le"
     },
     "newt": {
-      "evra": "0.52.23-1.fc37.ppc64le"
+      "evra": "0.52.23-2.fc38.ppc64le"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.2-2.rc6.fc37.ppc64le"
+      "evra": "1:2.6.2-2.rc6.fc38.1.ppc64le"
     },
     "nftables": {
-      "evra": "1:1.0.4-3.fc37.ppc64le"
+      "evra": "1:1.0.5-2.fc38.ppc64le"
     },
     "nmstate": {
-      "evra": "2.2.9-2.fc37.ppc64le"
+      "evra": "2.2.9-1.fc38.ppc64le"
     },
     "npth": {
-      "evra": "1.6-9.fc37.ppc64le"
+      "evra": "1.6-12.fc38.ppc64le"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-21.fc37.ppc64le"
+      "evra": "2.18.1-22.fc38.ppc64le"
     },
     "numactl-libs": {
-      "evra": "2.0.14-6.fc37.ppc64le"
+      "evra": "2.0.16-2.fc38.ppc64le"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "nvme-cli": {
-      "evra": "2.2.1-1.fc37.ppc64le"
+      "evra": "2.4-1.fc38.ppc64le"
     },
     "oniguruma": {
-      "evra": "6.9.8-2.D20220919gitb041f6d.fc37.ppc64le"
+      "evra": "6.9.8-2.D20220919gitb041f6d.fc38.1.ppc64le"
     },
     "openldap": {
-      "evra": "2.6.4-1.fc37.ppc64le"
+      "evra": "2.6.4-1.fc38.ppc64le"
     },
     "openssh": {
-      "evra": "8.8p1-9.fc37.ppc64le"
+      "evra": "9.0p1-14.fc38.1.ppc64le"
     },
     "openssh-clients": {
-      "evra": "8.8p1-9.fc37.ppc64le"
+      "evra": "9.0p1-14.fc38.1.ppc64le"
     },
     "openssh-server": {
-      "evra": "8.8p1-9.fc37.ppc64le"
+      "evra": "9.0p1-14.fc38.1.ppc64le"
     },
     "openssl": {
-      "evra": "1:3.0.8-1.fc37.ppc64le"
+      "evra": "1:3.0.8-2.fc38.ppc64le"
     },
     "openssl-libs": {
-      "evra": "1:3.0.8-1.fc37.ppc64le"
+      "evra": "1:3.0.8-2.fc38.ppc64le"
     },
     "os-prober": {
-      "evra": "1.81-1.fc37.ppc64le"
+      "evra": "1.81-3.fc38.ppc64le"
     },
     "ostree": {
-      "evra": "2022.7-2.fc37.ppc64le"
+      "evra": "2023.1-2.fc38.ppc64le"
     },
     "ostree-grub2": {
-      "evra": "2022.7-2.fc37.ppc64le"
+      "evra": "2023.1-2.fc38.ppc64le"
     },
     "ostree-libs": {
-      "evra": "2022.7-2.fc37.ppc64le"
+      "evra": "2023.1-2.fc38.ppc64le"
     },
     "p11-kit": {
-      "evra": "0.24.1-3.fc37.ppc64le"
+      "evra": "0.24.1-6.fc38.ppc64le"
     },
     "p11-kit-trust": {
-      "evra": "0.24.1-3.fc37.ppc64le"
+      "evra": "0.24.1-6.fc38.ppc64le"
     },
     "pam": {
-      "evra": "1.5.2-14.fc37.ppc64le"
+      "evra": "1.5.2-16.fc38.ppc64le"
     },
     "pam-libs": {
-      "evra": "1.5.2-14.fc37.ppc64le"
+      "evra": "1.5.2-16.fc38.ppc64le"
     },
     "passwd": {
-      "evra": "0.80-13.fc37.ppc64le"
-    },
-    "pcre": {
-      "evra": "8.45-1.fc37.2.ppc64le"
+      "evra": "0.80-14.fc38.ppc64le"
     },
     "pcre2": {
-      "evra": "10.40-1.fc37.1.ppc64le"
+      "evra": "10.42-1.fc38.1.ppc64le"
     },
     "pcre2-syntax": {
-      "evra": "10.40-1.fc37.1.noarch"
+      "evra": "10.42-1.fc38.1.noarch"
     },
     "pigz": {
-      "evra": "2.7-2.fc37.ppc64le"
+      "evra": "2.7-3.fc38.ppc64le"
     },
     "pkgconf": {
-      "evra": "1.8.0-3.fc37.ppc64le"
+      "evra": "1.8.0-6.fc38.ppc64le"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-3.fc37.noarch"
+      "evra": "1.8.0-6.fc38.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-3.fc37.ppc64le"
+      "evra": "1.8.0-6.fc38.ppc64le"
     },
     "podman": {
-      "evra": "5:4.4.4-3.fc37.ppc64le"
+      "evra": "5:4.5.0-1.fc38.ppc64le"
     },
     "podman-plugins": {
-      "evra": "5:4.4.4-3.fc37.ppc64le"
+      "evra": "5:4.5.0-1.fc38.ppc64le"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc37.ppc64le"
+      "evra": "3.5-1.fc38.ppc64le"
     },
     "polkit": {
-      "evra": "121-4.fc37.2.ppc64le"
+      "evra": "122-3.fc38.ppc64le"
     },
     "polkit-libs": {
-      "evra": "121-4.fc37.2.ppc64le"
+      "evra": "122-3.fc38.ppc64le"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-22.fc37.ppc64le"
+      "evra": "0.1-23.fc38.ppc64le"
     },
     "popt": {
-      "evra": "1.19-1.fc37.ppc64le"
+      "evra": "1.19-2.fc38.ppc64le"
     },
     "powerpc-utils-core": {
-      "evra": "1.3.10-4.fc37.ppc64le"
+      "evra": "1.3.11-1.fc38.ppc64le"
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.8-4.fc37.ppc64le"
+      "evra": "2.7.9-2.fc38.ppc64le"
     },
     "procps-ng": {
-      "evra": "3.3.17-6.fc37.2.ppc64le"
+      "evra": "3.3.17-9.fc38.ppc64le"
     },
     "protobuf-c": {
-      "evra": "1.4.1-2.fc37.ppc64le"
+      "evra": "1.4.1-4.fc38.ppc64le"
     },
     "psmisc": {
-      "evra": "23.4-4.fc37.ppc64le"
+      "evra": "23.6-2.fc38.ppc64le"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230318-1.fc37.noarch"
+      "evra": "20230318-1.fc38.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.0.0-15.fc37.ppc64le"
+      "evra": "2:7.2.0-6.fc38.ppc64le"
     },
     "readline": {
-      "evra": "8.2-2.fc37.ppc64le"
+      "evra": "8.2-3.fc38.ppc64le"
     },
     "rpcbind": {
-      "evra": "1.2.6-3.rc2.fc37.ppc64le"
+      "evra": "1.2.6-4.rc2.fc38.ppc64le"
     },
     "rpm": {
-      "evra": "4.18.0-1.fc37.ppc64le"
+      "evra": "4.18.1-1.fc38.ppc64le"
     },
     "rpm-libs": {
-      "evra": "4.18.0-1.fc37.ppc64le"
+      "evra": "4.18.1-1.fc38.ppc64le"
     },
     "rpm-ostree": {
-      "evra": "2023.2-1.fc37.ppc64le"
+      "evra": "2023.2-1.fc38.ppc64le"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.2-1.fc37.ppc64le"
+      "evra": "2023.2-1.fc38.ppc64le"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.0-1.fc37.ppc64le"
+      "evra": "4.18.1-1.fc38.ppc64le"
+    },
+    "rpm-sequoia": {
+      "evra": "1.3.0-1.fc38.ppc64le"
     },
     "rsync": {
-      "evra": "3.2.7-1.fc37.ppc64le"
+      "evra": "3.2.7-2.fc38.ppc64le"
     },
     "runc": {
-      "evra": "2:1.1.4-1.fc37.ppc64le"
+      "evra": "2:1.1.4-2.fc38.ppc64le"
     },
     "samba-client-libs": {
-      "evra": "2:4.17.7-0.fc37.ppc64le"
+      "evra": "2:4.18.1-0.fc38.ppc64le"
     },
     "samba-common": {
-      "evra": "2:4.17.7-0.fc37.noarch"
+      "evra": "2:4.18.1-0.fc38.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.17.7-0.fc37.ppc64le"
+      "evra": "2:4.18.1-0.fc38.ppc64le"
     },
     "sed": {
-      "evra": "4.8-11.fc37.ppc64le"
+      "evra": "4.8-12.fc38.ppc64le"
     },
     "selinux-policy": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "servicelog": {
-      "evra": "1.1.16-2.fc37.ppc64le"
+      "evra": "1.1.16-3.fc38.ppc64le"
     },
     "setup": {
-      "evra": "2.14.1-2.fc37.noarch"
+      "evra": "2.14.3-2.fc38.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-4.fc37.ppc64le"
+      "evra": "1.46-5.fc38.ppc64le"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-4.fc37.ppc64le"
+      "evra": "1.46-5.fc38.ppc64le"
     },
     "shadow-utils": {
-      "evra": "2:4.12.3-6.fc37.ppc64le"
+      "evra": "2:4.13-6.fc38.ppc64le"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.12.3-6.fc37.ppc64le"
+      "evra": "2:4.13-6.fc38.ppc64le"
     },
     "shared-mime-info": {
-      "evra": "2.2-2.fc37.ppc64le"
+      "evra": "2.2-3.fc38.ppc64le"
     },
     "skopeo": {
-      "evra": "1:1.11.2-1.fc37.ppc64le"
+      "evra": "1:1.11.2-1.fc38.ppc64le"
     },
     "slang": {
-      "evra": "2.3.3-1.fc37.ppc64le"
+      "evra": "2.3.3-3.fc38.ppc64le"
     },
     "slirp4netns": {
-      "evra": "1.2.0-8.fc37.ppc64le"
+      "evra": "1.2.0-12.fc38.ppc64le"
     },
     "snappy": {
-      "evra": "1.1.9-5.fc37.ppc64le"
+      "evra": "1.1.9-7.fc38.ppc64le"
     },
     "socat": {
-      "evra": "1.7.4.2-3.fc37.ppc64le"
+      "evra": "1.7.4.4-2.fc38.ppc64le"
     },
     "sqlite-libs": {
-      "evra": "3.40.0-1.fc37.ppc64le"
+      "evra": "3.40.1-2.fc38.ppc64le"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-2.fc37.ppc64le"
+      "evra": "4.5.1-3.fc38.ppc64le"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-1.fc37.ppc64le"
+      "evra": "0.1.4-3.fc38.ppc64le"
     },
     "sssd-ad": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-client": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-common": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-common-pac": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-ipa": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-krb5": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-krb5-common": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-ldap": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.8.2-1.fc37.ppc64le"
+      "evra": "2.8.2-4.fc38.ppc64le"
     },
     "stalld": {
-      "evra": "1.16-2.fc37.ppc64le"
+      "evra": "1.16-3.fc38.ppc64le"
     },
     "sudo": {
-      "evra": "1.9.13-1.p2.fc37.ppc64le"
+      "evra": "1.9.13-1.p2.fc38.ppc64le"
     },
     "systemd": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "systemd-container": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "systemd-libs": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "systemd-pam": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "systemd-resolved": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "systemd-udev": {
-      "evra": "251.14-2.fc37.ppc64le"
+      "evra": "253.2-1.fc38.ppc64le"
     },
     "tar": {
-      "evra": "2:1.34-6.fc37.ppc64le"
+      "evra": "2:1.34-8.fc38.ppc64le"
     },
     "teamd": {
-      "evra": "1.31-6.fc37.ppc64le"
+      "evra": "1.31-7.fc38.ppc64le"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc37.ppc64le"
+      "evra": "0.0.99.4-1.fc38.ppc64le"
     },
     "tpm2-tools": {
-      "evra": "5.4-1.fc37.ppc64le"
+      "evra": "5.5-1.fc38.ppc64le"
     },
     "tpm2-tss": {
-      "evra": "3.2.2-1.fc37.ppc64le"
+      "evra": "4.0.1-3.fc38.ppc64le"
     },
     "tzdata": {
-      "evra": "2022g-1.fc37.noarch"
+      "evra": "2023c-1.fc38.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-5.fc37.ppc64le"
+      "evra": "0.13.2-2.fc38.ppc64le"
     },
     "util-linux": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "util-linux-core": {
-      "evra": "2.38.1-1.fc37.ppc64le"
+      "evra": "2.38.1-4.fc38.ppc64le"
     },
     "vim-data": {
-      "evra": "2:9.0.1440-1.fc37.noarch"
+      "evra": "2:9.0.1440-1.fc38.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.1440-1.fc37.ppc64le"
+      "evra": "2:9.0.1440-1.fc38.ppc64le"
     },
     "which": {
-      "evra": "2.21-39.fc37.ppc64le"
+      "evra": "2.21-39.fc38.ppc64le"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-3.fc37.ppc64le"
+      "evra": "1.0.20210914-4.fc38.ppc64le"
     },
     "xfsprogs": {
-      "evra": "6.1.0-2.fc37.ppc64le"
+      "evra": "6.1.0-3.fc38.ppc64le"
     },
     "xxhash-libs": {
-      "evra": "0.8.1-3.fc37.ppc64le"
+      "evra": "0.8.1-4.fc38.ppc64le"
     },
     "xz": {
-      "evra": "5.4.1-1.fc37.ppc64le"
+      "evra": "5.4.1-1.fc38.ppc64le"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc37.ppc64le"
+      "evra": "5.4.1-1.fc38.ppc64le"
     },
     "yajl": {
-      "evra": "2.1.0-19.fc37.ppc64le"
+      "evra": "2.1.0-20.fc38.ppc64le"
     },
     "zchunk-libs": {
-      "evra": "1.3.1-1.fc37.ppc64le"
+      "evra": "1.3.1-1.fc38.ppc64le"
     },
     "zincati": {
-      "evra": "0.0.25-2.fc37.ppc64le"
+      "evra": "0.0.25-4.fc38.ppc64le"
     },
     "zlib": {
-      "evra": "1.2.12-5.fc37.ppc64le"
+      "evra": "1.2.13-3.fc38.ppc64le"
     },
     "zram-generator": {
-      "evra": "1.1.2-2.fc37.ppc64le"
+      "evra": "1.1.2-4.fc38.ppc64le"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc37.ppc64le"
+      "evra": "1.5.5-1.fc38.ppc64le"
     }
   },
   "metadata": {
-    "generated": "2023-04-13T00:00:00Z",
+    "generated": "2023-04-17T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2022-11-05T08:04:20Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:20:08Z"
+        "generated": "2023-04-17T00:29:43Z"
       },
-      "fedora-updates": {
-        "generated": "2023-04-13T01:45:19Z"
+      "fedora-next": {
+        "generated": "2023-04-14T09:32:11Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-04-16T01:55:15Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,1196 +1,1199 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.40.10-1.fc37.s390x"
+      "evra": "1:1.42.0-1.fc38.s390x"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.40.10-1.fc37.s390x"
+      "evra": "1:1.42.0-1.fc38.s390x"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.40.10-1.fc37.s390x"
+      "evra": "1:1.42.0-1.fc38.s390x"
     },
     "NetworkManager-team": {
-      "evra": "1:1.40.10-1.fc37.s390x"
+      "evra": "1:1.42.0-1.fc38.s390x"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.40.10-1.fc37.s390x"
+      "evra": "1:1.42.0-1.fc38.s390x"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.8.0.11-1.fc37.noarch"
+      "evra": "2.9.0.4-1.fc38.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.5.0-4.fc37.s390x"
+      "evra": "1.6.0-1.fc38.s390x"
     },
     "acl": {
-      "evra": "2.3.1-4.fc37.s390x"
+      "evra": "2.3.1-6.fc38.s390x"
     },
     "adcli": {
-      "evra": "0.9.1-11.fc37.s390x"
+      "evra": "0.9.2-2.fc38.s390x"
     },
     "afterburn": {
-      "evra": "5.4.0-2.fc37.s390x"
+      "evra": "5.4.0-2.fc38.s390x"
     },
     "afterburn-dracut": {
-      "evra": "5.4.0-2.fc37.s390x"
+      "evra": "5.4.0-2.fc38.s390x"
     },
     "alternatives": {
-      "evra": "1.22-1.fc37.s390x"
+      "evra": "1.22-1.fc38.s390x"
     },
     "amd-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "attr": {
-      "evra": "2.5.1-5.fc37.s390x"
+      "evra": "2.5.1-6.fc38.s390x"
     },
     "audit-libs": {
-      "evra": "3.1-2.fc37.s390x"
+      "evra": "3.1-2.fc38.s390x"
     },
     "authselect": {
-      "evra": "1.4.2-1.fc37.s390x"
+      "evra": "1.4.2-2.fc38.s390x"
     },
     "authselect-libs": {
-      "evra": "1.4.2-1.fc37.s390x"
+      "evra": "1.4.2-2.fc38.s390x"
     },
     "avahi-libs": {
-      "evra": "0.8-18.fc37.s390x"
+      "evra": "0.8-20.fc38.s390x"
     },
     "basesystem": {
-      "evra": "11-14.fc37.noarch"
+      "evra": "11-15.fc38.noarch"
     },
     "bash": {
-      "evra": "5.2.15-1.fc37.s390x"
+      "evra": "5.2.15-3.fc38.s390x"
     },
     "bash-completion": {
-      "evra": "1:2.11-8.fc37.noarch"
+      "evra": "1:2.11-9.fc38.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.13-1.fc37.s390x"
+      "evra": "32:9.18.13-1.fc38.s390x"
     },
     "bind-license": {
-      "evra": "32:9.18.13-1.fc37.noarch"
+      "evra": "32:9.18.13-1.fc38.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.13-1.fc37.s390x"
+      "evra": "32:9.18.13-1.fc38.s390x"
     },
     "bsdtar": {
-      "evra": "3.6.1-3.fc37.s390x"
+      "evra": "3.6.1-4.fc38.s390x"
     },
     "btrfs-progs": {
-      "evra": "6.2.2-1.fc37.s390x"
+      "evra": "6.2.2-1.fc38.s390x"
     },
     "bubblewrap": {
-      "evra": "0.5.0-3.fc37.s390x"
+      "evra": "0.7.0-1.fc38.s390x"
     },
     "bzip2": {
-      "evra": "1.0.8-12.fc37.s390x"
+      "evra": "1.0.8-13.fc38.s390x"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-12.fc37.s390x"
+      "evra": "1.0.8-13.fc38.s390x"
     },
     "c-ares": {
-      "evra": "1.19.0-1.fc37.s390x"
+      "evra": "1.19.0-1.fc38.s390x"
     },
     "ca-certificates": {
-      "evra": "2023.2.60-1.0.fc37.noarch"
+      "evra": "2023.2.60-2.fc38.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-10.fc37.s390x"
+      "evra": "0.1.7-14.fc38.s390x"
     },
     "chrony": {
-      "evra": "4.3-1.fc37.s390x"
+      "evra": "4.3-3.fc38.s390x"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc37.s390x"
+      "evra": "7.0-1.fc38.s390x"
     },
     "clevis": {
-      "evra": "19-2.fc37.s390x"
+      "evra": "19-2.fc38.s390x"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc37.s390x"
+      "evra": "19-2.fc38.s390x"
     },
     "clevis-luks": {
-      "evra": "19-2.fc37.s390x"
+      "evra": "19-2.fc38.s390x"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc37.s390x"
+      "evra": "19-2.fc38.s390x"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-11.fc37.noarch"
+      "evra": "0.31-12.fc38.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc37.s390x"
+      "evra": "2:2.1.7-2.fc38.s390x"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.209.0-1.fc37.noarch"
+      "evra": "2:2.209.0-1.fc38.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc37.s390x"
+      "evra": "1.6.19-1.fc38.s390x"
     },
     "containernetworking-plugins": {
-      "evra": "1.1.1-16.fc37.s390x"
+      "evra": "1.1.1-16.fc38.s390x"
     },
     "containers-common": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "coreos-installer": {
-      "evra": "0.17.0-1.fc37.s390x"
+      "evra": "0.17.0-1.fc38.s390x"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.17.0-1.fc37.s390x"
+      "evra": "0.17.0-1.fc38.s390x"
     },
     "coreutils": {
-      "evra": "9.1-7.fc37.s390x"
+      "evra": "9.1-11.fc38.s390x"
     },
     "coreutils-common": {
-      "evra": "9.1-7.fc37.s390x"
+      "evra": "9.1-11.fc38.s390x"
     },
     "cpio": {
-      "evra": "2.13-13.fc37.s390x"
+      "evra": "2.13-14.fc38.s390x"
     },
     "cracklib": {
-      "evra": "2.9.7-30.fc37.s390x"
+      "evra": "2.9.7-31.fc38.s390x"
     },
     "criu": {
-      "evra": "3.17.1-3.fc37.s390x"
+      "evra": "3.17.1-5.fc38.s390x"
     },
     "criu-libs": {
-      "evra": "3.17.1-3.fc37.s390x"
+      "evra": "3.17.1-5.fc38.s390x"
     },
     "crun": {
-      "evra": "1.8.3-2.fc37.s390x"
+      "evra": "1.8.3-2.fc38.s390x"
     },
     "crypto-policies": {
-      "evra": "20220815-1.gite4ed860.fc37.noarch"
+      "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc37.s390x"
+      "evra": "2.6.1-1.fc38.s390x"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc37.s390x"
+      "evra": "2.6.1-1.fc38.s390x"
     },
     "curl": {
-      "evra": "7.85.0-8.fc37.s390x"
+      "evra": "7.87.0-7.fc38.s390x"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-8.fc37.s390x"
+      "evra": "2.1.28-9.fc38.s390x"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-8.fc37.s390x"
+      "evra": "2.1.28-9.fc38.s390x"
     },
     "dbus": {
-      "evra": "1:1.14.6-1.fc37.s390x"
+      "evra": "1:1.14.6-1.fc38.s390x"
     },
     "dbus-broker": {
-      "evra": "33-1.fc37.s390x"
+      "evra": "33-1.fc38.s390x"
     },
     "dbus-common": {
-      "evra": "1:1.14.6-1.fc37.noarch"
+      "evra": "1:1.14.6-1.fc38.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.6-1.fc37.s390x"
+      "evra": "1:1.14.6-1.fc38.s390x"
     },
     "device-mapper": {
-      "evra": "1.02.175-9.fc37.s390x"
+      "evra": "1.02.189-2.fc38.s390x"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-9.fc37.s390x"
+      "evra": "1.02.189-2.fc38.s390x"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-9.fc37.s390x"
+      "evra": "1.02.189-2.fc38.s390x"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-9.fc37.s390x"
+      "evra": "1.02.189-2.fc38.s390x"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.0-4.fc37.s390x"
+      "evra": "0.9.4-2.fc38.s390x"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.0-4.fc37.s390x"
+      "evra": "0.9.4-2.fc38.s390x"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-8.fc37.s390x"
+      "evra": "0.9.0-10.fc38.s390x"
     },
     "diffutils": {
-      "evra": "3.8-3.fc37.s390x"
+      "evra": "3.9-1.fc38.s390x"
     },
     "dnsmasq": {
-      "evra": "2.89-2.fc37.s390x"
+      "evra": "2.89-1.fc38.s390x"
     },
     "dosfstools": {
-      "evra": "4.2-4.fc37.s390x"
+      "evra": "4.2-6.fc38.s390x"
     },
     "dracut": {
-      "evra": "059-1.fc37.s390x"
+      "evra": "059-2.fc38.s390x"
     },
     "dracut-network": {
-      "evra": "059-1.fc37.s390x"
+      "evra": "059-2.fc38.s390x"
     },
     "dracut-squash": {
-      "evra": "059-1.fc37.s390x"
+      "evra": "059-2.fc38.s390x"
+    },
+    "duktape": {
+      "evra": "2.7.0-2.fc38.s390x"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-3.fc37.s390x"
+      "evra": "1.46.5-4.fc38.s390x"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-3.fc37.s390x"
+      "evra": "1.46.5-4.fc38.s390x"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-1.fc37.noarch"
+      "evra": "0.189-1.fc38.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-1.fc37.s390x"
+      "evra": "0.189-1.fc38.s390x"
     },
     "elfutils-libs": {
-      "evra": "0.189-1.fc37.s390x"
+      "evra": "0.189-1.fc38.s390x"
     },
     "ethtool": {
-      "evra": "2:6.2-1.fc37.s390x"
+      "evra": "2:6.2-1.fc38.s390x"
     },
     "expat": {
-      "evra": "2.5.0-1.fc37.s390x"
+      "evra": "2.5.0-2.fc38.s390x"
     },
     "fedora-gpg-keys": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
-      "evra": "5.42-4.fc37.s390x"
+      "evra": "5.44-3.fc38.s390x"
     },
     "file-libs": {
-      "evra": "5.42-4.fc37.s390x"
+      "evra": "5.44-3.fc38.s390x"
     },
     "filesystem": {
-      "evra": "3.18-2.fc37.s390x"
+      "evra": "3.18-3.fc38.s390x"
     },
     "findutils": {
-      "evra": "1:4.9.0-2.fc37.s390x"
+      "evra": "1:4.9.0-3.fc38.s390x"
     },
     "flatpak-session-helper": {
-      "evra": "1.14.4-1.fc37.s390x"
+      "evra": "1.15.4-1.fc38.s390x"
     },
     "fstrm": {
-      "evra": "0.6.1-5.fc37.s390x"
+      "evra": "0.6.1-6.fc38.s390x"
     },
     "fuse": {
-      "evra": "2.9.9-15.fc37.s390x"
+      "evra": "2.9.9-16.fc38.s390x"
     },
     "fuse-common": {
-      "evra": "3.10.5-5.fc37.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "fuse-libs": {
-      "evra": "2.9.9-15.fc37.s390x"
+      "evra": "2.9.9-16.fc38.s390x"
     },
     "fuse-overlayfs": {
-      "evra": "1.9-6.fc37.s390x"
+      "evra": "1.10-3.fc38.s390x"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-2.fc37.s390x"
+      "evra": "3.7.3-3.fc38.s390x"
     },
     "fuse3": {
-      "evra": "3.10.5-5.fc37.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-5.fc37.s390x"
+      "evra": "3.13.1-2.fc38.s390x"
     },
     "gawk": {
-      "evra": "5.1.1-4.fc37.s390x"
+      "evra": "5.1.1-5.fc38.s390x"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-2.fc37.s390x"
+      "evra": "1:1.23-3.fc38.s390x"
     },
     "gdisk": {
-      "evra": "1.0.9-4.fc37.s390x"
+      "evra": "1.0.9-5.fc38.s390x"
     },
     "git-core": {
-      "evra": "2.39.2-1.fc37.s390x"
+      "evra": "2.40.0-1.fc38.s390x"
     },
     "glib2": {
-      "evra": "2.74.6-1.fc37.s390x"
+      "evra": "2.76.1-1.fc38.s390x"
     },
     "glibc": {
-      "evra": "2.36-9.fc37.s390x"
+      "evra": "2.37-1.fc38.s390x"
     },
     "glibc-common": {
-      "evra": "2.36-9.fc37.s390x"
+      "evra": "2.37-1.fc38.s390x"
     },
     "glibc-gconv-extra": {
-      "evra": "2.36-9.fc37.s390x"
+      "evra": "2.37-1.fc38.s390x"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.36-9.fc37.s390x"
+      "evra": "2.37-1.fc38.s390x"
     },
     "gmp": {
-      "evra": "1:6.2.1-3.fc37.s390x"
+      "evra": "1:6.2.1-4.fc38.s390x"
     },
     "gnupg2": {
-      "evra": "2.3.8-1.fc37.s390x"
+      "evra": "2.4.0-3.fc38.s390x"
     },
     "gnutls": {
-      "evra": "3.8.0-2.fc37.s390x"
+      "evra": "3.8.0-2.fc38.s390x"
     },
     "gpgme": {
-      "evra": "1.17.0-4.fc37.s390x"
+      "evra": "1.17.1-3.fc38.s390x"
     },
     "grep": {
-      "evra": "3.7-4.fc37.s390x"
+      "evra": "3.8-3.fc38.s390x"
     },
     "gzip": {
-      "evra": "1.12-2.fc37.s390x"
+      "evra": "1.12-3.fc38.s390x"
     },
     "hostname": {
-      "evra": "3.23-7.fc37.s390x"
+      "evra": "3.23-8.fc38.s390x"
     },
     "ignition": {
-      "evra": "2.15.0-3.fc37.s390x"
+      "evra": "2.15.0-3.fc38.s390x"
     },
     "inih": {
-      "evra": "56-2.fc37.s390x"
+      "evra": "56-3.fc38.s390x"
     },
     "intel-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "iproute": {
-      "evra": "5.18.0-2.fc37.s390x"
+      "evra": "6.1.0-1.fc38.s390x"
     },
     "iproute-tc": {
-      "evra": "5.18.0-2.fc37.s390x"
+      "evra": "6.1.0-1.fc38.s390x"
     },
     "iptables-legacy": {
-      "evra": "1.8.8-4.fc37.s390x"
+      "evra": "1.8.9-2.fc38.s390x"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.8-4.fc37.s390x"
+      "evra": "1.8.9-2.fc38.s390x"
     },
     "iptables-libs": {
-      "evra": "1.8.8-4.fc37.s390x"
+      "evra": "1.8.9-2.fc38.s390x"
     },
     "iptables-nft": {
-      "evra": "1.8.8-4.fc37.s390x"
+      "evra": "1.8.9-2.fc38.s390x"
     },
     "iptables-services": {
-      "evra": "1.8.8-4.fc37.noarch"
+      "evra": "1.8.9-2.fc38.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.8-4.fc37.s390x"
+      "evra": "1.8.9-2.fc38.s390x"
     },
     "iputils": {
-      "evra": "20221126-1.fc37.s390x"
+      "evra": "20221126-2.fc38.s390x"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.s390x"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.s390x"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.s390x"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.s390x"
     },
     "isns-utils-libs": {
-      "evra": "0.101-5.fc37.s390x"
+      "evra": "0.101-6.fc38.s390x"
     },
     "jansson": {
-      "evra": "2.13.1-5.fc37.s390x"
+      "evra": "2.13.1-6.fc38.s390x"
     },
     "jemalloc": {
-      "evra": "5.3.0-2.fc37.s390x"
+      "evra": "5.3.0-3.fc38.s390x"
     },
     "jose": {
-      "evra": "11-6.fc37.s390x"
+      "evra": "11-7.fc38.s390x"
     },
     "jq": {
-      "evra": "1.6-14.fc37.s390x"
+      "evra": "1.6-15.fc38.s390x"
     },
     "json-c": {
-      "evra": "0.16-3.fc37.s390x"
+      "evra": "0.16-4.fc38.s390x"
     },
     "json-glib": {
-      "evra": "1.6.6-3.fc37.s390x"
+      "evra": "1.6.6-4.fc38.s390x"
     },
     "kbd": {
-      "evra": "2.5.1-3.fc37.s390x"
+      "evra": "2.5.1-5.fc38.s390x"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.2.9-200.fc37.s390x"
+      "evra": "6.2.11-300.fc38.s390x"
     },
     "kernel-core": {
-      "evra": "6.2.9-200.fc37.s390x"
+      "evra": "6.2.11-300.fc38.s390x"
     },
     "kernel-modules": {
-      "evra": "6.2.9-200.fc37.s390x"
+      "evra": "6.2.11-300.fc38.s390x"
     },
     "kernel-modules-core": {
-      "evra": "6.2.9-200.fc37.s390x"
+      "evra": "6.2.11-300.fc38.s390x"
     },
     "kexec-tools": {
-      "evra": "2.0.25-1.fc37.s390x"
+      "evra": "2.0.26-3.fc38.s390x"
     },
     "keyutils": {
-      "evra": "1.6.1-5.fc37.s390x"
+      "evra": "1.6.1-6.fc38.s390x"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-5.fc37.s390x"
+      "evra": "1.6.1-6.fc38.s390x"
     },
     "kmod": {
-      "evra": "30-2.fc37.s390x"
+      "evra": "30-4.fc38.s390x"
     },
     "kmod-libs": {
-      "evra": "30-2.fc37.s390x"
+      "evra": "30-4.fc38.s390x"
     },
     "kpartx": {
-      "evra": "0.9.0-4.fc37.s390x"
+      "evra": "0.9.4-2.fc38.s390x"
     },
     "krb5-libs": {
-      "evra": "1.19.2-13.fc37.s390x"
+      "evra": "1.20.1-8.fc38.s390x"
     },
     "less": {
-      "evra": "590-5.fc37.s390x"
+      "evra": "608-2.fc38.s390x"
     },
     "libacl": {
-      "evra": "2.3.1-4.fc37.s390x"
+      "evra": "2.3.1-6.fc38.s390x"
     },
     "libaio": {
-      "evra": "0.3.111-14.fc37.s390x"
+      "evra": "0.3.111-15.fc38.s390x"
     },
     "libarchive": {
-      "evra": "3.6.1-3.fc37.s390x"
+      "evra": "3.6.1-4.fc38.s390x"
     },
     "libargon2": {
-      "evra": "20190702-1.fc37.s390x"
+      "evra": "20190702-2.fc38.s390x"
     },
     "libassuan": {
-      "evra": "2.5.5-5.fc37.s390x"
+      "evra": "2.5.5-6.fc38.s390x"
     },
     "libattr": {
-      "evra": "2.5.1-5.fc37.s390x"
+      "evra": "2.5.1-6.fc38.s390x"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-52.fc37.s390x"
+      "evra": "0.1.1-53.fc38.s390x"
     },
     "libblkid": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "libbpf": {
-      "evra": "2:0.8.0-2.fc37.s390x"
+      "evra": "2:1.1.0-2.fc38.s390x"
     },
     "libbsd": {
-      "evra": "0.11.7-2.fc37.s390x"
+      "evra": "0.11.7-4.fc38.s390x"
     },
     "libcap": {
-      "evra": "2.48-5.fc37.s390x"
+      "evra": "2.48-6.fc38.s390x"
     },
     "libcap-ng": {
-      "evra": "0.8.3-3.fc37.s390x"
+      "evra": "0.8.3-5.fc38.s390x"
     },
     "libcbor": {
-      "evra": "0.7.0-7.fc37.s390x"
+      "evra": "0.7.0-9.fc38.s390x"
     },
     "libcollection": {
-      "evra": "0.7.0-52.fc37.s390x"
+      "evra": "0.7.0-53.fc38.s390x"
     },
     "libcom_err": {
-      "evra": "1.46.5-3.fc37.s390x"
+      "evra": "1.46.5-4.fc38.s390x"
     },
     "libcurl-minimal": {
-      "evra": "7.85.0-8.fc37.s390x"
+      "evra": "7.87.0-7.fc38.s390x"
     },
     "libdaemon": {
-      "evra": "0.14-24.fc37.s390x"
+      "evra": "0.14-25.fc38.s390x"
     },
     "libdb": {
-      "evra": "5.3.28-53.fc37.s390x"
+      "evra": "5.3.28-55.fc38.s390x"
     },
     "libdhash": {
-      "evra": "0.5.0-52.fc37.s390x"
+      "evra": "0.5.0-53.fc38.s390x"
     },
     "libeconf": {
-      "evra": "0.4.0-4.fc37.s390x"
+      "evra": "0.4.0-5.fc38.s390x"
     },
     "libedit": {
-      "evra": "3.1-43.20221009cvs.fc37.s390x"
+      "evra": "3.1-45.20221030cvs.fc38.s390x"
     },
     "libevent": {
-      "evra": "2.1.12-7.fc37.s390x"
+      "evra": "2.1.12-8.fc38.s390x"
     },
     "libfdisk": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "libffi": {
-      "evra": "3.4.4-1.fc37.s390x"
+      "evra": "3.4.4-2.fc38.s390x"
     },
     "libfido2": {
-      "evra": "1.11.0-3.fc37.s390x"
+      "evra": "1.12.0-3.fc38.s390x"
     },
     "libgcc": {
-      "evra": "12.2.1-4.fc37.s390x"
+      "evra": "13.0.1-0.12.fc38.s390x"
     },
     "libgcrypt": {
-      "evra": "1.10.1-4.fc37.s390x"
+      "evra": "1.10.1-7.fc38.s390x"
     },
     "libgpg-error": {
-      "evra": "1.46-1.fc37.s390x"
+      "evra": "1.46-2.fc38.s390x"
     },
     "libibverbs": {
-      "evra": "41.0-1.fc37.s390x"
+      "evra": "44.0-3.fc38.s390x"
     },
     "libicu": {
-      "evra": "71.1-2.fc37.s390x"
+      "evra": "72.1-2.fc38.s390x"
     },
     "libidn2": {
-      "evra": "2.3.4-1.fc37.s390x"
+      "evra": "2.3.4-2.fc38.s390x"
     },
     "libini_config": {
-      "evra": "1.3.1-52.fc37.s390x"
+      "evra": "1.3.1-53.fc38.s390x"
     },
     "libipa_hbac": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "libjose": {
-      "evra": "11-6.fc37.s390x"
+      "evra": "11-7.fc38.s390x"
     },
     "libkcapi": {
-      "evra": "1.4.0-2.fc37.s390x"
+      "evra": "1.4.0-5.fc38.s390x"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-2.fc37.s390x"
+      "evra": "1.4.0-5.fc38.s390x"
     },
     "libksba": {
-      "evra": "1.6.3-1.fc37.s390x"
+      "evra": "1.6.3-2.fc38.s390x"
     },
     "libldb": {
-      "evra": "2.6.2-1.fc37.s390x"
+      "evra": "2.7.2-1.fc38.s390x"
     },
     "libluksmeta": {
-      "evra": "9-14.fc37.s390x"
+      "evra": "9-15.fc38.s390x"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-1.fc37.s390x"
+      "evra": "1.7.1-2.fc38.s390x"
     },
     "libmd": {
-      "evra": "1.0.4-2.fc37.s390x"
+      "evra": "1.0.4-3.fc38.s390x"
     },
     "libmnl": {
-      "evra": "1.0.5-1.fc37.s390x"
+      "evra": "1.0.5-2.fc38.s390x"
     },
     "libmodulemd": {
-      "evra": "2.14.0-4.fc37.s390x"
+      "evra": "2.14.0-5.fc38.s390x"
     },
     "libmount": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "libndp": {
-      "evra": "1.8-4.fc37.s390x"
+      "evra": "1.8-5.fc38.s390x"
     },
     "libnet": {
-      "evra": "1.2-6.fc37.s390x"
+      "evra": "1.2-7.fc38.s390x"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-5.fc37.s390x"
+      "evra": "1.0.8-7.fc38.s390x"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-22.fc37.s390x"
+      "evra": "1.0.1-23.fc38.s390x"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.2-2.rc6.fc37.s390x"
+      "evra": "1:2.6.2-2.rc6.fc38.1.s390x"
     },
     "libnftnl": {
-      "evra": "1.2.2-2.fc37.s390x"
+      "evra": "1.2.4-2.fc38.s390x"
     },
     "libnghttp2": {
-      "evra": "1.51.0-1.fc37.s390x"
+      "evra": "1.52.0-1.fc38.s390x"
     },
     "libnl3": {
-      "evra": "3.7.0-2.fc37.s390x"
+      "evra": "3.7.0-3.fc38.s390x"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-2.fc37.s390x"
+      "evra": "3.7.0-3.fc38.s390x"
     },
     "libnsl2": {
-      "evra": "2.0.0-4.fc37.s390x"
+      "evra": "2.0.0-5.fc38.s390x"
     },
     "libnvme": {
-      "evra": "1.2-1.fc37.s390x"
+      "evra": "1.4-1.fc38.s390x"
     },
     "libpath_utils": {
-      "evra": "0.2.1-52.fc37.s390x"
+      "evra": "0.2.1-53.fc38.s390x"
     },
     "libpcap": {
-      "evra": "14:1.10.3-1.fc37.s390x"
+      "evra": "14:1.10.3-2.fc38.s390x"
     },
     "libpkgconf": {
-      "evra": "1.8.0-3.fc37.s390x"
+      "evra": "1.8.0-6.fc38.s390x"
     },
     "libpsl": {
-      "evra": "0.21.1-6.fc37.s390x"
+      "evra": "0.21.2-2.fc38.s390x"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc37.s390x"
+      "evra": "1.4.5-3.fc38.s390x"
     },
     "libref_array": {
-      "evra": "0.1.5-52.fc37.s390x"
+      "evra": "0.1.5-53.fc38.s390x"
     },
     "librepo": {
-      "evra": "1.15.1-1.fc37.s390x"
+      "evra": "1.15.1-2.fc38.s390x"
     },
     "libreport-filesystem": {
-      "evra": "2.17.4-1.fc37.noarch"
+      "evra": "2.17.9-1.fc38.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-3.fc37.s390x"
+      "evra": "2.5.3-4.fc38.s390x"
     },
     "libselinux": {
-      "evra": "3.5-1.fc37.s390x"
+      "evra": "3.5-1.fc38.s390x"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc37.s390x"
+      "evra": "3.5-1.fc38.s390x"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc37.s390x"
+      "evra": "3.5-2.fc38.s390x"
     },
     "libsepol": {
-      "evra": "3.5-1.fc37.s390x"
+      "evra": "3.5-1.fc38.s390x"
     },
     "libsigsegv": {
-      "evra": "2.14-3.fc37.s390x"
+      "evra": "2.14-4.fc38.s390x"
     },
     "libslirp": {
-      "evra": "4.7.0-2.fc37.s390x"
+      "evra": "4.7.0-3.fc38.s390x"
     },
     "libsmartcols": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "libsmbclient": {
-      "evra": "2:4.17.7-0.fc37.s390x"
+      "evra": "2:4.18.1-0.fc38.s390x"
     },
     "libsolv": {
-      "evra": "0.7.22-3.fc37.s390x"
+      "evra": "0.7.22-4.fc38.s390x"
     },
     "libss": {
-      "evra": "1.46.5-3.fc37.s390x"
+      "evra": "1.46.5-4.fc38.s390x"
     },
     "libsss_certmap": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "libsss_idmap": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "libsss_nss_idmap": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "libsss_sudo": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "libstdc++": {
-      "evra": "12.2.1-4.fc37.s390x"
+      "evra": "13.0.1-0.12.fc38.s390x"
     },
     "libtalloc": {
-      "evra": "2.3.4-3.fc37.s390x"
+      "evra": "2.4.0-2.fc38.s390x"
     },
     "libtasn1": {
-      "evra": "4.19.0-1.fc37.s390x"
+      "evra": "4.19.0-2.fc38.s390x"
     },
     "libtdb": {
-      "evra": "1.4.7-3.fc37.s390x"
+      "evra": "1.4.8-1.fc38.s390x"
     },
     "libteam": {
-      "evra": "1.31-6.fc37.s390x"
+      "evra": "1.31-7.fc38.s390x"
     },
     "libtevent": {
-      "evra": "0.13.0-1.fc37.s390x"
+      "evra": "0.14.1-1.fc38.s390x"
     },
     "libtirpc": {
-      "evra": "1.3.3-0.fc37.s390x"
+      "evra": "1.3.3-1.fc38.s390x"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-2.fc37.s390x"
+      "evra": "2.4.7-6.fc38.s390x"
     },
     "libunistring": {
-      "evra": "1.0-2.fc37.s390x"
+      "evra": "1.1-3.fc38.s390x"
+    },
+    "libunistring1.0": {
+      "evra": "1.0-1.fc38.s390x"
     },
     "libuser": {
-      "evra": "0.63-13.fc37.s390x"
+      "evra": "0.64-2.fc38.s390x"
     },
     "libutempter": {
-      "evra": "1.2.1-7.fc37.s390x"
+      "evra": "1.2.1-8.fc38.s390x"
     },
     "libuuid": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "libuv": {
-      "evra": "1:1.44.2-2.fc37.s390x"
+      "evra": "1:1.44.2-3.fc38.s390x"
     },
     "libverto": {
-      "evra": "0.3.2-4.fc37.s390x"
+      "evra": "0.3.2-5.fc38.s390x"
     },
     "libwbclient": {
-      "evra": "2:4.17.7-0.fc37.s390x"
+      "evra": "2:4.18.1-0.fc38.s390x"
     },
     "libxcrypt": {
-      "evra": "4.4.33-4.fc37.s390x"
+      "evra": "4.4.33-7.fc38.s390x"
     },
     "libxml2": {
-      "evra": "2.10.3-2.fc37.s390x"
+      "evra": "2.10.3-3.fc38.s390x"
     },
     "libyaml": {
-      "evra": "0.2.5-8.fc37.s390x"
+      "evra": "0.2.5-9.fc38.s390x"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc37.s390x"
+      "evra": "1.5.5-1.fc38.s390x"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-33.fc37.s390x"
+      "evra": "2.5.1-34.fc38.s390x"
     },
     "linux-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.30-1.fc37.s390x"
+      "evra": "0.9.30-1.fc38.s390x"
     },
     "logrotate": {
-      "evra": "3.20.1-3.fc37.s390x"
+      "evra": "3.21.0-2.fc38.s390x"
     },
     "lsof": {
-      "evra": "4.94.0-4.fc37.s390x"
+      "evra": "4.96.3-3.fc38.s390x"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc37.s390x"
+      "evra": "5.4.4-9.fc38.s390x"
     },
     "luksmeta": {
-      "evra": "9-14.fc37.s390x"
+      "evra": "9-15.fc38.s390x"
     },
     "lvm2": {
-      "evra": "2.03.11-9.fc37.s390x"
+      "evra": "2.03.18-2.fc38.s390x"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-9.fc37.s390x"
+      "evra": "2.03.18-2.fc38.s390x"
     },
     "lz4-libs": {
-      "evra": "1.9.4-1.fc37.s390x"
+      "evra": "1.9.4-2.fc38.s390x"
     },
     "lzo": {
-      "evra": "2.10-7.fc37.s390x"
+      "evra": "2.10-8.fc38.s390x"
     },
     "mdadm": {
-      "evra": "4.2-2.fc37.s390x"
+      "evra": "4.2-4.fc38.s390x"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc37.s390x"
-    },
-    "mozjs102": {
-      "evra": "102.9.0-1.fc37.s390x"
+      "evra": "20.10.23-1.fc38.s390x"
     },
     "mpfr": {
-      "evra": "4.1.0-10.fc37.s390x"
+      "evra": "4.1.1-3.fc38.s390x"
     },
     "nano": {
-      "evra": "6.4-1.fc37.s390x"
+      "evra": "7.2-2.fc38.s390x"
     },
     "nano-default-editor": {
-      "evra": "6.4-1.fc37.noarch"
+      "evra": "7.2-2.fc38.noarch"
     },
     "ncurses": {
-      "evra": "6.3-4.20220501.fc37.s390x"
+      "evra": "6.4-3.20230114.fc38.s390x"
     },
     "ncurses-base": {
-      "evra": "6.3-4.20220501.fc37.noarch"
+      "evra": "6.4-3.20230114.fc38.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.3-4.20220501.fc37.s390x"
+      "evra": "6.4-3.20230114.fc38.s390x"
     },
     "net-tools": {
-      "evra": "2.0-0.64.20160912git.fc37.s390x"
+      "evra": "2.0-0.65.20160912git.fc38.s390x"
     },
     "netavark": {
-      "evra": "1.5.0-4.fc37.s390x"
+      "evra": "1.6.0-2.fc38.s390x"
     },
     "nettle": {
-      "evra": "3.8-2.fc37.s390x"
+      "evra": "3.8-3.fc38.s390x"
     },
     "newt": {
-      "evra": "0.52.23-1.fc37.s390x"
+      "evra": "0.52.23-2.fc38.s390x"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.2-2.rc6.fc37.s390x"
+      "evra": "1:2.6.2-2.rc6.fc38.1.s390x"
     },
     "nftables": {
-      "evra": "1:1.0.4-3.fc37.s390x"
+      "evra": "1:1.0.5-2.fc38.s390x"
     },
     "nmstate": {
-      "evra": "2.2.9-2.fc37.s390x"
+      "evra": "2.2.9-1.fc38.s390x"
     },
     "npth": {
-      "evra": "1.6-9.fc37.s390x"
+      "evra": "1.6-12.fc38.s390x"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-21.fc37.s390x"
+      "evra": "2.18.1-22.fc38.s390x"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "nvme-cli": {
-      "evra": "2.2.1-1.fc37.s390x"
+      "evra": "2.4-1.fc38.s390x"
     },
     "oniguruma": {
-      "evra": "6.9.8-2.D20220919gitb041f6d.fc37.s390x"
+      "evra": "6.9.8-2.D20220919gitb041f6d.fc38.1.s390x"
     },
     "openldap": {
-      "evra": "2.6.4-1.fc37.s390x"
+      "evra": "2.6.4-1.fc38.s390x"
     },
     "openssh": {
-      "evra": "8.8p1-9.fc37.s390x"
+      "evra": "9.0p1-14.fc38.1.s390x"
     },
     "openssh-clients": {
-      "evra": "8.8p1-9.fc37.s390x"
+      "evra": "9.0p1-14.fc38.1.s390x"
     },
     "openssh-server": {
-      "evra": "8.8p1-9.fc37.s390x"
+      "evra": "9.0p1-14.fc38.1.s390x"
     },
     "openssl": {
-      "evra": "1:3.0.8-1.fc37.s390x"
+      "evra": "1:3.0.8-2.fc38.s390x"
     },
     "openssl-libs": {
-      "evra": "1:3.0.8-1.fc37.s390x"
+      "evra": "1:3.0.8-2.fc38.s390x"
     },
     "ostree": {
-      "evra": "2022.7-2.fc37.s390x"
+      "evra": "2023.1-2.fc38.s390x"
     },
     "ostree-libs": {
-      "evra": "2022.7-2.fc37.s390x"
+      "evra": "2023.1-2.fc38.s390x"
     },
     "p11-kit": {
-      "evra": "0.24.1-3.fc37.s390x"
+      "evra": "0.24.1-6.fc38.s390x"
     },
     "p11-kit-trust": {
-      "evra": "0.24.1-3.fc37.s390x"
+      "evra": "0.24.1-6.fc38.s390x"
     },
     "pam": {
-      "evra": "1.5.2-14.fc37.s390x"
+      "evra": "1.5.2-16.fc38.s390x"
     },
     "pam-libs": {
-      "evra": "1.5.2-14.fc37.s390x"
+      "evra": "1.5.2-16.fc38.s390x"
     },
     "passwd": {
-      "evra": "0.80-13.fc37.s390x"
-    },
-    "pcre": {
-      "evra": "8.45-1.fc37.2.s390x"
+      "evra": "0.80-14.fc38.s390x"
     },
     "pcre2": {
-      "evra": "10.40-1.fc37.1.s390x"
+      "evra": "10.42-1.fc38.1.s390x"
     },
     "pcre2-syntax": {
-      "evra": "10.40-1.fc37.1.noarch"
+      "evra": "10.42-1.fc38.1.noarch"
     },
     "pigz": {
-      "evra": "2.7-2.fc37.s390x"
+      "evra": "2.7-3.fc38.s390x"
     },
     "pkgconf": {
-      "evra": "1.8.0-3.fc37.s390x"
+      "evra": "1.8.0-6.fc38.s390x"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-3.fc37.noarch"
+      "evra": "1.8.0-6.fc38.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-3.fc37.s390x"
+      "evra": "1.8.0-6.fc38.s390x"
     },
     "podman": {
-      "evra": "5:4.4.4-3.fc37.s390x"
+      "evra": "5:4.5.0-1.fc38.s390x"
     },
     "podman-plugins": {
-      "evra": "5:4.4.4-3.fc37.s390x"
+      "evra": "5:4.5.0-1.fc38.s390x"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc37.s390x"
+      "evra": "3.5-1.fc38.s390x"
     },
     "polkit": {
-      "evra": "121-4.fc37.2.s390x"
+      "evra": "122-3.fc38.s390x"
     },
     "polkit-libs": {
-      "evra": "121-4.fc37.2.s390x"
+      "evra": "122-3.fc38.s390x"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-22.fc37.s390x"
+      "evra": "0.1-23.fc38.s390x"
     },
     "popt": {
-      "evra": "1.19-1.fc37.s390x"
+      "evra": "1.19-2.fc38.s390x"
     },
     "procps-ng": {
-      "evra": "3.3.17-6.fc37.2.s390x"
+      "evra": "3.3.17-9.fc38.s390x"
     },
     "protobuf-c": {
-      "evra": "1.4.1-2.fc37.s390x"
+      "evra": "1.4.1-4.fc38.s390x"
     },
     "psmisc": {
-      "evra": "23.4-4.fc37.s390x"
+      "evra": "23.6-2.fc38.s390x"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230318-1.fc37.noarch"
+      "evra": "20230318-1.fc38.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.0.0-15.fc37.s390x"
+      "evra": "2:7.2.0-6.fc38.s390x"
     },
     "readline": {
-      "evra": "8.2-2.fc37.s390x"
+      "evra": "8.2-3.fc38.s390x"
     },
     "rpcbind": {
-      "evra": "1.2.6-3.rc2.fc37.s390x"
+      "evra": "1.2.6-4.rc2.fc38.s390x"
     },
     "rpm": {
-      "evra": "4.18.0-1.fc37.s390x"
+      "evra": "4.18.1-1.fc38.s390x"
     },
     "rpm-libs": {
-      "evra": "4.18.0-1.fc37.s390x"
+      "evra": "4.18.1-1.fc38.s390x"
     },
     "rpm-ostree": {
-      "evra": "2023.2-1.fc37.s390x"
+      "evra": "2023.2-1.fc38.s390x"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.2-1.fc37.s390x"
+      "evra": "2023.2-1.fc38.s390x"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.0-1.fc37.s390x"
+      "evra": "4.18.1-1.fc38.s390x"
+    },
+    "rpm-sequoia": {
+      "evra": "1.3.0-1.fc38.s390x"
     },
     "rsync": {
-      "evra": "3.2.7-1.fc37.s390x"
+      "evra": "3.2.7-2.fc38.s390x"
     },
     "runc": {
-      "evra": "2:1.1.4-1.fc37.s390x"
+      "evra": "2:1.1.4-2.fc38.s390x"
     },
     "s390utils-core": {
-      "evra": "2:2.25.0-4.fc37.s390x"
+      "evra": "2:2.25.0-4.fc38.s390x"
     },
     "samba-client-libs": {
-      "evra": "2:4.17.7-0.fc37.s390x"
+      "evra": "2:4.18.1-0.fc38.s390x"
     },
     "samba-common": {
-      "evra": "2:4.17.7-0.fc37.noarch"
+      "evra": "2:4.18.1-0.fc38.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.17.7-0.fc37.s390x"
+      "evra": "2:4.18.1-0.fc38.s390x"
     },
     "sed": {
-      "evra": "4.8-11.fc37.s390x"
+      "evra": "4.8-12.fc38.s390x"
     },
     "selinux-policy": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "setup": {
-      "evra": "2.14.1-2.fc37.noarch"
+      "evra": "2.14.3-2.fc38.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-4.fc37.s390x"
+      "evra": "1.46-5.fc38.s390x"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-4.fc37.s390x"
+      "evra": "1.46-5.fc38.s390x"
     },
     "shadow-utils": {
-      "evra": "2:4.12.3-6.fc37.s390x"
+      "evra": "2:4.13-6.fc38.s390x"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.12.3-6.fc37.s390x"
+      "evra": "2:4.13-6.fc38.s390x"
     },
     "skopeo": {
-      "evra": "1:1.11.2-1.fc37.s390x"
+      "evra": "1:1.11.2-1.fc38.s390x"
     },
     "slang": {
-      "evra": "2.3.3-1.fc37.s390x"
+      "evra": "2.3.3-3.fc38.s390x"
     },
     "slirp4netns": {
-      "evra": "1.2.0-8.fc37.s390x"
+      "evra": "1.2.0-12.fc38.s390x"
     },
     "snappy": {
-      "evra": "1.1.9-5.fc37.s390x"
+      "evra": "1.1.9-7.fc38.s390x"
     },
     "socat": {
-      "evra": "1.7.4.2-3.fc37.s390x"
+      "evra": "1.7.4.4-2.fc38.s390x"
     },
     "sqlite-libs": {
-      "evra": "3.40.0-1.fc37.s390x"
+      "evra": "3.40.1-2.fc38.s390x"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-2.fc37.s390x"
+      "evra": "4.5.1-3.fc38.s390x"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-1.fc37.s390x"
+      "evra": "0.1.4-3.fc38.s390x"
     },
     "sssd-ad": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-client": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-common": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-common-pac": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-ipa": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-krb5": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-krb5-common": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-ldap": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.8.2-1.fc37.s390x"
+      "evra": "2.8.2-4.fc38.s390x"
     },
     "stalld": {
-      "evra": "1.16-2.fc37.s390x"
+      "evra": "1.16-3.fc38.s390x"
     },
     "sudo": {
-      "evra": "1.9.13-1.p2.fc37.s390x"
+      "evra": "1.9.13-1.p2.fc38.s390x"
     },
     "systemd": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "systemd-container": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "systemd-libs": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "systemd-pam": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "systemd-resolved": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "systemd-udev": {
-      "evra": "251.14-2.fc37.s390x"
+      "evra": "253.2-1.fc38.s390x"
     },
     "tar": {
-      "evra": "2:1.34-6.fc37.s390x"
+      "evra": "2:1.34-8.fc38.s390x"
     },
     "teamd": {
-      "evra": "1.31-6.fc37.s390x"
+      "evra": "1.31-7.fc38.s390x"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc37.s390x"
+      "evra": "0.0.99.4-1.fc38.s390x"
     },
     "tpm2-tools": {
-      "evra": "5.4-1.fc37.s390x"
+      "evra": "5.5-1.fc38.s390x"
     },
     "tpm2-tss": {
-      "evra": "3.2.2-1.fc37.s390x"
+      "evra": "4.0.1-3.fc38.s390x"
     },
     "tzdata": {
-      "evra": "2022g-1.fc37.noarch"
+      "evra": "2023c-1.fc38.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-5.fc37.s390x"
+      "evra": "0.13.2-2.fc38.s390x"
     },
     "util-linux": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "util-linux-core": {
-      "evra": "2.38.1-1.fc37.s390x"
+      "evra": "2.38.1-4.fc38.s390x"
     },
     "veritysetup": {
-      "evra": "2.6.1-1.fc37.s390x"
+      "evra": "2.6.1-1.fc38.s390x"
     },
     "vim-data": {
-      "evra": "2:9.0.1440-1.fc37.noarch"
+      "evra": "2:9.0.1440-1.fc38.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.1440-1.fc37.s390x"
+      "evra": "2:9.0.1440-1.fc38.s390x"
     },
     "which": {
-      "evra": "2.21-39.fc37.s390x"
+      "evra": "2.21-39.fc38.s390x"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-3.fc37.s390x"
+      "evra": "1.0.20210914-4.fc38.s390x"
     },
     "xfsprogs": {
-      "evra": "6.1.0-2.fc37.s390x"
+      "evra": "6.1.0-3.fc38.s390x"
     },
     "xxhash-libs": {
-      "evra": "0.8.1-3.fc37.s390x"
+      "evra": "0.8.1-4.fc38.s390x"
     },
     "xz": {
-      "evra": "5.4.1-1.fc37.s390x"
+      "evra": "5.4.1-1.fc38.s390x"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc37.s390x"
+      "evra": "5.4.1-1.fc38.s390x"
     },
     "yajl": {
-      "evra": "2.1.0-19.fc37.s390x"
+      "evra": "2.1.0-20.fc38.s390x"
     },
     "zchunk-libs": {
-      "evra": "1.3.1-1.fc37.s390x"
+      "evra": "1.3.1-1.fc38.s390x"
     },
     "zincati": {
-      "evra": "0.0.25-2.fc37.s390x"
+      "evra": "0.0.25-4.fc38.s390x"
     },
     "zlib": {
-      "evra": "1.2.12-5.fc37.s390x"
+      "evra": "1.2.13-3.fc38.s390x"
     },
     "zram-generator": {
-      "evra": "1.1.2-2.fc37.s390x"
+      "evra": "1.1.2-4.fc38.s390x"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc37.s390x"
+      "evra": "1.5.5-1.fc38.s390x"
     }
   },
   "metadata": {
-    "generated": "2023-04-13T00:00:00Z",
+    "generated": "2023-04-17T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2022-11-05T08:04:18Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:18:50Z"
+        "generated": "2023-04-17T00:29:21Z"
       },
-      "fedora-updates": {
-        "generated": "2023-04-13T01:45:26Z"
+      "fedora-next": {
+        "generated": "2023-04-14T09:32:06Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-04-16T01:55:15Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1274 +1,1271 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.40.10-1.fc37.x86_64"
+      "evra": "1:1.42.0-1.fc38.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.40.10-1.fc37.x86_64"
+      "evra": "1:1.42.0-1.fc38.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.40.10-1.fc37.x86_64"
+      "evra": "1:1.42.0-1.fc38.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.40.10-1.fc37.x86_64"
+      "evra": "1:1.42.0-1.fc38.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.40.10-1.fc37.x86_64"
+      "evra": "1:1.42.0-1.fc38.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.8.0.11-1.fc37.noarch"
+      "evra": "2.9.0.4-1.fc38.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.5.0-4.fc37.x86_64"
+      "evra": "1.6.0-1.fc38.x86_64"
     },
     "acl": {
-      "evra": "2.3.1-4.fc37.x86_64"
+      "evra": "2.3.1-6.fc38.x86_64"
     },
     "adcli": {
-      "evra": "0.9.1-11.fc37.x86_64"
+      "evra": "0.9.2-2.fc38.x86_64"
     },
     "afterburn": {
-      "evra": "5.4.0-2.fc37.x86_64"
+      "evra": "5.4.0-2.fc38.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.4.0-2.fc37.x86_64"
+      "evra": "5.4.0-2.fc38.x86_64"
     },
     "alternatives": {
-      "evra": "1.22-1.fc37.x86_64"
+      "evra": "1.22-1.fc38.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "attr": {
-      "evra": "2.5.1-5.fc37.x86_64"
+      "evra": "2.5.1-6.fc38.x86_64"
     },
     "audit-libs": {
-      "evra": "3.1-2.fc37.x86_64"
+      "evra": "3.1-2.fc38.x86_64"
     },
     "authselect": {
-      "evra": "1.4.2-1.fc37.x86_64"
+      "evra": "1.4.2-2.fc38.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.4.2-1.fc37.x86_64"
+      "evra": "1.4.2-2.fc38.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.8-18.fc37.x86_64"
+      "evra": "0.8-20.fc38.x86_64"
     },
     "basesystem": {
-      "evra": "11-14.fc37.noarch"
+      "evra": "11-15.fc38.noarch"
     },
     "bash": {
-      "evra": "5.2.15-1.fc37.x86_64"
+      "evra": "5.2.15-3.fc38.x86_64"
     },
     "bash-completion": {
-      "evra": "1:2.11-8.fc37.noarch"
+      "evra": "1:2.11-9.fc38.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.13-1.fc37.x86_64"
+      "evra": "32:9.18.13-1.fc38.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.18.13-1.fc37.noarch"
+      "evra": "32:9.18.13-1.fc38.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.13-1.fc37.x86_64"
+      "evra": "32:9.18.13-1.fc38.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.8-3.fc37.x86_64"
+      "evra": "0.2.9-1.fc38.x86_64"
     },
     "bsdtar": {
-      "evra": "3.6.1-3.fc37.x86_64"
+      "evra": "3.6.1-4.fc38.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.2.2-1.fc37.x86_64"
+      "evra": "6.2.2-1.fc38.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.5.0-3.fc37.x86_64"
+      "evra": "0.7.0-1.fc38.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-12.fc37.x86_64"
+      "evra": "1.0.8-13.fc38.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-12.fc37.x86_64"
+      "evra": "1.0.8-13.fc38.x86_64"
     },
     "c-ares": {
-      "evra": "1.19.0-1.fc37.x86_64"
+      "evra": "1.19.0-1.fc38.x86_64"
     },
     "ca-certificates": {
-      "evra": "2023.2.60-1.0.fc37.noarch"
+      "evra": "2023.2.60-2.fc38.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-10.fc37.x86_64"
+      "evra": "0.1.7-14.fc38.x86_64"
     },
     "chrony": {
-      "evra": "4.3-1.fc37.x86_64"
+      "evra": "4.3-3.fc38.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc37.x86_64"
+      "evra": "7.0-1.fc38.x86_64"
     },
     "clevis": {
-      "evra": "19-2.fc37.x86_64"
+      "evra": "19-2.fc38.x86_64"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc37.x86_64"
+      "evra": "19-2.fc38.x86_64"
     },
     "clevis-luks": {
-      "evra": "19-2.fc37.x86_64"
+      "evra": "19-2.fc38.x86_64"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc37.x86_64"
+      "evra": "19-2.fc38.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.31-11.fc37.noarch"
+      "evra": "0.31-12.fc38.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc37.x86_64"
+      "evra": "2:2.1.7-2.fc38.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-3.fc37.noarch"
+      "evra": "0.21.3-4.fc38.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.209.0-1.fc37.noarch"
+      "evra": "2:2.209.0-1.fc38.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc37.x86_64"
+      "evra": "1.6.19-1.fc38.x86_64"
     },
     "containernetworking-plugins": {
-      "evra": "1.1.1-16.fc37.x86_64"
+      "evra": "1.1.1-16.fc38.x86_64"
     },
     "containers-common": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-80.fc37.noarch"
+      "evra": "4:1-89.fc38.noarch"
     },
     "coreos-installer": {
-      "evra": "0.17.0-1.fc37.x86_64"
+      "evra": "0.17.0-1.fc38.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.17.0-1.fc37.x86_64"
+      "evra": "0.17.0-1.fc38.x86_64"
     },
     "coreutils": {
-      "evra": "9.1-7.fc37.x86_64"
+      "evra": "9.1-11.fc38.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.1-7.fc37.x86_64"
+      "evra": "9.1-11.fc38.x86_64"
     },
     "cpio": {
-      "evra": "2.13-13.fc37.x86_64"
+      "evra": "2.13-14.fc38.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.7-30.fc37.x86_64"
+      "evra": "2.9.7-31.fc38.x86_64"
     },
     "criu": {
-      "evra": "3.17.1-3.fc37.x86_64"
+      "evra": "3.17.1-5.fc38.x86_64"
     },
     "criu-libs": {
-      "evra": "3.17.1-3.fc37.x86_64"
+      "evra": "3.17.1-5.fc38.x86_64"
     },
     "crun": {
-      "evra": "1.8.3-2.fc37.x86_64"
+      "evra": "1.8.3-2.fc38.x86_64"
     },
     "crypto-policies": {
-      "evra": "20220815-1.gite4ed860.fc37.noarch"
+      "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc37.x86_64"
+      "evra": "2.6.1-1.fc38.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc37.x86_64"
+      "evra": "2.6.1-1.fc38.x86_64"
     },
     "curl": {
-      "evra": "7.85.0-8.fc37.x86_64"
+      "evra": "7.87.0-7.fc38.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-8.fc37.x86_64"
+      "evra": "2.1.28-9.fc38.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-8.fc37.x86_64"
+      "evra": "2.1.28-9.fc38.x86_64"
     },
     "dbus": {
-      "evra": "1:1.14.6-1.fc37.x86_64"
+      "evra": "1:1.14.6-1.fc38.x86_64"
     },
     "dbus-broker": {
-      "evra": "33-1.fc37.x86_64"
+      "evra": "33-1.fc38.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.14.6-1.fc37.noarch"
+      "evra": "1:1.14.6-1.fc38.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.6-1.fc37.x86_64"
+      "evra": "1:1.14.6-1.fc38.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.175-9.fc37.x86_64"
+      "evra": "1.02.189-2.fc38.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.175-9.fc37.x86_64"
+      "evra": "1.02.189-2.fc38.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.175-9.fc37.x86_64"
+      "evra": "1.02.189-2.fc38.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.175-9.fc37.x86_64"
+      "evra": "1.02.189-2.fc38.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.0-4.fc37.x86_64"
+      "evra": "0.9.4-2.fc38.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.0-4.fc37.x86_64"
+      "evra": "0.9.4-2.fc38.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-8.fc37.x86_64"
+      "evra": "0.9.0-10.fc38.x86_64"
     },
     "diffutils": {
-      "evra": "3.8-3.fc37.x86_64"
+      "evra": "3.9-1.fc38.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.89-2.fc37.x86_64"
+      "evra": "2.89-1.fc38.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-4.fc37.x86_64"
+      "evra": "4.2-6.fc38.x86_64"
     },
     "dracut": {
-      "evra": "059-1.fc37.x86_64"
+      "evra": "059-2.fc38.x86_64"
     },
     "dracut-network": {
-      "evra": "059-1.fc37.x86_64"
+      "evra": "059-2.fc38.x86_64"
     },
     "dracut-squash": {
-      "evra": "059-1.fc37.x86_64"
+      "evra": "059-2.fc38.x86_64"
+    },
+    "duktape": {
+      "evra": "2.7.0-2.fc38.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-3.fc37.x86_64"
+      "evra": "1.46.5-4.fc38.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-3.fc37.x86_64"
+      "evra": "1.46.5-4.fc38.x86_64"
     },
     "efi-filesystem": {
-      "evra": "5-6.fc37.noarch"
+      "evra": "5-7.fc38.noarch"
     },
     "efibootmgr": {
-      "evra": "18-2.fc37.x86_64"
+      "evra": "18-3.fc38.x86_64"
     },
     "efivar-libs": {
-      "evra": "38-6.fc37.x86_64"
+      "evra": "38-7.fc38.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-1.fc37.noarch"
+      "evra": "0.189-1.fc38.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-1.fc37.x86_64"
+      "evra": "0.189-1.fc38.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.189-1.fc37.x86_64"
+      "evra": "0.189-1.fc38.x86_64"
     },
     "ethtool": {
-      "evra": "2:6.2-1.fc37.x86_64"
+      "evra": "2:6.2-1.fc38.x86_64"
     },
     "expat": {
-      "evra": "2.5.0-1.fc37.x86_64"
+      "evra": "2.5.0-2.fc38.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "37-16.noarch"
+      "evra": "38-34.noarch"
     },
     "fedora-repos": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-modular": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "37-2.noarch"
+      "evra": "38-1.noarch"
     },
     "file": {
-      "evra": "5.42-4.fc37.x86_64"
+      "evra": "5.44-3.fc38.x86_64"
     },
     "file-libs": {
-      "evra": "5.42-4.fc37.x86_64"
+      "evra": "5.44-3.fc38.x86_64"
     },
     "filesystem": {
-      "evra": "3.18-2.fc37.x86_64"
+      "evra": "3.18-3.fc38.x86_64"
     },
     "findutils": {
-      "evra": "1:4.9.0-2.fc37.x86_64"
+      "evra": "1:4.9.0-3.fc38.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.14.4-1.fc37.x86_64"
+      "evra": "1.15.4-1.fc38.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-5.fc37.x86_64"
+      "evra": "0.6.1-6.fc38.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-15.fc37.x86_64"
+      "evra": "2.9.9-16.fc38.x86_64"
     },
     "fuse-common": {
-      "evra": "3.10.5-5.fc37.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-15.fc37.x86_64"
+      "evra": "2.9.9-16.fc38.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.9-6.fc37.x86_64"
+      "evra": "1.10-3.fc38.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-2.fc37.x86_64"
+      "evra": "3.7.3-3.fc38.x86_64"
     },
     "fuse3": {
-      "evra": "3.10.5-5.fc37.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.10.5-5.fc37.x86_64"
+      "evra": "3.13.1-2.fc38.x86_64"
     },
     "fwupd": {
-      "evra": "1.8.14-1.fc37.x86_64"
+      "evra": "1.8.14-1.fc38.x86_64"
     },
     "gawk": {
-      "evra": "5.1.1-4.fc37.x86_64"
+      "evra": "5.1.1-5.fc38.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-2.fc37.x86_64"
+      "evra": "1:1.23-3.fc38.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.9-4.fc37.x86_64"
+      "evra": "1.0.9-5.fc38.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-1.fc37.x86_64"
+      "evra": "0.21.1-2.fc38.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.21.1-1.fc37.x86_64"
+      "evra": "0.21.1-2.fc38.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-1.fc37.x86_64"
+      "evra": "0.21.1-2.fc38.x86_64"
     },
     "git-core": {
-      "evra": "2.39.2-1.fc37.x86_64"
+      "evra": "2.40.0-1.fc38.x86_64"
     },
     "glib2": {
-      "evra": "2.74.6-1.fc37.x86_64"
+      "evra": "2.76.1-1.fc38.x86_64"
     },
     "glibc": {
-      "evra": "2.36-9.fc37.x86_64"
+      "evra": "2.37-1.fc38.x86_64"
     },
     "glibc-common": {
-      "evra": "2.36-9.fc37.x86_64"
+      "evra": "2.37-1.fc38.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.36-9.fc37.x86_64"
+      "evra": "2.37-1.fc38.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.36-9.fc37.x86_64"
+      "evra": "2.37-1.fc38.x86_64"
     },
     "gmp": {
-      "evra": "1:6.2.1-3.fc37.x86_64"
+      "evra": "1:6.2.1-4.fc38.x86_64"
     },
     "gnupg2": {
-      "evra": "2.3.8-1.fc37.x86_64"
+      "evra": "2.4.0-3.fc38.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.0-2.fc37.x86_64"
+      "evra": "3.8.0-2.fc38.x86_64"
     },
     "gpgme": {
-      "evra": "1.17.0-4.fc37.x86_64"
+      "evra": "1.17.1-3.fc38.x86_64"
     },
     "grep": {
-      "evra": "3.7-4.fc37.x86_64"
+      "evra": "3.8-3.fc38.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.06-94.fc37.noarch"
+      "evra": "1:2.06-89.fc38.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-94.fc37.x86_64"
+      "evra": "1:2.06-89.fc38.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.06-94.fc37.x86_64"
+      "evra": "1:2.06-89.fc38.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-94.fc37.noarch"
+      "evra": "1:2.06-89.fc38.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-94.fc37.x86_64"
+      "evra": "1:2.06-89.fc38.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-94.fc37.x86_64"
+      "evra": "1:2.06-89.fc38.x86_64"
     },
     "gzip": {
-      "evra": "1.12-2.fc37.x86_64"
+      "evra": "1.12-3.fc38.x86_64"
     },
     "hostname": {
-      "evra": "3.23-7.fc37.x86_64"
+      "evra": "3.23-8.fc38.x86_64"
     },
     "ignition": {
-      "evra": "2.15.0-3.fc37.x86_64"
+      "evra": "2.15.0-3.fc38.x86_64"
     },
     "inih": {
-      "evra": "56-2.fc37.x86_64"
+      "evra": "56-3.fc38.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "iproute": {
-      "evra": "5.18.0-2.fc37.x86_64"
+      "evra": "6.1.0-1.fc38.x86_64"
     },
     "iproute-tc": {
-      "evra": "5.18.0-2.fc37.x86_64"
+      "evra": "6.1.0-1.fc38.x86_64"
     },
     "iptables-legacy": {
-      "evra": "1.8.8-4.fc37.x86_64"
+      "evra": "1.8.9-2.fc38.x86_64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.8-4.fc37.x86_64"
+      "evra": "1.8.9-2.fc38.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.8-4.fc37.x86_64"
+      "evra": "1.8.9-2.fc38.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.8-4.fc37.x86_64"
+      "evra": "1.8.9-2.fc38.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.8-4.fc37.noarch"
+      "evra": "1.8.9-2.fc38.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.8-4.fc37.x86_64"
+      "evra": "1.8.9-2.fc38.x86_64"
     },
     "iputils": {
-      "evra": "20221126-1.fc37.x86_64"
+      "evra": "20221126-2.fc38.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.9.1-1.fc37.x86_64"
+      "evra": "2:1.9.1-2.fc38.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.x86_64"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-6.git2a8f9d8.fc37.x86_64"
+      "evra": "6.2.1.4-10.git2a8f9d8.fc38.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-5.fc37.x86_64"
+      "evra": "0.101-6.fc38.x86_64"
     },
     "jansson": {
-      "evra": "2.13.1-5.fc37.x86_64"
+      "evra": "2.13.1-6.fc38.x86_64"
     },
     "jemalloc": {
-      "evra": "5.3.0-2.fc37.x86_64"
+      "evra": "5.3.0-3.fc38.x86_64"
     },
     "jose": {
-      "evra": "11-6.fc37.x86_64"
+      "evra": "11-7.fc38.x86_64"
     },
     "jq": {
-      "evra": "1.6-14.fc37.x86_64"
+      "evra": "1.6-15.fc38.x86_64"
     },
     "json-c": {
-      "evra": "0.16-3.fc37.x86_64"
+      "evra": "0.16-4.fc38.x86_64"
     },
     "json-glib": {
-      "evra": "1.6.6-3.fc37.x86_64"
+      "evra": "1.6.6-4.fc38.x86_64"
     },
     "kbd": {
-      "evra": "2.5.1-3.fc37.x86_64"
+      "evra": "2.5.1-5.fc38.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-3.fc37.noarch"
+      "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.2.9-200.fc37.x86_64"
+      "evra": "6.2.11-300.fc38.x86_64"
     },
     "kernel-core": {
-      "evra": "6.2.9-200.fc37.x86_64"
+      "evra": "6.2.11-300.fc38.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.2.9-200.fc37.x86_64"
+      "evra": "6.2.11-300.fc38.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.2.9-200.fc37.x86_64"
+      "evra": "6.2.11-300.fc38.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.25-1.fc37.x86_64"
+      "evra": "2.0.26-3.fc38.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.1-5.fc37.x86_64"
+      "evra": "1.6.1-6.fc38.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-5.fc37.x86_64"
+      "evra": "1.6.1-6.fc38.x86_64"
     },
     "kmod": {
-      "evra": "30-2.fc37.x86_64"
+      "evra": "30-4.fc38.x86_64"
     },
     "kmod-libs": {
-      "evra": "30-2.fc37.x86_64"
+      "evra": "30-4.fc38.x86_64"
     },
     "kpartx": {
-      "evra": "0.9.0-4.fc37.x86_64"
+      "evra": "0.9.4-2.fc38.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.19.2-13.fc37.x86_64"
+      "evra": "1.20.1-8.fc38.x86_64"
     },
     "less": {
-      "evra": "590-5.fc37.x86_64"
+      "evra": "608-2.fc38.x86_64"
     },
     "libacl": {
-      "evra": "2.3.1-4.fc37.x86_64"
+      "evra": "2.3.1-6.fc38.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-14.fc37.x86_64"
+      "evra": "0.3.111-15.fc38.x86_64"
     },
     "libarchive": {
-      "evra": "3.6.1-3.fc37.x86_64"
+      "evra": "3.6.1-4.fc38.x86_64"
     },
     "libargon2": {
-      "evra": "20190702-1.fc37.x86_64"
+      "evra": "20190702-2.fc38.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.5-5.fc37.x86_64"
+      "evra": "2.5.5-6.fc38.x86_64"
     },
     "libattr": {
-      "evra": "2.5.1-5.fc37.x86_64"
+      "evra": "2.5.1-6.fc38.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-52.fc37.x86_64"
+      "evra": "0.1.1-53.fc38.x86_64"
     },
     "libblkid": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "libbpf": {
-      "evra": "2:0.8.0-2.fc37.x86_64"
+      "evra": "2:1.1.0-2.fc38.x86_64"
     },
     "libbsd": {
-      "evra": "0.11.7-2.fc37.x86_64"
+      "evra": "0.11.7-4.fc38.x86_64"
     },
     "libcap": {
-      "evra": "2.48-5.fc37.x86_64"
+      "evra": "2.48-6.fc38.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.3-3.fc37.x86_64"
+      "evra": "0.8.3-5.fc38.x86_64"
     },
     "libcbor": {
-      "evra": "0.7.0-7.fc37.x86_64"
+      "evra": "0.7.0-9.fc38.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-52.fc37.x86_64"
+      "evra": "0.7.0-53.fc38.x86_64"
     },
     "libcom_err": {
-      "evra": "1.46.5-3.fc37.x86_64"
+      "evra": "1.46.5-4.fc38.x86_64"
     },
     "libcurl-minimal": {
-      "evra": "7.85.0-8.fc37.x86_64"
+      "evra": "7.87.0-7.fc38.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-24.fc37.x86_64"
+      "evra": "0.14-25.fc38.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-53.fc37.x86_64"
+      "evra": "5.3.28-55.fc38.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-52.fc37.x86_64"
+      "evra": "0.5.0-53.fc38.x86_64"
     },
     "libeconf": {
-      "evra": "0.4.0-4.fc37.x86_64"
+      "evra": "0.4.0-5.fc38.x86_64"
     },
     "libedit": {
-      "evra": "3.1-43.20221009cvs.fc37.x86_64"
+      "evra": "3.1-45.20221030cvs.fc38.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-7.fc37.x86_64"
+      "evra": "2.1.12-8.fc38.x86_64"
     },
     "libfdisk": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "libffi": {
-      "evra": "3.4.4-1.fc37.x86_64"
+      "evra": "3.4.4-2.fc38.x86_64"
     },
     "libfido2": {
-      "evra": "1.11.0-3.fc37.x86_64"
+      "evra": "1.12.0-3.fc38.x86_64"
     },
     "libgcab1": {
-      "evra": "1.5-1.fc37.x86_64"
+      "evra": "1.5-2.fc38.x86_64"
     },
     "libgcc": {
-      "evra": "12.2.1-4.fc37.x86_64"
+      "evra": "13.0.1-0.12.fc38.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.10.1-4.fc37.x86_64"
+      "evra": "1.10.1-7.fc38.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.46-1.fc37.x86_64"
+      "evra": "1.46-2.fc38.x86_64"
     },
     "libgudev": {
-      "evra": "237-3.fc37.x86_64"
+      "evra": "237-4.fc38.x86_64"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc37.x86_64"
+      "evra": "0.4.5-1.fc38.x86_64"
     },
     "libibverbs": {
-      "evra": "41.0-1.fc37.x86_64"
+      "evra": "44.0-3.fc38.x86_64"
     },
     "libicu": {
-      "evra": "71.1-2.fc37.x86_64"
+      "evra": "72.1-2.fc38.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.4-1.fc37.x86_64"
+      "evra": "2.3.4-2.fc38.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-52.fc37.x86_64"
+      "evra": "1.3.1-53.fc38.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc37.x86_64"
+      "evra": "0.1.13-1.fc38.x86_64"
     },
     "libjose": {
-      "evra": "11-6.fc37.x86_64"
+      "evra": "11-7.fc38.x86_64"
     },
     "libkcapi": {
-      "evra": "1.4.0-2.fc37.x86_64"
+      "evra": "1.4.0-5.fc38.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-2.fc37.x86_64"
+      "evra": "1.4.0-5.fc38.x86_64"
     },
     "libksba": {
-      "evra": "1.6.3-1.fc37.x86_64"
+      "evra": "1.6.3-2.fc38.x86_64"
     },
     "libldb": {
-      "evra": "2.6.2-1.fc37.x86_64"
+      "evra": "2.7.2-1.fc38.x86_64"
     },
     "libluksmeta": {
-      "evra": "9-14.fc37.x86_64"
+      "evra": "9-15.fc38.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-1.fc37.x86_64"
+      "evra": "1.7.1-2.fc38.x86_64"
     },
     "libmd": {
-      "evra": "1.0.4-2.fc37.x86_64"
+      "evra": "1.0.4-3.fc38.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.5-1.fc37.x86_64"
+      "evra": "1.0.5-2.fc38.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.14.0-4.fc37.x86_64"
+      "evra": "2.14.0-5.fc38.x86_64"
     },
     "libmount": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "libndp": {
-      "evra": "1.8-4.fc37.x86_64"
+      "evra": "1.8-5.fc38.x86_64"
     },
     "libnet": {
-      "evra": "1.2-6.fc37.x86_64"
+      "evra": "1.2-7.fc38.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.8-5.fc37.x86_64"
+      "evra": "1.0.8-7.fc38.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-22.fc37.x86_64"
+      "evra": "1.0.1-23.fc38.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.2-2.rc6.fc37.x86_64"
+      "evra": "1:2.6.2-2.rc6.fc38.1.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.2-2.fc37.x86_64"
+      "evra": "1.2.4-2.fc38.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.51.0-1.fc37.x86_64"
+      "evra": "1.52.0-1.fc38.x86_64"
     },
     "libnl3": {
-      "evra": "3.7.0-2.fc37.x86_64"
+      "evra": "3.7.0-3.fc38.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-2.fc37.x86_64"
+      "evra": "3.7.0-3.fc38.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.0-4.fc37.x86_64"
+      "evra": "2.0.0-5.fc38.x86_64"
     },
     "libnvme": {
-      "evra": "1.2-1.fc37.x86_64"
+      "evra": "1.4-1.fc38.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-52.fc37.x86_64"
+      "evra": "0.2.1-53.fc38.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.3-1.fc37.x86_64"
+      "evra": "14:1.10.3-2.fc38.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-3.fc37.x86_64"
+      "evra": "1.8.0-6.fc38.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.1-6.fc37.x86_64"
+      "evra": "0.21.2-2.fc38.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc37.x86_64"
+      "evra": "1.4.5-3.fc38.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-52.fc37.x86_64"
+      "evra": "0.1.5-53.fc38.x86_64"
     },
     "librepo": {
-      "evra": "1.15.1-1.fc37.x86_64"
+      "evra": "1.15.1-2.fc38.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.4-1.fc37.noarch"
+      "evra": "2.17.9-1.fc38.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-3.fc37.x86_64"
+      "evra": "2.5.3-4.fc38.x86_64"
     },
     "libselinux": {
-      "evra": "3.5-1.fc37.x86_64"
+      "evra": "3.5-1.fc38.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc37.x86_64"
+      "evra": "3.5-1.fc38.x86_64"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc37.x86_64"
+      "evra": "3.5-2.fc38.x86_64"
     },
     "libsepol": {
-      "evra": "3.5-1.fc37.x86_64"
+      "evra": "3.5-1.fc38.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.14-3.fc37.x86_64"
+      "evra": "2.14-4.fc38.x86_64"
     },
     "libslirp": {
-      "evra": "4.7.0-2.fc37.x86_64"
+      "evra": "4.7.0-3.fc38.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.17.7-0.fc37.x86_64"
-    },
-    "libsmbios": {
-      "evra": "2.4.3-7.fc37.x86_64"
+      "evra": "2:4.18.1-0.fc38.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.22-3.fc37.x86_64"
+      "evra": "0.7.22-4.fc38.x86_64"
     },
     "libss": {
-      "evra": "1.46.5-3.fc37.x86_64"
+      "evra": "1.46.5-4.fc38.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "libstdc++": {
-      "evra": "12.2.1-4.fc37.x86_64"
+      "evra": "13.0.1-0.12.fc38.x86_64"
     },
     "libtalloc": {
-      "evra": "2.3.4-3.fc37.x86_64"
+      "evra": "2.4.0-2.fc38.x86_64"
     },
     "libtasn1": {
-      "evra": "4.19.0-1.fc37.x86_64"
+      "evra": "4.19.0-2.fc38.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.7-3.fc37.x86_64"
+      "evra": "1.4.8-1.fc38.x86_64"
     },
     "libteam": {
-      "evra": "1.31-6.fc37.x86_64"
+      "evra": "1.31-7.fc38.x86_64"
     },
     "libtevent": {
-      "evra": "0.13.0-1.fc37.x86_64"
+      "evra": "0.14.1-1.fc38.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.3-0.fc37.x86_64"
+      "evra": "1.3.3-1.fc38.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-2.fc37.x86_64"
+      "evra": "2.4.7-6.fc38.x86_64"
     },
     "libunistring": {
-      "evra": "1.0-2.fc37.x86_64"
+      "evra": "1.1-3.fc38.x86_64"
+    },
+    "libunistring1.0": {
+      "evra": "1.0-1.fc38.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.25-9.fc37.x86_64"
+      "evra": "1.0.26-2.fc38.x86_64"
     },
     "libuser": {
-      "evra": "0.63-13.fc37.x86_64"
+      "evra": "0.64-2.fc38.x86_64"
     },
     "libutempter": {
-      "evra": "1.2.1-7.fc37.x86_64"
+      "evra": "1.2.1-8.fc38.x86_64"
     },
     "libuuid": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "libuv": {
-      "evra": "1:1.44.2-2.fc37.x86_64"
+      "evra": "1:1.44.2-3.fc38.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-4.fc37.x86_64"
+      "evra": "0.3.2-5.fc38.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.17.7-0.fc37.x86_64"
+      "evra": "2:4.18.1-0.fc38.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.33-4.fc37.x86_64"
+      "evra": "4.4.33-7.fc38.x86_64"
     },
     "libxml2": {
-      "evra": "2.10.3-2.fc37.x86_64"
+      "evra": "2.10.3-3.fc38.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.11-1.fc37.x86_64"
+      "evra": "0.3.11-1.fc38.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-8.fc37.x86_64"
+      "evra": "0.2.5-9.fc38.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc37.x86_64"
+      "evra": "1.5.5-1.fc38.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-33.fc37.x86_64"
+      "evra": "2.5.1-34.fc38.x86_64"
     },
     "linux-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.30-1.fc37.x86_64"
+      "evra": "0.9.30-1.fc38.x86_64"
     },
     "logrotate": {
-      "evra": "3.20.1-3.fc37.x86_64"
+      "evra": "3.21.0-2.fc38.x86_64"
     },
     "lsof": {
-      "evra": "4.94.0-4.fc37.x86_64"
+      "evra": "4.96.3-3.fc38.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc37.x86_64"
+      "evra": "5.4.4-9.fc38.x86_64"
     },
     "luksmeta": {
-      "evra": "9-14.fc37.x86_64"
+      "evra": "9-15.fc38.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.11-9.fc37.x86_64"
+      "evra": "2.03.18-2.fc38.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.11-9.fc37.x86_64"
+      "evra": "2.03.18-2.fc38.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.4-1.fc37.x86_64"
+      "evra": "1.9.4-2.fc38.x86_64"
     },
     "lzo": {
-      "evra": "2.10-7.fc37.x86_64"
+      "evra": "2.10-8.fc38.x86_64"
     },
     "mdadm": {
-      "evra": "4.2-2.fc37.x86_64"
+      "evra": "4.2-4.fc38.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-53.fc37.x86_64"
+      "evra": "2:2.1-54.fc38.x86_64"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc37.x86_64"
+      "evra": "20.10.23-1.fc38.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.6.0-5.fc37.x86_64"
-    },
-    "mozjs102": {
-      "evra": "102.9.0-1.fc37.x86_64"
+      "evra": "2:0.6.0-6.fc38.x86_64"
     },
     "mpfr": {
-      "evra": "4.1.0-10.fc37.x86_64"
+      "evra": "4.1.1-3.fc38.x86_64"
     },
     "nano": {
-      "evra": "6.4-1.fc37.x86_64"
+      "evra": "7.2-2.fc38.x86_64"
     },
     "nano-default-editor": {
-      "evra": "6.4-1.fc37.noarch"
+      "evra": "7.2-2.fc38.noarch"
     },
     "ncurses": {
-      "evra": "6.3-4.20220501.fc37.x86_64"
+      "evra": "6.4-3.20230114.fc38.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.3-4.20220501.fc37.noarch"
+      "evra": "6.4-3.20230114.fc38.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.3-4.20220501.fc37.x86_64"
+      "evra": "6.4-3.20230114.fc38.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.64.20160912git.fc37.x86_64"
+      "evra": "2.0-0.65.20160912git.fc38.x86_64"
     },
     "netavark": {
-      "evra": "1.5.0-4.fc37.x86_64"
+      "evra": "1.6.0-2.fc38.x86_64"
     },
     "nettle": {
-      "evra": "3.8-2.fc37.x86_64"
+      "evra": "3.8-3.fc38.x86_64"
     },
     "newt": {
-      "evra": "0.52.23-1.fc37.x86_64"
+      "evra": "0.52.23-2.fc38.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.2-2.rc6.fc37.x86_64"
+      "evra": "1:2.6.2-2.rc6.fc38.1.x86_64"
     },
     "nftables": {
-      "evra": "1:1.0.4-3.fc37.x86_64"
+      "evra": "1:1.0.5-2.fc38.x86_64"
     },
     "nmstate": {
-      "evra": "2.2.9-2.fc37.x86_64"
+      "evra": "2.2.9-1.fc38.x86_64"
     },
     "npth": {
-      "evra": "1.6-9.fc37.x86_64"
+      "evra": "1.6-12.fc38.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-21.fc37.x86_64"
+      "evra": "2.18.1-22.fc38.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.14-6.fc37.x86_64"
+      "evra": "2.0.16-2.fc38.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20230310-148.fc37.noarch"
+      "evra": "20230310-148.fc38.noarch"
     },
     "nvme-cli": {
-      "evra": "2.2.1-1.fc37.x86_64"
+      "evra": "2.4-1.fc38.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.8-2.D20220919gitb041f6d.fc37.x86_64"
+      "evra": "6.9.8-2.D20220919gitb041f6d.fc38.1.x86_64"
     },
     "openldap": {
-      "evra": "2.6.4-1.fc37.x86_64"
+      "evra": "2.6.4-1.fc38.x86_64"
     },
     "openssh": {
-      "evra": "8.8p1-9.fc37.x86_64"
+      "evra": "9.0p1-14.fc38.1.x86_64"
     },
     "openssh-clients": {
-      "evra": "8.8p1-9.fc37.x86_64"
+      "evra": "9.0p1-14.fc38.1.x86_64"
     },
     "openssh-server": {
-      "evra": "8.8p1-9.fc37.x86_64"
+      "evra": "9.0p1-14.fc38.1.x86_64"
     },
     "openssl": {
-      "evra": "1:3.0.8-1.fc37.x86_64"
+      "evra": "1:3.0.8-2.fc38.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.0.8-1.fc37.x86_64"
+      "evra": "1:3.0.8-2.fc38.x86_64"
     },
     "os-prober": {
-      "evra": "1.81-1.fc37.x86_64"
+      "evra": "1.81-3.fc38.x86_64"
     },
     "ostree": {
-      "evra": "2022.7-2.fc37.x86_64"
+      "evra": "2023.1-2.fc38.x86_64"
     },
     "ostree-libs": {
-      "evra": "2022.7-2.fc37.x86_64"
+      "evra": "2023.1-2.fc38.x86_64"
     },
     "p11-kit": {
-      "evra": "0.24.1-3.fc37.x86_64"
+      "evra": "0.24.1-6.fc38.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.24.1-3.fc37.x86_64"
+      "evra": "0.24.1-6.fc38.x86_64"
     },
     "pam": {
-      "evra": "1.5.2-14.fc37.x86_64"
+      "evra": "1.5.2-16.fc38.x86_64"
     },
     "pam-libs": {
-      "evra": "1.5.2-14.fc37.x86_64"
+      "evra": "1.5.2-16.fc38.x86_64"
     },
     "passwd": {
-      "evra": "0.80-13.fc37.x86_64"
-    },
-    "pcre": {
-      "evra": "8.45-1.fc37.2.x86_64"
+      "evra": "0.80-14.fc38.x86_64"
     },
     "pcre2": {
-      "evra": "10.40-1.fc37.1.x86_64"
+      "evra": "10.42-1.fc38.1.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.40-1.fc37.1.noarch"
+      "evra": "10.42-1.fc38.1.noarch"
     },
     "pigz": {
-      "evra": "2.7-2.fc37.x86_64"
+      "evra": "2.7-3.fc38.x86_64"
     },
     "pkgconf": {
-      "evra": "1.8.0-3.fc37.x86_64"
+      "evra": "1.8.0-6.fc38.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-3.fc37.noarch"
+      "evra": "1.8.0-6.fc38.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-3.fc37.x86_64"
+      "evra": "1.8.0-6.fc38.x86_64"
     },
     "podman": {
-      "evra": "5:4.4.4-3.fc37.x86_64"
+      "evra": "5:4.5.0-1.fc38.x86_64"
     },
     "podman-plugins": {
-      "evra": "5:4.4.4-3.fc37.x86_64"
+      "evra": "5:4.5.0-1.fc38.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc37.x86_64"
+      "evra": "3.5-1.fc38.x86_64"
     },
     "polkit": {
-      "evra": "121-4.fc37.2.x86_64"
+      "evra": "122-3.fc38.x86_64"
     },
     "polkit-libs": {
-      "evra": "121-4.fc37.2.x86_64"
+      "evra": "122-3.fc38.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-22.fc37.x86_64"
+      "evra": "0.1-23.fc38.x86_64"
     },
     "popt": {
-      "evra": "1.19-1.fc37.x86_64"
+      "evra": "1.19-2.fc38.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.17-6.fc37.2.x86_64"
+      "evra": "3.3.17-9.fc38.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.4.1-2.fc37.x86_64"
+      "evra": "1.4.1-4.fc38.x86_64"
     },
     "psmisc": {
-      "evra": "23.4-4.fc37.x86_64"
+      "evra": "23.6-2.fc38.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230318-1.fc37.noarch"
+      "evra": "20230318-1.fc38.noarch"
     },
     "readline": {
-      "evra": "8.2-2.fc37.x86_64"
+      "evra": "8.2-3.fc38.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.6-3.rc2.fc37.x86_64"
+      "evra": "1.2.6-4.rc2.fc38.x86_64"
     },
     "rpm": {
-      "evra": "4.18.0-1.fc37.x86_64"
+      "evra": "4.18.1-1.fc38.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.18.0-1.fc37.x86_64"
+      "evra": "4.18.1-1.fc38.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2023.2-1.fc37.x86_64"
+      "evra": "2023.2-1.fc38.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.2-1.fc37.x86_64"
+      "evra": "2023.2-1.fc38.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.0-1.fc37.x86_64"
+      "evra": "4.18.1-1.fc38.x86_64"
+    },
+    "rpm-sequoia": {
+      "evra": "1.3.0-1.fc38.x86_64"
     },
     "rsync": {
-      "evra": "3.2.7-1.fc37.x86_64"
+      "evra": "3.2.7-2.fc38.x86_64"
     },
     "runc": {
-      "evra": "2:1.1.4-1.fc37.x86_64"
+      "evra": "2:1.1.4-2.fc38.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.17.7-0.fc37.x86_64"
+      "evra": "2:4.18.1-0.fc38.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.17.7-0.fc37.noarch"
+      "evra": "2:4.18.1-0.fc38.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.17.7-0.fc37.x86_64"
+      "evra": "2:4.18.1-0.fc38.x86_64"
     },
     "sed": {
-      "evra": "4.8-11.fc37.x86_64"
+      "evra": "4.8-12.fc38.x86_64"
     },
     "selinux-policy": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "37.19-1.fc37.noarch"
+      "evra": "38.10-1.fc38.noarch"
     },
     "setup": {
-      "evra": "2.14.1-2.fc37.noarch"
+      "evra": "2.14.3-2.fc38.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-4.fc37.x86_64"
+      "evra": "1.46-5.fc38.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-4.fc37.x86_64"
+      "evra": "1.46-5.fc38.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.12.3-6.fc37.x86_64"
+      "evra": "2:4.13-6.fc38.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.12.3-6.fc37.x86_64"
+      "evra": "2:4.13-6.fc38.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.2-2.fc37.x86_64"
+      "evra": "2.2-3.fc38.x86_64"
     },
     "shim-x64": {
       "evra": "15.6-2.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.11.2-1.fc37.x86_64"
+      "evra": "1:1.11.2-1.fc38.x86_64"
     },
     "slang": {
-      "evra": "2.3.3-1.fc37.x86_64"
+      "evra": "2.3.3-3.fc38.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.2.0-8.fc37.x86_64"
+      "evra": "1.2.0-12.fc38.x86_64"
     },
     "snappy": {
-      "evra": "1.1.9-5.fc37.x86_64"
+      "evra": "1.1.9-7.fc38.x86_64"
     },
     "socat": {
-      "evra": "1.7.4.2-3.fc37.x86_64"
+      "evra": "1.7.4.4-2.fc38.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.40.0-1.fc37.x86_64"
+      "evra": "3.40.1-2.fc38.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-2.fc37.x86_64"
+      "evra": "4.5.1-3.fc38.x86_64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-1.fc37.x86_64"
+      "evra": "0.1.4-3.fc38.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-client": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-common": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.8.2-1.fc37.x86_64"
+      "evra": "2.8.2-4.fc38.x86_64"
     },
     "stalld": {
-      "evra": "1.16-2.fc37.x86_64"
+      "evra": "1.16-3.fc38.x86_64"
     },
     "sudo": {
-      "evra": "1.9.13-1.p2.fc37.x86_64"
+      "evra": "1.9.13-1.p2.fc38.x86_64"
     },
     "systemd": {
-      "evra": "251.14-2.fc37.x86_64"
-    },
-    "systemd-boot-unsigned": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "systemd-container": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "systemd-libs": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "systemd-pam": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "systemd-resolved": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "systemd-udev": {
-      "evra": "251.14-2.fc37.x86_64"
+      "evra": "253.2-1.fc38.x86_64"
     },
     "tar": {
-      "evra": "2:1.34-6.fc37.x86_64"
+      "evra": "2:1.34-8.fc38.x86_64"
     },
     "teamd": {
-      "evra": "1.31-6.fc37.x86_64"
+      "evra": "1.31-7.fc38.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc37.x86_64"
+      "evra": "0.0.99.4-1.fc38.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.4-1.fc37.x86_64"
+      "evra": "5.5-1.fc38.x86_64"
     },
     "tpm2-tss": {
-      "evra": "3.2.2-1.fc37.x86_64"
+      "evra": "4.0.1-3.fc38.x86_64"
     },
     "tzdata": {
-      "evra": "2022g-1.fc37.noarch"
+      "evra": "2023c-1.fc38.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.0-5.fc37.x86_64"
+      "evra": "0.13.2-2.fc38.x86_64"
     },
     "util-linux": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.38.1-1.fc37.x86_64"
+      "evra": "2.38.1-4.fc38.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.0.1440-1.fc37.noarch"
+      "evra": "2:9.0.1440-1.fc38.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.1440-1.fc37.x86_64"
+      "evra": "2:9.0.1440-1.fc38.x86_64"
     },
     "which": {
-      "evra": "2.21-39.fc37.x86_64"
+      "evra": "2.21-39.fc38.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-3.fc37.x86_64"
+      "evra": "1.0.20210914-4.fc38.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.1.0-2.fc37.x86_64"
+      "evra": "6.1.0-3.fc38.x86_64"
     },
     "xxhash-libs": {
-      "evra": "0.8.1-3.fc37.x86_64"
+      "evra": "0.8.1-4.fc38.x86_64"
     },
     "xz": {
-      "evra": "5.4.1-1.fc37.x86_64"
+      "evra": "5.4.1-1.fc38.x86_64"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc37.x86_64"
+      "evra": "5.4.1-1.fc38.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-19.fc37.x86_64"
+      "evra": "2.1.0-20.fc38.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.3.1-1.fc37.x86_64"
+      "evra": "1.3.1-1.fc38.x86_64"
     },
     "zincati": {
-      "evra": "0.0.25-2.fc37.x86_64"
+      "evra": "0.0.25-4.fc38.x86_64"
     },
     "zlib": {
-      "evra": "1.2.12-5.fc37.x86_64"
+      "evra": "1.2.13-3.fc38.x86_64"
     },
     "zram-generator": {
-      "evra": "1.1.2-2.fc37.x86_64"
+      "evra": "1.1.2-4.fc38.x86_64"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc37.x86_64"
+      "evra": "1.5.5-1.fc38.x86_64"
     }
   },
   "metadata": {
-    "generated": "2023-04-13T00:00:00Z",
+    "generated": "2023-04-17T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2022-11-05T08:04:38Z"
-      },
       "fedora-coreos-pool": {
-        "generated": "2023-04-08T14:19:57Z"
+        "generated": "2023-04-17T00:31:40Z"
       },
-      "fedora-updates": {
-        "generated": "2023-04-13T01:45:33Z"
+      "fedora-next": {
+        "generated": "2023-04-14T09:32:40Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-04-16T01:55:16Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: testing-devel
   prod: false
 
-releasever: 37
+releasever: 38
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to


### PR DESCRIPTION
The Fedora 38 GA is to be released Tuesday April 18th.