### PR TITLE
[stable] manifest-lock*: Revert kernel versions

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -502,16 +502,16 @@
       "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.4.11-200.fc38.aarch64"
+      "evra": "6.4.7-200.fc38.aarch64"
     },
     "kernel-core": {
-      "evra": "6.4.11-200.fc38.aarch64"
+      "evra": "6.4.7-200.fc38.aarch64"
     },
     "kernel-modules": {
-      "evra": "6.4.11-200.fc38.aarch64"
+      "evra": "6.4.7-200.fc38.aarch64"
     },
     "kernel-modules-core": {
-      "evra": "6.4.11-200.fc38.aarch64"
+      "evra": "6.4.7-200.fc38.aarch64"
     },
     "kexec-tools": {
       "evra": "2.0.26-3.fc38.aarch64"

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -493,16 +493,16 @@
       "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.4.11-200.fc38.ppc64le"
+      "evra": "6.3.12-200.fc38.ppc64le"
     },
     "kernel-core": {
-      "evra": "6.4.11-200.fc38.ppc64le"
+      "evra": "6.3.12-200.fc38.ppc64le"
     },
     "kernel-modules": {
-      "evra": "6.4.11-200.fc38.ppc64le"
+      "evra": "6.3.12-200.fc38.ppc64le"
     },
     "kernel-modules-core": {
-      "evra": "6.4.11-200.fc38.ppc64le"
+      "evra": "6.3.12-200.fc38.ppc64le"
     },
     "kexec-tools": {
       "evra": "2.0.26-3.fc38.ppc64le"

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -460,16 +460,16 @@
       "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.4.11-200.fc38.s390x"
+      "evra": "6.4.7-200.fc38.s390x"
     },
     "kernel-core": {
-      "evra": "6.4.11-200.fc38.s390x"
+      "evra": "6.4.7-200.fc38.s390x"
     },
     "kernel-modules": {
-      "evra": "6.4.11-200.fc38.s390x"
+      "evra": "6.4.7-200.fc38.s390x"
     },
     "kernel-modules-core": {
-      "evra": "6.4.11-200.fc38.s390x"
+      "evra": "6.4.7-200.fc38.s390x"
     },
     "kexec-tools": {
       "evra": "2.0.26-3.fc38.s390x"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -508,16 +508,16 @@
       "evra": "2.5.1-5.fc38.noarch"
     },
     "kernel": {
-      "evra": "6.4.11-200.fc38.x86_64"
+      "evra": "6.4.7-200.fc38.x86_64"
     },
     "kernel-core": {
-      "evra": "6.4.11-200.fc38.x86_64"
+      "evra": "6.4.7-200.fc38.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.4.11-200.fc38.x86_64"
+      "evra": "6.4.7-200.fc38.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.4.11-200.fc38.x86_64"
+      "evra": "6.4.7-200.fc38.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.26-3.fc38.x86_64"


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-streams/issues/756#issuecomment-1699870750
See: https://github.com/coreos/fedora-coreos-config/pull/2579