### PR TITLE
overlay.d/05core: drop nmstate.service in preset file

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,24 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a3adea94d9
       type: fast-track
+  fedora-release-common:
+    evra: 38-36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
+      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
+      type: fast-track
+  fedora-release-coreos:
+    evra: 38-36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
+      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
+      type: fast-track
+  fedora-release-identity-coreos:
+    evra: 38-36.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
+      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
+      type: fast-track
   moby-engine:
     evr: 20.10.23-1.fc38
     metadata:

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -32,6 +32,3 @@ enable rtas_errd.service
 enable clevis-luks-askpass.path
 # Provide status information about the Ignition run
 enable coreos-ignition-write-issues.service
-# Apply network configuration from /etc/nmstate/*.yml
-# We can drop this after merging https://src.fedoraproject.org/rpms/fedora-release/pull-request/255
-enable nmstate.service


### PR DESCRIPTION
The service is now in the 90-default.preset file shipped in the fedora-release-common RPM. The PR [1] merged.

[1] https://src.fedoraproject.org/rpms/fedora-release/pull-request/255