### PR TITLE
[rawhide] overrides: pin kexec-tools-2.0.27-1.fc40 on ppc64le only

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  kexec-tools:
+    evr: 2.0.27-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/1598
+      type: pin


### PR DESCRIPTION
Recent rawhide ppc64le builds have been failing with a newer version of kexec-tools. 
Let's pin on kexec-tools-2.0.27-1.fc40 until we can find a fix for: https://github.com/coreos/fedora-coreos-tracker/issues/1598