### PR TITLE
kola: enable tests with 'appendKernelArgs' on s390x

### DIFF
--- a/tests/kola/networking/bridge-static-via-kargs
+++ b/tests/kola/networking/bridge-static-via-kargs
@@ -9,9 +9,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:mybridge:br0:none bridge=br0:eth1,eth2 net.ifnames=0"
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify bridge networks works via kernel arguments.
 
 set -xeuo pipefail

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -9,9 +9,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip"
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that coreos.force_persist_ip will force propagating 
 ##     kernel argument based networking configuration into the real root.
 

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
@@ -7,9 +7,6 @@
 ##   # validate that the systemd.link file gets created by
 ##   # systemd-network-generator.
 ##   appendFirstbootKernelArgs: "coreos.no_persist_ip"
-##   # appendFirstbootKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 
 set -xeuo pipefail
 

--- a/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
+++ b/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
@@ -6,9 +6,6 @@
 ##   # Append ifname kernel argument to set the given MAC address to the NIC
 ##   # named `kolatest`. The MAC address is the default one QEMU assigns.
 ##   appendFirstbootKernelArgs: "ifname=kolatest:52:54:00:12:34:56"
-##   # appendFirstbootKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 
 # Part of https://github.com/coreos/fedora-coreos-tracker/issues/553
 

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -4,9 +4,6 @@
 ##   platforms: qemu
 ##   # The functionality we're testing here.
 ##   appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
-##   # appendFirstbootKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify rd.net.timeout.dhcp and rd.net.dhcp.retry 
 ##     are supported by NetworkManager.
 

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -8,9 +8,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: net.ifnames=0
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that configure MTU on a VLAN subinterface for 
 ##     the bond via Ignition works.
 #

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -9,9 +9,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0"
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that configuring MTU on a VLAN subinterface 
 ##     for the bond via kernel arguements works.
 

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -3,9 +3,6 @@
 ##   # appendKernelArgs is only supported on QEMU
 ##   platforms: qemu
 ##   appendKernelArgs: "nameserver=8.8.8.8 nameserver=1.1.1.1"
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that we config multiple nameservers via kernel 
 ##     arguments work well.
 

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -9,8 +9,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none net.ifnames=0 coreos.no_persist_ip"
-##   # appendKernelArgs doesn't work on s390x, see https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that the coreos.no_persist_ip kernel argument will 
 ##     prevent propagating kernel argument based networking configuration 
 ##     into the real root. 

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -9,9 +9,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0"
-##   # appendKernelArgs doesn't work on s390x so skip there
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify that networking configuration is propagated 
 ##     via Ignition by default.
 

--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -8,9 +8,6 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "net.ifnames=0"
-##   # appendKernelArgs doesn't work on s390x
-##   # https://github.com/coreos/coreos-assembler/issues/2776
-##   architectures: "!s390x"
 ##   description: Verify team networking works via Ignition config.
 
 # The Ignition config refers to


### PR DESCRIPTION
Requires: https://github.com/coreos/coreos-assembler/pull/3440