### PR TITLE
manifests: Move kernel into separate manifest

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -1,12 +1,11 @@
-# This minimal base starts just from: kernel + systemd + rpm-ostree + bootloader.
+# This minimal base is the userspace: systemd + rpm-ostree + bootloader.
 # The intent of this is to inherit from this if you are doing something highly
 # custom that e.g. might not involve Ignition or podman, but you do want
 # rpm-ostree.
 # We expect most people though using coreos-assembler to inherit from
 # fedora-coreos-base.yaml.
 packages:
- # Kernel + systemd.
- - kernel systemd
+ - systemd
  # linux-firmware now a recommends so let's explicitly include it
  # https://gitlab.com/cki-project/kernel-ark/-/commit/32271d0cd9bd52d386eb35497c4876a8f041f70b
  # https://src.fedoraproject.org/rpms/kernel/c/f55c3e9ed8605ff28cb9a922efbab1055947e213?branch=rawhide

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -3,6 +3,7 @@
 # core functionality.
 
 include:
+  - kernel.yaml
   - system-configuration.yaml
   - ignition-and-ostree.yaml
   - file-transfer.yaml

--- a/manifests/kernel.yaml
+++ b/manifests/kernel.yaml
@@ -1,0 +1,3 @@
+packages:
+  # We use the default kernel package, but note c9s may differ
+  - kernel


### PR DESCRIPTION


This is prep for rebasing on [sagano](https://gitlab.com/cgwalters-playground/sagano)
where I hit on the issue that to build images with `kernel-rt`,
we need to clearly separate the `kernel` package from userspace
stuff (`systemd`, `rpm-ostree`) etc.

Note that we'll need to make the same change in RHCOS - until
we rebase both on sagano.

---

