### PR TITLE
tests/kola/networking: add new `tls` test

### DIFF
--- a/tests/kola/networking/tls
+++ b/tests/kola/networking/tls
@@ -1,0 +1,21 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   tags: "platform-independent needs-internet"
+##   description: Verify we can fetch from various popular hosts over TLS.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+urls_to_fetch=(
+    "https://cloud.google.com"
+    "https://aws.amazon.com/"
+    "https://azure.microsoft.com"
+    "https://start.fedoraproject.org/"
+)
+
+for url in "${urls_to_fetch[@]}"; do
+    curl -I -s -S -m 30 --retry 5 "$url"
+done
+ok "tls"


### PR DESCRIPTION
This is migrated from cosa's `coreos.tls.fetch-urls` but does a few additional changes in the process.

`example.com` is currently down. Let's remove that and Wikipedia and replace them with more websites that host cloud-related services, since that seems more realistic (and likely to have better uptime).

Use `-I` since we're just exercising the TLS stack and don't actually need the page contents.

While we're here, bump retries to 5 since it's much cheaper to retry here than at the kola level.