### PR TITLE
[rawhide] overrides: pin systemd-253.5-6.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,34 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  systemd:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin
+  systemd-container:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin
+  systemd-libs:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin
+  systemd-pam:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin
+  systemd-resolved:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin
+  systemd-udev:
+    evr: 253.5-6.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).