### PR TITLE
[rawhide] overrides: pin systemd-253.4-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,6 +34,36 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
       type: pin
+  systemd:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-container:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-libs:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-pam:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-resolved:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-udev:
+    evr: 253.4-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
   util-linux:
     evr: 2.39-3.fc39
     metadata:


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).