### PR TITLE
overlay/dracut: omit ifcfg module

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf
@@ -9,6 +9,9 @@ omit_dracutmodules+=" nfs lvm iscsi dmraid "
 omit_dracutmodules+=" fcoe fcoe-uefi nbd "
 # We use NetworkManager
 omit_dracutmodules+=" systemd-networkd network-legacy network-wicked "
+# We only want to propagate NM keyfiles.
+# See also https://github.com/dracutdevs/dracut/pull/2529.
+omit_dracutmodules+=" ifcfg "
 # We use systemd network naming
 omit_dracutmodules+=" biosdevname "
 # Random stuff we don't want


### PR DESCRIPTION
It's been a while since we've moved to only propagating NM keyfiles from the initrd to the real root, so we no longer need this module.

It currently still gets pulled in due to the `/etc/sysconfig/network- scripts` directory existing in the real root (which contains a README by default).

There's a patch upstream to make it purely opt-in[[1]], but for now let's just explicitly opt out ourselves.

(Note this has no impact on whether ifcfg in the real root is supported, which it still is in RHCOS. It just stops uselessly generating ifcfg files in the initrd.)

[1]: https://github.com/dracutdevs/dracut/pull/2529