### PR TITLE
denylist: drop ext.config.extensions.module denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -42,8 +42,3 @@
   snooze: 2023-07-20
   streams:
     - rawhide
-- pattern: ext.config.extensions.module
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1526
-  snooze: 2023-08-02
-  streams:
-    - rawhide


### PR DESCRIPTION
We deleted the test in https://github.com/coreos/fedora-coreos-config/pull/2508 so we have no need for the denial any longer.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1526