### PR TITLE
[rawhide] kola-denylist: snooze new `ext.config.networking.nmstate.*` tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,3 +18,6 @@
   snooze: 2023-05-03
   arches:
     - aarch64
+- pattern: ext.config.networking.nmstate.*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1480
+  snooze: 2023-05-08


### PR DESCRIPTION
The new nmstate tests are failing in rawhide. Let's snooze until we find a fix for them or disable them in FCOS.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1480