### PR TITLE
tests/kola: add two files to files.setuid test

### DIFF
--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -11,6 +11,8 @@ set -xeuo pipefail
 # List of known files and directories with SetUID bit set
 list_setuid_files=(
     '/usr/bin/chage'
+    '/usr/bin/chfn'
+    '/usr/bin/chsh'
     '/usr/bin/fusermount'
     '/usr/bin/fusermount3'
     '/usr/bin/gpasswd'


### PR DESCRIPTION
The util-linux-user subpackage was folded back in to the util-linux main package [1]. This means we now have two new setuid files that we didn't have before.

[1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/HENKGZ22XTSVJWHZKP6YSMFZCOQR3HZN/