### PR TITLE
overrides: drop systemd-253.4-1.fc38 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,33 +14,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1476
       type: pin
-  systemd:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-container:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-libs:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-pam:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-resolved:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin
-  systemd-udev:
-    evr: 253.4-1.fc38
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1508
-      type: pin


### PR DESCRIPTION
This was fixed in v253.6+. See
https://github.com/coreos/fedora-coreos-tracker/issues/1508#issuecomment-1674182241