### PR TITLE
[rhcos-4.14] ignition-ostree: make sure we don't mount /sysroot before transposefs

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-autosave-xfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-autosave-xfs.service
@@ -5,6 +5,11 @@ After=ignition-disks.service
 # Avoid racing with UUID regeneration
 After=ignition-ostree-uuid-root.service
 After=ignition-ostree-growfs.service
+Before=initrd-root-fs.target
+# https://issues.redhat.com/browse/OCPBUGS-16157
+# On multipath systems mounting the /sysroot before
+# the ignition-ostree services causes the transpose to fai.
+Before=sysroot.mount
 Before=ignition-ostree-transposefs-restore.service
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-autosave-xfs.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-autosave-xfs.service
@@ -5,10 +5,9 @@ After=ignition-disks.service
 # Avoid racing with UUID regeneration
 After=ignition-ostree-uuid-root.service
 After=ignition-ostree-growfs.service
-Before=initrd-root-fs.target
 # https://issues.redhat.com/browse/OCPBUGS-16157
 # On multipath systems mounting the /sysroot before
-# the ignition-ostree services causes the transpose to fai.
+# the ignition-ostree services causes the transpose to fail.
 Before=sysroot.mount
 Before=ignition-ostree-transposefs-restore.service
 OnFailure=emergency.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
@@ -8,8 +8,7 @@ After=ignition-ostree-growfs.service
 Before=ignition-ostree-mount-firstboot-sysroot.service
 # https://issues.redhat.com/browse/OCPBUGS-16157
 # On multipath systems mounting the /sysroot before
-# the ignition-ostree services causes the transpose to fai.
-Before=initrd-root-fs.target
+# the ignition-ostree services causes the transpose to fail.
 Before=sysroot.mount
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-restore.service
@@ -6,6 +6,11 @@ After=ignition-disks.service
 After=ignition-ostree-uuid-root.service
 After=ignition-ostree-growfs.service
 Before=ignition-ostree-mount-firstboot-sysroot.service
+# https://issues.redhat.com/browse/OCPBUGS-16157
+# On multipath systems mounting the /sysroot before
+# the ignition-ostree services causes the transpose to fai.
+Before=initrd-root-fs.target
+Before=sysroot.mount
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
@@ -7,11 +7,6 @@ ConditionKernelCommandLine=ostree
 ConditionPathIsDirectory=/run/ignition-ostree-transposefs
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
-# https://issues.redhat.com/browse/OCPBUGS-16157
-# On multipath systems mounting the /sysroot before
-# the ignition-ostree services causes the transpose to fai.
-Before=initrd-root-fs.target
-Before=sysroot.mount
 After=coreos-gpt-setup.service
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs-save.service
@@ -7,6 +7,11 @@ ConditionKernelCommandLine=ostree
 ConditionPathIsDirectory=/run/ignition-ostree-transposefs
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
+# https://issues.redhat.com/browse/OCPBUGS-16157
+# On multipath systems mounting the /sysroot before
+# the ignition-ostree services causes the transpose to fai.
+Before=initrd-root-fs.target
+Before=sysroot.mount
 After=coreos-gpt-setup.service
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
When enabling multipath the ignition-ostree-mount-firstboot-sysroot service loses to the systemd's generator, which causes /sysroot to be mounted before we finish transposing the fs. This change makes sure we wait to mount the /sysroot until we are done. This was reported via: https://issues.redhat.com/browse/OCPBUGS-16157

Cherry-picked from #2526 & #2535