### PR TITLE
[next-devel] overrides: bump containerd override to 1.6.19-2.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,7 @@
 
 packages:
   containerd:
-    evr: 1.6.19-1.fc39
+    evr: 1.6.19-2.fc39
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin


### PR DESCRIPTION
I didn't see 1.6.19-2.fc39 when I originally did the pin because it wasn't ever a bodhi update (it was part of the mass rebuild). Let's bump to -2 because that was the one done as part of the F39 mass rebuild.