### PR TITLE
manifests/fedora-coreos: drop removal of sysusers.d/dbus.conf

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -131,11 +131,6 @@ postprocess:
     done
 
 
-remove-from-packages:
-  # Drop some buggy sysusers fragments which do not match static IDs allocation:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2105177
-  - [dbus-common, /usr/lib/sysusers.d/dbus.conf]
-
 remove-files:
   # We don't ship man(1) or info(1)
   - usr/share/info


### PR DESCRIPTION
Originally introduced as part of d3a0cf9, the bug [1] was fixed by a PR to the RPM [2] a while back so we shouldn't need to carry this any longer.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2105177
[2] https://src.fedoraproject.org/rpms/dbus/pull-request/16#