### PR TITLE
denylist: extend snooze for coreos.ignition.ssh.key

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -92,7 +92,7 @@
     - next-devel
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2023-09-12
+  snooze: 2023-09-27
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
This test is still failing so let's bump the snooze while we work to find a fix for https://github.com/coreos/fedora-coreos-tracker/issues/1553