### PR TITLE
[next-devel] overrides: fast-track podman-4.6.2-3.fc39, gvisor-tap-vsock-gvforwarder

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -31,3 +31,21 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-faf8348c34
       type: fast-track
+  podman:
+    evr: 5:4.6.2-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7fe120ca99
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1557#issuecomment-1720041318
+      type: fast-track
+  podman-plugins:
+    evr: 5:4.6.2-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7fe120ca99
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1557#issuecomment-1720041318
+      type: fast-track
+  gvisor-tap-vsock-gvforwarder:
+    evr: 6:0.7.0-6.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7fe120ca99
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1557#issuecomment-1720041318
+      type: fast-track


### PR DESCRIPTION
Includes gvisor-tap-vsock-gvforwarder to fix
https://github.com/coreos/fedora-coreos-tracker/issues/1557

(cherry picked from commit dad0d707f8390650e31f38cc637500e52f91774f)