### PR TITLE
denylist: deny kdump.crash test on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -89,3 +89,9 @@
   warn: true
   platforms:
     - azure
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1560
+  snooze: 2023-09-30
+  warn: true
+  platforms:
+    - rawhide


### PR DESCRIPTION
Adding `ext.config.kdump.crash` to the denylist as it is failing right now with selinux enabled. 
see https://github.com/coreos/fedora-coreos-tracker/issues/1560