### PR TITLE
manifests/system-configuration: Add audit

### DIFF
--- a/manifests/audit.yaml
+++ b/manifests/audit.yaml
@@ -1,0 +1,6 @@
+# https://github.com/coreos/fedora-coreos-tracker/issues/1362
+# Merge with manifests/system-configuration.yaml once Fedora 39 is released to
+# all streams
+packages:
+  # Manage and load rules in the audit subsystem in the kernel
+  - audit

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -51,6 +51,11 @@ conditional-include:
     # Merge with overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
     # once Fedora 39 is released to all streams
     include: enable-fwupd-refresh-timer.yaml
+  - if: releasever >= 39
+    # https://github.com/coreos/fedora-coreos-tracker/issues/1362
+    # Merge with manifests/system-configuration.yaml once Fedora 39 is released
+    # to all streams
+    include: audit.yaml
 
 ostree-layers:
   - overlay/15fcos


### PR DESCRIPTION
manifests/system-configuration: Add audit

Include audit to be able to manage and load rules in the audit subsystem
in the kernel.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1362