### PR TITLE
denylist: fix entry for 1st kdump.crash denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,7 +19,7 @@
   warn: true
   arches:
     - aarch64
-  platforms:
+  streams:
     - stable
     - testing
     - next


### PR DESCRIPTION
rawhide is a stream, not a platform.