### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,27 +14,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
-  glibc:
-    evr: 2.38-6.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
-      type: fast-track
-  glibc-common:
-    evr: 2.38-6.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
-      type: fast-track
-  glibc-gconv-extra:
-    evr: 2.38-6.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
-      type: fast-track
-  glibc-minimal-langpack:
-    evr: 2.38-6.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-63e5a77522
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1591
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).