### PR TITLE
Enable fwupd refresh timer on Fedora 39

### DIFF
--- a/manifests/enable-fwupd-refresh-timer.yaml
+++ b/manifests/enable-fwupd-refresh-timer.yaml
@@ -1,0 +1,2 @@
+ostree-layers:
+  - overlay/18fwupd-refresh-timer

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -46,6 +46,11 @@ conditional-include:
     # Modularity is going away in F39+ so we'll only include
     # the fedora-repos-modular package in <39.
     include: fedora-modularity.yaml
+  - if: releasever >= 39
+    # https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
+    # Merge with overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+    # once Fedora 39 is released to all streams
+    include: enable-fwupd-refresh-timer.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/overlay.d/18fwupd-refresh-timer/statoverride
+++ b/overlay.d/18fwupd-refresh-timer/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/18fwupd-refresh-timer/usr/lib/systemd/system-preset/50-fwupd-refresh-timer.preset
+++ b/overlay.d/18fwupd-refresh-timer/usr/lib/systemd/system-preset/50-fwupd-refresh-timer.preset
@@ -1,0 +1,4 @@
+# https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
+# As this is for FCOS only for now, once Fedora 39 is released to all streams,
+# this should be moved to overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+enable fwupd-refresh.timer

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -42,6 +42,14 @@ Things that are more closely "Fedora CoreOS":
 Disable Zincati on non-production streams:
 https://github.com/coreos/fedora-coreos-tracker/issues/163
 
+17fedora-modularity
+-------------------
+
+Check for layered modularity RPMs to warn users of the retirement in Fedora 39
+via Console Login Helper Messages.
+
+Remove once Fedora 39 lands in all streams.
+
 18fwupd-refresh-timer
 ---------------------
 

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -42,6 +42,15 @@ Things that are more closely "Fedora CoreOS":
 Disable Zincati on non-production streams:
 https://github.com/coreos/fedora-coreos-tracker/issues/163
 
+18fwupd-refresh-timer
+---------------------
+
+Enable fwupd-refresh.timer on Fedora 39:
+https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
+
+Move to overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset once
+Fedora 39 lands in all streams.
+
 20platform-chrony
 -----------------
 

--- a/tests/kola/files/fwupd-refresh-timer
+++ b/tests/kola/files/fwupd-refresh-timer
@@ -1,0 +1,21 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Verify fwupd-refresh.timer is enabled.
+##   tags: "platform-independent"
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if verlt "$(get_fedora_ver)" 39; then
+    ok "Skipping fwupd-refresh.timer test"
+    exit 0
+fi
+
+unit="fwupd-refresh.timer"
+if ! systemctl is-enabled ${unit} 1>/dev/null; then
+    fatal "Unit ${unit} should be enabled"
+fi
+ok "Unit ${unit} is enabled as expected"


### PR DESCRIPTION
Enable fwupd refresh timer on Fedora 39

See: https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1512

---

overlay/README: Update for 17fedora-modularity overlay