### PR TITLE
Revert partially for `ext.config.shared.ntp.chrony.dhcp-propagation`

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -27,14 +27,7 @@ RUN echo -e 'dhcp-range=172.16.0.10,172.16.0.20,12h\nbind-interfaces\ninterface=
 CMD [ "/sbin/init" ]
 EOF
 
-    if is_fcos || is_rhcos8; then
-        podman build -t dnsmasq .
-    else
-        # only workaround for scos and rhel9
-        # https://github.com/openshift/os/issues/964
-        # https://bugzilla.redhat.com/show_bug.cgi?id=2123246 (revert PR when bug is fixed)
-        podman build --security-opt seccomp=/usr/share/containers/seccomp.json -t dnsmasq .
-    fi
+    podman build -t dnsmasq .
     popd
     podman run -d --rm --name dnsmasq --privileged --network ns:/var/run/netns/container dnsmasq
 


### PR DESCRIPTION
This is to revert partially for https://github.com/coreos/fedora-coreos-config/pull/1952/commits/089a8f37a2d7a07a84c8f71871a6b61a217f68cd, as https://bugzilla.redhat.com/show_bug.cgi?id=2123251 is fixed. The fixed version is `podman-4.3.1`.