### PR TITLE
[rawhide] overrides: pin passt-0^20230509.g96f8d55-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,6 +34,16 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1501
       type: pin
+  passt:
+    evr: 0^20230509.g96f8d55-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
+      type: pin
+  passt-selinux:
+    evra: 0^20230509.g96f8d55-1.fc39.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
+      type: pin
   systemd:
     evr: 253.4-1.fc39
     metadata:


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).