### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,36 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  aardvark-dns:
-    evr: 1.8.0-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d97c0821fa
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  bind-libs:
-    evr: 32:9.18.19-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b4acb0f7c6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  bind-license:
-    evra: 32:9.18.19-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b4acb0f7c6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  bind-utils:
-    evr: 32:9.18.19-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b4acb0f7c6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  container-selinux:
-    evra: 2:2.224.0-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-b1dc756a08
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
   containerd:
     evr: 1.6.19-2.fc39
     metadata:
@@ -48,96 +18,6 @@ packages:
     evr: 1.11-1.fc39
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-0a1f1f38a9
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  fwupd:
-    evr: 1.9.6-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-e629516951
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  google-compute-engine-guest-configs-udev:
-    evra: 20230929.00-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-4e6f9b9b1a
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  gvisor-tap-vsock-gvforwarder:
-    evr: 6:0.7.1-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-817ed9e906
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  kernel:
-    evr: 6.5.9-300.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  kernel-core:
-    evr: 6.5.9-300.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  kernel-modules:
-    evr: 6.5.9-300.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  kernel-modules-core:
-    evr: 6.5.9-300.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-cfd46a8051
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  libnet:
-    evr: 1.3-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-bd2629d771
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  libsolv:
-    evr: 0.7.25-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-741a85e537
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  netavark:
-    evr: 1.8.0-2.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-45ddc00341
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  oniguruma:
-    evr: 6.9.9-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2060e8fdb9
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  passt:
-    evr: 0^20231004.gf851084-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d7f3eb64c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  passt-selinux:
-    evra: 0^20231004.gf851084-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-d7f3eb64c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  rpm-ostree:
-    evr: 2023.8-2.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2628cc885c
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  rpm-ostree-libs:
-    evr: 2023.8-2.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-2628cc885c
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
   selinux-policy:
@@ -151,39 +31,4 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-24872e50a0
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  skopeo:
-    evr: 1:1.13.3-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-35b56210f0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  slirp4netns:
-    evr: 1.2.2-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-3b0f23654b
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  vim-data:
-    evra: 2:9.0.2048-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1976197889
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  vim-minimal:
-    evr: 2:9.0.2048-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-1976197889
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  zchunk-libs:
-    evr: 1.3.2-1.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-14ee3e26c2
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  zincati:
-    evr: 0.0.26-2.fc39
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-586e8dc477
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).