### PR TITLE
[next-devel] overrides: fast-track aardvark-dns-1.6.0-1.fc38, containers-common-1-89.fc38, netavark-1.6.0-2.fc38, podman-4.5.0-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,40 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  aardvark-dns:
+    evr: 1.6.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  containers-common:
+    evra: 4:1-89.fc38.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  containers-common-extra:
+    evra: 4:1-89.fc38.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  netavark:
+    evr: 1.6.0-2.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  podman:
+    evr: 5:4.5.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track
+  podman-plugins:
+    evr: 5:4.5.0-1.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).