### PR TITLE
denylist: extend and adjust kdump.crash aarch64 denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,10 +15,17 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-08-31
+  snooze: 2023-09-13
   warn: true
   arches:
     - aarch64
+  platforms:
+    - stable
+    - testing
+    - next
+    - testing-devel
+    - next-devel
+    - branched
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-13

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -100,5 +100,5 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1560
   snooze: 2023-09-30
   warn: true
-  platforms:
+  streams:
     - rawhide


### PR DESCRIPTION
The new kexec-tools v2.0.27 is in rawhide now so the problem should be fixed there. Let's extend the snooze some time to see if the new version makes it into the other streams.