### PR TITLE
[testing-devel] overrides: pin kernel-6.3.12-200.fc38

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -30,6 +30,8 @@
   snooze: 2023-08-04
   arches:
     - ppc64le
+  streams:
+    - rawhide
 - pattern: ext.config.ntp.chrony.dhcp-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1508
   snooze: 2023-08-20

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,26 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  kernel:
+    evr: 6.3.12-200.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-core:
+    evr: 6.3.12-200.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-modules:
+    evr: 6.3.12-200.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-modules-core:
+    evr: 6.3.12-200.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
   moby-engine:
     evr: 20.10.23-1.fc38
     metadata:


### PR DESCRIPTION
We decided to pin the kernel the kernel in `testing-devel` instead of snoozing the repvosion tests while we track down a solution to https://github.com/coreos/fedora-coreos-tracker/issues/1489.

Pin kernel `kernel-6.3.12-200.fc38` in testing-devel and remove the snooze for the reprovision tests on `testing-devel`, which reverts commit 17ec963ed7b581e8ae461e48a8b37d7ec64c5fa2.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1489#issuecomment-1654472521