### PR TITLE
tests: enable `ext.config.shared.root-reprovision.swap-before-root` on rhcos

### DIFF
--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -2,9 +2,6 @@
 ## kola:
 ##   # This test's config manually references /dev/vda and is thus QEMU only
 ##   platforms: qemu
-##   # This test only runs on FCOS due to a problem enabling a swap partition on
-##   # RHCOS. See: https://github.com/openshift/os/issues/665
-##   distros: fcos
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher


### PR DESCRIPTION
As https://bugzilla.redhat.com/show_bug.cgi?id=1952686 is fixed, and fixed version is `systemd-239-48.el8`.
See https://github.com/openshift/os/issues/665