### PR TITLE
test: Collection of cleanups & Action for whitespace check

### DIFF
--- a/.github/workflows/find-whitespace.yml
+++ b/.github/workflows/find-whitespace.yml
@@ -1,0 +1,22 @@
+name: Find whitespace
+
+on:
+  pull_request:
+    branches: [testing-devel]
+
+permissions:
+  contents: read
+
+jobs:
+  find-whitespace:
+    name: Find whitespace
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Look for whitespace at the end of line
+        run: ci/find-whitespace

--- a/ci/find-whitespace
+++ b/ci/find-whitespace
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+    local files_with_whitespace
+    files_with_whitespace="$(find manifests overlay.d tests -type f -exec grep -El " +$" {} \;)"
+
+    if [[ -n "${files_with_whitespace}" ]]; then
+        echo "[+] Found files with whitespace at the end of line"
+        echo "${files_with_whitespace}"
+        exit 1
+    fi
+
+    echo "[+] No files with whitespace at the end of line"
+    exit 0
+}
+
+main "${@}"

--- a/overlay.d/17fedora-modularity/usr/libexec/coreos-check-modularity
+++ b/overlay.d/17fedora-modularity/usr/libexec/coreos-check-modularity
@@ -19,7 +19,7 @@ ${warn}
 ############################################################################
 WARNING: This system has layered modularity RPMs. In Fedora 39 modularity
 has been retired. The system will most likely stop updating successfully
-when Fedora CoreOS transitions to Fedora 39. See this tracker for more info: 
+when Fedora CoreOS transitions to Fedora 39. See this tracker for more info:
 https://github.com/coreos/fedora-coreos-tracker/issues/1513
 
 To disable this warning, use:

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -15,7 +15,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "$(arch)" in
     aarch64|ppc64le|s390x)

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "$(arch)" in
     x86_64|aarch64)

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -35,7 +35,7 @@ case ${arch} in
     device=$(realpath /dev/disk/by-partlabel/PowerPC-PReP-boot)
     # sync grub2-install parameter according to image build script
     # https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh
-    grub_install_args="--no-nvram"   
+    grub_install_args="--no-nvram"
     ;;
 
   *)

--- a/tests/kola/boot/grub2-install
+++ b/tests/kola/boot/grub2-install
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 boot_dev=/boot
 arch=$(arch)

--- a/tests/kola/butane/grub-users/test.sh
+++ b/tests/kola/butane/grub-users/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")

--- a/tests/kola/clhm/ignition-warnings/test.sh
+++ b/tests/kola/clhm/ignition-warnings/test.sh
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 WARN='\e\[0;33m' # yellow
 RESET='\e\[0m' # reset

--- a/tests/kola/clhm/network-device-info
+++ b/tests/kola/clhm/network-device-info
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 for file in /etc/issue.d/22*.issue
 do

--- a/tests/kola/containers/cgroups-v2
+++ b/tests/kola/containers/cgroups-v2
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # make sure the system is on cgroups v2
 has_cgroup_karg=1

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [[ "$(podman volume inspect systemd-test | jq -r '.[0].Labels."org.test.Key"')" != "quadlet-test-volume" ]]; then
     fatal "Volume not correctly created"

--- a/tests/kola/content-origins/test.sh
+++ b/tests/kola/content-origins/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 . /usr/lib/os-release
 

--- a/tests/kola/content-origins/test.sh
+++ b/tests/kola/content-origins/test.sh
@@ -5,7 +5,7 @@
 ##   exclusive: false
 ##   # May support e.g. centos in the future
 ##   distros: "fcos rhcos"
-##   description: Verify the RPM %{vendor} flag for everything installed 
+##   description: Verify the RPM %{vendor} flag for everything installed
 ##     matches what we expect.
 
 set -xeuo pipefail

--- a/tests/kola/disks/growfs
+++ b/tests/kola/disks/growfs
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ ! -f /run/ignition-ostree-growfs.stamp ]; then
     fatal "rootfs was not grown on first boot"

--- a/tests/kola/disks/growfs
+++ b/tests/kola/disks/growfs
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that the rootfs is automatically grown on first 
+##   description: Verify that the rootfs is automatically grown on first
 ##     boot by default and that the autosave-xfs logic didn't kick in.
 
 set -xeuo pipefail

--- a/tests/kola/disks/no-google-device-links
+++ b/tests/kola/disks/no-google-device-links
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 links=$(find /dev/disk/by-id/ -iname "*google*")
 if [[ -n "${links:-}" ]]; then

--- a/tests/kola/disks/root-boot-ro
+++ b/tests/kola/disks/root-boot-ro
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 for part in /sysroot /boot; do
     if ! findmnt -n -o options ${part} | grep -q "ro,"; then

--- a/tests/kola/disks/root-prjquota
+++ b/tests/kola/disks/root-prjquota
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 rootflags=$(findmnt /sysroot -no OPTIONS)
 if ! grep prjquota <<< "${rootflags}"; then

--- a/tests/kola/disks/systemd-repart-service
+++ b/tests/kola/disks/systemd-repart-service
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ "$(systemctl is-enabled systemd-repart.service)" != 'masked' ]; then
     fatal "systemd-repart.service systemd unit should be masked"

--- a/tests/kola/disks/tmpfs
+++ b/tests/kola/disks/tmpfs
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 tmpfs=$(findmnt -n -o FSTYPE /tmp)
 if [ "${tmpfs}" != "tmpfs" ]; then

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 commands=(
   'gdb'

--- a/tests/kola/files/aleph-version
+++ b/tests/kola/files/aleph-version
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 jq . < /sysroot/.coreos-aleph-version.json >/dev/null
 ok aleph

--- a/tests/kola/files/check-symlink
+++ b/tests/kola/files/check-symlink
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 for file_name in /etc/system-release-cpe /etc/system-release /etc/redhat-release /etc/os-release
 do

--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -5,10 +5,10 @@
 ##   # s390x doesn't have any configuration in platforms.yaml, so
 ##   # platforms.json is not included in the image
 ##   architectures: "! s390x"
-##   description: Verify that the kargs and grub.cfg commands specified in 
-##     platforms.json have been properly applied to the image. 
+##   description: Verify that the kargs and grub.cfg commands specified in
+##     platforms.json have been properly applied to the image.
 
-# Also check cosa correctly translated platforms.yaml to platforms.json, by 
+# Also check cosa correctly translated platforms.yaml to platforms.json, by
 # spot-checking certain expected values in platforms.json.
 
 set -xeuo pipefail

--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 platform_json_kargs() {
     jq -r ".$1.kernel_arguments // [] | join(\" \")" < /boot/coreos/platforms.json

--- a/tests/kola/files/etc-passwd-group-permissions
+++ b/tests/kola/files/etc-passwd-group-permissions
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 for f in '/etc/passwd' '/etc/group'; do
     if [[ $(stat --format="%a %u %g" "${f}") != "644 0 0" ]]; then

--- a/tests/kola/files/file-directory-permissions
+++ b/tests/kola/files/file-directory-permissions
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # List of known files and directories with group write permission
 list_known=()

--- a/tests/kola/files/file-directory-permissions
+++ b/tests/kola/files/file-directory-permissions
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that there are no files and directories 
+##   description: Verify that there are no files and directories
 ##     with 'g+w' or 'o+w' permission in /etc, except the known lists.
 
 set -xeuo pipefail

--- a/tests/kola/files/initrd/compression
+++ b/tests/kola/files/initrd/compression
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Check initrd for zstd magic number
 if is_rhcos8; then

--- a/tests/kola/files/initrd/executables
+++ b/tests/kola/files/initrd/executables
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 tmpd=$(mktemp -d)
 ( cd "${tmpd}" && lsinitrd --unpack /boot/ostree/*/init* )

--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 required_initrd_files=(
     # Files from the 25azure-udev-rules overlay

--- a/tests/kola/files/kernel-headers
+++ b/tests/kola/files/kernel-headers
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if test -d /usr/include/linux; then
    fatal "Error: should not have kernel headers on host"

--- a/tests/kola/files/license
+++ b/tests/kola/files/license
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! test -f /usr/share/licenses/fedora-coreos-config/LICENSE; then
     fatal missing LICENSE

--- a/tests/kola/files/logrotate-service
+++ b/tests/kola/files/logrotate-service
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 for unit in logrotate logrotate.timer; do
     if ! systemctl is-enabled ${unit} 1>/dev/null; then

--- a/tests/kola/files/remove-manifest-files
+++ b/tests/kola/files/remove-manifest-files
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # See remove-files in the manifest
 if test -d /usr/share/info; then

--- a/tests/kola/files/root-immutable-bit
+++ b/tests/kola/files/root-immutable-bit
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! lsattr -d / | grep -qe '--i--'; then
     fatal "missing immutable bit on /"

--- a/tests/kola/files/rpmdb-sqlite
+++ b/tests/kola/files/rpmdb-sqlite
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if is_rhcos8; then
     ok "nothing to check for RHCOS 8"

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # List of known files and directories with SetGID bit set
 # Drop '/usr/libexec/openssh/ssh-keysign' after

--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that there are no file/directory with 
+##   description: Verify that there are no file/directory with
 ##     SetGID bit set, except the known files and directories.
 
 set -xeuo pipefail

--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that there are no file/directory with 
+##   description: Verify that there are no file/directory with
 ##     SetUID bit set, except the known files and directories.
 
 set -xeuo pipefail

--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # List of known files and directories with SetUID bit set
 list_setuid_files=(

--- a/tests/kola/files/sudoers
+++ b/tests/kola/files/sudoers
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify the permissions and syntax of /etc/sudoers 
+##   description: Verify the permissions and syntax of /etc/sudoers
 ##     and /etc/sudoers.d/* are readable only for root.
 
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1981979

--- a/tests/kola/files/sudoers
+++ b/tests/kola/files/sudoers
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 visudo -c
 ok "sudoers files are valid"

--- a/tests/kola/files/system-generators
+++ b/tests/kola/files/system-generators
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 find /usr/lib/systemd/system-generators -type f | while read -r f; do
     mode=$(stat -c '%a' "${f}")

--- a/tests/kola/files/unlabeled-contexts
+++ b/tests/kola/files/unlabeled-contexts
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # check that no files are unlabeled
 unlabeled=$(find /var /etc -context '*:unlabeled_t:*')

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # List of known broken symlinks that require further investigation.
 # The sym links in /usr/lib/firmware are often broken and are

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -3,7 +3,7 @@
 ##   tags: "platform-independent"
 ##   # This is a read-only test that can be run with other tests.
 ##   exclusive: false
-##   description: Verify that there are no broken symlinks in /etc/ and /usr/, 
+##   description: Verify that there are no broken symlinks in /etc/ and /usr/,
 ##     except the known files which require further investigation.
 
 # See https://github.com/coreos/fedora-coreos-config/issues/1782

--- a/tests/kola/files/yum-repo-dir
+++ b/tests/kola/files/yum-repo-dir
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! test -d /etc/yum.repos.d; then
     fatal "Error: not find /etc/yum.repos.d"

--- a/tests/kola/firewall/iptables-legacy/test.sh
+++ b/tests/kola/firewall/iptables-legacy/test.sh
@@ -2,8 +2,8 @@
 ## kola:
 ##   distros: fcos
 ##   exclusive: true
-##   description: Verify that one can configure a node to use the legacy 
-##     iptables backend. 
+##   description: Verify that one can configure a node to use the legacy
+##     iptables backend.
 
 # It is scoped to only FCOS because RHCOS only supports nft.
 

--- a/tests/kola/firewall/iptables-legacy/test.sh
+++ b/tests/kola/firewall/iptables-legacy/test.sh
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Make sure we're on legacy iptables
 if ! iptables --version | grep legacy; then

--- a/tests/kola/firewall/iptables/test.sh
+++ b/tests/kola/firewall/iptables/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! iptables --version | grep nf_tables; then
     iptables --version # output for logs

--- a/tests/kola/gshadow
+++ b/tests/kola/gshadow
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## kola:
-##   description: Verify that glibc's parsing of /etc/gshadow does 
+##   description: Verify that glibc's parsing of /etc/gshadow does
 ##     not cause systemd-sysusers to segfault on specially constructed lines.
 
 # See https://github.com/coreos/bugs/issues/1394

--- a/tests/kola/ignition/delete-config/test.sh
+++ b/tests/kola/ignition/delete-config/test.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 ## kola:
 ##   platforms: qemu
-##   description: Verify that we delete userdata from provider after Ignition 
+##   description: Verify that we delete userdata from provider after Ignition
 ##     completes.
 
 # See https://github.com/coreos/ignition/issues/1315
-# There are 2 services: 
-# 1)ignition-delete-config.service, which deletes Ignition 
+# There are 2 services:
+# 1)ignition-delete-config.service, which deletes Ignition
 # configs from VMware and VirtualBox on first boot.
-# 2)coreos-ignition-delete-config.service, do the same thing 
-# on existing machines on upgrade, using a stamp file in /var/lib 
+# 2)coreos-ignition-delete-config.service, do the same thing
+# on existing machines on upgrade, using a stamp file in /var/lib
 # to avoid multiple runs.
 # Ideally we'd test on virtualbox and vmware, but we don't have tests
 # there, so we mock specifically for ignition.platform.id=qemu.
 # Test scenarios:
-# On first boot, verify that both 2 services ran. 
+# On first boot, verify that both 2 services ran.
 # On upgrade boot, verify that 1) should not run, 2) should run.
 # On normal boot, verify that both 2 services should not run.
-# On upgrade boot with 2) masked, verify that both 2 services 
+# On upgrade boot with 2) masked, verify that both 2 services
 # should not run.
 
 set -xeuo pipefail

--- a/tests/kola/ignition/delete-config/test.sh
+++ b/tests/kola/ignition/delete-config/test.sh
@@ -22,7 +22,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")

--- a/tests/kola/ignition/journald-log
+++ b/tests/kola/ignition/journald-log
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that we send the journald log entry for a 
+##   description: Verify that we send the journald log entry for a
 ##     user-provided config.
 
 # See https://github.com/coreos/ignition/pull/958 for the MESSAGE_ID source.

--- a/tests/kola/ignition/journald-log
+++ b/tests/kola/ignition/journald-log
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 ignitionJournalMsgId="57124006b5c94805b77ce473e92a8aeb"
 

--- a/tests/kola/ignition/kargs/test.sh
+++ b/tests/kola/ignition/kargs/test.sh
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! grep foobar /proc/cmdline; then
     fatal "missing foobar in kernel cmdline"

--- a/tests/kola/ignition/remote/test.sh
+++ b/tests/kola/ignition/remote/test.sh
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! grep -q foobar /proc/cmdline; then
     fatal "missing foobar in kernel cmdline"

--- a/tests/kola/ignition/remote/test.sh
+++ b/tests/kola/ignition/remote/test.sh
@@ -4,7 +4,7 @@
 ##   description: Verify Ignition supports remote config.
 
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1980679
-# remote.ign is on github, inject kernelArguments and write 
+# remote.ign is on github, inject kernelArguments and write
 # something to /etc/testfile.
 # config.ign is to include remote kargsfile.ign.
 

--- a/tests/kola/ignition/resource/authenticated-gs/test.sh
+++ b/tests/kola/ignition/resource/authenticated-gs/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
     fatal "fetched data mismatch"

--- a/tests/kola/ignition/resource/authenticated-s3/test.sh
+++ b/tests/kola/ignition/resource/authenticated-s3/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
     fatal "fetched data mismatch"

--- a/tests/kola/ignition/resource/remote/test.sh
+++ b/tests/kola/ignition/resource/remote/test.sh
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
     fatal "fetched data mismatch"

--- a/tests/kola/ignition/resource/remote/test.sh
+++ b/tests/kola/ignition/resource/remote/test.sh
@@ -3,7 +3,7 @@
 ##   tags: needs-internet
 ##   # Don't pass AWS or GCP credentials to instance
 ##   noInstanceCreds: true
-##   description: Verify that Ignition can fetch anonymous resources within a 
+##   description: Verify that Ignition can fetch anonymous resources within a
 ##     cloud platform (S3 -> AWS, GCS -> GCP) when no credentials are supplied.
 
 set -xeuo pipefail

--- a/tests/kola/ignition/stable-boot/test.sh
+++ b/tests/kola/ignition/stable-boot/test.sh
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # symlink shouldn't be propogated to real-root
 link="/dev/disk/by-id/coreos-boot-disk"

--- a/tests/kola/ignition/systemd-disable/test.sh
+++ b/tests/kola/ignition/systemd-disable/test.sh
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ "$(systemctl is-enabled zincati.service)" != 'disabled' ]; then
     fatal "zincati.service systemd unit should be disabled"

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # make sure the presets worked and the instantiated unit is enabled
 if [ "$(systemctl is-enabled touch@foo.service)" != 'enabled' ]; then

--- a/tests/kola/ignition/systemd-enable-units/test.sh
+++ b/tests/kola/ignition/systemd-enable-units/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   tags: "platform-independent"
-##   description: Verify that Ignition supports to enable systemd units 
+##   description: Verify that Ignition supports to enable systemd units
 ##     of different types.
 
 # See

--- a/tests/kola/ignition/systemd-unmasking/test.sh
+++ b/tests/kola/ignition/systemd-unmasking/test.sh
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Make sure the systemd unit (dnsmasq) is unmasked and enabled
 if [ "$(systemctl is-enabled dnsmasq.service)" != 'enabled' ]; then

--- a/tests/kola/k8s/node-e2e/data/node-e2e
+++ b/tests/kola/k8s/node-e2e/data/node-e2e
@@ -3,7 +3,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 SELF=$(realpath "$0")
 IMAGE=quay.io/projectquay/golang:1.17

--- a/tests/kola/k8s/node-e2e/master
+++ b/tests/kola/k8s/node-e2e/master
@@ -7,7 +7,7 @@
 ##   architectures: x86_64
 ##   requiredTag: k8s
 ##   tags: needs-internet
-##   description: Verify the Kubernetes e2e node tests work, and 
+##   description: Verify the Kubernetes e2e node tests work, and
 ##     ensure that we don't inadvertedly break Kubernetes.
 
 set -xeuo pipefail

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -14,7 +14,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")

--- a/tests/kola/kdump/service
+++ b/tests/kola/kdump/service
@@ -3,7 +3,7 @@
 ##   exclusive: false
 ##   description: Verify that kdump didn't start by default.
 
-# It's either disabled, or enabled but conditional on crashkernel= karg, 
+# It's either disabled, or enabled but conditional on crashkernel= karg,
 # which we don't bake.
 
 set -xeuo pipefail

--- a/tests/kola/kdump/service
+++ b/tests/kola/kdump/service
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! systemctl show -p ActiveState kdump.service | grep -q ActiveState=inactive; then
     fatal "Unit kdump.service shouldn't be active"

--- a/tests/kola/kubernetes/kube-watch/test.sh
+++ b/tests/kola/kubernetes/kube-watch/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ "$(systemctl is-active kube-watch.path)" != "active" ]; then
     fatal "kube-watch.path did not activate successfully"

--- a/tests/kola/kubernetes/systemd-env-read/test.sh
+++ b/tests/kola/kubernetes/systemd-env-read/test.sh
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ "$( stat -c %C /etc/kubernetes/envfile)" != "system_u:object_r:kubernetes_file_t:s0" ]; then
     fatal "/etc/kubernetes/envfile is labeled incorrectly"

--- a/tests/kola/kubernetes/systemd-env-read/test.sh
+++ b/tests/kola/kubernetes/systemd-env-read/test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify that `kubernetes_file_t` labeled files can be read 
-##     by systemd, also verify the `kube-env` service started successfully  
+##   description: Verify that `kubernetes_file_t` labeled files can be read
+##     by systemd, also verify the `kube-env` service started successfully
 ##     and the service wrote to the journal successfully.
 
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1973418

--- a/tests/kola/logging/printk
+++ b/tests/kola/logging/printk
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 printk=$(cat /proc/sys/kernel/printk)
 

--- a/tests/kola/networking/bridge-static-via-kargs
+++ b/tests/kola/networking/bridge-static-via-kargs
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 bridge="br0"
 

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # EXPECTED_INITRD_NETWORK_CFG2
 #   - used on older RHEL 8.4 release

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   tags: "platform-independent"
 ##   exclusive: false
-##   description: Verify the default networking configurations match expected 
+##   description: Verify the default networking configurations match expected
 ##     results.
 #
 # Since we depend so much on the default networking configurations let's

--- a/tests/kola/networking/dnsmasq-service
+++ b/tests/kola/networking/dnsmasq-service
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ "$(systemctl is-enabled dnsmasq.service)" != 'masked' ]; then
     fatal "dnsmasq.service systemd unit should be masked"

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -22,7 +22,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Verify eth1 gets staic ip via kargs
 nic_name="eth1"

--- a/tests/kola/networking/force-persist-ip/test.sh
+++ b/tests/kola/networking/force-persist-ip/test.sh
@@ -9,7 +9,7 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0 coreos.force_persist_ip"
-##   description: Verify that coreos.force_persist_ip will force propagating 
+##   description: Verify that coreos.force_persist_ip will force propagating
 ##     kernel argument based networking configuration into the real root.
 
 # Setup configuration for a single NIC with two different ways:

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -48,7 +48,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if is_rhcos8; then
     if [ $(hostnamectl --transient) != 'localhost' ]; then

--- a/tests/kola/networking/ifname-karg/data/ifname-karg-lib.sh
+++ b/tests/kola/networking/ifname-karg/data/ifname-karg-lib.sh
@@ -1,6 +1,7 @@
 # This is a library created for our ifname-karg tests
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # check IP for given NIC name
 check_ip() {

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
@@ -18,7 +18,7 @@ nicname='kolatest'
 
 run_tests() {
     # Make sure nothing was persisted from the initramfs
-    check_file_not_exists '/etc/udev/rules.d/80-ifname.rules' 
+    check_file_not_exists '/etc/udev/rules.d/80-ifname.rules'
     # Make sure systemd-network-generator ran (from the real root)
     check_file_exists "/run/systemd/network/90-${nicname}.link"
     # Make sure the NIC is in use and got the expected IP address

--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 . $KOLA_EXT_DATA/ifname-karg-lib.sh
 
 nicname='kolatest'

--- a/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
+++ b/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 . $KOLA_EXT_DATA/ifname-karg-lib.sh
 
 nicname='kolatest'

--- a/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
+++ b/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
@@ -21,7 +21,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     "")
         ok "first boot"
         # Make sure the rules were persisted from the initramfs
-        check_file_exists '/etc/udev/rules.d/80-ifname.rules' 
+        check_file_exists '/etc/udev/rules.d/80-ifname.rules'
         # On first boot we expect systemd-network-generator to run too
         # because the ifname= karg was present, but only for first boot
         check_file_exists "/run/systemd/network/90-${nicname}.link"
@@ -33,7 +33,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rebooted)
         ok "second boot"
         # Make sure the rules are still there
-        check_file_exists '/etc/udev/rules.d/80-ifname.rules' 
+        check_file_exists '/etc/udev/rules.d/80-ifname.rules'
         # On second boot the ifname= karg isn't there so the file
         # created by systemd-network-generator shouldn't exist.
         check_file_not_exists "/run/systemd/network/90-${nicname}.link"

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -18,7 +18,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # check kernel parameter
 cmdline="/proc/cmdline"

--- a/tests/kola/networking/kargs-rd-net
+++ b/tests/kola/networking/kargs-rd-net
@@ -4,7 +4,7 @@
 ##   platforms: qemu
 ##   # The functionality we're testing here.
 ##   appendFirstbootKernelArgs: "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8"
-##   description: Verify rd.net.timeout.dhcp and rd.net.dhcp.retry 
+##   description: Verify rd.net.timeout.dhcp and rd.net.dhcp.retry
 ##     are supported by NetworkManager.
 
 # See
@@ -12,7 +12,7 @@
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1879094#c10
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1877740
 
-# Append "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8" to kernel parameter 
+# Append "rd.net.timeout.dhcp=30 rd.net.dhcp.retry=8" to kernel parameter
 # when boot, get total timeout is `timeout * retry`, 30*8(240) seconds
 # in this test scenario.
 

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -28,7 +28,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 bond="bond0"
 vlan="bond0.100"

--- a/tests/kola/networking/mtu-on-bond-ignition/test.sh
+++ b/tests/kola/networking/mtu-on-bond-ignition/test.sh
@@ -8,7 +8,7 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: net.ifnames=0
-##   description: Verify that configure MTU on a VLAN subinterface for 
+##   description: Verify that configure MTU on a VLAN subinterface for
 ##     the bond via Ignition works.
 #
 # Set MTU on a VLAN subinterface for the bond using Ignition config and check

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -9,7 +9,7 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "bond=bond0:eth1,eth2:mode=active-backup,miimon=100:9000 ip=10.10.10.10::10.10.10.1:255.255.255.0:staticvlanbond:bond0.100:none:9000 vlan=bond0.100:bond0 net.ifnames=0"
-##   description: Verify that configuring MTU on a VLAN subinterface 
+##   description: Verify that configuring MTU on a VLAN subinterface
 ##     for the bond via kernel arguements works.
 
 # Configuring MTU on a VLAN subinterface for the bond,

--- a/tests/kola/networking/mtu-on-bond-kargs
+++ b/tests/kola/networking/mtu-on-bond-kargs
@@ -20,7 +20,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 bond="bond0"
 vlan="bond0.100"

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -12,7 +12,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if is_fcos; then
     # run resolvectl

--- a/tests/kola/networking/nameserver
+++ b/tests/kola/networking/nameserver
@@ -3,7 +3,7 @@
 ##   # appendKernelArgs is only supported on QEMU
 ##   platforms: qemu
 ##   appendKernelArgs: "nameserver=8.8.8.8 nameserver=1.1.1.1"
-##   description: Verify that we config multiple nameservers via kernel 
+##   description: Verify that we config multiple nameservers via kernel
 ##     arguments work well.
 
 # RHCOS: need to check /etc/resolv.conf and nmconnection.

--- a/tests/kola/networking/network-online-service
+++ b/tests/kola/networking/network-online-service
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # We shouldn't pull this into the transaction by default.
 # https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

--- a/tests/kola/networking/nic-naming
+++ b/tests/kola/networking/nic-naming
@@ -14,7 +14,8 @@
 # - https://github.com/coreos/fedora-coreos-config/commit/2a5c2abc796ac645d705700bf445b50d4cda8f5f
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ip link | grep -o -e " eth[0-9]:"; then
     fatal "detected eth* NIC naming on node"

--- a/tests/kola/networking/nm-dhcp-client
+++ b/tests/kola/networking/nm-dhcp-client
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! journalctl -b 0 -u NetworkManager --grep=dhcp | grep -q "Using DHCP client 'internal'"; then
   fatal "Error: NetworkManager's internal DHCP client is not running"

--- a/tests/kola/networking/nm-ifcfg-rh-plugin
+++ b/tests/kola/networking/nm-ifcfg-rh-plugin
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Check if it exists or not. The plugin provides a dbus interface
 # so if it is loaded there will be something listening at that name

--- a/tests/kola/networking/nm-start
+++ b/tests/kola/networking/nm-start
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify kola on QEMU shouldn't bring up networking in the 
+##   description: Verify kola on QEMU shouldn't bring up networking in the
 ##     initrd by default, and on AWS we did bring up networking in the initrd.
 
 # See https://github.com/coreos/fedora-coreos-config/pull/426

--- a/tests/kola/networking/nm-start
+++ b/tests/kola/networking/nm-start
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 get_journal_msg_timestamp() {
     journalctl -o json -b 0 --grep "$1" \

--- a/tests/kola/networking/nmstate/data/nmstate-common.sh
+++ b/tests/kola/networking/nmstate/data/nmstate-common.sh
@@ -1,4 +1,5 @@
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 main() {
     nmstatectl show

--- a/tests/kola/networking/nmstate/data/nmstate-common.sh
+++ b/tests/kola/networking/nmstate/data/nmstate-common.sh
@@ -4,18 +4,18 @@
 main() {
     nmstatectl show
     journalctl -u nmstate
-    
+
     local prefix="first boot"
     if [ "${AUTOPKGTEST_REBOOT_MARK:-}" == rebooted ]; then
         prefix="second boot"
     fi
-    
+
     if ! nmcli c show br-ex; then
         fatal "${prefix}: bridge not configured"
     fi
 
     if ! ls /etc/nmstate/*applied; then
-        fatal "${prefix}: nmstate yamls files not marked as applied"    
+        fatal "${prefix}: nmstate yamls files not marked as applied"
     fi
 
     if [ "${AUTOPKGTEST_REBOOT_MARK:-}" == "" ]; then

--- a/tests/kola/networking/nmstate/policy/test.sh
+++ b/tests/kola/networking/nmstate/policy/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   tags: "platform-independent needs-internet"
-##   description: Verify that configure a DHCP linux bridge using 
+##   description: Verify that configure a DHCP linux bridge using
 ##     butane and nmstate service with policy works.
 
 # See https://github.com/coreos/fedora-coreos-tracker/issues/1175

--- a/tests/kola/networking/nmstate/state/test.sh
+++ b/tests/kola/networking/nmstate/state/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   tags: "platform-independent needs-internet"
-##   description: Verify that configure a DHCP linux bridge using 
+##   description: Verify that configure a DHCP linux bridge using
 ##     butane and nmstate service with state works.
 
 # See https://github.com/coreos/fedora-coreos-tracker/issues/1175

--- a/tests/kola/networking/no-default-initramfs-net-propagation/bootif
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/bootif
@@ -16,7 +16,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Run the test bits (sets the $fail var)
 . $KOLA_EXT_DATA/test-net-propagation.sh

--- a/tests/kola/networking/no-default-initramfs-net-propagation/default
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/default
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Run the test bits (sets the $fail var)
 . $KOLA_EXT_DATA/test-net-propagation.sh

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -9,11 +9,11 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none net.ifnames=0 coreos.no_persist_ip"
-##   description: Verify that the coreos.no_persist_ip kernel argument will 
-##     prevent propagating kernel argument based networking configuration 
-##     into the real root. 
+##   description: Verify that the coreos.no_persist_ip kernel argument will
+##     prevent propagating kernel argument based networking configuration
+##     into the real root.
 
-# It does this by providing karg static networking config for eth1 and 
+# It does this by providing karg static networking config for eth1 and
 # then verifying that DHCP is used in the real root.
 
 set -xeuo pipefail

--- a/tests/kola/networking/no-persist-ip
+++ b/tests/kola/networking/no-persist-ip
@@ -18,7 +18,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Verify eth1 gets ip address via dhcp
 nic_name="eth1"

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -9,7 +9,7 @@
 ##   # different firmwares (BIOS vs UEFI) the NIC names are different.
 ##   # See https://github.com/coreos/fedora-coreos-tracker/issues/1060
 ##   appendKernelArgs: "ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:eth1:none:8.8.8.8 net.ifnames=0"
-##   description: Verify that networking configuration is propagated 
+##   description: Verify that networking configuration is propagated
 ##     via Ignition by default.
 
 # Setup configuration for a single NIC with two different ways:

--- a/tests/kola/networking/prefer-ignition-networking/test.sh
+++ b/tests/kola/networking/prefer-ignition-networking/test.sh
@@ -22,7 +22,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Verify eth1 gets ip address via dhcp
 nic_name="eth1"

--- a/tests/kola/networking/rd-net-timeout-carrier/test.sh
+++ b/tests/kola/networking/rd-net-timeout-carrier/test.sh
@@ -20,7 +20,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")

--- a/tests/kola/networking/resolv/systemd-resolved
+++ b/tests/kola/networking/resolv/systemd-resolved
@@ -9,7 +9,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! systemctl is-enabled systemd-resolved 1>/dev/null; then
     fatal "Unit systemd-resolved should be enabled"

--- a/tests/kola/networking/resolv/systemd-resolved
+++ b/tests/kola/networking/resolv/systemd-resolved
@@ -4,7 +4,7 @@
 ##  # RHCOS
 ##   distros:  fcos
 ##   exclusive: false
-##   description: Verify systemd-resolved and the stub listener 
+##   description: Verify systemd-resolved and the stub listener
 ##     should be enabled by default.
 
 set -xeuo pipefail

--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -15,7 +15,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 team="team0"
 

--- a/tests/kola/networking/tls
+++ b/tests/kola/networking/tls
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 urls_to_fetch=(
     "https://cloud.google.com"

--- a/tests/kola/ntp/chrony/coreos-platform-chrony-config
+++ b/tests/kola/ntp/chrony/coreos-platform-chrony-config
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 platform=$(cmdline_arg ignition.platform.id)
 case "${platform}" in

--- a/tests/kola/ntp/chrony/dhcp-propagation
+++ b/tests/kola/ntp/chrony/dhcp-propagation
@@ -23,7 +23,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 . $KOLA_EXT_DATA/ntplib.sh
 
 main() {

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -1,6 +1,7 @@
 # This is a library created for our NTP tests
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 ntp_test_setup() {
     ntp_host_ip=$1

--- a/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
+++ b/tests/kola/ntp/timesyncd/dhcp-propagation/test.sh
@@ -25,7 +25,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 . $KOLA_EXT_DATA/ntplib.sh
 
 main() {

--- a/tests/kola/platforms/aws/assert-xen
+++ b/tests/kola/platforms/aws/assert-xen
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 hypervisor=$(curl http://169.254.169.254/2022-09-24/meta-data/system || true)
 if [ "${hypervisor}" != "xen" ]; then

--- a/tests/kola/platforms/aws/nvme
+++ b/tests/kola/platforms/aws/nvme
@@ -35,7 +35,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 nvme_info=$(nvme list-subsys -o json || true)
 has_nvme=$(jq -r ".[].Subsystems[].Paths[] | select(.Name == \"nvme0\").Name" <<< "$nvme_info")

--- a/tests/kola/platforms/gcp/nvme-symlink
+++ b/tests/kola/platforms/gcp/nvme-symlink
@@ -13,7 +13,7 @@
 # or `--tag confidential` is passed to `kola run`, also requires
 # `--gcp-machinetype n2d-standard-2 --gcp-confidential-vm`
 #
-# It will create confidential instance on GCP with 1 nvme persistent disk 
+# It will create confidential instance on GCP with 1 nvme persistent disk
 # and 1 local ssd disk, then check the new udev rules make effect.
 
 set -xeuo pipefail

--- a/tests/kola/platforms/gcp/nvme-symlink
+++ b/tests/kola/platforms/gcp/nvme-symlink
@@ -18,7 +18,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Set global variable with NVME json info
 NVME_INFO=$(nvme list-subsys -o json)

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -8,7 +8,7 @@
 ##   # This test reaches out to the internet and it could take more
 ##   # time to pull down the container.
 ##   timeoutMin: 3
-##   description: Verify that DNS in rootless podman containers can 
+##   description: Verify that DNS in rootless podman containers can
 ##     resolve external domains.
 
 # See https://github.com/coreos/fedora-coreos-tracker/issues/923

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -15,7 +15,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 runascoreuserscript='
 #!/bin/bash

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -13,7 +13,9 @@
 # See https://github.com/coreos/fedora-coreos-tracker/issues/1436
 
 set -xeuo pipefail
-. $KOLA_EXT_DATA/commonlib.sh
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -21,7 +21,9 @@
 # both on cgroups v1 and cgroups v2.
 
 set -xeuo pipefail
-. $KOLA_EXT_DATA/commonlib.sh
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 runascoreuserscript='
 #!/bin/bash

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   platforms: qemu
-##   description: Verify default system configuration are both on first and 
+##   description: Verify default system configuration are both on first and
 ##     subsequent boots.
 
 set -xeuo pipefail

--- a/tests/kola/reboot/test.sh
+++ b/tests/kola/reboot/test.sh
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # /var
 varsrc=$(findmnt -nvr /var -o SOURCE)

--- a/tests/kola/root-reprovision/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/autosave-xfs/test.sh
@@ -9,7 +9,7 @@
 ##   # This test includes a lot of disk I/O and needs a higher
 ##   # timeout value than the default.
 ##   timeoutMin: 15
-##   description: Verify the root reprovision with XFS 
+##   description: Verify the root reprovision with XFS
 ##     on large disk triggers autosaved.
 
 set -xeuo pipefail

--- a/tests/kola/root-reprovision/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/autosave-xfs/test.sh
@@ -14,7 +14,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ ! -f /run/ignition-ostree-autosaved-xfs.stamp ]; then
     fatal "expected autosaved XFS"

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 fstype=$(findmnt -nvr / -o FSTYPE)
 [[ $fstype == ext4 ]]

--- a/tests/kola/root-reprovision/linear/test.sh
+++ b/tests/kola/root-reprovision/linear/test.sh
@@ -15,7 +15,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 srcdev=$(findmnt -nvr / -o SOURCE)
 [[ ${srcdev} == $(realpath /dev/md/foobar) ]]

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -11,7 +11,7 @@
 ##   timeoutMin: 15
 ##   # Trigger automatic XFS reprovisioning
 ##   minDisk: 100
-##   description: Verify the root reprovision with XFS and TPM 
+##   description: Verify the root reprovision with XFS and TPM
 ##     on large disk triggers autosaved.
 
 set -xeuo pipefail

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -16,7 +16,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # check that we ran automatic XFS reprovisioning
 if [ -z "${AUTOPKGTEST_REBOOT_MARK:-}" ]; then

--- a/tests/kola/root-reprovision/luks/data/luks-test.sh
+++ b/tests/kola/root-reprovision/luks/data/luks-test.sh
@@ -1,7 +1,8 @@
 # This file is sourced by both `ext.config.root-reprovision.luks`
 # and `ext.config.root-reprovision.luks.autosave-xfs`.
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 srcdev=$(findmnt -nvr / -o SOURCE)
 [[ ${srcdev} == /dev/mapper/myluksdev ]]

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -14,7 +14,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # check that we didn't run automatic XFS reprovisioning
 if [ -z "${AUTOPKGTEST_REBOOT_MARK:-}" ]; then

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -9,7 +9,7 @@
 ##   # This test includes a lot of disk I/O and needs a higher
 ##   # timeout value than the default.
 ##   timeoutMin: 15
-##   description: Verify the root reprovision with XFS and TPM 
+##   description: Verify the root reprovision with XFS and TPM
 ##     does not trigger autosaved.
 
 set -xeuo pipefail

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -15,7 +15,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 srcdev=$(findmnt -nvr / -o SOURCE)
 [[ ${srcdev} == $(realpath /dev/md/foobar) ]]

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -16,7 +16,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 swapstatus=$(systemctl is-active dev-disk-by\\x2dpartlabel-swap.swap)
 [[ ${swapstatus} == active ]]

--- a/tests/kola/rpm-ostree-countme/test.sh
+++ b/tests/kola/rpm-ostree-countme/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 journal_cursor() {
     journalctl --output json --lines 1 \

--- a/tests/kola/rpm-ostree/container-deps
+++ b/tests/kola/rpm-ostree/container-deps
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Verify this command exists since it's a hard dependency of ostree's container bits.
 skopeo experimental-image-proxy --help

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -31,9 +31,11 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -euo pipefail
-. $KOLA_EXT_DATA/commonlib.sh
-set -x
+set -euxo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
 cd $(mktemp -d)
 
 # TODO: It'd be much better to test this via a registry

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -10,7 +10,7 @@
 ##   distros: fcos
 ##   # Needs internet access as we fetch files from koji
 ##   tags: "needs-internet platform-independent"
-##   description: Verify that build of a container image with a new kernel 
+##   description: Verify that build of a container image with a new kernel
 ##     and reboot into it succeeds.
 
 #

--- a/tests/kola/secex/ensure/test.sh
+++ b/tests/kola/secex/ensure/test.sh
@@ -5,7 +5,7 @@
 ##   requiredTag: secex
 ##   timeoutMin: 3
 ##   description: Verify the s390x Secure Execution QEMU image works. It also
-##     implicitly tests Ignition config decryption. 
+##     implicitly tests Ignition config decryption.
 
 # We don't run it by default because it requires running with `--qemu-secex`.
 

--- a/tests/kola/secex/reboot/test.sh
+++ b/tests/kola/secex/reboot/test.sh
@@ -7,7 +7,7 @@
 ##   description: Verify the qemu-secex image reboots with SE enabled. It also
 ##     implicitly tests Ignition config decryption.
 
-# We don't run it by default because it requires running with 
+# We don't run it by default because it requires running with
 # `--qemu-secex --qemu-secex-hostkey HKD-<serial>.crt`.
 
 set -xeuo pipefail

--- a/tests/kola/security/coreos-update-ca-trust/test.sh
+++ b/tests/kola/security/coreos-update-ca-trust/test.sh
@@ -5,7 +5,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Make sure that coreos-update-ca-trust kicked in and observe the result.
 if ! systemctl show coreos-update-ca-trust.service -p ActiveState | grep ActiveState=active; then

--- a/tests/kola/security/passwd/test.sh
+++ b/tests/kola/security/passwd/test.sh
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 OUTPUT=$(echo 'foobar' | setsid su - tester -c id)
 

--- a/tests/kola/selinux/default
+++ b/tests/kola/selinux/default
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ostree admin config-diff | grep 'selinux/targeted/policy'; then
     fatal "SELinux policy is marked as modified"

--- a/tests/kola/selinux/enforcing
+++ b/tests/kola/selinux/enforcing
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")

--- a/tests/kola/selinux/enforcing
+++ b/tests/kola/selinux/enforcing
@@ -41,14 +41,14 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     ;;
   rebooted)
     # check SELinux is in permissive mode
-    enforce=$(getenforce)  
+    enforce=$(getenforce)
     if [ "${enforce}" != "Permissive" ]; then
       fatal "Error: Expected SELinux Permissive, found ${enforce}"
     fi
     ok "SELinux is Permissive"
     ok "Second boot"
     ;;
-  *) 
+  *)
     fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"
     ;;
 esac

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -5,7 +5,7 @@
 ##   exclusive: false
 ##   # This test pulls a container image from the network.
 ##   tags: "needs-internet platform-independent"
-##   description: Verify that tmpfs mounts inside a container 
+##   description: Verify that tmpfs mounts inside a container
 ##     have the `container_file_t` label.
 
 # See https://github.com/coreos/fedora-coreos-tracker/issues/1366

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -12,7 +12,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 context=$(podman run --rm --privileged registry.fedoraproject.org/fedora:38 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")

--- a/tests/kola/selinux/stub-resolve-context
+++ b/tests/kola/selinux/stub-resolve-context
@@ -13,7 +13,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 context=$(stat --format "%C" /run/systemd/resolve/stub-resolv.conf)
 if [ "$context" != "system_u:object_r:net_conf_t:s0" ]; then

--- a/tests/kola/selinux/stub-resolve-context
+++ b/tests/kola/selinux/stub-resolve-context
@@ -4,7 +4,7 @@
 ##   # RHCOS
 ##   distros:  fcos
 ##   exclusive: false
-##   description: Verify that the stub-resolv.conf file has the correct 
+##   description: Verify that the stub-resolv.conf file has the correct
 ##     selinux context.
 
 # See

--- a/tests/kola/selinux/usrlocal-context
+++ b/tests/kola/selinux/usrlocal-context
@@ -6,7 +6,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 bin_ctx=$(stat -c %C /usr/sbin)
 usrlocal_sbin_ctx=$(stat -c %C /var/usrlocal/sbin)

--- a/tests/kola/selinux/usrlocal-context
+++ b/tests/kola/selinux/usrlocal-context
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   description: Verify /usr/sbin and /var/usrlocal/sbin have 
+##   description: Verify /usr/sbin and /var/usrlocal/sbin have
 ##     the same SELinux security context.
 
 set -xeuo pipefail

--- a/tests/kola/ssh/custom-host-key-permissions/test.sh
+++ b/tests/kola/ssh/custom-host-key-permissions/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # recent Fedora sshd binaries will fail to start if all configured host keys
 # have mode > 600 and their modes haven't automatically been fixed

--- a/tests/kola/ssh/custom-host-key-permissions/test.sh
+++ b/tests/kola/ssh/custom-host-key-permissions/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   tags: platform-independent
-##   description: Verify that sshd still works with a custom 
+##   description: Verify that sshd still works with a custom
 ##     host key with mode 640 and group ssh_keys.
 
 # See

--- a/tests/kola/swap/zram-default
+++ b/tests/kola/swap/zram-default
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if [ -e /dev/zram0 ]; then
     fatal "zram0 swap device set up on default install"

--- a/tests/kola/swap/zram-generator/test.sh
+++ b/tests/kola/swap/zram-generator/test.sh
@@ -4,7 +4,7 @@
 ##   distros: fcos
 ##   # This test conflicts with swap/zram-default so we cannot set this to non-exclusive
 ##   exclusive: true
-##   description: Verify that swap on zram devices can be set up using the 
+##   description: Verify that swap on zram devices can be set up using the
 ##     zram-generator as defined.
 
 # See docs at https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-configure-swaponzram/

--- a/tests/kola/swap/zram-generator/test.sh
+++ b/tests/kola/swap/zram-generator/test.sh
@@ -11,7 +11,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 if ! grep -q 'zram0' /proc/swaps; then
     fatal "expected zram0 to be set up"

--- a/tests/kola/systemd/default-unit-timeouts
+++ b/tests/kola/systemd/default-unit-timeouts
@@ -8,7 +8,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 DefaultTimeoutStartUSec=$(systemctl show --value --property=DefaultTimeoutStartUSec)
 DefaultTimeoutStopUSec=$(systemctl show --value --property=DefaultTimeoutStopUSec)

--- a/tests/kola/systemd/network-online/test.sh
+++ b/tests/kola/systemd/network-online/test.sh
@@ -20,7 +20,8 @@
 
 set -euo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # The fact that we're here means that `systemd-user-sessions.service` was
 # reached and logins work since kola was able to SSH to start us. But let's do

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -8,7 +8,7 @@
 ##   distros: fcos
 ##   # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
 ##   architectures: x86_64 aarch64
-##   description: Make sure that basic toolbox functionality works (creating, 
+##   description: Make sure that basic toolbox functionality works (creating,
 ##     running commands, and removing).
 
 # Important note: Commands are run indirectly via calls to `machinectl shell`

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -19,7 +19,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # Try five times to create the toolbox to avoid Fedora registry infra flakes
 for i in $(seq 1 5); do

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -10,7 +10,8 @@
 
 set -eux -o pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # This test will attempt to test an upgrade from a given starting
 # point (assumed by the caller passing in a specific

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # /var
 

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -10,7 +10,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 fstype=$(findmnt -nvr /var -o FSTYPE)
 if [ $fstype != xfs ]; then

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -3,7 +3,7 @@
 ##   # additionalDisks is only supported on QEMU
 ##   platforms: qemu
 ##   additionalDisks: ["5G:mpath"]
-##   description: Verify udev rules /dev/disk/by-id/scsi-* symlinks exist 
+##   description: Verify udev rules /dev/disk/by-id/scsi-* symlinks exist
 ##     in initramfs.
 
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1990506

--- a/tests/kola/var-mount/simple/test.sh
+++ b/tests/kola/var-mount/simple/test.sh
@@ -7,7 +7,8 @@
 
 set -xeuo pipefail
 
-. $KOLA_EXT_DATA/commonlib.sh
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
 
 # /var
 


### PR DESCRIPTION
test: Disable 'source' ShellCheck warnings

---

test: Remove unneeded whitespace at EOL

---

overlay.d/usr/libexec/coreos-check-modularity: Remove whitespace at EOL

---

ci: Add action to check for whitespace at EOL

While usually harmless, this can create issue in some edge cases and
creates noise when looking at the code in editors that highlight
unneeded whitespace.
