### PR TITLE
denylist: mark snoozed tests as warn: true

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,11 +16,13 @@
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
   snooze: 2023-08-31
+  warn: true
   arches:
     - aarch64
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -28,6 +30,7 @@
 - pattern: ext.config.networking.no-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -35,6 +38,7 @@
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -42,6 +46,7 @@
 - pattern: ext.config.networking.ifname-karg.everyboot-systemd-link-file
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -49,6 +54,7 @@
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -56,6 +62,7 @@
 - pattern: ext.config.networking.bridge-static-via-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -63,6 +70,7 @@
 - pattern: ext.config.networking.ifname-karg.udev-rule-firstboot-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched
@@ -70,6 +78,7 @@
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-08-28
+  warn: true
   streams:
     - rawhide
     - branched


### PR DESCRIPTION
This is a new feature that was added recently in
https://github.com/coreos/coreos-assembler/pull/3539.

Now when a snooze expires we can configure it to warn us and continue to build rather than marking the entire run as a failure.