### PR TITLE
tests/kola: wait longer in commonlib.sh is_service_active

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -76,10 +76,10 @@ cmdline_arg() {
     echo "${value}"
 }
 
-# wait for 20s when in activating status
+# wait for ~60s when in activating status
 is_service_active() {
     local service="$1"
-    for x in {0..20}; do
+    for x in {0..60}; do
         [ $(systemctl is-active "${service}") != "activating" ] && break
         sleep 1
     done


### PR DESCRIPTION
In https://github.com/coreos/coreos-assembler/pull/3487 we are changing the `sshChecker` in `CheckMachine()` to return earlier in the `starting` and `initializing` states. This means the kola test code might start to run earlier and we may need to wait longer here.