### PR TITLE
denylist: extend snooze for ext.config.kdump.crash on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,7 +15,7 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-07-12
+  snooze: 2023-08-02
   arches:
     - aarch64
 - pattern: ext.config.kdump.crash


### PR DESCRIPTION
This still isn't fixed upstream.
No update on https://github.com/coreos/fedora-coreos-tracker/issues/1430