### PR TITLE
denylist: extend snoozes for recently un-snoozed tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,7 +15,7 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-05-23
+  snooze: 2023-06-01
   arches:
     - aarch64
 # This snooze won't fully work because we run our reprovision tests in
@@ -24,7 +24,7 @@
 # To workaround we've added the reprovision label to the `boot.grub2-install` test.
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-  snooze: 2023-05-23
+  snooze: 2023-06-01
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
These both still fail. I added a comment to the issues.