### PR TITLE
denylist: drop ext.config.kdump.crash test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,14 +21,6 @@
   warn: true
   platforms:
     - azure
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1560
-  snooze: 2023-09-30
-  warn: true
-  streams:
-    - rawhide
-    - next-devel
-    - next
 - pattern: ext.config.docker.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1578
   snooze: 2023-10-13


### PR DESCRIPTION
ext.config.kdump.crash test can be dropped from the denylist for as the new selinux-policy-38.28-1 pkg has landed in F39 and rawhide.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1560