### PR TITLE
denylist: Snooze kdump.crash in ppc64le for rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,6 +18,13 @@
   snooze: 2023-07-12
   arches:
     - aarch64
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1523
+  snooze: 2023-07-20
+  arches:
+    - ppc64le
+  streams:
+    - rawhide
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1489
   snooze: 2023-07-12


### PR DESCRIPTION
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1523