### PR TITLE
overrides: pin moby-engine-20.10.23-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,8 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-eec1379708
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1477
       type: fast-track
+  moby-engine:
+    evr: 20.10.23-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1476
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).