### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,24 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  aardvark-dns:
-    evr: 1.6.0-1.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
-      type: fast-track
-  containers-common:
-    evra: 4:1-89.fc38.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
-      type: fast-track
-  containers-common-extra:
-    evra: 4:1-89.fc38.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
-      type: fast-track
   curl:
     evr: 7.87.0-8.fc38
     metadata:
@@ -38,22 +20,4 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-eec1379708
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1477
-      type: fast-track
-  netavark:
-    evr: 1.6.0-2.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
-      type: fast-track
-  podman:
-    evr: 5:4.5.0-1.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
-      type: fast-track
-  podman-plugins:
-    evr: 5:4.5.0-1.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-92b7759c3e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1471
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).