### PR TITLE
manifest: Add fwupd for all arches

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -13,16 +13,14 @@ packages:
  - linux-firmware
  # rpm-ostree
  - rpm-ostree nss-altfiles
+ # firmware updates
+ - fwupd
 
 # bootloader
 packages-aarch64:
   - grub2-efi-aa64 efibootmgr shim
-  # firmware updates
-  - fwupd
 packages-ppc64le:
   - grub2 ostree-grub2
-  # firmware updates
-  - fwupd
 packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
@@ -32,8 +30,6 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
-  # firmware updates
-  - fwupd
 
 exclude-packages:
   # Exclude kernel-debug-core to make sure that it doesn't somehow get


### PR DESCRIPTION
 - Add fwupd package for all architecture, eliminating the exclusion for 's390x';
 - Now that we enabled/start 'fwupd' by default in #2562. We should have this package to all arhces.