### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,15 +14,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
-  selinux-policy:
-    evra: 39.1-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-24872e50a0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track
-  selinux-policy-targeted:
-    evra: 39.1-1.fc39.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-24872e50a0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).