### PR TITLE
[rhcos-4.13] tests/kola: upstream network-online login test from RHCOS

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -76,10 +76,10 @@ cmdline_arg() {
     echo "${value}"
 }
 
-# wait for 20s when in activating status
+# wait for ~60s when in activating status
 is_service_active() {
     local service="$1"
-    for x in {0..20}; do
+    for x in {0..60}; do
         [ $(systemctl is-active "${service}") != "activating" ] && break
         sleep 1
     done

--- a/tests/kola/systemd/network-online/config.bu
+++ b/tests/kola/systemd/network-online/config.bu
@@ -1,0 +1,19 @@
+variant: fcos
+version: 1.4.0
+systemd:
+  units:
+    - name: block-network-online.service
+      enabled: true
+      contents: |
+        [Unit]
+        After=NetworkManager-wait-online.service
+        Before=network-online.target
+        Wants=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=sleep infinity
+
+        [Install]
+        WantedBy=multi-user.target

--- a/tests/kola/systemd/network-online/data/commonlib.sh
+++ b/tests/kola/systemd/network-online/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/systemd/network-online/test.sh
+++ b/tests/kola/systemd/network-online/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+## kola:
+##   description: Verify that network-online.target doesn't block login
+##   tags: platform-independent
+##   # this really shouldn't take long; if it does, it's that we're hitting the
+##   # very issue we're testing for
+##   timeoutMin: 3
+
+# If the user provides a systemd unit which pulls in `network-online.target`,
+# we want to make sure that logins don't block on `network-online.target` being
+# reached. `block-network-online.service` verifies this by pulling in `network-
+# online.target` and preventing it from being reached by running `Before=` it
+# and sleeping forever.
+
+# We hit this in RHCOS with iscsi.service causing network-online.target to block
+# remote-fs-pre.target and hence systemd-user-sessions.service from running:
+#
+# https://github.com/openshift/os/pull/1279
+# https://issues.redhat.com/browse/OCPBUGS-11124
+
+set -euo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# The fact that we're here means that `systemd-user-sessions.service` was
+# reached and logins work since kola was able to SSH to start us. But let's do
+# some sanity-checks to verify that the test was valid.
+
+# verify that block-network-online.service is still activating since it's stuck sleeping
+if [[ $(systemctl show block-network-online -p ActiveState) != "ActiveState=activating" ]]; then
+  systemctl status block-network-online.service
+  fatal "block-network-online.service isn't activating"
+fi
+
+# verify that network-online.target is not yet active since it's still blocked on block-network-online.service
+if [[ $(systemctl show network-online.target -p ActiveState) != "ActiveState=inactive" ]]; then
+  systemctl status network-online.target
+  fatal "network-online.target isn't inactive"
+fi
+
+echo "ok network-online.target does not block login"


### PR DESCRIPTION
tests/kola: upstream network-online login test from RHCOS

This test was originally added in RHCOS[[1]], but it's equally valid to
run in FCOS. That would have caught the original issue when it was still
present in Fedora.

[1]: https://github.com/openshift/os/pull/1294

(cherry picked from commit 5f322cbc8bd5dcd0b992f883d38079abd5d16c3d)

---

tests/kola: wait longer in commonlib.sh is_service_active

In https://github.com/coreos/coreos-assembler/pull/3487 we are
changing the `sshChecker` in `CheckMachine()` to return earlier
in the `starting` and `initializing` states. This means the kola
test code might start to run earlier and we may need to wait longer
here.

(cherry picked from commit 3952477046cf36833fde603241eb9a9008a32763)

---

Cherry-picked from: https://github.com/coreos/fedora-coreos-config/pull/2437 &  https://github.com/coreos/fedora-coreos-config/pull/2438