### PR TITLE
denylist: drop coreos.boot-mirror tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,14 +5,6 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: coreos.boot-mirror.luks
-  tracker: https://github.com/coreos/coreos-assembler/issues/3360
-  arches:
-    - ppc64le
-- pattern: coreos.boot-mirror
-  tracker: https://github.com/coreos/coreos-assembler/issues/3361
-  arches:
-    - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
   snooze: 2023-09-13


### PR DESCRIPTION
These should now be fixed by
https://github.com/coreos/coreos-assembler/pull/3611.