### PR TITLE
[rawhide] overrides: fast-track passt-0^20230625.g32660ce-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,15 +10,17 @@
 
 packages:
   passt:
-    evr: 0^20230509.g96f8d55-1.fc39
+    evr: 0^20230625.g32660ce-1.fc39
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cf99684fe2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509#issuecomment-1608091938
+      type: fast-track
   passt-selinux:
-    evra: 0^20230509.g96f8d55-1.fc39.noarch
+    evra: 0^20230625.g32660ce-1.fc39.noarch
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cf99684fe2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509#issuecomment-1608091938
+      type: fast-track
   systemd:
     evr: 253.4-1.fc39
     metadata:


### PR DESCRIPTION
Requested by @gursewak1997 via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).