### PR TITLE
[branched] manifest: bump to F39

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 38
+releasever: 39
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 39 has now been branched from rawhide