### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,34 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  afterburn:
-    evr: 5.4.2-1.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a3adea94d9
-      type: fast-track
-  afterburn-dracut:
-    evr: 5.4.2-1.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a3adea94d9
-      type: fast-track
-  fedora-release-common:
-    evra: 38-36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
-      type: fast-track
-  fedora-release-coreos:
-    evra: 38-36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
-      type: fast-track
-  fedora-release-identity-coreos:
-    evra: 38-36.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0504b1f717
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2439
-      type: fast-track
   moby-engine:
     evr: 20.10.23-1.fc38
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).