### PR TITLE
[next-devel] manifest: include crun-wasm and wasmedge-rt

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -189,6 +189,9 @@
     "crun": {
       "evra": "1.9-1.fc39.aarch64"
     },
+    "crun-wasm": {
+      "evra": "1.9-1.fc39.aarch64"
+    },
     "crypto-policies": {
       "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
@@ -326,6 +329,9 @@
     },
     "flatpak-session-helper": {
       "evra": "1.15.4-3.fc39.aarch64"
+    },
+    "fmt": {
+      "evra": "10.0.0-3.fc39.aarch64"
     },
     "fstrm": {
       "evra": "0.6.1-8.fc39.aarch64"
@@ -1149,6 +1155,9 @@
     "socat": {
       "evra": "1.7.4.4-3.fc39.aarch64"
     },
+    "spdlog": {
+      "evra": "1.12.0-2.fc39.aarch64"
+    },
     "sqlite-libs": {
       "evra": "3.42.0-7.fc39.aarch64"
     },
@@ -1241,6 +1250,9 @@
     },
     "vim-minimal": {
       "evra": "2:9.0.1927-1.fc39.aarch64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.3-1.fc39.aarch64"
     },
     "which": {
       "evra": "2.21-40.fc39.aarch64"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -189,6 +189,9 @@
     "crun": {
       "evra": "1.9-1.fc39.x86_64"
     },
+    "crun-wasm": {
+      "evra": "1.9-1.fc39.x86_64"
+    },
     "crypto-policies": {
       "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
@@ -326,6 +329,9 @@
     },
     "flatpak-session-helper": {
       "evra": "1.15.4-3.fc39.x86_64"
+    },
+    "fmt": {
+      "evra": "10.0.0-3.fc39.x86_64"
     },
     "fstrm": {
       "evra": "0.6.1-8.fc39.x86_64"
@@ -1152,6 +1158,9 @@
     "socat": {
       "evra": "1.7.4.4-3.fc39.x86_64"
     },
+    "spdlog": {
+      "evra": "1.12.0-2.fc39.x86_64"
+    },
     "sqlite-libs": {
       "evra": "3.42.0-7.fc39.x86_64"
     },
@@ -1244,6 +1253,9 @@
     },
     "vim-minimal": {
       "evra": "2:9.0.1927-1.fc39.x86_64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.3-1.fc39.x86_64"
     },
     "which": {
       "evra": "2.21-40.fc39.x86_64"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,3 +13,11 @@ repos:
   - fedora-next-updates
 
 include: manifests/fedora-coreos.yaml
+
+conditional-include:
+  # we only want these in next for now; see
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1375
+  - if: basearch == "x86_64"
+    include: manifests/crun-wasm.yaml
+  - if: basearch == "aarch64"
+    include: manifests/crun-wasm.yaml


### PR DESCRIPTION
We want to ship this in `next` for now to allow podman machines to make use of it. We may either promote it to all streams (if there are more people asking for it) or remove it at some point in the future (once podman machines move to a layering model).

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1375