### PR TITLE
denylist: snooze ext.config.docker.basic on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -29,3 +29,9 @@
     - rawhide
     - next-devel
     - next
+- pattern: ext.config.docker.basic
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1578
+  snooze: 2023-10-13
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
This test is failing on rawhide.
Snooze the test, with `warn: true` for three weeks until resolving https://github.com/coreos/fedora-coreos-tracker/issues/1578