### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -38,12 +38,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
-  curl:
-    evr: 8.2.1-3.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
-      type: fast-track
   fwupd:
     evr: 1.9.6-1.fc39
     metadata:
@@ -61,12 +55,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-817ed9e906
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  libcurl-minimal:
-    evr: 8.2.1-3.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0f8d1871d8
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1593
       type: fast-track
   libnet:
     evr: 1.3-1.fc39


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).