### PR TITLE
denylist: extend snooze for ext.config.ntp.* tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,11 +34,11 @@
     - rawhide
 - pattern: ext.config.ntp.chrony.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-  snooze: 2023-07-20
+  snooze: 2023-08-20
   streams:
     - rawhide
 - pattern: ext.config.ntp.timesyncd.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-  snooze: 2023-07-20
+  snooze: 2023-08-20
   streams:
     - rawhide


### PR DESCRIPTION
ext.config.ntp.chrony.dhcp-propagation &
ext.config.ntp.timesyncd.dhcp-propagation gets times out in rawhide build. It is not fixed in the upstream.
see: coreos/fedora-coreos-tracker#1508