### PR TITLE
denylist: bump snooze for ext.config.root-reprovision.*

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,7 +27,7 @@
     - rawhide
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-  snooze: 2023-07-12
+  snooze: 2023-08-04
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
These tests are still failing in rawhide `ppc64le` builds.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1489