### PR TITLE
overlay.d/05core: add ifname= karg udev rule propagation

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-teardown-initramfs.sh
@@ -168,6 +168,20 @@ propagate_initramfs_hostname() {
     fi
 }
 
+# Propagate the ifname= karg udev rules. The policy here is:
+#
+#     - IF ifname karg udev rule file exists
+#     - THEN copy it to the real root
+#
+propagate_ifname_udev_rules() {
+    local udev_file='/etc/udev/rules.d/80-ifname.rules'
+    if [ -e "${udev_file}" ]; then
+        echo "info: propagating ifname karg udev rules to the real root"
+        cp -v "${udev_file}" "/sysroot/${udev_file}"
+        coreos-relabel "${udev_file}"
+    fi
+}
+
 main() {
     # Load libraries from dracut
     load_dracut_libs
@@ -192,6 +206,7 @@ main() {
     else
         propagate_initramfs_hostname
         propagate_initramfs_networking
+        propagate_ifname_udev_rules
     fi
 
     # Configuration has been propagated, but we can't clean up

--- a/tests/kola/networking/ifname-karg/data/commonlib.sh
+++ b/tests/kola/networking/ifname-karg/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/networking/ifname-karg/data/ifname-karg-lib.sh
+++ b/tests/kola/networking/ifname-karg/data/ifname-karg-lib.sh
@@ -1,0 +1,36 @@
+# This is a library created for our ifname-karg tests
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# check IP for given NIC name
+check_ip() {
+    # User provides the NIC name.
+    local nic_name=$1
+    # The expected IP is the first one in the range given out by QEMU
+    # user mode networking: https://www.qemu.org/docs/master/system/devices/net.html#using-the-user-mode-network-stack
+    local expected_ip="10.0.2.15"
+    # Verify the given nic name has the expected IP.
+    local nic_ip=$(get_ipv4_for_nic ${nic_name})
+    if [ "${nic_ip}" != "${expected_ip}" ]; then
+        fatal "Error: get ${nic_name} ip = ${nic_ip}, expected is ${expected_ip}"
+    fi
+    ok "get ${nic_name} ip is ${expected_ip}"
+}
+
+# simple file existence check
+check_file_exists() {
+    local file=$1
+    if [ ! -f $file ]; then
+        fatal "expected file ${file} doesn't exist on disk"
+    fi
+    ok "expected file ${file} exists on disk"
+}
+
+# simple file non-existence check
+check_file_not_exists() {
+    local file=$1
+    if [ -f $file ]; then
+        fatal "expected file ${file} to not exist on disk"
+    fi
+    ok "file ${file} does not exist on disk"
+}

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/config.bu
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/config.bu
@@ -1,0 +1,7 @@
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_exist:
+    # Persistently set the ifname kernel argument to set the given MAC to the
+    # NIC named `kolatest`. The MAC address is the default one QEMU assigns.
+    - ifname=kolatest:52:54:00:12:34:56

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/data/commonlib.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../data/commonlib.sh

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/data/ifname-karg-lib.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/data/ifname-karg-lib.sh
@@ -1,0 +1,1 @@
+../../data/ifname-karg-lib.sh

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+## kola:
+##   description: Verify persistent ifname= karg works via systemd-network-generator.
+##   # appendFirstbootKernelArgs is only supported on QEMU
+##   platforms: qemu
+##   # Don't run the propagate code. With this test we want to
+##   # validate that the systemd.link file gets created by
+##   # systemd-network-generator.
+##   appendFirstbootKernelArgs: "coreos.no_persist_ip"
+##   # appendFirstbootKernelArgs doesn't work on s390x
+##   # https://github.com/coreos/coreos-assembler/issues/2776
+##   architectures: "!s390x"
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+. $KOLA_EXT_DATA/ifname-karg-lib.sh
+
+nicname='kolatest'
+
+run_tests() {
+    # Make sure nothing was persisted from the initramfs
+    check_file_not_exists '/etc/udev/rules.d/80-ifname.rules' 
+    # Make sure systemd-network-generator ran (from the real root)
+    check_file_exists "/run/systemd/network/90-${nicname}.link"
+    # Make sure the NIC is in use and got the expected IP address
+    check_ip "${nicname}"
+}
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+    "")
+        ok "first boot"
+        run_tests
+        /tmp/autopkgtest-reboot rebooted
+      ;;
+
+    rebooted)
+        ok "second boot"
+        run_tests
+      ;;
+
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac

--- a/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
+++ b/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
@@ -1,0 +1,47 @@
+#!/bin/bash
+## kola:
+##   description: Verify firstboot ifname= karg udev rule propoagation works.
+##   # appendFirstbootKernelArgs is only supported on QEMU
+##   platforms: qemu
+##   # Append ifname kernel argument to set the given MAC address to the NIC
+##   # named `kolatest`. The MAC address is the default one QEMU assigns.
+##   appendFirstbootKernelArgs: "ifname=kolatest:52:54:00:12:34:56"
+##   # appendFirstbootKernelArgs doesn't work on s390x
+##   # https://github.com/coreos/coreos-assembler/issues/2776
+##   architectures: "!s390x"
+
+# Part of https://github.com/coreos/fedora-coreos-tracker/issues/553
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+. $KOLA_EXT_DATA/ifname-karg-lib.sh
+
+nicname='kolatest'
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+    "")
+        ok "first boot"
+        # Make sure the rules were persisted from the initramfs
+        check_file_exists '/etc/udev/rules.d/80-ifname.rules' 
+        # On first boot we expect systemd-network-generator to run too
+        # because the ifname= karg was present, but only for first boot
+        check_file_exists "/run/systemd/network/90-${nicname}.link"
+        # Make sure the NIC is in use and got the expected IP address
+        check_ip "${nicname}"
+        /tmp/autopkgtest-reboot rebooted
+      ;;
+
+    rebooted)
+        ok "second boot"
+        # Make sure the rules are still there
+        check_file_exists '/etc/udev/rules.d/80-ifname.rules' 
+        # On second boot the ifname= karg isn't there so the file
+        # created by systemd-network-generator shouldn't exist.
+        check_file_not_exists "/run/systemd/network/90-${nicname}.link"
+        # Make sure the NIC is in use and got the expected IP address
+        check_ip "${nicname}"
+      ;;
+
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -3,8 +3,8 @@
 ##   # appendFirstbootKernelArgs is only supported on qemu
 ##   platforms: qemu
 ##   # Append BOOTIF kernel argument so we can test how nm-initrd-generator
-##   # and the coreos-teardown-initramfs interact. The MAC address is from:
-##   # https://github.com/coreos/coreos-assembler/blob/d5f1623aad6d133b2c7c00e784c04ab6828450c1/mantle/platform/metal.go#L468
+##   # and the coreos-teardown-initramfs interact. The MAC address is the
+##   # default one QEMU assigns.
 ##   # Add rd.neednet=1 so we can force networking to be brought up on
 ##   # qemu to test that doing so doesn't materially change things.
 ##   appendFirstbootKernelArgs: "BOOTIF=52:54:00:12:34:56 rd.neednet=1"


### PR DESCRIPTION
This adds to coreos-teardown-initramfs.{service,sh} the ability to propagate udev rules that were generated by ifname-genrules.sh [1] to the real root of the machine to allow for an ephemeral ifname= karg on the first boot to have persistent configuration effect (similar to our other networking kernel arguments).

This also adds tests for both the firstboot and everyboot case for the ifname= karg.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/553

[1] https://github.com/dracutdevs/dracut/blob/5c3d0a96473ac339fa2d1b25213b8f301c1cfd0d/modules.d/40network/ifname-genrules.sh