### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -15,3 +15,45 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  grub2-common:
+    evra: 1:2.06-104.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  grub2-efi-aa64:
+    evra: 1:2.06-104.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.06-104.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.06-104.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libatomic:
+    evra: 13.2.1-4.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libgcc:
+    evra: 13.2.1-4.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libstdc++:
+    evra: 13.2.1-4.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -9,56 +9,50 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  crun-wasm:
-    evra: 1.9.2-1.fc39.x86_64
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
   grub2-common:
     evra: 1:2.06-104.fc39.noarch
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
-  grub2-efi-x64:
-    evra: 1:2.06-104.fc39.x86_64
+  grub2-ppc64le:
+    evra: 1:2.06-104.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
-  grub2-pc:
-    evra: 1:2.06-104.fc39.x86_64
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  grub2-pc-modules:
-    evra: 1:2.06-104.fc39.noarch
+  grub2-ppc64le-modules:
+    evra: 1:2.06-104.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   grub2-tools:
-    evra: 1:2.06-104.fc39.x86_64
+    evra: 1:2.06-104.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   grub2-tools-minimal:
-    evra: 1:2.06-104.fc39.x86_64
+    evra: 1:2.06-104.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f46483e5b5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  libatomic:
+    evra: 13.2.1-4.fc39.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
   libgcc:
-    evra: 13.2.1-4.fc39.x86_64
+    evra: 13.2.1-4.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   libstdc++:
-    evra: 13.2.1-4.fc39.x86_64
+    evra: 13.2.1-4.fc39.ppc64le
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,30 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+
+packages:
+  libatomic:
+    evra: 13.2.1-4.fc39.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libgcc:
+    evra: 13.2.1-4.fc39.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libstdc++:
+    evra: 13.2.1-4.fc39.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1c6c5ebe1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -44,15 +44,99 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
       type: fast-track
+  fwupd:
+    evr: 1.9.6-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e629516951
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  google-compute-engine-guest-configs-udev:
+    evra: 20230929.00-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-4e6f9b9b1a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
   libcurl-minimal:
     evr: 8.2.1-3.fc39
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
       type: fast-track
+  libnet:
+    evr: 1.3-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bd2629d771
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  libsolv:
+    evr: 0.7.25-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-741a85e537
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  netavark:
+    evr: 1.8.0-2.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-45ddc00341
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  passt:
+    evr: 0^20231004.gf851084-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d7f3eb64c1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  passt-selinux:
+    evra: 0^20231004.gf851084-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d7f3eb64c1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  rpm-ostree:
+    evr: 2023.8-2.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2628cc885c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2023.8-2.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2628cc885c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  selinux-policy:
+    evra: 38.29-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a2cd3807b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 38.29-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-a2cd3807b5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
   skopeo:
     evr: 1:1.13.3-1.fc39
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-35b56210f0
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  vim-data:
+    evra: 2:9.0.1984-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3f5484c774
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  vim-minimal:
+    evr: 2:9.0.1984-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3f5484c774
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  zchunk-libs:
+    evr: 1.3.2-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-14ee3e26c2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track


### PR DESCRIPTION
F39 is now in final freeze. This means some packages in F38 will sort as newer than packages in F39. We'll prevent downgrades by fast-tracking any packages that would violoate this "no downgrade" rule.

Today they are: aardvark-dns, fwupd, google-compute-engine-guest-configs, grub2, gvisor-tap-vsock, gcc, libnet, libsolv, netavark, passt, rpm-ostree, selinux-policy, vim, zchunk.