### PR TITLE
[rawhide] overrides: drop systemd-253.4-1.fc39 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,33 +19,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1509
       type: pin
-  systemd:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-container:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-libs:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-pam:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-resolved:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-udev:
-    evr: 253.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin


### PR DESCRIPTION
Drop systemd-253.4-1.fc39 pin as to resolve pkg dependency problem as seen in rawhide build [1484](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build/1484/)

For rawhide we can unpin and just denylist the tests https://github.com/coreos/fedora-coreos-config/pull/2492