### PR TITLE
denylist: extend snooze for failing kola tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,13 +17,13 @@
     - testing-devel
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2023-10-31
+  snooze: 2023-11-15
   warn: true
   platforms:
     - azure
 - pattern: ext.config.docker.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1578
-  snooze: 2023-10-31
+  snooze: 2023-11-15
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
ext.config.docker.basic and coreos.ignition.ssh.key are still failing, so let's extend the snooze on them while we wait for a fix.