### PR TITLE
fix failure at second boot

### DIFF
--- a/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
+++ b/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete
@@ -17,3 +17,5 @@ rm /boot/ignition.firstboot
 if [[ $(uname -m) = s390x ]]; then
     /usr/lib/dracut/modules.d/50rdcore/rdcore zipl --boot-mount=/boot
 fi
+
+sync


### PR DESCRIPTION
The issue occurs at unexpected shutdown (such as power-off, or ctrl + a +x to exit qemu) after first boot, data was not completely saved to disk.
------
Ignition has failed. Please ensure your config is valid. Note that only Ignition spec v3.0.0+ configs are accepted.

A CLI validation tool to check this called ignition-validate can be downloaded from GitHub:
    https://github.com/coreos/ignition/releases
------

CoreOS uses boot args `ignition.firstboot' as flag for the first boot, during first boot, ignition parse and apply user define config (add user/passwd/ssh key), and remove the config file; then call script /usr/libexec/coreos-ignition-firstboot-complete.

In script /usr/libexec/coreos-ignition-firstboot-complete, it remove /boot/ignition.firstboot, the GRUB detect it and remove boot args `ignition.firstboot' if /boot/ignition.firstboot does not exists at second boot

If shundown at the time after ignition removes ignition user define config, before script /usr/libexec/coreos-ignition-firstboot-complete removes /boot/ignition.firstboot, the coming boot will be recognized as first boot, but the ignition user define config is lost

Call sync to assure the remove operation on disk