### PR TITLE
overrides: pin kernel-6.3.12-200 on `ppc64le` only

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  kernel:
+    evra: 6.3.12-200.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-core:
+    evra: 6.3.12-200.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-modules:
+    evra: 6.3.12-200.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin
+  kernel-modules-core:
+    evra: 6.3.12-200.fc38.ppc64le
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,26 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 6.3.12-200.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-      type: pin
-  kernel-core:
-    evr: 6.3.12-200.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-      type: pin
-  kernel-modules:
-    evr: 6.3.12-200.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-      type: pin
-  kernel-modules-core:
-    evr: 6.3.12-200.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1489
-      type: pin
   moby-engine:
     evr: 20.10.23-1.fc38
     metadata:


### PR DESCRIPTION
In the community meeting this week, we decided to pin `kernel-6.3.12-200` on `ppc64le` only for the next release cycle while we wait on a fix to the upstream issue: https://github.com/coreos/fedora-coreos-tracker/issues/1489.

Unpin the kernel from all of testing-devel and then add a `manifest-lock.overrides.ppc64le.yaml` to pin `kernel-6.3.12-200` on `ppc64le` only. This file is consumed when building on `ppc64le` and ignored on all other arches.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1489#issuecomment-1662811923
