### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,30 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  kernel:
-    evr: 6.4.15-200.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-775674d7f1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1555
-      type: fast-track
-  kernel-core:
-    evr: 6.4.15-200.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-775674d7f1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1555
-      type: fast-track
-  kernel-modules:
-    evr: 6.4.15-200.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-775674d7f1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1555
-      type: fast-track
-  kernel-modules-core:
-    evr: 6.4.15-200.fc38
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-775674d7f1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1555
-      type: fast-track
   moby-engine:
     evr: 20.10.23-1.fc38
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).