### PR TITLE
tests/kola: switch to IMDSV2 for aws.assert-xen test

### DIFF
--- a/tests/kola/platforms/aws/assert-xen
+++ b/tests/kola/platforms/aws/assert-xen
@@ -16,7 +16,8 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-hypervisor=$(curl http://169.254.169.254/2022-09-24/meta-data/system || true)
+token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+hypervisor=$(curl -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/2022-09-24/meta-data/system || true)
 if [ "${hypervisor}" != "xen" ]; then
     fatal "expected xen instance type"
 fi


### PR DESCRIPTION
We switched to IMDSV2 by default in COSA so let's update our call here. https://github.com/coreos/coreos-assembler/pull/3607