### PR TITLE
#1534 Change: Allow Removal of tzdata 

### DIFF
--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -39,6 +39,8 @@ packages:
   - stalld
   # Ignition aware SSH key management
   - ssh-key-dir
+  # Allow for configuring different timezones
+  - tzdata
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first


### PR DESCRIPTION
This PR is adding the tzdata package in Fedora CoreOS.  :package:



<br class="Apple-interchange-newline">To know more about this change, please check this [documentation ](https://fedoraproject.org/wiki/Changes/AllowRemovalOfTzdata).