### PR TITLE
overrides: fast-track ostree-2023.3-3.fc38

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,14 +10,14 @@
 
 packages:
   ostree:
-    evra: 2023.3-2.fc38.aarch64
+    evra: 2023.3-3.fc38.aarch64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track
   ostree-libs:
-    evra: 2023.3-2.fc38.aarch64
+    evra: 2023.3-3.fc38.aarch64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -10,20 +10,20 @@
 
 packages:
   ostree:
-    evra: 2023.3-2.fc38.ppc64le
+    evra: 2023.3-3.fc38.ppc64le
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track
   ostree-libs:
-    evra: 2023.3-2.fc38.ppc64le
+    evra: 2023.3-3.fc38.ppc64le
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track
   ostree-grub2:
-    evra: 2023.3-2.fc38.ppc64le
+    evra: 2023.3-3.fc38.ppc64le
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -10,14 +10,14 @@
 
 packages:
   ostree:
-    evra: 2023.3-2.fc38.s390x
+    evra: 2023.3-3.fc38.s390x
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track
   ostree-libs:
-    evra: 2023.3-2.fc38.s390x
+    evra: 2023.3-3.fc38.s390x
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,14 +10,14 @@
 
 packages:
   ostree:
-    evra: 2023.3-2.fc38.x86_64
+    evra: 2023.3-3.fc38.x86_64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track
   ostree-libs:
-    evra: 2023.3-2.fc38.x86_64
+    evra: 2023.3-3.fc38.x86_64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-971df1fe12
-      reason: https://github.com/ostreedev/ostree/pull/2866
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+      reason: https://github.com/ostreedev/ostree/pull/2871
       type: fast-track


### PR DESCRIPTION
It has a fix for an autopruning corner case.
https://github.com/ostreedev/ostree/pull/2871