### PR TITLE
ci & tests: Switch to quay.io/fedora/fedora

### DIFF
--- a/.github/workflows/add-override.yml
+++ b/.github/workflows/add-override.yml
@@ -37,7 +37,7 @@ jobs:
   add-override:
     name: Add package override
     runs-on: ubuntu-latest
-    container: registry.fedoraproject.org/fedora:latest
+    container: quay.io/fedora/fedora:latest
     steps:
       - name: Install dependencies
         run: dnf install -y git jq python3-bodhi-client python3-pyyaml

--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,6 +5,6 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM registry.fedoraproject.org/fedora:38
+FROM quay.io/fedora/fedora:38
 COPY . /src
 RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -20,7 +20,7 @@ set -xeuo pipefail
 
 case "$(arch)" in
     aarch64|ppc64le|s390x)
-        containerArch=$(podman run --arch=amd64 --rm registry.fedoraproject.org/fedora:38 arch)
+        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:38 arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"
         fi

--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=registry.fedoraproject.org/fedora-minimal
+          Image=quay.io/fedora/fedora-minimal
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -17,7 +17,7 @@ if [[ "$(podman network inspect systemd-test | jq -r '.[0].labels."org.test.Key"
     fatal "Network not correctly created"
 fi
 
-if [[ "$(podman inspect systemd-test | jq -r '.[0].ImageName')" != "registry.fedoraproject.org/fedora-minimal:latest" ]]; then
+if [[ "$(podman inspect systemd-test | jq -r '.[0].ImageName')" != "quay.io/fedora/fedora-minimal:latest" ]]; then
     fatal "Container not using the correct image"
 fi
 

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -11,6 +11,6 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-docker run --rm registry.fedoraproject.org/fedora:38 true
+docker run --rm quay.io/fedora/fedora:38 true
 
 ok "basic docker run successfully"

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,7 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM registry.fedoraproject.org/fedora:38
+FROM quay.io/fedora/fedora:38
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -23,7 +23,7 @@ runascoreuserscript='
 set -euxo pipefail
 
 podman network create testnetwork
-podman run --rm -t --network=testnetwork registry.fedoraproject.org/fedora:38 getent hosts google.com
+podman run --rm -t --network=testnetwork quay.io/fedora/fedora:38 getent hosts google.com
 podman network rm testnetwork
 '
 

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -20,7 +20,7 @@ set -xeuo pipefail
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --net=pasta:--mtu,1500 registry.fedoraproject.org/fedora:38 bash <<"EOF"
+podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:38 bash <<"EOF"
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,7 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM registry.fedoraproject.org/fedora:38
+FROM quay.io/fedora/fedora:38
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged registry.fedoraproject.org/fedora:38 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora:38 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"

--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -22,7 +22,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-# Try five times to create the toolbox to avoid Fedora registry infra flakes
+# Try five times to create the toolbox to avoid container registry infra flakes
 for i in $(seq 1 5); do
     machinectl shell core@ /bin/toolbox create --assumeyes 1>/dev/null
     if [[ $(machinectl shell core@ /bin/toolbox list --containers | grep --count fedora-toolbox-) -ne 1 ]]; then


### PR DESCRIPTION
Fedora is planning on deprecating the registry and moving to quay.io for
all containers.

Existing containers are mirrors to quay.io so we should be able to
switch now.

See: https://discussion.fedoraproject.org/t/registry-fedoraproject-org-to-quay-io-migration/88231
See: https://pagure.io/fedora-infrastructure/issue/10386