### PR TITLE
denylist: snooze `kdump.crash` for ppc64le in rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,3 +27,11 @@
   warn: true
   streams:
     - rawhide
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1588
+  snooze: 2023-10-24
+  warn: true
+  arches:
+    - ppc64le
+  streams:
+    - rawhide


### PR DESCRIPTION
Ref issue: https://github.com/coreos/fedora-coreos-tracker/issues/1588