### PR TITLE
[rhcos-4.13] tests/validate-symlinks: Skip '/etc/pki/tls/'

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -29,8 +29,9 @@ list_broken_symlinks_skip=(
 if is_scos || is_rhcos; then
     rhcos_list=(
         '/etc/grub2-efi.cfg'
-        '/etc/rhsm-host'
         '/etc/pki/entitlement-host'
+        '/etc/pki/tls/'
+        '/etc/rhsm-host'
         '/etc/sysconfig/grub'
     )
     list_broken_symlinks_skip+=("${rhcos_list[@]}")


### PR DESCRIPTION
The following error showed up today in RHCOS 4.13-9.2
```
Error: /etc/pki/tls/fips_local.cnf symlink to /etc/crypto-policies/back-ends/openssl_fips.config which does not exist
```

This was [seen in 4.14](https://github.com/coreos/fedora-coreos-config/pull/2525) recently and the location `/etc/pki/tls` was added to the list of sym links to skip in the `validate-symlinks` kola test.

Cherry pick 208630a8622046ecbbc6f9f20b1a2967e07c9081 to add this same broken sym link to `rhcos-4.13` as well.
