### PR TITLE
denylist: add next stream to denial for networking selinux issue

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,6 +23,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.no-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -31,6 +32,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.prefer-ignition-networking
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -39,6 +41,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.ifname-karg.everyboot-systemd-link-file
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -47,6 +50,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.force-persist-ip
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -55,6 +59,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.bridge-static-via-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -63,6 +68,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.ifname-karg.udev-rule-firstboot-propagation
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -71,6 +77,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: ext.config.networking.mtu-on-bond-kargs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1542
   snooze: 2023-09-28
@@ -79,6 +86,7 @@
     - rawhide
     - branched
     - next-devel
+    - next
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
   snooze: 2023-09-27


### PR DESCRIPTION
Now that we have moved the next stream over to F39 we'll need these denials to apply there too.