### PR TITLE
denylist: bump snooze for ext.config.kdump.crash on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,6 +15,6 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-05-03
+  snooze: 2023-05-23
   arches:
     - aarch64


### PR DESCRIPTION
Still not fixed yet, but is being worked on.