### PR TITLE
core/dracut/ignition-ostree: add `ignition-ostree-sysusers.service`

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Needed to work around the initrd `rootfs` / filesystem not being a valid
+# mount to pivot out of. For reference, see:
+#  - https://github.com/torvalds/linux/blob/26bc672134241a080a83b2ab9aa8abede8d30e1c/fs/namespace.c#L3605
+#  - https://gist.github.com/jlebon/fb6e7c6dcc3ce17d3e2a86f5938ec033
+set -euo pipefail
+
+TMP_CHROOT_DIR=""
+
+main() {
+    setup_chroot_tmpdir
+    run_chrooted_bwrap "$@"
+}
+
+setup_chroot_tmpdir() {
+    TMP_CHROOT_DIR=$(mktemp --directory --tmpdir=/mnt '.coreos-sysroot-bwrap.tmp.XXXXXXXXXX')
+    mount --bind / "${TMP_CHROOT_DIR}"
+    mount --make-private "${TMP_CHROOT_DIR}"
+    mount --bind "${TMP_CHROOT_DIR}" "${TMP_CHROOT_DIR}"
+    for mnt in proc sys dev; do
+      mount --bind /$mnt "${TMP_CHROOT_DIR}"/$mnt
+    done
+    touch "${TMP_CHROOT_DIR}"/run/ostree-booted
+    mount --bind /sysroot "${TMP_CHROOT_DIR}"/sysroot
+}
+
+run_chrooted_bwrap() {
+    chroot "${TMP_CHROOT_DIR}" \
+        /usr/bin/env --chdir /sysroot \
+            bwrap \
+            --unshare-pid --unshare-uts --unshare-ipc --unshare-net \
+            --unshare-cgroup-try --dev /dev --proc /proc --chdir / \
+            --ro-bind usr /usr --bind etc /etc --dir /tmp --tmpfs /var/tmp \
+            --tmpfs /run --ro-bind /run/ostree-booted /run/ostree-booted \
+            --symlink usr/lib /lib \
+            --symlink usr/lib64 /lib64 \
+            --symlink usr/bin /bin \
+            --symlink usr/sbin /sbin -- "$@"
+}
+
+cleanup() {
+  if test -z "${TMP_CHROOT_DIR}"; then
+    return
+  fi
+
+  umount --lazy --recursive "${TMP_CHROOT_DIR}"
+  umount --recursive "${TMP_CHROOT_DIR}"
+  rmdir "${TMP_CHROOT_DIR}"
+}
+
+trap cleanup EXIT
+main "$@"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/coreos-sysroot-bwrap
@@ -46,7 +46,7 @@ cleanup() {
 
   umount --lazy --recursive "${TMP_CHROOT_DIR}"
   umount --recursive "${TMP_CHROOT_DIR}"
-  rmdir "${TMP_CHROOT_DIR}"
+  rm --dir "${TMP_CHROOT_DIR}"
 }
 
 trap cleanup EXIT

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run systemd-sysusers for the target OSTree sysroot.
+
+set -euo pipefail
+
+main() {
+    coreos-sysroot-bwrap systemd-sysusers
+    coreos-relabel \
+        /etc/group \
+        /etc/group- \
+        /etc/gshadow \
+        /etc/gshadow- \
+        /etc/passwd \
+        /etc/passwd- \
+        /etc/shadow \
+        /etc/shadow-
+}
+
+main "$@"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Populate OSTree sysusers
+DefaultDependencies=false
+ConditionKernelCommandLine=|ostree
+
+# Need to do this with all mount points active
+After=ignition-mount.service
+
+# But *before* we start dumping files in there
+Before=ignition-files.service
+Before=ignition-ostree-populate-var.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+ExecStart=/usr/sbin/ignition-ostree-sysusers

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-sysusers.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Populate OSTree sysusers
+Description=Ignition OSTree: Create System Users
 DefaultDependencies=false
 ConditionKernelCommandLine=|ostree
 

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -75,6 +75,10 @@ install() {
         sgdisk    \
         find
 
+    inst_script "$moddir/ignition-ostree-sysusers" \
+        "/usr/sbin/ignition-ostree-sysusers"
+    install_ignition_unit ignition-ostree-sysusers.service
+
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service
         inst_script "$moddir/ignition-ostree-${x}-var.sh" "/usr/sbin/ignition-ostree-${x}-var"

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -22,7 +22,9 @@ installkernel() {
 
 install() {
     inst_multiple \
+        bwrap \
         realpath \
+        rmdir \
         setfiles \
         chcon \
         systemd-sysusers \
@@ -107,4 +109,5 @@ install() {
         /usr/libexec/ignition-ostree-mount-state-overlays
 
     inst_script "$moddir/coreos-relabel" /usr/bin/coreos-relabel
+    inst_script "$moddir/coreos-sysroot-bwrap" /usr/bin/coreos-sysroot-bwrap
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -22,9 +22,9 @@ installkernel() {
 
 install() {
     inst_multiple \
+        chroot \
         bwrap \
         realpath \
-        rmdir \
         setfiles \
         chcon \
         systemd-sysusers \


### PR DESCRIPTION
Based on https://github.com/coreos/fedora-coreos-config/pull/774.

Copy text here:
This introduces a new `ignition-ostree-sysusers.service`, which takes
care of poulating users and groups on the target sysroot before the
`Ignition` files stage.