### PR TITLE
tests/kola/docker: Add a basic docker run test

### DIFF
--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -1,0 +1,16 @@
+#!/bin/bash
+## kola:
+##   # Must not run this test with another podman test
+##   exclusive: true
+##   # This test pulls a container image from remote sources.
+##   tags: "platform-independent needs-internet"
+##   description: Verify that running a basic container with docker works.
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+docker run --rm registry.fedoraproject.org/fedora:38 true
+
+ok "basic docker run successfully"

--- a/tests/kola/docker/data/commonlib.sh
+++ b/tests/kola/docker/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/1578