### PR TITLE
selectively enable ostree autopruning

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.3-2.fc38.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track
+  ostree-libs:
+    evra: 2023.3-2.fc38.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,29 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.3-2.fc38.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track
+  ostree-libs:
+    evra: 2023.3-2.fc38.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track
+  ostree-grub2:
+    evra: 2023.3-2.fc38.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.3-2.fc38.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track
+  ostree-libs:
+    evra: 2023.3-2.fc38.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.3-2.fc38.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track
+  ostree-libs:
+    evra: 2023.3-2.fc38.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
+      reason: https://github.com/ostreedev/ostree/pull/2866
+      type: fast-track

--- a/manifests/aarch64-drop-qcom-dtb-files.yaml
+++ b/manifests/aarch64-drop-qcom-dtb-files.yaml
@@ -1,0 +1,8 @@
+# Short term hack to avoid running out of space on aarch64. This should
+# save us about 14M. https://github.com/coreos/fedora-coreos-tracker/issues/1464
+# This can be removed once we are on F39+.
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -63,20 +63,6 @@ postprocess:
     #!/usr/bin/env bash
     systemctl mask dnsmasq.service
 
-  # Fedora 37 adds the nvmf dracut module to the initrd, causing
-  # ext.config.files.dracut-executable to notice that the module puts a
-  # non-executable file in /usr/sbin.  Dracut has been updated to fix the
-  # missing permission, and hopefully this can be removed for Fedora 38.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1155
-  # https://github.com/dracutdevs/dracut/pull/1777
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    source /etc/os-release
-    if [ ${VERSION_ID} -le 37 ]; then
-        chmod +x /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
-    fi
-
   # Default to iptables-nft. Otherwise, legacy wins. We can drop this once/if we
   # remove iptables-legacy. This is needed because alternatives don't work
   # https://github.com/coreos/fedora-coreos-tracker/issues/677

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -77,13 +77,6 @@ postprocess:
     ln -sf /usr/sbin/iptables-nft-restore  /etc/alternatives/iptables-restore
     ln -sf /usr/sbin/iptables-nft-save     /etc/alternatives/iptables-save
 
-  # Short term hack to avoid running out of space on aarch64. This should
-  # save us about 14M. https://github.com/coreos/fedora-coreos-tracker/issues/1464
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/
-
   # Force the ssh-host-keys-migration to happen on every boot
   # to handle cases where someone did a upgrade->rollback->upgrade
   # See https://github.com/coreos/fedora-coreos-tracker/issues/1473

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -29,6 +29,18 @@ conditional-include:
     # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1355314761
     # https://github.com/coreos/fedora-coreos-tracker/issues/1495#issuecomment-1561765705
     include: ostree-autoprune.yaml
+  - if:
+      - basearch == "aarch64"
+      - releasever >= 39
+    # In F39+ we will stop removing the qcom dtb files and thus we'll leverage OSTree autopruning
+    # so that we don't run into https://github.com/coreos/fedora-coreos-tracker/issues/1464
+    # again. OSTree autopruning is new so we're selectively enabling it before making it the default.
+    include: ostree-autoprune.yaml
+  - if:
+      - basearch == "aarch64"
+      - releasever == 38
+    # Remove qcom dtb on F38 files since autopruning isn't in place yet
+    include: aarch64-drop-qcom-dtb-files.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -23,6 +23,12 @@ conditional-include:
   - if: basearch != "s390x"
     # And remove some cruft from grub2
     include: grub2-removals.yaml
+  - if: basearch == "ppc64le"
+    # Need OSTree autopruning on ppc64le (because kernels aren't compressed)
+    # until we increase the size of /boot.
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1247#issuecomment-1355314761
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1495#issuecomment-1561765705
+    include: ostree-autoprune.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/ostree-autoprune.yaml
+++ b/manifests/ostree-autoprune.yaml
@@ -1,0 +1,11 @@
+# Enable OSTree autopruning to help with /boot size constraints
+# https://github.com/coreos/fedora-coreos-tracker/issues/1495
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    mkdir -p /usr/lib/systemd/system/ostree-finalize-staged.service.d
+    cat <<'EOF' > /usr/lib/systemd/system/ostree-finalize-staged.service.d/ostree-autoprune.conf
+    [Service]
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1495
+    Environment=OSTREE_SYSROOT_OPTS=early-prune
+    EOF


### PR DESCRIPTION
This adds autopruning for ppc64le so we can start to officially release it.

It also adds back in the qualcomm dtbs and autopruning for aarch64 on F39+, which allows us to passively pick up the change when the `next-devel` branch is re-enabled at F39 beta time. If we re-enable the `next-devel` branch earlier then we can change this to pick it up quicker too.

Finally, there is a commit in there to drop some code that's no longer necessary.