### PR TITLE
Collection of ShellCheck fixes + Make tests/logrotate-service platform independent

### DIFF
--- a/overlay.d/05core/usr/lib/coreos/generator-lib.sh
+++ b/overlay.d/05core/usr/lib/coreos/generator-lib.sh
@@ -8,7 +8,7 @@ UNIT_DIR="${1:-/tmp}"
 
 have_karg() {
     local arg="$1"
-    local cmdline=( $(</proc/cmdline) )
+    IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
     local i
     for i in "${cmdline[@]}"; do
         if [[ "$i" =~ "$arg=" ]]; then
@@ -20,7 +20,7 @@ have_karg() {
 
 karg() {
     local name="$1" value="${2:-}"
-    local cmdline=( $(</proc/cmdline) )
+    IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
     for arg in "${cmdline[@]}"; do
         if [[ "${arg%%=*}" == "${name}" ]]; then
             value="${arg#*=}"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # For a description of how this is used, see `coreos-boot-edit.service`.
 
-cmdline=( $(</proc/cmdline) )
+IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 karg() {
     local name="$1" value="${2:-}"
     for arg in "${cmdline[@]}"; do

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -14,7 +14,7 @@ exec 1>/dev/kmsg; exec 2>&1
 
 UNIT_DIR="${1:-/tmp}"
 
-cmdline=( $(</proc/cmdline) )
+IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 cmdline_arg() {
     local name="$1" value="$2"
     for arg in "${cmdline[@]}"; do

--- a/overlay.d/05core/usr/libexec/coreos-ignition-delete-config
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-delete-config
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cmdline=( $(</proc/cmdline) )
+IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 cmdline_arg() {
     local name="$1" value
     for arg in "${cmdline[@]}"; do

--- a/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
+++ b/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
@@ -23,7 +23,7 @@ if ! cmp {/usr,}/etc/sysconfig/chronyd >/dev/null; then
     exit 0
 fi
 
-cmdline=( $(</proc/cmdline) )
+IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 cmdline_arg() {
     local name="$1" value
     for arg in "${cmdline[@]}"; do

--- a/tests/kola/files/logrotate-service
+++ b/tests/kola/files/logrotate-service
@@ -2,6 +2,7 @@
 ## kola:
 ##   exclusive: false
 ##   description: Verify logrotate and logrotate.timer services are enabled.
+##   tags: "platform-independent"
 
 set -xeuo pipefail
 


### PR DESCRIPTION
tests/logrotate-service: Make platform independent

This should pass on all platforms if it passes on one.

---

tests/kola/data/commonlib.sh: ShellCheck fixes

---

overlay.d/*: ShellCheck fix for /proc/cmdline reading

Fix ShellCheck warning:
```
In ./overlay.d/05core/usr/lib/coreos/generator-lib.sh line 11:
    local cmdline=( $(</proc/cmdline) )
                    ^---------------^ SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
```