### PR TITLE
Add space after `!` to `kola` YAML architecture field

### DIFF
--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -7,7 +7,7 @@
 ##   tags: "platform-independent reprovision"
 ##   # The test is not available for aarch64 and s390x,
 ##   # as aarch64 is UEFI only and s390x is not using grub2
-##   architectures: "!aarch64 s390x"
+##   architectures: "! aarch64 s390x"
 ##   description: Verify that we install BIOS/PReP bootloader
 ##     using grub2-install from the target system.
 

--- a/tests/kola/butane/grub-users/test.sh
+++ b/tests/kola/butane/grub-users/test.sh
@@ -5,7 +5,7 @@
 ##   distros: fcos
 ##   # coreos-post-ignition-checks.service forbids GRUB passwords on
 ##   # ppc64le and s390x
-##   architectures: "!ppc64le s390x"
+##   architectures: "! ppc64le s390x"
 ##   description: Verify that setting GRUB password works.
 
 set -xeuo pipefail

--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -4,7 +4,7 @@
 ##   exclusive: false
 ##   # s390x doesn't have any configuration in platforms.yaml, so
 ##   # platforms.json is not included in the image
-##   architectures: "!s390x"
+##   architectures: "! s390x"
 ##   description: Verify that the kargs and grub.cfg commands specified in 
 ##     platforms.json have been properly applied to the image. 
 

--- a/tests/kola/networking/nic-naming
+++ b/tests/kola/networking/nic-naming
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   platforms: "!azure"
+##   platforms: "! azure"
 ##   description: Verify that we detected eth* NIC naming after booted.
 
 # Disable on azure because of a limitation of the hv_netvsc driver

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -5,7 +5,7 @@
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # A TPM backend device is not available on s390x to suport TPM.
-##   architectures: "!s390x"
+##   architectures: "! s390x"
 ##   # This test includes a lot of disk I/O and needs a higher
 ##   # timeout value than the default.
 ##   timeoutMin: 15

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -5,7 +5,7 @@
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # A TPM backend device is not available on s390x to suport TPM.
-##   architectures: "!s390x"
+##   architectures: "! s390x"
 ##   # This test includes a lot of disk I/O and needs a higher
 ##   # timeout value than the default.
 ##   timeoutMin: 15

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   # Restrict to qemu for now because the primary disk path is platform-dependent
 ##   platforms: qemu
-##   architectures: "!s390x"
+##   architectures: "! s390x"
 ##   description: Verify that reprovision disk with luks works.
 
 set -xeuo pipefail


### PR DESCRIPTION
Fixes #2157 

The commit adds a space to all `kola` tests that use `!` to indicate the negation semantic for architectures. This helps convey to users that the `!` is distrubutive and not per element.