### PR TITLE
kola/validate-symlinks: skip `/usr/lib/firmware` symlinks

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -11,14 +11,16 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-# List of known broken symlinks that require further investigation:
+# List of known broken symlinks that require further investigation.
+# The sym links in /usr/lib/firmware are often broken and are
+# typically not an issue, so let's skip this location altogether.
 list_broken_symlinks_skip=(
     '/etc/mtab'
     '/etc/ssl/'
     '/etc/swid/swidtags.d/fedoraproject.org'
     '/etc/xdg/systemd/user'
     '/usr/lib/.build-id/'
-    '/usr/lib/firmware/qcom/LENOVO/21BX.xz'
+    '/usr/lib/firmware'
     '/usr/lib/modules/'
     '/usr/share/rhel/secrets/etc-pki-entitlement'
     '/usr/share/rhel/secrets/redhat.repo'


### PR DESCRIPTION
A recent rawhide package of linux-firmware caused the validate-symlinks kola tests to fail. Let's modify the broken-symlinks list to skip all of `/usr/lib/firmware` so we can unblock FCOS rawhide builds.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1479