### PR TITLE
[next-devel] overrides: fast-track audit-3.1.2-3.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  audit:
+    evr: 3.1.2-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-16fc6e5f21
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
+      type: fast-track
+  audit-libs:
+    evr: 3.1.2-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-16fc6e5f21
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).