### PR TITLE
Revert "Revert "manifests/fedora-coreos: ban initscripts-service""

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -186,6 +186,8 @@ exclude-packages:
   # Let's make sure initscripts doesn't get pulled back in
   # https://github.com/coreos/fedora-coreos-tracker/issues/220#issuecomment-611566254
   - initscripts
+  # nor /usr/sbin/service
+  - initscripts-service
   # For (datacenter/cloud oriented) servers, we want to see the details by default.
   # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HSMISZ3ETWQ4ETVLWZQJ55ARZT27AAV3/
   - plymouth


### PR DESCRIPTION
This reverts commit aa78282b7782fa53fb257f880df415691a235ee6.

Now that https://src.fedoraproject.org/rpms/audit/pull-request/10 is in next-devel and rawhide, we should be good with re-adding this now.