### PR TITLE
[next-devel] overrides: fast-track rust-zincati-0.0.26-2.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -164,3 +164,8 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-14ee3e26c2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  zincati:
+    evr: 0.0.26-2.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-586e8dc477
+      type: fast-track


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).