### PR TITLE
denylist: extend snooze for `ext.config.networking.*` tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,7 +21,7 @@
     - aarch64
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -29,7 +29,7 @@
     - next-devel
 - pattern: ext.config.networking.no-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -37,7 +37,7 @@
     - next-devel
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -45,7 +45,7 @@
     - next-devel
 - pattern: ext.config.networking.ifname-karg.everyboot-systemd-link-file
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -53,7 +53,7 @@
     - next-devel
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -61,7 +61,7 @@
     - next-devel
 - pattern: ext.config.networking.bridge-static-via-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -69,7 +69,7 @@
     - next-devel
 - pattern: ext.config.networking.ifname-karg.udev-rule-firstboot-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide
@@ -77,7 +77,7 @@
     - next-devel
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-08-28
+  snooze: 2023-09-13
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
These tests are still failing. 
Extend the snooze while we wait for a fix on https://github.com/coreos/fedora-coreos-tracker/issues/1542.