### PR TITLE
overrides: pin systemd-253.4-1.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -30,3 +30,33 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
       type: pin
+  systemd:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-container:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-libs:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-pam:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-resolved:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin
+  systemd-udev:
+    evr: 253.4-1.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).