### PR TITLE
[stable] image.yaml: aws; add old defaults for new fields

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,9 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# see https://github.com/coreos/coreos-assembler/pull/3607
+# Defaults for AWS
+aws-imdsv2-only: false
+aws-volume-type: "gp2"
+aws-x86-boot-mode: "legacy-bios"


### PR DESCRIPTION
see coreos/coreos-assembler#3607

With the above PR, cosa's image-default.yaml adds 3 configuration fields. The defaults provided differ from before. Overide the new configuration fields to maintain old defaults.