### PR TITLE
buildroot: Add clippy

### DIFF
--- a/ci/buildroot/buildroot-reqs.txt
+++ b/ci/buildroot/buildroot-reqs.txt
@@ -25,8 +25,9 @@ util-linux
 which
 xz
 
-# For rust projects like rpm-ostree
+# For rust projects
 rustfmt
+clippy
 
 # For unit tests at least.
 ostree


### PR DESCRIPTION
For the same reason we have `rustfmt`; I plan to rework the ostree-rs-ext build flow to use this there.