### PR TITLE
Ignition tweaks to work with composefs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
@@ -32,6 +32,7 @@ rm -vrf ${initramfs_firstboot_network_dir}
 root=$(karg root)
 if [ -z "${root}" ]; then
     rdcore rootmap /sysroot --boot-mount ${bootmnt}
+    echo "Prepared rootmap"
 fi
 
 # This does a few things:

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-check-rootfs-size
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-check-rootfs-size
@@ -4,7 +4,8 @@ set -euo pipefail
 # See also ignition-ostree-check-rootfs-size.service
 # https://github.com/coreos/fedora-coreos-tracker/issues/586#issuecomment-777220000
 
-srcdev=$(findmnt -nvr -o SOURCE /sysroot | tail -n1)
+# /sysroot is the mounted deploy root, /sysroot/sysroot is the physical root filesystem
+srcdev=$(findmnt -nvr -o SOURCE /sysroot/sysroot | tail -n1)
 size=$(lsblk --nodeps --noheadings --bytes -o SIZE "${srcdev}")
 
 MINIMUM_GB=8


### PR DESCRIPTION
I'm currently working on composefs use in ostree:
 https://github.com/ostreedev/ostree/pull/2640

I'm running into issues with ignition when testing it. Several places look at /sysroot and try to find the backing filesystem for it. This works because /sysroot is typically a bind-mount of some deploy directory in the real sysroot. However, in the composefs case, /sysroot is a composefs mount and doesn't have a real backing block device.

This change switches these cases to look at /sysroot/sysroot instead. This is the actual real sysroot after ostree-prepare-root did its work (and before pivot-rooting into it).