### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -92,12 +92,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bd2629d771
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
-  libnvme:
-    evr: 1.6-2.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b4ed0a0db1
-      reason: https://pagure.io/releng/issue/11742#comment-880608
-      type: fast-track
   libsolv:
     evr: 0.7.25-1.fc39
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).