### PR TITLE
denylist: extend snoozes for `kdump.crash`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1430
-  snooze: 2023-10-24
+  snooze: 2023-11-15
   warn: true
   arches:
     - aarch64
@@ -29,7 +29,7 @@
     - rawhide
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1588
-  snooze: 2023-10-24
+  snooze: 2023-11-15
   warn: true
   arches:
     - ppc64le


### PR DESCRIPTION
For rawhide ppc64le failure, we don't have a fixed kernel yet. For the aarch64 selinux failure, it's been fixed in kexec-tools 2.0.27 which is now in F39. Will remove this once the prod streams have moved to F39