### PR TITLE
05core/dracut: enable `iscsi` module

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
@@ -3,8 +3,8 @@
 # in /var/ and then ignition can't cleanly unmount it. For example:
 # https://github.com/dracutdevs/dracut/blob/1856ae95c873a6fe855b3dccd0144f1a96b9e71c/modules.d/95nfs/nfs-start-rpc.sh#L7
 # See also discussion in https://github.com/coreos/fedora-coreos-config/pull/60
-# Further, we currently do not use LVM, iSCSI or dmraid
-omit_dracutmodules+=" nfs lvm iscsi dmraid "
+# Further, we currently do not use LVM or dmraid
+omit_dracutmodules+=" nfs lvm dmraid "
 # More storage modules we don't use
 omit_dracutmodules+=" fcoe fcoe-uefi nbd "
 # We use NetworkManager

--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -27,6 +27,12 @@ required_initrd_files=(
     "/usr/lib/udev/google_nvme_id"
 )
 
+required_initrd_kmods=(
+    # iSCSI iBFT kernel module
+    # https://issues.redhat.com/browse/OCPBUGS-19811
+    "iscsi_ibft"
+)
+
 tmpd=$(mktemp -d)
 cleanup() {
     rm -r "${tmpd}"
@@ -37,6 +43,13 @@ trap cleanup EXIT
 for file in "${required_initrd_files[@]}"; do
     if [ ! -e "${tmpd}/${file}" ]; then
         fatal "${file} was not found in initrd"
+    fi
+done
+
+for kmod in "${required_initrd_kmods[@]}"; do
+    found=$(find "${tmpd}/usr/lib/modules/$(uname -r)" -name "${kmod}.ko*")
+    if [ -z "${found}" ]; then
+        fatal "kernel module ${kmod} was not found in initrd"
     fi
 done
 


### PR DESCRIPTION
In 9997df7b ("Move from `initramfs-args` in manifest to `dracut.conf.d` files"), we migrated FCOS to use dracut dropins rather than CLI args. One notable semantic change was that these dropins were also now inherited by RHCOS.

One of the migrated directives was omitting the `iscsi` module. But RHCOS OTOH has always included the `iscsi` dracut module, using `--add iscsi`. This apparent conflict was noted in a comment and deemed safe[[1]]. And in fact, it *did* seem to work at the time, but only because there was a bug in dracut: RHCOS happened to define some `--omit` arguments as well and the bug made it so that the CLI arguments overrode the inherited `omit_dracutmodules` dropin directives rather than being added to them.[[2]]

The presence of this bug meant that `--add iscsi` still worked. However, in RHEL9, the bug was fixed[[3]], which meant that we now stopped pulling in the `iscsi` module since it's listed in the set of modules to omit (`--add` arguments cannot undo earlier `--omit`/ `omit_dracutmodules` arguments).

The minimal fix needed here is to stop omitting the `iscsi` module. This fixes https://issues.redhat.com/browse/OCPBUGS-19811, where some users had already taken a dep on iSCSI iBFT support for autoconfiguration. It also aligns with efforts to support root-on-iSCSI in the near future, and there's no reason to not have that work happen in FCOS too.

A related larger task is to stop using `initramfs-args` in RHCOS since it's now deprecated.[[4]]

[1]: https://github.com/coreos/fedora-coreos-config/pull/1828#discussion_r918220313
[2]: https://github.com/dracutdevs/dracut/issues/1341
[3]: https://github.com/dracutdevs/dracut/pull/1342
[4]: https://github.com/coreos/rpm-ostree/pull/3834