### PR TITLE
tests/validate-symlinks: Skip '/etc/pki/tls/'

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -32,8 +32,9 @@ list_broken_symlinks_skip=(
 if is_scos || is_rhcos; then
     rhcos_list=(
         '/etc/grub2-efi.cfg'
-        '/etc/rhsm-host'
         '/etc/pki/entitlement-host'
+        '/etc/pki/tls/'
+        '/etc/rhsm-host'
         '/etc/sysconfig/grub'
     )
     list_broken_symlinks_skip+=("${rhcos_list[@]}")


### PR DESCRIPTION
```
Error: /etc/pki/tls/fips_local.cnf symlink to /etc/crypto-policies/back-ends/openssl_fips.config which does not exist
```

See: https://github.com/openshift/os/pull/1328