### PR TITLE
denylist: extend snooze for `ext.config.networking.*` tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,7 +28,7 @@
     - branched
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -36,7 +36,7 @@
     - next-devel
 - pattern: ext.config.networking.no-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -44,7 +44,7 @@
     - next-devel
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -52,7 +52,7 @@
     - next-devel
 - pattern: ext.config.networking.ifname-karg.everyboot-systemd-link-file
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -60,7 +60,7 @@
     - next-devel
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -68,7 +68,7 @@
     - next-devel
 - pattern: ext.config.networking.bridge-static-via-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -76,7 +76,7 @@
     - next-devel
 - pattern: ext.config.networking.ifname-karg.udev-rule-firstboot-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide
@@ -84,7 +84,7 @@
     - next-devel
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
Extend the snooze on these tests again while we wait for a fix for https://github.com/coreos/fedora-coreos-tracker/issues/1542