### PR TITLE
denylist: extend/rework kdump.crash snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,17 +7,14 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-09-13
+  snooze: 2023-09-28
   warn: true
   arches:
     - aarch64
   streams:
     - stable
     - testing
-    - next
     - testing-devel
-    - next-devel
-    - branched
 - pattern: ext.config.networking.nameserver
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -94,3 +91,5 @@
   warn: true
   streams:
     - rawhide
+    - next-devel
+    - next


### PR DESCRIPTION
The kexec-tools 2.0.27 reached F39 so the `#1430` entry can now just be for streams that are based on F38. The `#1560` denial now needs to apply to F39 streams too because the selinux issue still is in play.

Also extend the snooze for the `#1430` denial.