### PR TITLE
workflows: update the normalize denylist in the promotion-diff workflow

### DIFF
--- a/.github/workflows/promotion-diff.yml
+++ b/.github/workflows/promotion-diff.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Normalize kola-denylist.yaml
         run: |
           # When we promote to a production branch we strip out the
-          # snooze lines. Let's do the same here so we don't get warnings.
-          # See https://github.com/coreos/fedora-coreos-releng-automation/pull/165
-          sed -E -i 's/^(\s+)(snooze:\s+.*)/\1# \2 (disabled on promotion)/' origin/kola-denylist.yaml
+          # snooze and warn lines. Let's do the same here so we don't get warnings.
+          # See https://github.com/coreos/fedora-coreos-releng-automation/pull/179
+          sed -E -i 's/^(\s+)((snooze:|warn:)\s+.*)/\1# \2 (disabled on promotion)/' origin/kola-denylist.yaml
       - name: Compare trees
         uses: coreos/actions-lib/check-diff@main
         with:


### PR DESCRIPTION
 - In coreos/fedora-coreos-releng-automation#179 we updated the normalization denylist. Additionally, we are currently excluding the `warn:` comment in the kola denylist, which was recently added. Let's apply the same exclusion here to prevent unwanted warnings."