### PR TITLE
[testing] manifests/fedora-coreos-base: add systemd override for ssh host key migration

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -108,6 +108,22 @@ postprocess:
     set -xeuo pipefail
     rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/
 
+  # Force the ssh-host-keys-migration to happen on every boot
+  # to handle cases where someone did a upgrade->rollback->upgrade
+  # See https://github.com/coreos/fedora-coreos-tracker/issues/1473
+  # We should remove this after the next barrier release.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    mkdir -p /usr/lib/systemd/system/ssh-host-keys-migration.service.d
+    cat <<'EOF' > /usr/lib/systemd/system/ssh-host-keys-migration.service.d/coreos-force-migration-on-every-boot.conf
+    # Force the ssh-host-keys-migration to happen on every boot
+    # to handle cases where someone did a upgrade->rollback->upgrade
+    # See https://github.com/coreos/fedora-coreos-tracker/issues/1473
+    [Unit]
+    ConditionPathExists=
+    EOF
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.


### PR DESCRIPTION
In this case we'll override the ConditionPathExists from ssh-host-keys-migration.service [1] to force it to run every boot. We want to do this to handle the case where someone could do an upgrade->rollback->upgrade and end up locked out of their system [2].

[1] https://src.fedoraproject.org/rpms/openssh/blob/6f7c765ed4cf0e8eef664fb93b26f4ea2a14d955/f/ssh-host-keys-migration.service
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1473

(cherry picked from commit 5e1efaedb108f0c3ecd4e50aa8022846189d7a58)