### PR TITLE
tests/kola: fixes for upgrade test for early `next` releases

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -59,6 +59,14 @@ if [ -f /etc/zincati/config.d/90-disable-auto-updates.toml ]; then
     need_zincati_restart='true'
 fi
 
+# Early `next` releases before [1] had auto-updates disabled too. Let's
+# drop that config if it exists.
+# [1] https://github.com/coreos/fedora-coreos-config/commit/99eab318998441760cca224544fc713651f7a16d
+if [ -f /etc/zincati/config.d/90-disable-on-non-production-stream.toml ]; then
+    rm -f /etc/zincati/config.d/90-disable-on-non-production-stream.toml
+    need_zincati_restart='true'
+fi
+
 get_booted_deployment_json() {
     rpm-ostree status  --json | jq -r '.deployments[] | select(.booted == true)'
 }

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -117,6 +117,16 @@ EOF
     need_zincati_restart='true'
 }
 
+fix-allow-downgrade() {
+    # Older FCOS will complain about an upgrade target being 'chronologically older than current'
+    # This is documented in https://github.com/coreos/fedora-coreos-tracker/issues/481
+    # We can workaround the problem via a config dropin:
+    cat <<'EOF' > /run/zincati/config.d/99-fedora-coreos-allow-downgrade.toml
+updates.allow_downgrade = true
+EOF
+    need_zincati_restart='true'
+}
+
 ok "Reached version: $version"
 
 # Are we all the way at the desired target version?
@@ -140,17 +150,25 @@ fi
 # - 35.20211119.2.0
 # - 35.20211119.1.0
 #
+# First release with new enough rpm-ostree with fix for allow-downgrade issue
+# - 31.20200517.3.0
+# - 31.20200517.2.0
+# - 32.20200517.1.0
+#
 case "$stream" in
     'next')
         verlt $version '35.20211119.1.0' && grab-gpg-keys
+        verlt $version '32.20200517.1.0' && fix-allow-downgrade
         verlt $version '32.20200505.1.0' && fix-update-url
         ;;
     'testing')
         verlt $version '35.20211119.2.0' && grab-gpg-keys
+        verlt $version '31.20200517.2.0' && fix-allow-downgrade
         verlt $version '31.20200505.2.0' && fix-update-url
         ;;
     'stable')
         verlt $version '35.20211119.3.0' && grab-gpg-keys
+        verlt $version '31.20200517.3.0' && fix-allow-downgrade
         verlt $version '31.20200505.3.0' && fix-update-url
         ;;
     *) fatal "unexpected stream: $stream";;

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -117,7 +117,7 @@ fi
 
 # Apply workarounds based on the current version of the system.
 #
-# First release on each stream with new enough zincati for updates stg.fedoraprojec.org
+# First release on each stream with new enough zincati for updates stg.fedoraproject.org
 # - 31.20200505.3.0
 # - 31.20200505.2.0
 # - 32.20200505.1.0
@@ -130,7 +130,7 @@ fi
 case "$stream" in
     'next')
         verlt $version '35.20211119.1.0' && grab-gpg-keys
-        verlt $version '31.20200505.1.0' && fix-update-url
+        verlt $version '32.20200505.1.0' && fix-update-url
         ;;
     'testing')
         verlt $version '35.20211119.2.0' && grab-gpg-keys


### PR DESCRIPTION
```
commit 5c8aec846f44be8b77330946ecf9712fe96c689d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 17 13:26:11 2023 -0400

    tests/kola: fix version comparison for upgrade test
    
    I had inappropriately used 31.20200505.1.0 when it should have been
    32.20200505.1.0. Also fixed a typo in the comment URL above.

commit ea1f0faa9d56b519da1402de0a4c5434460ce19e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 17 13:24:25 2023 -0400

    tests/kola: workaround early next builds zincati config
    
    Early `next` releases before [1] had auto-updates disabled too. Let's
    drop that config if it exists.
    
    [1] https://github.com/coreos/fedora-coreos-config/commit/99eab318998441760cca224544fc713651f7a16d

```