### PR TITLE
denylist: extend expired snoozes for two kola tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,13 +17,13 @@
     - testing-devel
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2023-10-13
+  snooze: 2023-10-31
   warn: true
   platforms:
     - azure
 - pattern: ext.config.docker.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1578
-  snooze: 2023-10-13
+  snooze: 2023-10-31
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
These tests are still failing, so let's extend the snooze on them while we wait for a fix.

- `coreos.ignition.ssh.key`
    -  https://github.com/coreos/fedora-coreos-tracker/issues/1553
- `ext.config.docker.basic`
    -   https://github.com/coreos/fedora-coreos-tracker/issues/1578