### PR TITLE
overrides: fast-track curl-7.87.0-8.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -27,6 +27,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
       type: fast-track
+  curl:
+    evr: 7.87.0-8.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-eec1379708
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1477
+      type: fast-track
+  libcurl-minimal:
+    evr: 7.87.0-8.fc38
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-eec1379708
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1477
+      type: fast-track
   netavark:
     evr: 1.6.0-2.fc38
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).