### PR TITLE
kola/expected-contents: only check for `iscsi_ibft` on supported arches

### DIFF
--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -27,11 +27,13 @@ required_initrd_files=(
     "/usr/lib/udev/google_nvme_id"
 )
 
-required_initrd_kmods=(
+required_initrd_kmods=()
+
+if grep CONFIG_ISCSI_IBFT=m "/usr/lib/modules/$(uname -r)/config"; then
     # iSCSI iBFT kernel module
     # https://issues.redhat.com/browse/OCPBUGS-19811
-    "iscsi_ibft"
-)
+    required_initrd_kmods+=("iscsi_ibft")
+fi
 
 tmpd=$(mktemp -d)
 cleanup() {


### PR DESCRIPTION
The module is currently only built on x86_64. It looks like support for aarch64 is possible but just not enabled, so just grep for the config knob.

Fixes bc9ce579 ("05core/dracut: enable `iscsi` module").