### PR TITLE
drop a few no longer required pieces

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -63,20 +63,6 @@ postprocess:
     #!/usr/bin/env bash
     systemctl mask dnsmasq.service
 
-  # Fedora 37 adds the nvmf dracut module to the initrd, causing
-  # ext.config.files.dracut-executable to notice that the module puts a
-  # non-executable file in /usr/sbin.  Dracut has been updated to fix the
-  # missing permission, and hopefully this can be removed for Fedora 38.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1155
-  # https://github.com/dracutdevs/dracut/pull/1777
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    source /etc/os-release
-    if [ ${VERSION_ID} -le 37 ]; then
-        chmod +x /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
-    fi
-
   # Default to iptables-nft. Otherwise, legacy wins. We can drop this once/if we
   # remove iptables-legacy. This is needed because alternatives don't work
   # https://github.com/coreos/fedora-coreos-tracker/issues/677

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -32,6 +32,3 @@ enable rtas_errd.service
 enable clevis-luks-askpass.path
 # Provide status information about the Ignition run
 enable coreos-ignition-write-issues.service
-# Apply network configuration from /etc/nmstate/*.yml
-# We can drop this after merging https://src.fedoraproject.org/rpms/fedora-release/pull-request/255
-enable nmstate.service


### PR DESCRIPTION
```
commit efa505a323a96421ea7fc04cf428313f369813ef
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu May 25 11:34:29 2023 -0400

    overlay.d/05core: drop nmstate.service in preset file
    
    The service is now pulled in by NetworkManager.service [1] so we
    can stop adding it as a preset.
    
    [1] https://github.com/nmstate/nmstate/pull/2285

commit e9b3d7c296b12c0a6c74b387cfd1cb1a865d4cbd
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed May 24 23:20:00 2023 -0400

    manifests/fedora-coreos-base: drop dracut nvmf workaround
    
    Mostly a revert of e49baba. This was fixed in dracut some time ago [1]
    and this is now dead code since we are on F38.
    
    [1] https://github.com/dracutdevs/dracut/pull/1777
```
