### PR TITLE
overlay.d/20platform-chrony: accept `ec2` and `gce` platform IDs

### DIFF
--- a/overlay.d/20platform-chrony/usr/lib/systemd/system/coreos-platform-chrony-config.service
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system/coreos-platform-chrony-config.service
@@ -3,6 +3,10 @@ Description=CoreOS Configure Chrony Based On The Platform
 ConditionKernelCommandLine=|ignition.platform.id=azurestack
 ConditionKernelCommandLine=|ignition.platform.id=azure
 ConditionKernelCommandLine=|ignition.platform.id=aws
+# RHCOS 4.1/4.2 bootimages
+ConditionKernelCommandLine=|ignition.platform.id=ec2
+# RHCOS 4.1/4.2 bootimages
+ConditionKernelCommandLine=|ignition.platform.id=gce
 ConditionKernelCommandLine=|ignition.platform.id=gcp
 ConditionKernelCommandLine=|ignition.platform.id=qemu
 Before=NetworkManager.service

--- a/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
+++ b/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
@@ -83,11 +83,11 @@ case "${platform}" in
          echo 'refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0'
          echo 'leapsectz right/UTC'
         ) >> "${confpath}" ;;
-    aws)
+    aws | ec2)
         (echo '# See also https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html'
          echo 'server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4'
         ) >> "${confpath}" ;;
-    gcp)
+    gcp | gce)
         (echo '# See also https://cloud.google.com/compute/docs/instances/managing-instances#configure-ntp'
          echo '# and https://cloud.google.com/compute/docs/images/configuring-imported-images'
          echo 'server metadata.google.internal prefer iburst'


### PR DESCRIPTION
RHCOS 4.1 and 4.2 bootimages are still in use, and they produce systems that claim to be `ec2`/`gce` instead of `aws`/`gcp`.  Detect those and handle appropriately.