### PR TITLE
[next-devel] overrides: fast-track curl-8.2.1-3.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -38,6 +38,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  curl:
+    evr: 8.2.1-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
+      type: fast-track
+  libcurl-minimal:
+    evr: 8.2.1-3.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
+      type: fast-track
   skopeo:
     evr: 1:1.13.3-1.fc39
     metadata:


### PR DESCRIPTION
Requested by @travier via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).