### PR TITLE
[rawhide] overrides: pin linux-firmware-20230310-148.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,16 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  amd-gpu-firmware:
+    evra: 20230310-148.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
+      type: pin
+  intel-gpu-firmware:
+    evra: 20230310-148.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
+      type: pin
   libblkid:
     evr: 2.38.1-4.fc38
     metadata:
@@ -33,6 +43,21 @@ packages:
     evr: 2.38.1-4.fc38
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1462
+      type: pin
+  linux-firmware:
+    evra: 20230310-148.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
+      type: pin
+  linux-firmware-whence:
+    evra: 20230310-148.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
+      type: pin
+  nvidia-gpu-firmware:
+    evra: 20230310-148.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
       type: pin
   util-linux:
     evr: 2.38.1-4.fc38


### PR DESCRIPTION
The new linux-firmware-20230404-149.fc39 causes `files.validate-symlinks` kola tests to fail in rawhide. 
Pin on linux-firmware-20230310-148.fc39 so the tests pass. 

See: https://github.com/coreos/fedora-coreos-tracker/issues/1479