### PR TITLE
[rhcos 4.13] cherry-pick secex tests

### DIFF
--- a/tests/kola/secex/ensure/test.sh
+++ b/tests/kola/secex/ensure/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+## kola:
+##   # This test verifies the s390x Secure Execution QEMU image works. It also
+##   # implicitly tests Ignition config decryption. We don't run it by default
+##   # because it requires running with `--qemu-secex`.
+##   architectures: s390x
+##   platforms: qemu
+##   requiredTag: secex
+##   timeoutMin: 3
+
+set -xeuo pipefail
+
+check_luks() {
+    local mnt dev type
+    mnt=${1}
+    dev=$(findmnt -nvr ${mnt} -o SOURCE)
+    type=$(lsblk -o TYPE "${dev}" --noheadings)
+    [[ ${type} == crypt ]]
+}
+
+# 1 means system runs with Secure Execution
+grep -q 1 /sys/firmware/uv/prot_virt_guest
+
+# Check firstboot kargs have dm-verity hashes
+grep -q rootfs.roothash /proc/cmdline
+grep -q bootfs.roothash /proc/cmdline
+
+# Check we have SE partition with sdboot image
+mount /dev/disk/by-label/se /sysroot/se
+[[ -f /sysroot/se/sdboot ]]
+
+check_luks /
+check_luks /boot

--- a/tests/kola/secex/reboot/test.sh
+++ b/tests/kola/secex/reboot/test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+## kola:
+##   # This test verifies the qemu-secex image reboots with SE enabled. It also
+##   # implicitly tests Ignition config decryption. We don't run it by default
+##   # because it requires running with `--qemu-secex --qemu-secex-hostkey HKD-<serial>.crt`.
+##   architectures: s390x
+##   platforms: qemu
+##   requiredTag: secex
+##   timeoutMin: 3
+
+set -xeuo pipefail
+
+grep -q 1 /sys/firmware/uv/prot_virt_guest
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+    rpm-ostree kargs --append secex_test
+    /tmp/autopkgtest-reboot rebooted
+    ;;
+rebooted)
+    grep -q rd.luks.name=$(cryptsetup luksUUID /dev/disk/by-label/crypt_rootfs)=root /proc/cmdline
+    grep -q secex_test /proc/cmdline
+    ;;
+*)
+    echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This adds
-  tests: add "ext.config.secex.reboot" test (cherry picked from commit 1efd1066c7271bae09ebd192aee57278595bf96a)
- tests: add "ext.config.secex.ensure" test (cherry picked from commit 842329ae0572f3a32e5cbe24ecb2baf2b5434175)