### PR TITLE
denylist: Snooze ext.config.toolbox for rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -35,3 +35,8 @@
   snooze: 2023-08-20
   streams:
     - rawhide
+- pattern: ext.config.toolbox
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1539
+  snooze: 2023-09-10
+  streams:
+    - rawhide


### PR DESCRIPTION
Fedora 40 has branched from Rawhide. There is no 'f40' toolbox container. So running ext.config.toolbox on Rawhide fails now. ext.config.toolbox is added to the kola denylist till its fixed.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1539
See : https://github.com/containers/toolbox/issues/1350