### PR TITLE
tests/kola: remove reprovision tag from grub2-install test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,10 +18,6 @@
   snooze: 2023-06-01
   arches:
     - aarch64
-# This snooze won't fully work because we run our reprovision tests in
-# the pipeline in a separate step and there is an issue if all tests in
-# a kola run are denylisted: https://github.com/coreos/coreos-assembler/issues/3464
-# To workaround we've added the reprovision label to the `boot.grub2-install` test.
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1489
   snooze: 2023-06-01

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -1,10 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # add the reprovision tag here to temporarily to workaround
-##   # https://github.com/coreos/coreos-assembler/issues/3464. We can
-##   # remove the tag when https://github.com/coreos/fedora-coreos-tracker/issues/1489
-##   # is fixed.
-##   tags: "platform-independent reprovision"
+##   tags: "platform-independent"
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2
 ##   architectures: "!aarch64 s390x"


### PR DESCRIPTION
We were doing this as a workaround for [1]. Now that that issue has been fixed we can remove the reprovision tag from the grub2-install test again.

[1] https://github.com/coreos/coreos-assembler/issues/3464