### PR TITLE
denylist: bump snooze for ext.config.root-reprovision.*

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -20,7 +20,7 @@
     - aarch64
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-  snooze: 2023-06-21
+  snooze: 2023-07-12
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
These tests are still failing in rawhide `ppc64le` builds.