### PR TITLE
.cci.jenkinsfile: change path for download-overrides.py

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -12,8 +12,7 @@ cosaPod(cpus: 4, memory: "9Gi") {
     shwrap("""
         mkdir -p /srv/coreos && cd /srv/coreos
         cosa init ${env.WORKSPACE}/config
-        curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/main/scripts/download-overrides.py
-        python3 download-overrides.py
+        python3 ${env.WORKSPACE}/usr/lib/coreos-assembler/download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
         cosa buildfetch --stream=${env.CHANGE_TARGET}
     """)

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -12,6 +12,8 @@ cosaPod(cpus: 4, memory: "9Gi") {
     shwrap("""
         mkdir -p /srv/coreos && cd /srv/coreos
         cosa init ${env.WORKSPACE}/config
+        pwd
+        ls -al ${env.WORKSPACE}
         python3 ${env.WORKSPACE}/usr/lib/coreos-assembler/download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
         cosa buildfetch --stream=${env.CHANGE_TARGET}

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -12,9 +12,7 @@ cosaPod(cpus: 4, memory: "9Gi") {
     shwrap("""
         mkdir -p /srv/coreos && cd /srv/coreos
         cosa init ${env.WORKSPACE}/config
-        pwd
-        ls -al ${env.WORKSPACE}
-        python3 ${env.WORKSPACE}/usr/lib/coreos-assembler/download-overrides.py
+        python3 /usr/lib/coreos-assembler/download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
         cosa buildfetch --stream=${env.CHANGE_TARGET}
     """)


### PR DESCRIPTION
Once below PR's, requesting the move of download-overrides.py
has been merged, the file path will change to modified. 

See: https://github.com/coreos/coreos-assembler/pull/3510
See: https://github.com/coreos/fedora-coreos-releng-automation/pull/176

Issue:

See: https://github.com/coreos/fedora-coreos-tracker/issues/1185