### PR TITLE
manifests: add crun-wasm.yaml

### DIFF
--- a/manifests/crun-wasm.yaml
+++ b/manifests/crun-wasm.yaml
@@ -1,0 +1,4 @@
+# for podman experimentation:
+# https://github.com/coreos/fedora-coreos-tracker/issues/1375
+packages:
+  - crun-wasm wasmedge-rt


### PR DESCRIPTION
This will be sourced by `next-devel` and `next` as part of https://github.com/coreos/fedora-coreos-tracker/issues/1375.