### PR TITLE
denylist: snooze `coreos.ignition.ssh.key` on kola-azure

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -83,3 +83,9 @@
     - rawhide
     - branched
     - next-devel
+- pattern: coreos.ignition.ssh.key
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
+  snooze: 2023-09-04
+  warn: true
+  platforms:
+    - azure


### PR DESCRIPTION
This test is failing for all streams on kola-azure. 
Snooze the test, with `warn: true`, for a week while we investigate https://github.com/coreos/fedora-coreos-tracker/issues/1553