### PR TITLE
[next] overrides: pin containerd-1.6.19-1.fc39, add docker test

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,6 +21,11 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-641e1cd18e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
       type: fast-track
+  containerd:
+    evr: 1.6.19-1.fc39
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
+      type: pin
   coreos-installer:
     evr: 0.18.0-1.fc39
     metadata:

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -1,0 +1,16 @@
+#!/bin/bash
+## kola:
+##   # Must not run this test with another podman test
+##   exclusive: true
+##   # This test pulls a container image from remote sources.
+##   tags: "platform-independent needs-internet"
+##   description: Verify that running a basic container with docker works.
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+docker run --rm registry.fedoraproject.org/fedora:38 true
+
+ok "basic docker run successfully"

--- a/tests/kola/docker/data/commonlib.sh
+++ b/tests/kola/docker/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh


### PR DESCRIPTION
Pin to workaround https://github.com/coreos/fedora-coreos-tracker/issues/1578

Will be part of https://github.com/coreos/fedora-coreos-streams/issues/774