### PR TITLE
[testing] .cci.jenkinsfile: change path for download-overrides.py

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -12,8 +12,7 @@ cosaPod(cpus: 4, memory: "9Gi") {
     shwrap("""
         mkdir -p /srv/coreos && cd /srv/coreos
         cosa init ${env.WORKSPACE}/config
-        curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-releng-automation/main/scripts/download-overrides.py
-        python3 download-overrides.py
+        python3 /usr/lib/coreos-assembler/download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
         cosa buildfetch --stream=${env.CHANGE_TARGET}
     """)


### PR DESCRIPTION

This is a forward port of https://github.com/coreos/fedora-coreos-config/pull/2464 so we can go ahead and merge  https://github.com/coreos/fedora-coreos-releng-automation/pull/176

We'll merge it into the `testing` branch now and it will get promoted to `stable` next round so CI for `stable` will pass.