### PR TITLE
denylist: snooze ext.config.ntp.* tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,3 +25,13 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: ext.config.ntp.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+  snooze: 2023-07-20
+  streams:
+    - rawhide
+- pattern: ext.config.ntp.timesyncd.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
+  snooze: 2023-07-20
+  streams:
+    - rawhide


### PR DESCRIPTION
ext.config.ntp.chrony.dhcp-propagation & ext.config.ntp.timesyncd.dhcp-propagation gets times out in rawhide build 
see: https://github.com/coreos/fedora-coreos-tracker/issues/1508