### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,9 +10,9 @@
 
 packages:
   crun-wasm:
-    evra: 1.9.2-1.fc39.aarch64
+    evra: 1.11-1.fc39.aarch64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0a1f1f38a9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   grub2-common:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -10,9 +10,9 @@
 
 packages:
   crun-wasm:
-    evra: 1.9.2-1.fc39.x86_64
+    evra: 1.11-1.fc39.x86_64
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0a1f1f38a9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   grub2-common:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -33,15 +33,21 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b4acb0f7c6
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  container-selinux:
+    evra: 2:2.224.0-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b1dc756a08
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
   containerd:
     evr: 1.6.19-2.fc39
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
   crun:
-    evr: 1.9.2-1.fc39
+    evr: 1.11-1.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3e03106a9e
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0a1f1f38a9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   fwupd:
@@ -63,27 +69,27 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   kernel:
-    evr: 6.5.7-300.fc39
+    evr: 6.5.9-300.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3747088120
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   kernel-core:
-    evr: 6.5.7-300.fc39
+    evr: 6.5.9-300.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3747088120
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   kernel-modules:
-    evr: 6.5.7-300.fc39
+    evr: 6.5.9-300.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3747088120
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   kernel-modules-core:
-    evr: 6.5.7-300.fc39
+    evr: 6.5.9-300.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3747088120
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   libnet:
@@ -102,6 +108,12 @@ packages:
     evr: 1.8.0-2.fc39
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-45ddc00341
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  oniguruma:
+    evr: 6.9.9-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2060e8fdb9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   passt:
@@ -146,16 +158,22 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-35b56210f0
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
-  vim-data:
-    evra: 2:9.0.1984-1.fc39.noarch
+  slirp4netns:
+    evr: 1.2.2-1.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3f5484c774
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3b0f23654b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
+      type: fast-track
+  vim-data:
+    evra: 2:9.0.2048-1.fc39.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1976197889
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   vim-minimal:
-    evr: 2:9.0.1984-1.fc39
+    evr: 2:9.0.2048-1.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3f5484c774
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1976197889
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   zchunk-libs:


### PR DESCRIPTION
F39 is now in final freeze. This means some packages in F38 will sort as newer than packages in F39. We'll prevent downgrades by fast-tracking any packages that would violoate this "no downgrade" rule.

Today they are: container-selinux, crun, kernel, oniguruma, selinux-policy, slirp4netns, vim

```
Downgraded:
  container-selinux 2:2.224.0-1.fc38 -> 2:2.222.0-1.fc39
  crun 1.10-1.fc38 -> 1.9.2-1.fc39
  kernel 6.5.8-200.fc38 -> 6.5.7-300.fc39
  kernel-core 6.5.8-200.fc38 -> 6.5.7-300.fc39
  kernel-modules 6.5.8-200.fc38 -> 6.5.7-300.fc39
  kernel-modules-core 6.5.8-200.fc38 -> 6.5.7-300.fc39
  oniguruma 6.9.9-1.fc38 -> 6.9.8^20230501git41a3b80-2.fc39
  selinux-policy 38.30-1.fc38 -> 38.29-1.fc39
  selinux-policy-targeted 38.30-1.fc38 -> 38.29-1.fc39
  slirp4netns 1.2.2-1.fc38 -> 1.2.1-1.fc39
  vim-data 2:9.0.2048-1.fc38 -> 2:9.0.1984-1.fc39
  vim-minimal 2:9.0.2048-1.fc38 -> 2:9.0.1984-1.fc39
```