### PR TITLE
manifests: include wasm packages in fedora-coreos-base manifest

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -183,6 +183,9 @@
     "crun": {
       "evra": "1.10-1.fc38.aarch64"
     },
+    "crun-wasm": {
+      "evra": "1.10-1.fc38.aarch64"
+    },
     "crypto-policies": {
       "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
@@ -323,6 +326,9 @@
     },
     "flatpak-session-helper": {
       "evra": "1.15.4-1.fc38.aarch64"
+    },
+    "fmt": {
+      "evra": "9.1.0-2.fc38.aarch64"
     },
     "fstrm": {
       "evra": "0.6.1-6.fc38.aarch64"
@@ -1149,6 +1155,9 @@
     "socat": {
       "evra": "1.7.4.4-2.fc38.aarch64"
     },
+    "spdlog": {
+      "evra": "1.11.0-5.fc38.aarch64"
+    },
     "sqlite-libs": {
       "evra": "3.40.1-2.fc38.aarch64"
     },
@@ -1241,6 +1250,9 @@
     },
     "vim-minimal": {
       "evra": "2:9.0.2048-1.fc38.aarch64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.4-2.fc38.aarch64"
     },
     "which": {
       "evra": "2.21-39.fc38.aarch64"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -183,6 +183,9 @@
     "crun": {
       "evra": "1.10-1.fc38.x86_64"
     },
+    "crun-wasm": {
+      "evra": "1.10-1.fc38.x86_64"
+    },
     "crypto-policies": {
       "evra": "20230301-1.gita12f7b2.fc38.noarch"
     },
@@ -323,6 +326,9 @@
     },
     "flatpak-session-helper": {
       "evra": "1.15.4-1.fc38.x86_64"
+    },
+    "fmt": {
+      "evra": "9.1.0-2.fc38.x86_64"
     },
     "fstrm": {
       "evra": "0.6.1-6.fc38.x86_64"
@@ -1152,6 +1158,9 @@
     "socat": {
       "evra": "1.7.4.4-2.fc38.x86_64"
     },
+    "spdlog": {
+      "evra": "1.11.0-5.fc38.x86_64"
+    },
     "sqlite-libs": {
       "evra": "3.40.1-2.fc38.x86_64"
     },
@@ -1244,6 +1253,9 @@
     },
     "vim-minimal": {
       "evra": "2:9.0.2048-1.fc38.x86_64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.4-2.fc38.x86_64"
     },
     "which": {
       "evra": "2.21-39.fc38.x86_64"

--- a/manifests/crun-wasm.yaml
+++ b/manifests/crun-wasm.yaml
@@ -1,4 +1,0 @@
-# for podman experimentation:
-# https://github.com/coreos/fedora-coreos-tracker/issues/1375
-packages:
-  - crun-wasm wasmedge-rt

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -173,14 +173,16 @@ packages:
 #   - Include this on non-x86_64 FCOS images to allow access to the large
 #     inventory of containers only built for x86_64.
 #     https://github.com/coreos/fedora-coreos-tracker/issues/1237
-#
 # - google-compute-engine-guest-configs-udev
 #   - Add this package on x86_64 and aarch64 (the two architectures
 #     GCP supports. https://github.com/coreos/fedora-coreos-tracker/issues/1494
 #     This should be moved to a shared manifest when RHEL has this package.
+# - crun-wasm wasmedge-rt
+#   - Support for wasm runtime: https://github.com/coreos/fedora-coreos-tracker/issues/1375
 packages-x86_64:
   - irqbalance
   - google-compute-engine-guest-configs-udev
+  - crun-wasm wasmedge-rt
 packages-ppc64le:
   - irqbalance
   - librtas
@@ -191,6 +193,7 @@ packages-aarch64:
   - irqbalance
   - qemu-user-static-x86
   - google-compute-engine-guest-configs-udev
+  - crun-wasm wasmedge-rt
 packages-s390x:
   - qemu-user-static-x86
 


### PR DESCRIPTION
It's a bit confusing to folks that this didn't make it into the testing and stable streams [1]. Let's just include them everywhere like we agreed to originally.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1375#issuecomment-1750114083