### PR TITLE
initramfs: Ensure we `Requires=ostree-prepare-root.service`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/live-generator
@@ -217,6 +217,7 @@ Requires=sysroot.mount
 After=sysroot.mount
 # And after OSTree has set up the chroot() equivalent
 After=ostree-prepare-root.service
+Requires=ostree-prepare-root.service
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-check-rootfs-size.service
@@ -6,6 +6,7 @@ ConditionKernelCommandLine=ostree
 ConditionPathExists=!/run/ostree-live
 After=ignition-ostree-growfs.service
 After=ostree-prepare-root.service
+Requires=ostree-prepare-root.service
 # Allow Ignition config to blank out the warning
 Before=ignition-files.service
 


### PR DESCRIPTION
Today if that unit doesn't start we can continue on and continue on to `ignition-ostree-check-rootfs-size.service` which will fail.