### PR TITLE
[rhcos-4.13] kola secex tests: Increase test timeout to 5min.

### DIFF
--- a/tests/kola/secex/ensure/test.sh
+++ b/tests/kola/secex/ensure/test.sh
@@ -6,7 +6,11 @@
 ##   architectures: s390x
 ##   platforms: qemu
 ##   requiredTag: secex
-##   timeoutMin: 3
+##   timeoutMin: 5
+##   description: Verify the s390x Secure Execution QEMU image works. It also
+##     implicitly tests Ignition config decryption.
+
+# We don't run it by default because it requires running with `--qemu-secex`.
 
 set -xeuo pipefail
 

--- a/tests/kola/secex/reboot/test.sh
+++ b/tests/kola/secex/reboot/test.sh
@@ -6,7 +6,12 @@
 ##   architectures: s390x
 ##   platforms: qemu
 ##   requiredTag: secex
-##   timeoutMin: 3
+##   timeoutMin: 5
+##   description: Verify the qemu-secex image reboots with SE enabled. It also
+##     implicitly tests Ignition config decryption.
+
+# We don't run it by default because it requires running with
+# `--qemu-secex --qemu-secex-hostkey HKD-<serial>.crt`.
 
 set -xeuo pipefail
 


### PR DESCRIPTION
We are experiencing test timeouts in the RHCOS Pipeline. Local testing shows that 3min. seems to be around the time needed for the test. Thus increasing the timeout from 3min. to 5min. should prevent future trouble. The secex.ensure test does not timeout, but is on the border with 160s. Increase timeout for it as well to prevent potential problems later.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>
(cherry picked from commit 81d97de70f3cdb3f9230c816ff7d33b3841dd964)