### PR TITLE
manifests: name wifi/BT firmware files in packages lists

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -158,6 +158,8 @@ packages:
   - iptables-legacy
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
+  # Wifi/BT firmware files https://github.com/coreos/fedora-coreos-tracker/issues/1575
+  - atheros-firmware brcmfmac-firmware mt7xxx-firmware realtek-firmware
 
 
 # - irqbalance


### PR DESCRIPTION
These were demoted to a recommends in F39 and we're not sure if we want to drop them yet:
https://github.com/coreos/fedora-coreos-tracker/issues/1575