### PR TITLE
kola secex tests: Increase test timeout to 5min.

### DIFF
--- a/tests/kola/secex/ensure/test.sh
+++ b/tests/kola/secex/ensure/test.sh
@@ -3,7 +3,7 @@
 ##   architectures: s390x
 ##   platforms: qemu
 ##   requiredTag: secex
-##   timeoutMin: 3
+##   timeoutMin: 5
 ##   description: Verify the s390x Secure Execution QEMU image works. It also
 ##     implicitly tests Ignition config decryption.
 

--- a/tests/kola/secex/reboot/test.sh
+++ b/tests/kola/secex/reboot/test.sh
@@ -3,7 +3,7 @@
 ##   architectures: s390x
 ##   platforms: qemu
 ##   requiredTag: secex
-##   timeoutMin: 3
+##   timeoutMin: 5
 ##   description: Verify the qemu-secex image reboots with SE enabled. It also
 ##     implicitly tests Ignition config decryption.
 


### PR DESCRIPTION
We are experiencing test timeouts in the RHCOS Pipeline. Local testing shows that 3min. seems to be around the time needed for the test. Thus increasing the timeout from 3min. to 5min. should prevent future trouble. The secex.ensure test does not timeout, but is on the border with 160s. Increase timeout for it as well to prevent potential problems later.