### PR TITLE
[next-devel] overrides: fast-track glibc-2.38-6.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,27 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
+  glibc:
+    evr: 2.38-6.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
+      type: fast-track
+  glibc-common:
+    evr: 2.38-6.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
+      type: fast-track
+  glibc-gconv-extra:
+    evr: 2.38-6.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
+      type: fast-track
+  glibc-minimal-langpack:
+    evr: 2.38-6.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
+      type: fast-track


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/1591