### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,33 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  audit:
-    evr: 3.1.2-4.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-641e1cd18e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
-      type: fast-track
-  audit-libs:
-    evr: 3.1.2-4.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-641e1cd18e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1362
-      type: fast-track
   containerd:
     evr: 1.6.19-1.fc39
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
-  coreos-installer:
-    evr: 0.18.0-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-faf8348c34
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.18.0-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-faf8348c34
-      type: fast-track
   gvisor-tap-vsock-gvforwarder:
     evr: 6:0.7.0-6.fc39
     metadata:
@@ -53,16 +31,4 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7fe120ca99
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1557#issuecomment-1720041318
-      type: fast-track
-  selinux-policy:
-    evra: 38.28-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-22190b6562
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1542
-      type: fast-track
-  selinux-policy-targeted:
-    evra: 38.28-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-22190b6562
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1542
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).