### PR TITLE
tests/kola: cancel any pending rpm-ostree transaction in upgrade test

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -186,7 +186,10 @@ if vereq $version $last_release; then
 fi
 
 # Restart Zincati if configuration was changed
-[ "${need_zincati_restart}" == "true" ] && systemctl restart zincati
+if [ "${need_zincati_restart}" == "true" ]; then
+    rpm-ostree cancel # in case anything was already in progress
+    systemctl restart zincati
+fi
 
 # Watch the Zincati logs to see if it got a lead on a new update.
 # Timeout after some time if no update. Unset pipefail since the


### PR DESCRIPTION
We've seen it where zincati gets restarted but a previous rpm-ostree deploy (that had been scheduled by Zincati) was still running. Let's cancel anything that's pending before restarting Zincati.