### PR TITLE
[rawhide] overrides: pin util-linux-2.39-3.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,39 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  libblkid:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  libfdisk:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  libmount:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  libsmartcols:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  libuuid:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  util-linux:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin
+  util-linux-core:
+    evr: 2.39-3.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).