### PR TITLE
[next-devel] overrides: fast-track audit-3.1.2-4.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,15 +10,15 @@
 
 packages:
   audit:
-    evr: 3.1.2-3.fc39
+    evr: 3.1.2-4.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-16fc6e5f21
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-641e1cd18e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
       type: fast-track
   audit-libs:
-    evr: 3.1.2-3.fc39
+    evr: 3.1.2-4.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-16fc6e5f21
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-641e1cd18e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
       type: fast-track
   coreos-installer:


### PR DESCRIPTION
Requested by @travier via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).