### PR TITLE
[rawhide] overrides: drop systemd-253.5-6.fc39 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,34 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  systemd:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
-  systemd-container:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
-  systemd-libs:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
-  systemd-pam:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
-  systemd-resolved:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
-  systemd-udev:
-    evr: 253.5-6.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1527
-      type: pin
+packages: {}


### PR DESCRIPTION
The feature that caused us to pin systemd has been fixed and is up to https://koji.fedoraproject.org/koji/buildinfo?buildID=2259554. 
The [fix](https://github.com/systemd/systemd/commit/2bfe7261de98ca47063d58b4b559f2ad0d55c1da) which is in [systemd v254](https://github.com/systemd/systemd/releases/tag/v254) & [systemd v254-rc3](https://github.com/systemd/systemd/releases/tag/v254-rc3) 
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1527