### PR TITLE
kola/denylist: Denylist `ext.config.files.validate-symlinks` due to a broken symlink

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -29,3 +29,8 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: ext.config.files.validate-symlinks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1496
+  snooze: 2023-06-01
+  streams:
+    - rawhide


### PR DESCRIPTION
The symlink `/usr/lib/debug/usr/lib64/bfd-plugins/libdep.so-2.40-7.fc39.x86_64.debug` is broken. So denylisting this test till we get a fix for that.
Tracker issue: https://github.com/coreos/fedora-coreos-tracker/issues/1496
BZ issue: https://bugzilla.redhat.com/show_bug.cgi?id=2208360