### PR TITLE
tests/kola: fix exclusion for gcp platform on no-google-device-links test

### DIFF
--- a/tests/kola/disks/no-google-device-links
+++ b/tests/kola/disks/no-google-device-links
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## kola:
-##   platforms: !gcp
+##   platforms: "! gcp"
 ##   exclusive: false
 ##   description: Verify no /dev/disk/by-id/*google* device links are found on non GCP.
 


### PR DESCRIPTION
A "!" at the beginning of an element has a special meaning in YAML [1] so we need to put it in quotes. While we are here also insert a space to comply with the future work that will happen as part of [2].

[1] https://stackoverflow.com/questions/9664113/what-does-a-single-exclamation-mark-do-in-yaml
[2] https://github.com/coreos/fedora-coreos-config/issues/2157