### PR TITLE
denylist: snooze rpmostree and ostree tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,3 +25,24 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: rpmostree.install-uninstall
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1515
+  snooze: 2023-07-12
+  platforms:
+    - azure
+  streams:
+    - rawhide
+- pattern: rpmostree.upgrade-rollback
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1515
+  snooze: 2023-07-12
+  platforms:
+    - azure
+  streams:
+    - rawhide
+- pattern: ostree.hotfix
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1515
+  snooze: 2023-07-12
+  platforms:
+    - azure
+  streams:
+    - rawhide


### PR DESCRIPTION
Snooze the following tests for 3 weeks while we wait for a fix in the kernel to the mlx5 driver.
- `rpmostree.install-uninstall`
- `rpmostree.upgrade-rollback`
- `ostree.hotfix`

These three tests started failing in rawhide on Azure. See: https://github.com/coreos/fedora-coreos-tracker/issues/1515