### PR TITLE
denylist: snooze root-reprovision on testing-devel `ppc64le`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -30,8 +30,6 @@
   snooze: 2023-08-04
   arches:
     - ppc64le
-  streams:
-    - rawhide
 - pattern: ext.config.ntp.chrony.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
   snooze: 2023-08-20


### PR DESCRIPTION
These tests are now failing on testing-devel. Remove the rawhide field to snooze these tests on testing-devel as well.

see: https://github.com/coreos/fedora-coreos-tracker/issues/1489
