### PR TITLE
denylist: bump snooze for `ext.config.kdump.crash` on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-09-28
+  snooze: 2023-10-24
   warn: true
   arches:
     - aarch64


### PR DESCRIPTION
This test is still failing.