### PR TITLE
tests/kernel-replace: extend timeout to 20m

### DIFF
--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   # Increase timeout since this test has a lot of I/O and involves rebasing
-##   timeoutMin: 15
+##   timeoutMin: 20
 ##   # We've seen some OOM when 1024M is used:
 ##   # https://github.com/coreos/fedora-coreos-tracker/issues/1506
 ##   minMemory: 2048


### PR DESCRIPTION
We've seen this test timing out our ppc64le builder often lately. It seems the heavy I/O for this test is causing that builder to take longer and judging from the logs it looks like it is just getting to the override of the kernel and is in the middle of the transaction when it times out. Let't bump it to 20m.