### PR TITLE
[rawhide] overrides: drop glib2-2.76.4-1.fc39 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,11 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  glib2:
-    evr: 2.76.4-1.fc39
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1530
-      type: pin
   systemd:
     evr: 253.5-6.fc39
     metadata:


### PR DESCRIPTION
The change here was determined to be intentional and the test was updated to ignore newlines in the comparison of NM configs in https://github.com/coreos/fedora-coreos-config/pull/2528.

See https://github.com/coreos/fedora-coreos-tracker/issues/1530 for more context.