### PR TITLE
[next] manifests: name wifi/BT firmware files in packages lists

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -39,6 +39,9 @@
     "amd-gpu-firmware": {
       "evra": "20230804-153.fc39.noarch"
     },
+    "atheros-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "attr": {
       "evra": "2.5.1-8.fc39.aarch64"
     },
@@ -77,6 +80,9 @@
     },
     "bootupd": {
       "evra": "0.2.9-2.fc39.aarch64"
+    },
+    "brcmfmac-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "bsdtar": {
       "evra": "3.7.1-1.fc39.aarch64"
@@ -894,6 +900,9 @@
     "mpfr": {
       "evra": "4.2.0-3.fc39.aarch64"
     },
+    "mt7xxx-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "nano": {
       "evra": "7.2-4.fc39.aarch64"
     },
@@ -1052,6 +1061,9 @@
     },
     "readline": {
       "evra": "8.2-4.fc39.aarch64"
+    },
+    "realtek-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "rpcbind": {
       "evra": "1.2.6-4.rc2.fc39.1.aarch64"

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -39,6 +39,9 @@
     "amd-gpu-firmware": {
       "evra": "20230804-153.fc39.noarch"
     },
+    "atheros-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "attr": {
       "evra": "2.5.1-8.fc39.ppc64le"
     },
@@ -77,6 +80,9 @@
     },
     "bind-utils": {
       "evra": "32:9.18.17-1.fc39.ppc64le"
+    },
+    "brcmfmac-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "bsdtar": {
       "evra": "3.7.1-1.fc39.ppc64le"
@@ -888,6 +894,9 @@
     "mpfr": {
       "evra": "4.2.0-3.fc39.ppc64le"
     },
+    "mt7xxx-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "nano": {
       "evra": "7.2-4.fc39.ppc64le"
     },
@@ -1055,6 +1064,9 @@
     },
     "readline": {
       "evra": "8.2-4.fc39.ppc64le"
+    },
+    "realtek-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "rpcbind": {
       "evra": "1.2.6-4.rc2.fc39.1.ppc64le"

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -39,6 +39,9 @@
     "amd-gpu-firmware": {
       "evra": "20230804-153.fc39.noarch"
     },
+    "atheros-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "attr": {
       "evra": "2.5.1-8.fc39.s390x"
     },
@@ -74,6 +77,9 @@
     },
     "bind-utils": {
       "evra": "32:9.18.17-1.fc39.s390x"
+    },
+    "brcmfmac-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "bsdtar": {
       "evra": "3.7.1-1.fc39.s390x"
@@ -852,6 +858,9 @@
     "mpfr": {
       "evra": "4.2.0-3.fc39.s390x"
     },
+    "mt7xxx-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "nano": {
       "evra": "7.2-4.fc39.s390x"
     },
@@ -1004,6 +1013,9 @@
     },
     "readline": {
       "evra": "8.2-4.fc39.s390x"
+    },
+    "realtek-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "rpcbind": {
       "evra": "1.2.6-4.rc2.fc39.1.s390x"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -39,6 +39,9 @@
     "amd-gpu-firmware": {
       "evra": "20230804-153.fc39.noarch"
     },
+    "atheros-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "attr": {
       "evra": "2.5.1-8.fc39.x86_64"
     },
@@ -77,6 +80,9 @@
     },
     "bootupd": {
       "evra": "0.2.9-2.fc39.x86_64"
+    },
+    "brcmfmac-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "bsdtar": {
       "evra": "3.7.1-1.fc39.x86_64"
@@ -900,6 +906,9 @@
     "mpfr": {
       "evra": "4.2.0-3.fc39.x86_64"
     },
+    "mt7xxx-firmware": {
+      "evra": "20230804-153.fc39.noarch"
+    },
     "nano": {
       "evra": "7.2-4.fc39.x86_64"
     },
@@ -1055,6 +1064,9 @@
     },
     "readline": {
       "evra": "8.2-4.fc39.x86_64"
+    },
+    "realtek-firmware": {
+      "evra": "20230804-153.fc39.noarch"
     },
     "rpcbind": {
       "evra": "1.2.6-4.rc2.fc39.1.x86_64"

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -158,6 +158,8 @@ packages:
   - iptables-legacy
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
+  # Wifi/BT firmware files https://github.com/coreos/fedora-coreos-tracker/issues/1575
+  - atheros-firmware brcmfmac-firmware mt7xxx-firmware realtek-firmware
 
 
 # - irqbalance


### PR DESCRIPTION
These were demoted to a recommends in F39 and we're not sure if we want to drop them yet:
https://github.com/coreos/fedora-coreos-tracker/issues/1575