### PR TITLE
transposefs: Only autosave-xfs for much larger filesystems

### DIFF
--- a/tests/kola/root-reprovision/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/autosave-xfs/test.sh
@@ -2,8 +2,8 @@
 ## kola:
 ##   # This test reprovisions the rootfs automatically.
 ##   tags: "platform-independent reprovision"
-##   # Trigger automatic XFS reprovisioning
-##   minDisk: 100
+##   # Trigger automatic XFS reprovisioning (heuristic)
+##   minDisk: 1000
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher
@@ -11,6 +11,7 @@
 ##   timeoutMin: 15
 ##   description: Verify the root reprovision with XFS
 ##     on large disk triggers autosaved.
+##     This test is meant to cover ignition-ostree-transposefs-autosave-xfs.service
 
 set -xeuo pipefail
 
@@ -20,10 +21,13 @@ set -xeuo pipefail
 if [ ! -f /run/ignition-ostree-autosaved-xfs.stamp ]; then
     fatal "expected autosaved XFS"
 fi
+# Verify we printed something about the agcount
+journalctl -u ignition-ostree-transposefs-autosave-xfs.service --grep=agcount
 ok "autosaved XFS on large disk"
 
 eval $(xfs_info / | grep -o 'agcount=[0-9]*')
-if [ "$agcount" -gt 4 ]; then
-    fatal "expected agcount of at most 4, got ${agcount}"
+expected=4
+if [ "$agcount" -gt "$expected" ]; then
+    fatal "expected agcount of at most ${expected}, got ${agcount}"
 fi
 ok "low agcount on large disk"

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -10,9 +10,10 @@
 ##   # timeout value than the default.
 ##   timeoutMin: 15
 ##   # Trigger automatic XFS reprovisioning
-##   minDisk: 100
+##   minDisk: 1000
 ##   description: Verify the root reprovision with XFS and TPM
 ##     on large disk triggers autosaved.
+##     This test is meant to cover ignition-ostree-transposefs-autosave-xfs.service
 
 set -xeuo pipefail
 
@@ -27,8 +28,9 @@ if [ -z "${AUTOPKGTEST_REBOOT_MARK:-}" ]; then
     ok "autosaved XFS on large disk"
 
     eval $(xfs_info / | grep -o 'agcount=[0-9]*')
-    if [ "$agcount" -gt 4 ]; then
-        fatal "expected agcount of at most 4, got ${agcount}"
+    expected=4
+    if [ "$agcount" -gt "${expected}" ]; then
+        fatal "expected agcount of at most ${expected}, got ${agcount}"
     fi
     ok "low agcount on large disk"
 fi


### PR DESCRIPTION

The change in https://github.com/coreos/fedora-coreos-config/pull/2320
has been very problematic for OpenShift because our default node
configuration is *always* over the threshold, and that causes
significant latency on instance provisioning.

Experimentally bumping to 400 allocation groups, which is about 700GiB.
This is comfortably about the default OpenShift node root disk sizes,
and returns us to the prior status quo.

While we're here, rework the logging a bit so that we *always*
log the `agcount` for debugging purposes.

---

