### PR TITLE
[rawhide] overrides: unpin linux-firmware-20230310-148.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,29 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  amd-gpu-firmware:
-    evra: 20230310-148.fc39.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
-      type: pin
-  intel-gpu-firmware:
-    evra: 20230310-148.fc39.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
-      type: pin
-  linux-firmware:
-    evra: 20230310-148.fc39.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
-      type: pin
-  linux-firmware-whence:
-    evra: 20230310-148.fc39.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
-      type: pin
-  nvidia-gpu-firmware:
-    evra: 20230310-148.fc39.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1479
-      type: pin
+packages: {}


### PR DESCRIPTION
Now that we are skipping sym link validation in `/usr/lib/firmware` we can drop this pin.
See: https://github.com/coreos/fedora-coreos-config/pull/2402