### PR TITLE
tests/kola/ntp/chrony: use `chrony -n sources`

### DIFF
--- a/tests/kola/ntp/chrony/coreos-platform-chrony-config
+++ b/tests/kola/ntp/chrony/coreos-platform-chrony-config
@@ -11,14 +11,14 @@ set -xeuo pipefail
 
 platform=$(cmdline_arg ignition.platform.id)
 case "${platform}" in
-    aws) chronyc sources |grep '169.254.169.123'; echo "ok chrony aws" ;;
-    azure) chronyc sources |grep 'PHC'; echo "ok chrony azure" ;;
-    gcp) chronyc sources | grep '169.254.169.254'; echo "ok chrony gcp" ;;
+    aws) chronyc -n sources |grep '169.254.169.123'; echo "ok chrony aws" ;;
+    azure) chronyc -n sources |grep 'PHC'; echo "ok chrony azure" ;;
+    gcp) chronyc -n sources | grep '169.254.169.254'; echo "ok chrony gcp" ;;
     qemu)
         # ptp_kvm isn't available on all arches nor all hosts, so don't assume it's always there; see
         # https://github.com/coreos/fedora-coreos-config/pull/2263#discussion_r1157694192
         if lsmod | grep -q ptp_kvm; then
-            chronyc sources | grep 'PHC0'; echo "ok chrony qemu"
+            chronyc -n sources | grep 'PHC0'; echo "ok chrony qemu"
         fi ;;
     *) echo "unhandled platform ${platform} ?"; exit 1 ;;
 esac


### PR DESCRIPTION
By default, chrony tries to resolve source IP hostnames, which makes the test take longer. This has caused a timeout flake at least once:

```
--- FAIL: non-exclusive-test-bucket-0/ext.config.ntp.chrony.coreos-platform-chrony-config (60.48s)
        harness.go:103: TIMEOUT[1m0s]: ssh: sudo ./kolet run-test-unit --deny-reboots kola-runext-49.service
        harness.go:103: TIMEOUT[1m0s]: ssh: journalctl -t kola-runext-coreos-platform-chrony-config
```

We could bump the timeout but we don't actually need hostnames for this test so just use `-n` to disable it.