### PR TITLE
add CLHM helper to warn about modularity on F39 systems

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -45,7 +45,7 @@ conditional-include:
       - releasever == 38
     # Modularity is going away in F39+ so we'll only include
     # the fedora-repos-modular package in <39.
-    include: fedora-repos-modular.yaml
+    include: fedora-modularity.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/fedora-modularity.yaml
+++ b/manifests/fedora-modularity.yaml
@@ -2,3 +2,6 @@
 # the fedora-repos-modular package in <39.
 packages:
   - fedora-repos-modular
+# And we'll warn users who have layered modular packages
+ostree-layers:
+  - overlay/17fedora-modularity

--- a/overlay.d/17fedora-modularity/usr/lib/systemd/system-preset/46-fcos-fedora-modularity.preset
+++ b/overlay.d/17fedora-modularity/usr/lib/systemd/system-preset/46-fcos-fedora-modularity.preset
@@ -1,0 +1,1 @@
+enable coreos-check-modularity.service

--- a/overlay.d/17fedora-modularity/usr/lib/systemd/system/coreos-check-modularity.service
+++ b/overlay.d/17fedora-modularity/usr/lib/systemd/system/coreos-check-modularity.service
@@ -1,0 +1,10 @@
+# This service is used for printing a message if
+# modular RPMs are being used
+[Unit]
+Description=Check if modular packages are layered
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-check-modularity
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/17fedora-modularity/usr/libexec/coreos-check-modularity
+++ b/overlay.d/17fedora-modularity/usr/libexec/coreos-check-modularity
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+# This script checks if the system has layered modular packages and
+# prints a message to the serial console.
+
+# Change the output color to yellow
+warn=$(echo -e '\033[0;33m')
+# No color
+nc=$(echo -e '\033[0m')
+
+# Find the number of installed modules
+num_modules=$(rpm-ostree status --json | jq '.deployments[0].modules | length')
+
+# If there are no modules then nothing to do here
+[ "$num_modules" == "0" ] && exit 0
+
+motd_path=/run/motd.d/35_modularity_warning.motd
+cat << EOF > "${motd_path}"
+${warn}
+############################################################################
+WARNING: This system has layered modularity RPMs. In Fedora 39 modularity
+has been retired. The system will most likely stop updating successfully
+when Fedora CoreOS transitions to Fedora 39. See this tracker for more info: 
+https://github.com/coreos/fedora-coreos-tracker/issues/1513
+
+To disable this warning, use:
+sudo systemctl disable coreos-check-modularity.service
+############################################################################
+${nc}
+EOF


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1513