### PR TITLE
Move to Fedora 39 #1490

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,6 +5,6 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM quay.io/fedora/fedora:38
+FROM quay.io/fedora/fedora:39
 COPY . /src
 RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf

--- a/image.yaml
+++ b/image.yaml
@@ -2,9 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# see https://github.com/coreos/coreos-assembler/pull/3607
-# Defaults for AWS
-aws-imdsv2-only: false
-aws-volume-type: "gp2"
-aws-x86-boot-mode: "legacy-bios"

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -982,10 +982,10 @@
       "evra": "1.81-3.fc38.aarch64"
     },
     "ostree": {
-      "evra": "2023.7-2.fc38.aarch64"
+      "evra": "2023.6-1.fc38.aarch64"
     },
     "ostree-libs": {
-      "evra": "2023.7-2.fc38.aarch64"
+      "evra": "2023.6-1.fc38.aarch64"
     },
     "p11-kit": {
       "evra": "0.25.2-1.fc38.aarch64"
@@ -1027,10 +1027,10 @@
       "evra": "1.8.0-6.fc38.aarch64"
     },
     "podman": {
-      "evra": "5:4.7.2-1.fc38.aarch64"
+      "evra": "5:4.7.0-1.fc38.aarch64"
     },
     "podman-plugins": {
-      "evra": "5:4.7.2-1.fc38.aarch64"
+      "evra": "5:4.7.0-1.fc38.aarch64"
     },
     "policycoreutils": {
       "evra": "3.5-1.fc38.aarch64"
@@ -1280,16 +1280,16 @@
     }
   },
   "metadata": {
-    "generated": "2023-11-07T00:00:00Z",
+    "generated": "2023-11-04T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2023-04-13T20:36:48Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-06T21:11:14Z"
+        "generated": "2023-11-04T02:16:19Z"
       },
       "fedora-updates": {
-        "generated": "2023-11-07T04:06:48Z"
+        "generated": "2023-11-04T03:32:31Z"
       }
     }
   }

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,1295 +1,1310 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.42.8-1.fc38.aarch64"
+      "evra": "1:1.44.2-1.fc39.aarch64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.42.8-1.fc38.aarch64"
+      "evra": "1:1.44.2-1.fc39.aarch64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.42.8-1.fc38.aarch64"
+      "evra": "1:1.44.2-1.fc39.aarch64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.42.8-1.fc38.aarch64"
+      "evra": "1:1.44.2-1.fc39.aarch64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.42.8-1.fc38.aarch64"
+      "evra": "1:1.44.2-1.fc39.aarch64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.0.4-1.fc38.noarch"
+      "evra": "2.9.1.1-1.fc39.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.8.0-1.fc38.aarch64"
+      "evra": "1.8.0-1.fc39.aarch64"
     },
     "acl": {
-      "evra": "2.3.1-6.fc38.aarch64"
+      "evra": "2.3.1-8.fc39.aarch64"
     },
     "adcli": {
-      "evra": "0.9.2-2.fc38.aarch64"
+      "evra": "0.9.2-3.fc39.aarch64"
     },
     "afterburn": {
-      "evra": "5.4.2-1.fc38.aarch64"
+      "evra": "5.4.2-2.fc39.aarch64"
     },
     "afterburn-dracut": {
-      "evra": "5.4.2-1.fc38.aarch64"
+      "evra": "5.4.2-2.fc39.aarch64"
     },
     "alternatives": {
-      "evra": "1.25-1.fc38.aarch64"
+      "evra": "1.25-1.fc39.aarch64"
     },
     "amd-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "atheros-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "attr": {
-      "evra": "2.5.1-6.fc38.aarch64"
+      "evra": "2.5.1-8.fc39.aarch64"
+    },
+    "audit": {
+      "evra": "3.1.2-4.fc39.aarch64"
     },
     "audit-libs": {
-      "evra": "3.1.2-1.fc38.aarch64"
+      "evra": "3.1.2-4.fc39.aarch64"
     },
     "authselect": {
-      "evra": "1.4.3-1.fc38.aarch64"
+      "evra": "1.4.3-1.fc39.aarch64"
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc38.aarch64"
+      "evra": "1.4.3-1.fc39.aarch64"
     },
     "avahi-libs": {
-      "evra": "0.8-22.fc38.aarch64"
+      "evra": "0.8-24.fc39.aarch64"
     },
     "basesystem": {
-      "evra": "11-15.fc38.noarch"
+      "evra": "11-18.fc39.noarch"
     },
     "bash": {
-      "evra": "5.2.15-3.fc38.aarch64"
+      "evra": "5.2.15-5.fc39.aarch64"
+    },
+    "bash-color-prompt": {
+      "evra": "0.1-6.fc39.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.11-9.fc38.noarch"
+      "evra": "1:2.11-12.fc39.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.19-1.fc38.aarch64"
+      "evra": "32:9.18.19-1.fc39.aarch64"
     },
     "bind-license": {
-      "evra": "32:9.18.19-1.fc38.noarch"
+      "evra": "32:9.18.19-1.fc39.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.19-1.fc38.aarch64"
+      "evra": "32:9.18.19-1.fc39.aarch64"
     },
     "bootupd": {
-      "evra": "0.2.12-2.fc38.aarch64"
+      "evra": "0.2.12-2.fc39.aarch64"
     },
     "brcmfmac-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "bsdtar": {
-      "evra": "3.6.1-4.fc38.aarch64"
+      "evra": "3.7.1-1.fc39.aarch64"
     },
     "btrfs-progs": {
-      "evra": "6.5.1-1.fc38.aarch64"
+      "evra": "6.5.1-1.fc39.aarch64"
     },
     "bubblewrap": {
-      "evra": "0.7.0-1.fc38.aarch64"
+      "evra": "0.7.0-2.fc39.aarch64"
     },
     "bzip2": {
-      "evra": "1.0.8-13.fc38.aarch64"
+      "evra": "1.0.8-16.fc39.aarch64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-13.fc38.aarch64"
+      "evra": "1.0.8-16.fc39.aarch64"
     },
     "c-ares": {
-      "evra": "1.19.1-1.fc38.aarch64"
+      "evra": "1.19.1-1.fc39.aarch64"
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-1.0.fc38.noarch"
+      "evra": "2023.2.60_v7.0.306-2.fc39.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-14.fc38.aarch64"
+      "evra": "0.1.7-18.fc39.aarch64"
     },
     "chrony": {
-      "evra": "4.4-1.fc38.aarch64"
+      "evra": "4.4-1.fc39.aarch64"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc38.aarch64"
+      "evra": "7.0-2.fc39.aarch64"
     },
     "clevis": {
-      "evra": "19-2.fc38.aarch64"
+      "evra": "19-4.fc39.aarch64"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc38.aarch64"
+      "evra": "19-4.fc39.aarch64"
     },
     "clevis-luks": {
-      "evra": "19-2.fc38.aarch64"
+      "evra": "19-4.fc39.aarch64"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc38.aarch64"
+      "evra": "19-4.fc39.aarch64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc38.noarch"
+      "evra": "0.33-3.fc39.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc38.aarch64"
+      "evra": "2:2.1.7-3.fc39.aarch64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.224.0-1.fc38.noarch"
+      "evra": "2:2.224.0-1.fc39.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc38.aarch64"
+      "evra": "1.6.19-2.fc39.aarch64"
     },
     "containernetworking-plugins": {
-      "evra": "1.3.0-2.fc38.aarch64"
+      "evra": "1.3.0-3.fc39.aarch64"
     },
     "containers-common": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "coreos-installer": {
-      "evra": "0.18.0-1.fc38.aarch64"
+      "evra": "0.18.0-1.fc39.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.18.0-1.fc38.aarch64"
+      "evra": "0.18.0-1.fc39.aarch64"
     },
     "coreutils": {
-      "evra": "9.1-12.fc38.aarch64"
+      "evra": "9.3-4.fc39.aarch64"
     },
     "coreutils-common": {
-      "evra": "9.1-12.fc38.aarch64"
+      "evra": "9.3-4.fc39.aarch64"
     },
     "cpio": {
-      "evra": "2.13-14.fc38.aarch64"
+      "evra": "2.14-4.fc39.aarch64"
     },
     "cracklib": {
-      "evra": "2.9.11-1.fc38.aarch64"
+      "evra": "2.9.11-2.fc39.aarch64"
     },
     "criu": {
-      "evra": "3.18-1.fc38.aarch64"
+      "evra": "3.18-3.fc39.aarch64"
     },
     "criu-libs": {
-      "evra": "3.18-1.fc38.aarch64"
+      "evra": "3.18-3.fc39.aarch64"
     },
     "crun": {
-      "evra": "1.11-1.fc38.aarch64"
+      "evra": "1.11.1-1.fc39.aarch64"
+    },
+    "crun-wasm": {
+      "evra": "1.11.1-1.fc39.aarch64"
     },
     "crypto-policies": {
-      "evra": "20230301-1.gita12f7b2.fc38.noarch"
+      "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc38.aarch64"
+      "evra": "2.6.1-3.fc39.aarch64"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc38.aarch64"
+      "evra": "2.6.1-3.fc39.aarch64"
     },
     "curl": {
-      "evra": "8.0.1-5.fc38.aarch64"
+      "evra": "8.2.1-3.fc39.aarch64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-9.fc38.aarch64"
+      "evra": "2.1.28-11.fc39.aarch64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-9.fc38.aarch64"
+      "evra": "2.1.28-11.fc39.aarch64"
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc38.aarch64"
+      "evra": "1:1.14.10-1.fc39.aarch64"
     },
     "dbus-broker": {
-      "evra": "33-1.fc38.aarch64"
+      "evra": "33-2.fc39.aarch64"
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc38.noarch"
+      "evra": "1:1.14.10-1.fc39.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc38.aarch64"
+      "evra": "1:1.14.10-1.fc39.aarch64"
     },
     "device-mapper": {
-      "evra": "1.02.189-2.fc38.aarch64"
+      "evra": "1.02.196-1.fc39.aarch64"
     },
     "device-mapper-event": {
-      "evra": "1.02.189-2.fc38.aarch64"
+      "evra": "1.02.196-1.fc39.aarch64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.189-2.fc38.aarch64"
+      "evra": "1.02.196-1.fc39.aarch64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.189-2.fc38.aarch64"
+      "evra": "1.02.196-1.fc39.aarch64"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.4-2.fc38.aarch64"
+      "evra": "0.9.5-2.fc39.aarch64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.4-2.fc38.aarch64"
+      "evra": "0.9.5-2.fc39.aarch64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-10.fc38.aarch64"
+      "evra": "1.0.6-2.fc39.aarch64"
     },
     "diffutils": {
-      "evra": "3.10-1.fc38.aarch64"
+      "evra": "3.10-3.fc39.aarch64"
     },
     "dnsmasq": {
-      "evra": "2.89-5.fc38.aarch64"
+      "evra": "2.89-6.fc39.aarch64"
     },
     "dosfstools": {
-      "evra": "4.2-6.fc38.aarch64"
+      "evra": "4.2-7.fc39.aarch64"
     },
     "dracut": {
-      "evra": "059-4.fc38.aarch64"
+      "evra": "059-15.fc39.aarch64"
     },
     "dracut-network": {
-      "evra": "059-4.fc38.aarch64"
+      "evra": "059-15.fc39.aarch64"
     },
     "dracut-squash": {
-      "evra": "059-4.fc38.aarch64"
+      "evra": "059-15.fc39.aarch64"
     },
     "duktape": {
-      "evra": "2.7.0-2.fc38.aarch64"
+      "evra": "2.7.0-5.fc39.aarch64"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-4.fc38.aarch64"
+      "evra": "1.47.0-2.fc39.aarch64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-4.fc38.aarch64"
+      "evra": "1.47.0-2.fc39.aarch64"
     },
     "efi-filesystem": {
-      "evra": "5-7.fc38.noarch"
+      "evra": "5-9.fc39.noarch"
     },
     "efibootmgr": {
-      "evra": "18-3.fc38.aarch64"
+      "evra": "18-4.fc39.aarch64"
     },
     "efivar-libs": {
-      "evra": "38-7.fc38.aarch64"
+      "evra": "38-8.fc39.aarch64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-3.fc38.noarch"
+      "evra": "0.189-4.fc39.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-3.fc38.aarch64"
+      "evra": "0.189-4.fc39.aarch64"
     },
     "elfutils-libs": {
-      "evra": "0.189-3.fc38.aarch64"
+      "evra": "0.189-4.fc39.aarch64"
     },
     "ethtool": {
-      "evra": "2:6.5-1.fc38.aarch64"
+      "evra": "2:6.5-1.fc39.aarch64"
     },
     "expat": {
-      "evra": "2.5.0-2.fc38.aarch64"
+      "evra": "2.5.0-3.fc39.aarch64"
     },
     "fedora-gpg-keys": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-repos": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-1.noarch"
-    },
-    "fedora-repos-modular": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "file": {
-      "evra": "5.44-3.fc38.aarch64"
+      "evra": "5.44-5.fc39.aarch64"
     },
     "file-libs": {
-      "evra": "5.44-3.fc38.aarch64"
+      "evra": "5.44-5.fc39.aarch64"
     },
     "filesystem": {
-      "evra": "3.18-3.fc38.aarch64"
+      "evra": "3.18-6.fc39.aarch64"
     },
     "findutils": {
-      "evra": "1:4.9.0-3.fc38.aarch64"
+      "evra": "1:4.9.0-5.fc39.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.15.4-1.fc38.aarch64"
+      "evra": "1.15.4-3.fc39.aarch64"
+    },
+    "fmt": {
+      "evra": "10.0.0-3.fc39.aarch64"
     },
     "fstrm": {
-      "evra": "0.6.1-6.fc38.aarch64"
+      "evra": "0.6.1-8.fc39.aarch64"
     },
     "fuse": {
-      "evra": "2.9.9-16.fc38.aarch64"
+      "evra": "2.9.9-17.fc39.aarch64"
     },
     "fuse-common": {
-      "evra": "3.14.1-1.fc38.aarch64"
+      "evra": "3.16.1-1.fc39.aarch64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-16.fc38.aarch64"
+      "evra": "2.9.9-17.fc39.aarch64"
     },
     "fuse-overlayfs": {
-      "evra": "1.12-1.fc38.aarch64"
+      "evra": "1.12-2.fc39.aarch64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-3.fc38.aarch64"
+      "evra": "3.7.3-4.fc39.aarch64"
     },
     "fuse3": {
-      "evra": "3.14.1-1.fc38.aarch64"
+      "evra": "3.16.1-1.fc39.aarch64"
     },
     "fuse3-libs": {
-      "evra": "3.14.1-1.fc38.aarch64"
+      "evra": "3.16.1-1.fc39.aarch64"
     },
     "fwupd": {
-      "evra": "1.9.7-1.fc38.aarch64"
+      "evra": "1.9.7-1.fc39.aarch64"
     },
     "gawk": {
-      "evra": "5.1.1-5.fc38.aarch64"
+      "evra": "5.2.2-2.fc39.aarch64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-3.fc38.aarch64"
+      "evra": "1:1.23-4.fc39.aarch64"
     },
     "gdisk": {
-      "evra": "1.0.9-5.fc38.aarch64"
+      "evra": "1.0.9-6.fc39.aarch64"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-2.fc38.aarch64"
+      "evra": "0.22-2.fc39.aarch64"
     },
     "gettext-libs": {
-      "evra": "0.21.1-2.fc38.aarch64"
+      "evra": "0.22-2.fc39.aarch64"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-2.fc38.aarch64"
+      "evra": "0.22-2.fc39.aarch64"
     },
     "git-core": {
-      "evra": "2.41.0-1.fc38.aarch64"
+      "evra": "2.41.0-2.fc39.aarch64"
     },
     "glib2": {
-      "evra": "2.76.5-2.fc38.aarch64"
+      "evra": "2.78.1-1.fc39.aarch64"
     },
     "glibc": {
-      "evra": "2.37-13.fc38.aarch64"
+      "evra": "2.38-10.fc39.aarch64"
     },
     "glibc-common": {
-      "evra": "2.37-13.fc38.aarch64"
+      "evra": "2.38-10.fc39.aarch64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.37-13.fc38.aarch64"
+      "evra": "2.38-10.fc39.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.37-13.fc38.aarch64"
+      "evra": "2.38-10.fc39.aarch64"
     },
     "gmp": {
-      "evra": "1:6.2.1-4.fc38.aarch64"
+      "evra": "1:6.2.1-5.fc39.aarch64"
     },
     "gnupg2": {
-      "evra": "2.4.0-3.fc38.aarch64"
+      "evra": "2.4.3-2.fc39.aarch64"
     },
     "gnutls": {
-      "evra": "3.8.1-1.fc38.aarch64"
+      "evra": "3.8.1-1.fc39.aarch64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20230929.00-1.fc38.noarch"
+      "evra": "20230929.00-1.fc39.noarch"
     },
     "gpgme": {
-      "evra": "1.17.1-5.fc38.aarch64"
+      "evra": "1.20.0-5.fc39.aarch64"
     },
     "grep": {
-      "evra": "3.8-3.fc38.aarch64"
+      "evra": "3.11-3.fc39.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.06-102.fc38.noarch"
+      "evra": "1:2.06-104.fc39.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-102.fc38.aarch64"
+      "evra": "1:2.06-104.fc39.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.06-102.fc38.aarch64"
+      "evra": "1:2.06-104.fc39.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-102.fc38.aarch64"
+      "evra": "1:2.06-104.fc39.aarch64"
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.1-1.fc38.aarch64"
+      "evra": "6:0.7.1-1.fc39.aarch64"
     },
     "gzip": {
-      "evra": "1.12-3.fc38.aarch64"
+      "evra": "1.12-6.fc39.aarch64"
     },
     "hostname": {
-      "evra": "3.23-8.fc38.aarch64"
+      "evra": "3.23-9.fc39.aarch64"
     },
     "ignition": {
-      "evra": "2.16.2-1.fc38.aarch64"
+      "evra": "2.16.2-2.fc39.aarch64"
     },
     "inih": {
-      "evra": "57-1.fc38.aarch64"
+      "evra": "57-2.fc39.aarch64"
     },
     "intel-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-1.fc38.aarch64"
+      "evra": "1.0.3-2.fc39.aarch64"
     },
     "iproute": {
-      "evra": "6.4.0-1.fc38.aarch64"
+      "evra": "6.4.0-2.fc39.aarch64"
     },
     "iproute-tc": {
-      "evra": "6.4.0-1.fc38.aarch64"
+      "evra": "6.4.0-2.fc39.aarch64"
     },
     "iptables-legacy": {
-      "evra": "1.8.9-4.fc38.1.aarch64"
+      "evra": "1.8.9-5.fc39.aarch64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-4.fc38.1.aarch64"
+      "evra": "1.8.9-5.fc39.aarch64"
     },
     "iptables-libs": {
-      "evra": "1.8.9-4.fc38.1.aarch64"
+      "evra": "1.8.9-5.fc39.aarch64"
     },
     "iptables-nft": {
-      "evra": "1.8.9-4.fc38.1.aarch64"
+      "evra": "1.8.9-5.fc39.aarch64"
     },
     "iptables-services": {
-      "evra": "1.8.9-4.fc38.1.noarch"
+      "evra": "1.8.9-5.fc39.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.9-4.fc38.1.aarch64"
+      "evra": "1.8.9-5.fc39.aarch64"
     },
     "iputils": {
-      "evra": "20221126-2.fc38.aarch64"
+      "evra": "20221126-4.fc39.aarch64"
     },
     "irqbalance": {
-      "evra": "2:1.9.2-1.fc38.aarch64"
+      "evra": "2:1.9.2-2.fc39.aarch64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.aarch64"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.aarch64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.aarch64"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.aarch64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-6.fc38.aarch64"
+      "evra": "0.101-7.fc39.aarch64"
     },
     "jansson": {
-      "evra": "2.13.1-6.fc38.aarch64"
+      "evra": "2.13.1-7.fc39.aarch64"
     },
     "jemalloc": {
-      "evra": "5.3.0-3.fc38.aarch64"
+      "evra": "5.3.0-4.fc39.aarch64"
     },
     "jose": {
-      "evra": "11-7.fc38.aarch64"
+      "evra": "11-8.fc39.aarch64"
     },
     "jq": {
-      "evra": "1.6-16.fc38.aarch64"
+      "evra": "1.6-17.fc39.aarch64"
     },
     "json-c": {
-      "evra": "0.17-1.fc38.aarch64"
+      "evra": "0.17-1.fc39.aarch64"
     },
     "json-glib": {
-      "evra": "1.6.6-4.fc38.aarch64"
+      "evra": "1.8.0-1.fc39.aarch64"
     },
     "kbd": {
-      "evra": "2.5.1-5.fc38.aarch64"
+      "evra": "2.6.3-1.fc39.aarch64"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kernel": {
-      "evra": "6.5.9-200.fc38.aarch64"
+      "evra": "6.5.9-300.fc39.aarch64"
     },
     "kernel-core": {
-      "evra": "6.5.9-200.fc38.aarch64"
+      "evra": "6.5.9-300.fc39.aarch64"
     },
     "kernel-modules": {
-      "evra": "6.5.9-200.fc38.aarch64"
+      "evra": "6.5.9-300.fc39.aarch64"
     },
     "kernel-modules-core": {
-      "evra": "6.5.9-200.fc38.aarch64"
+      "evra": "6.5.9-300.fc39.aarch64"
     },
     "kexec-tools": {
-      "evra": "2.0.26-3.fc38.aarch64"
+      "evra": "2.0.27-2.fc39.aarch64"
     },
     "keyutils": {
-      "evra": "1.6.1-6.fc38.aarch64"
+      "evra": "1.6.1-7.fc39.aarch64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-6.fc38.aarch64"
+      "evra": "1.6.1-7.fc39.aarch64"
     },
     "kmod": {
-      "evra": "30-4.fc38.aarch64"
+      "evra": "30-6.fc39.aarch64"
     },
     "kmod-libs": {
-      "evra": "30-4.fc38.aarch64"
+      "evra": "30-6.fc39.aarch64"
     },
     "kpartx": {
-      "evra": "0.9.4-2.fc38.aarch64"
+      "evra": "0.9.5-2.fc39.aarch64"
     },
     "krb5-libs": {
-      "evra": "1.21-3.fc38.aarch64"
+      "evra": "1.21.2-2.fc39.aarch64"
     },
     "less": {
-      "evra": "633-1.fc38.aarch64"
+      "evra": "633-2.fc39.aarch64"
     },
     "libacl": {
-      "evra": "2.3.1-6.fc38.aarch64"
+      "evra": "2.3.1-8.fc39.aarch64"
     },
     "libaio": {
-      "evra": "0.3.111-15.fc38.aarch64"
+      "evra": "0.3.111-16.fc39.aarch64"
     },
     "libarchive": {
-      "evra": "3.6.1-4.fc38.aarch64"
+      "evra": "3.7.1-1.fc39.aarch64"
     },
     "libargon2": {
-      "evra": "20190702-2.fc38.aarch64"
+      "evra": "20190702-3.fc39.aarch64"
     },
     "libassuan": {
-      "evra": "2.5.6-1.fc38.aarch64"
+      "evra": "2.5.6-2.fc39.aarch64"
     },
     "libatomic": {
-      "evra": "13.2.1-4.fc38.aarch64"
+      "evra": "13.2.1-4.fc39.aarch64"
     },
     "libattr": {
-      "evra": "2.5.1-6.fc38.aarch64"
+      "evra": "2.5.1-8.fc39.aarch64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-53.fc38.aarch64"
+      "evra": "0.1.1-54.fc39.aarch64"
     },
     "libblkid": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "libbpf": {
-      "evra": "2:1.1.0-2.fc38.aarch64"
+      "evra": "2:1.1.0-4.fc39.aarch64"
     },
     "libbsd": {
-      "evra": "0.11.7-4.fc38.aarch64"
+      "evra": "0.11.7-5.fc39.aarch64"
     },
     "libcap": {
-      "evra": "2.48-6.fc38.aarch64"
+      "evra": "2.48-7.fc39.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc38.aarch64"
+      "evra": "0.8.3-8.fc39.aarch64"
     },
     "libcbor": {
-      "evra": "0.7.0-9.fc38.aarch64"
+      "evra": "0.10.2-2.fc39.aarch64"
     },
     "libcollection": {
-      "evra": "0.7.0-53.fc38.aarch64"
+      "evra": "0.7.0-54.fc39.aarch64"
     },
     "libcom_err": {
-      "evra": "1.46.5-4.fc38.aarch64"
+      "evra": "1.47.0-2.fc39.aarch64"
     },
     "libcurl-minimal": {
-      "evra": "8.0.1-5.fc38.aarch64"
+      "evra": "8.2.1-3.fc39.aarch64"
     },
     "libdaemon": {
-      "evra": "0.14-25.fc38.aarch64"
+      "evra": "0.14-26.fc39.aarch64"
     },
     "libdb": {
-      "evra": "5.3.28-55.fc38.aarch64"
+      "evra": "5.3.28-56.fc39.aarch64"
     },
     "libdhash": {
-      "evra": "0.5.0-53.fc38.aarch64"
+      "evra": "0.5.0-54.fc39.aarch64"
     },
     "libeconf": {
-      "evra": "0.5.2-1.fc38.aarch64"
+      "evra": "0.5.2-1.fc39.aarch64"
     },
     "libedit": {
-      "evra": "3.1-45.20221030cvs.fc38.aarch64"
+      "evra": "3.1-48.20230828cvs.fc39.aarch64"
     },
     "libevent": {
-      "evra": "2.1.12-8.fc38.aarch64"
+      "evra": "2.1.12-9.fc39.aarch64"
     },
     "libfdisk": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "libffi": {
-      "evra": "3.4.4-2.fc38.aarch64"
+      "evra": "3.4.4-4.fc39.aarch64"
     },
     "libfido2": {
-      "evra": "1.12.0-3.fc38.aarch64"
+      "evra": "1.13.0-3.fc39.aarch64"
     },
     "libgcc": {
-      "evra": "13.2.1-4.fc38.aarch64"
+      "evra": "13.2.1-4.fc39.aarch64"
     },
     "libgcrypt": {
-      "evra": "1.10.2-1.fc38.aarch64"
+      "evra": "1.10.2-2.fc39.aarch64"
     },
     "libgpg-error": {
-      "evra": "1.47-1.fc38.aarch64"
+      "evra": "1.47-2.fc39.aarch64"
     },
     "libgudev": {
-      "evra": "237-4.fc38.aarch64"
+      "evra": "238-2.fc39.aarch64"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc38.aarch64"
+      "evra": "0.4.7-1.fc39.aarch64"
     },
     "libibverbs": {
-      "evra": "44.0-3.fc38.aarch64"
+      "evra": "46.0-4.fc39.aarch64"
     },
     "libicu": {
-      "evra": "72.1-2.fc38.aarch64"
+      "evra": "73.2-2.fc39.aarch64"
     },
     "libidn2": {
-      "evra": "2.3.4-2.fc38.aarch64"
+      "evra": "2.3.4-3.fc39.aarch64"
     },
     "libini_config": {
-      "evra": "1.3.1-53.fc38.aarch64"
+      "evra": "1.3.1-54.fc39.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc38.aarch64"
+      "evra": "0.1.14-2.fc39.aarch64"
     },
     "libjose": {
-      "evra": "11-7.fc38.aarch64"
+      "evra": "11-8.fc39.aarch64"
     },
     "libkcapi": {
-      "evra": "1.4.0-5.fc38.aarch64"
+      "evra": "1.4.0-7.fc39.aarch64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-5.fc38.aarch64"
+      "evra": "1.4.0-7.fc39.aarch64"
     },
     "libksba": {
-      "evra": "1.6.4-1.fc38.aarch64"
+      "evra": "1.6.4-2.fc39.aarch64"
     },
     "libldb": {
-      "evra": "2.7.2-1.fc38.aarch64"
+      "evra": "2.8.0-1.fc39.aarch64"
     },
     "libluksmeta": {
-      "evra": "9-15.fc38.aarch64"
+      "evra": "9-16.fc39.aarch64"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-2.fc38.aarch64"
+      "evra": "1.7.1-3.fc39.aarch64"
     },
     "libmd": {
-      "evra": "1.1.0-1.fc38.aarch64"
+      "evra": "1.1.0-2.fc39.aarch64"
     },
     "libmnl": {
-      "evra": "1.0.5-2.fc38.aarch64"
+      "evra": "1.0.5-3.fc39.aarch64"
     },
     "libmodulemd": {
-      "evra": "2.15.0-2.fc38.aarch64"
+      "evra": "2.15.0-5.fc39.aarch64"
     },
     "libmount": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "libndp": {
-      "evra": "1.8-5.fc38.aarch64"
+      "evra": "1.8-6.fc39.aarch64"
     },
     "libnet": {
-      "evra": "1.3-1.fc38.aarch64"
+      "evra": "1.3-1.fc39.aarch64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-1.fc38.aarch64"
+      "evra": "1.0.9-2.fc39.aarch64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-23.fc38.aarch64"
+      "evra": "1.0.1-24.fc39.aarch64"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.3-1.rc3.fc38.aarch64"
+      "evra": "1:2.6.3-2.rc3.fc39.aarch64"
     },
     "libnftnl": {
-      "evra": "1.2.4-2.fc38.aarch64"
+      "evra": "1.2.6-2.fc39.aarch64"
     },
     "libnghttp2": {
-      "evra": "1.52.0-2.fc38.aarch64"
+      "evra": "1.55.1-4.fc39.aarch64"
     },
     "libnl3": {
-      "evra": "3.7.0-3.fc38.aarch64"
+      "evra": "3.8.0-1.fc39.aarch64"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-3.fc38.aarch64"
+      "evra": "3.8.0-1.fc39.aarch64"
     },
     "libnsl2": {
-      "evra": "2.0.0-5.fc38.aarch64"
+      "evra": "2.0.0-6.fc39.aarch64"
     },
     "libnvme": {
-      "evra": "1.4-2.fc38.aarch64"
+      "evra": "1.6-2.fc39.aarch64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-53.fc38.aarch64"
+      "evra": "0.2.1-54.fc39.aarch64"
     },
     "libpcap": {
-      "evra": "14:1.10.4-1.fc38.aarch64"
+      "evra": "14:1.10.4-2.fc39.aarch64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-6.fc38.aarch64"
+      "evra": "1.9.5-2.fc39.aarch64"
     },
     "libpsl": {
-      "evra": "0.21.2-2.fc38.aarch64"
+      "evra": "0.21.2-4.fc39.aarch64"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc38.aarch64"
+      "evra": "1.4.5-6.fc39.aarch64"
     },
     "libref_array": {
-      "evra": "0.1.5-53.fc38.aarch64"
+      "evra": "0.1.5-54.fc39.aarch64"
     },
     "librepo": {
-      "evra": "1.17.0-1.fc38.aarch64"
+      "evra": "1.17.0-1.fc39.aarch64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-1.fc38.noarch"
+      "evra": "2.17.11-3.fc39.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-4.fc38.aarch64"
+      "evra": "2.5.3-6.fc39.aarch64"
     },
     "libselinux": {
-      "evra": "3.5-1.fc38.aarch64"
+      "evra": "3.5-5.fc39.aarch64"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc38.aarch64"
+      "evra": "3.5-5.fc39.aarch64"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc38.aarch64"
+      "evra": "3.5-4.fc39.aarch64"
     },
     "libsepol": {
-      "evra": "3.5-1.fc38.aarch64"
+      "evra": "3.5-2.fc39.aarch64"
     },
     "libsigsegv": {
-      "evra": "2.14-4.fc38.aarch64"
+      "evra": "2.14-5.fc39.aarch64"
     },
     "libslirp": {
-      "evra": "4.7.0-3.fc38.aarch64"
+      "evra": "4.7.0-4.fc39.aarch64"
     },
     "libsmartcols": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.18.8-1.fc38.aarch64"
+      "evra": "2:4.19.2-1.fc39.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.25-1.fc38.aarch64"
+      "evra": "0.7.25-1.fc39.aarch64"
     },
     "libss": {
-      "evra": "1.46.5-4.fc38.aarch64"
+      "evra": "1.47.0-2.fc39.aarch64"
     },
     "libsss_certmap": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "libstdc++": {
-      "evra": "13.2.1-4.fc38.aarch64"
+      "evra": "13.2.1-4.fc39.aarch64"
     },
     "libtalloc": {
-      "evra": "2.4.0-2.fc38.aarch64"
+      "evra": "2.4.1-1.fc39.aarch64"
     },
     "libtasn1": {
-      "evra": "4.19.0-2.fc38.aarch64"
+      "evra": "4.19.0-3.fc39.aarch64"
     },
     "libtdb": {
-      "evra": "1.4.8-1.fc38.aarch64"
+      "evra": "1.4.9-1.fc39.aarch64"
     },
     "libteam": {
-      "evra": "1.31-7.fc38.aarch64"
+      "evra": "1.32-1.fc39.aarch64"
     },
     "libtevent": {
-      "evra": "0.14.1-1.fc38.aarch64"
+      "evra": "0.15.0-1.fc39.aarch64"
     },
     "libtirpc": {
-      "evra": "1.3.4-0.fc38.aarch64"
+      "evra": "1.3.4-0.fc39.aarch64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-6.fc38.aarch64"
+      "evra": "2.4.7-7.fc39.aarch64"
     },
     "libunistring": {
-      "evra": "1.1-3.fc38.aarch64"
-    },
-    "libunistring1.0": {
-      "evra": "1.0-1.fc38.aarch64"
+      "evra": "1.1-5.fc39.aarch64"
     },
     "libusb1": {
-      "evra": "1.0.26-2.fc38.aarch64"
+      "evra": "1.0.26-3.fc39.aarch64"
     },
     "libuser": {
-      "evra": "0.64-2.fc38.aarch64"
+      "evra": "0.64-4.fc39.aarch64"
     },
     "libutempter": {
-      "evra": "1.2.1-8.fc38.aarch64"
+      "evra": "1.2.1-10.fc39.aarch64"
     },
     "libuuid": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "libuv": {
-      "evra": "1:1.46.0-1.fc38.aarch64"
+      "evra": "1:1.46.0-2.fc39.aarch64"
     },
     "libverto": {
-      "evra": "0.3.2-5.fc38.aarch64"
+      "evra": "0.3.2-6.fc39.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.18.8-1.fc38.aarch64"
+      "evra": "2:4.19.2-1.fc39.aarch64"
     },
     "libxcrypt": {
-      "evra": "4.4.36-1.fc38.aarch64"
+      "evra": "4.4.36-2.fc39.aarch64"
     },
     "libxml2": {
-      "evra": "2.10.4-1.fc38.aarch64"
+      "evra": "2.10.4-3.fc39.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.14-1.fc38.aarch64"
+      "evra": "0.3.14-1.fc39.aarch64"
     },
     "libyaml": {
-      "evra": "0.2.5-9.fc38.aarch64"
+      "evra": "0.2.5-12.fc39.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc38.aarch64"
+      "evra": "1.5.5-4.fc39.aarch64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-34.fc38.aarch64"
+      "evra": "2.5.1-36.fc39.aarch64"
     },
     "linux-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.31-1.fc38.aarch64"
+      "evra": "0.9.31-2.fc39.aarch64"
     },
     "logrotate": {
-      "evra": "3.21.0-2.fc38.aarch64"
+      "evra": "3.21.0-4.fc39.aarch64"
     },
     "lsof": {
-      "evra": "4.96.3-3.fc38.aarch64"
+      "evra": "4.96.3-4.fc39.aarch64"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc38.aarch64"
+      "evra": "5.4.6-3.fc39.aarch64"
     },
     "luksmeta": {
-      "evra": "9-15.fc38.aarch64"
+      "evra": "9-16.fc39.aarch64"
     },
     "lvm2": {
-      "evra": "2.03.18-2.fc38.aarch64"
+      "evra": "2.03.22-1.fc39.aarch64"
     },
     "lvm2-libs": {
-      "evra": "2.03.18-2.fc38.aarch64"
+      "evra": "2.03.22-1.fc39.aarch64"
     },
     "lz4-libs": {
-      "evra": "1.9.4-2.fc38.aarch64"
+      "evra": "1.9.4-4.fc39.aarch64"
     },
     "lzo": {
-      "evra": "2.10-8.fc38.aarch64"
+      "evra": "2.10-9.fc39.aarch64"
     },
     "mdadm": {
-      "evra": "4.2-4.fc38.aarch64"
+      "evra": "4.2-6.fc39.aarch64"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc38.aarch64"
+      "evra": "24.0.5-1.fc39.aarch64"
     },
     "mokutil": {
-      "evra": "2:0.6.0-6.fc38.aarch64"
+      "evra": "2:0.6.0-7.fc39.aarch64"
     },
     "mpfr": {
-      "evra": "4.1.1-3.fc38.aarch64"
+      "evra": "4.2.0-3.fc39.aarch64"
     },
     "mt7xxx-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nano": {
-      "evra": "7.2-2.fc38.aarch64"
+      "evra": "7.2-4.fc39.aarch64"
     },
     "nano-default-editor": {
-      "evra": "7.2-2.fc38.noarch"
+      "evra": "7.2-4.fc39.noarch"
     },
     "ncurses": {
-      "evra": "6.4-3.20230114.fc38.aarch64"
+      "evra": "6.4-7.20230520.fc39.aarch64"
     },
     "ncurses-base": {
-      "evra": "6.4-3.20230114.fc38.noarch"
+      "evra": "6.4-7.20230520.fc39.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.4-3.20230114.fc38.aarch64"
+      "evra": "6.4-7.20230520.fc39.aarch64"
     },
     "net-tools": {
-      "evra": "2.0-0.65.20160912git.fc38.aarch64"
+      "evra": "2.0-0.67.20160912git.fc39.aarch64"
     },
     "netavark": {
-      "evra": "1.8.0-2.fc38.aarch64"
+      "evra": "1.8.0-2.fc39.aarch64"
     },
     "nettle": {
-      "evra": "3.8-3.fc38.aarch64"
+      "evra": "3.9.1-2.fc39.aarch64"
     },
     "newt": {
-      "evra": "0.52.23-2.fc38.aarch64"
+      "evra": "0.52.23-4.fc39.aarch64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.3-1.rc3.fc38.aarch64"
+      "evra": "1:2.6.3-2.rc3.fc39.aarch64"
     },
     "nftables": {
-      "evra": "1:1.0.5-2.fc38.aarch64"
+      "evra": "1:1.0.7-3.fc39.aarch64"
     },
     "nmstate": {
-      "evra": "2.2.15-1.fc38.aarch64"
+      "evra": "2.2.15-1.fc39.aarch64"
     },
     "npth": {
-      "evra": "1.6-12.fc38.aarch64"
+      "evra": "1.6-14.fc39.aarch64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-22.fc38.aarch64"
+      "evra": "2.23.0-1.fc39.aarch64"
     },
     "numactl-libs": {
-      "evra": "2.0.16-2.fc38.aarch64"
+      "evra": "2.0.16-3.fc39.aarch64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nvme-cli": {
-      "evra": "2.4-3.fc38.aarch64"
+      "evra": "2.6-1.fc39.aarch64"
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc38.aarch64"
+      "evra": "6.9.9-1.fc39.aarch64"
     },
     "openldap": {
-      "evra": "2.6.6-1.fc38.aarch64"
+      "evra": "2.6.6-1.fc39.aarch64"
     },
     "openssh": {
-      "evra": "9.0p1-17.fc38.aarch64"
+      "evra": "9.3p1-9.fc39.aarch64"
     },
     "openssh-clients": {
-      "evra": "9.0p1-17.fc38.aarch64"
+      "evra": "9.3p1-9.fc39.aarch64"
     },
     "openssh-server": {
-      "evra": "9.0p1-17.fc38.aarch64"
+      "evra": "9.3p1-9.fc39.aarch64"
     },
     "openssl": {
-      "evra": "1:3.0.9-2.fc38.aarch64"
+      "evra": "1:3.1.1-4.fc39.aarch64"
     },
     "openssl-libs": {
-      "evra": "1:3.0.9-2.fc38.aarch64"
+      "evra": "1:3.1.1-4.fc39.aarch64"
     },
     "os-prober": {
-      "evra": "1.81-3.fc38.aarch64"
+      "evra": "1.81-4.fc39.aarch64"
     },
     "ostree": {
-      "evra": "2023.6-1.fc38.aarch64"
+      "evra": "2023.7-2.fc39.aarch64"
     },
     "ostree-libs": {
-      "evra": "2023.6-1.fc38.aarch64"
+      "evra": "2023.7-2.fc39.aarch64"
     },
     "p11-kit": {
-      "evra": "0.25.2-1.fc38.aarch64"
+      "evra": "0.25.2-1.fc39.aarch64"
     },
     "p11-kit-trust": {
-      "evra": "0.25.2-1.fc38.aarch64"
+      "evra": "0.25.2-1.fc39.aarch64"
     },
     "pam": {
-      "evra": "1.5.2-16.fc38.aarch64"
+      "evra": "1.5.3-3.fc39.aarch64"
     },
     "pam-libs": {
-      "evra": "1.5.2-16.fc38.aarch64"
+      "evra": "1.5.3-3.fc39.aarch64"
     },
     "passt": {
-      "evra": "0^20231004.gf851084-1.fc38.aarch64"
+      "evra": "0^20231004.gf851084-1.fc39.aarch64"
     },
     "passt-selinux": {
-      "evra": "0^20231004.gf851084-1.fc38.noarch"
+      "evra": "0^20231004.gf851084-1.fc39.noarch"
     },
     "passwd": {
-      "evra": "0.80-14.fc38.aarch64"
+      "evra": "0.80-15.fc39.aarch64"
     },
     "pcre2": {
-      "evra": "10.42-1.fc38.1.aarch64"
+      "evra": "10.42-1.fc39.2.aarch64"
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc38.1.noarch"
+      "evra": "10.42-1.fc39.2.noarch"
     },
     "pigz": {
-      "evra": "2.7-3.fc38.aarch64"
+      "evra": "2.8-2.fc39.aarch64"
     },
     "pkgconf": {
-      "evra": "1.8.0-6.fc38.aarch64"
+      "evra": "1.9.5-2.fc39.aarch64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-6.fc38.noarch"
+      "evra": "1.9.5-2.fc39.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-6.fc38.aarch64"
+      "evra": "1.9.5-2.fc39.aarch64"
     },
     "podman": {
-      "evra": "5:4.7.0-1.fc38.aarch64"
+      "evra": "5:4.7.0-1.fc39.aarch64"
     },
     "podman-plugins": {
-      "evra": "5:4.7.0-1.fc38.aarch64"
+      "evra": "5:4.7.0-1.fc39.aarch64"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc38.aarch64"
+      "evra": "3.5-8.fc39.aarch64"
     },
     "polkit": {
-      "evra": "122-3.fc38.1.aarch64"
+      "evra": "123-1.fc39.aarch64"
     },
     "polkit-libs": {
-      "evra": "122-3.fc38.1.aarch64"
+      "evra": "123-1.fc39.aarch64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-23.fc38.aarch64"
+      "evra": "0.1-26.fc39.aarch64"
     },
     "popt": {
-      "evra": "1.19-2.fc38.aarch64"
+      "evra": "1.19-3.fc39.aarch64"
     },
     "procps-ng": {
-      "evra": "3.3.17-11.fc38.aarch64"
+      "evra": "4.0.3-4.fc39.aarch64"
     },
     "protobuf-c": {
-      "evra": "1.4.1-4.fc38.aarch64"
+      "evra": "1.4.1-5.fc39.aarch64"
     },
     "psmisc": {
-      "evra": "23.6-2.fc38.aarch64"
+      "evra": "23.6-4.fc39.aarch64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230812-1.fc38.noarch"
+      "evra": "20230812-1.fc39.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.2.6-1.fc38.aarch64"
+      "evra": "2:8.1.1-1.fc39.aarch64"
     },
     "readline": {
-      "evra": "8.2-3.fc38.aarch64"
+      "evra": "8.2-4.fc39.aarch64"
     },
     "realtek-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc2.fc38.aarch64"
+      "evra": "1.2.6-4.rc2.fc39.1.aarch64"
     },
     "rpm": {
-      "evra": "4.18.1-3.fc38.aarch64"
+      "evra": "4.19.0-1.fc39.aarch64"
     },
     "rpm-libs": {
-      "evra": "4.18.1-3.fc38.aarch64"
+      "evra": "4.19.0-1.fc39.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2023.8-2.fc38.aarch64"
+      "evra": "2023.8-2.fc39.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.8-2.fc38.aarch64"
+      "evra": "2023.8-2.fc39.aarch64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.1-3.fc38.aarch64"
+      "evra": "4.19.0-1.fc39.aarch64"
     },
     "rpm-sequoia": {
-      "evra": "1.5.0-1.fc38.aarch64"
+      "evra": "1.5.0-1.fc39.aarch64"
     },
     "rsync": {
-      "evra": "3.2.7-2.fc38.aarch64"
+      "evra": "3.2.7-5.fc39.aarch64"
     },
     "runc": {
-      "evra": "2:1.1.8-1.fc38.aarch64"
+      "evra": "2:1.1.8-1.fc39.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.18.8-1.fc38.aarch64"
+      "evra": "2:4.19.2-1.fc39.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.18.8-1.fc38.noarch"
+      "evra": "2:4.19.2-1.fc39.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.18.8-1.fc38.aarch64"
+      "evra": "2:4.19.2-1.fc39.aarch64"
     },
     "sed": {
-      "evra": "4.8-12.fc38.aarch64"
+      "evra": "4.8-14.fc39.aarch64"
     },
     "selinux-policy": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "setup": {
-      "evra": "2.14.3-2.fc38.noarch"
+      "evra": "2.14.4-1.fc39.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-5.fc38.aarch64"
+      "evra": "1.46-6.fc39.aarch64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-5.fc38.aarch64"
+      "evra": "1.46-6.fc39.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.13-6.fc38.aarch64"
+      "evra": "2:4.14.0-2.fc39.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.13-6.fc38.aarch64"
+      "evra": "2:4.14.0-2.fc39.aarch64"
     },
     "shared-mime-info": {
-      "evra": "2.2-3.fc38.aarch64"
+      "evra": "2.2-4.fc39.aarch64"
     },
     "shim-aa64": {
       "evra": "15.6-2.aarch64"
     },
     "skopeo": {
-      "evra": "1:1.13.3-1.fc38.aarch64"
+      "evra": "1:1.13.3-1.fc39.aarch64"
     },
     "slang": {
-      "evra": "2.3.3-3.fc38.aarch64"
+      "evra": "2.3.3-4.fc39.aarch64"
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc38.aarch64"
+      "evra": "1.2.2-1.fc39.aarch64"
     },
     "snappy": {
-      "evra": "1.1.9-7.fc38.aarch64"
+      "evra": "1.1.10-2.fc39.aarch64"
     },
     "socat": {
-      "evra": "1.7.4.4-2.fc38.aarch64"
+      "evra": "1.7.4.4-3.fc39.aarch64"
+    },
+    "spdlog": {
+      "evra": "1.12.0-2.fc39.aarch64"
     },
     "sqlite-libs": {
-      "evra": "3.40.1-2.fc38.aarch64"
+      "evra": "3.42.0-7.fc39.aarch64"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-3.fc38.aarch64"
+      "evra": "4.6.1-2.fc39.aarch64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-3.fc38.aarch64"
+      "evra": "0.1.4-4.fc39.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-client": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-common": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.1-1.fc38.aarch64"
+      "evra": "2.9.2-2.fc39.aarch64"
     },
     "stalld": {
-      "evra": "1.16-3.fc38.aarch64"
+      "evra": "1.16-4.fc39.aarch64"
     },
     "sudo": {
-      "evra": "1.9.13-2.p2.fc38.aarch64"
+      "evra": "1.9.14-1.p3.fc39.aarch64"
     },
     "systemd": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "systemd-container": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "systemd-libs": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "systemd-pam": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "systemd-resolved": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "systemd-udev": {
-      "evra": "253.12-1.fc38.aarch64"
+      "evra": "254.5-2.fc39.aarch64"
     },
     "tar": {
-      "evra": "2:1.34-8.fc38.aarch64"
+      "evra": "2:1.35-2.fc39.aarch64"
     },
     "teamd": {
-      "evra": "1.31-7.fc38.aarch64"
+      "evra": "1.32-1.fc39.aarch64"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc38.aarch64"
+      "evra": "0.0.99.4-3.fc39.aarch64"
     },
     "tpm2-tools": {
-      "evra": "5.5-3.fc38.aarch64"
+      "evra": "5.5-4.fc39.aarch64"
     },
     "tpm2-tss": {
-      "evra": "4.0.1-3.fc38.aarch64"
+      "evra": "4.0.1-4.fc39.aarch64"
     },
     "tzdata": {
-      "evra": "2023c-1.fc38.noarch"
+      "evra": "2023c-2.fc39.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.2-2.fc38.aarch64"
+      "evra": "0.14.0-3.fc39.aarch64"
     },
     "util-linux": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "util-linux-core": {
-      "evra": "2.38.1-4.fc38.aarch64"
+      "evra": "2.39.2-1.fc39.aarch64"
     },
     "vim-data": {
-      "evra": "2:9.0.2081-1.fc38.noarch"
+      "evra": "2:9.0.2081-1.fc39.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.2081-1.fc38.aarch64"
+      "evra": "2:9.0.2081-1.fc39.aarch64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.4-1.fc39.aarch64"
     },
     "which": {
-      "evra": "2.21-39.fc38.aarch64"
+      "evra": "2.21-40.fc39.aarch64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-4.fc38.aarch64"
+      "evra": "1.0.20210914-5.fc39.aarch64"
     },
     "xfsprogs": {
-      "evra": "6.1.0-3.fc38.aarch64"
+      "evra": "6.4.0-1.fc39.aarch64"
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc38.aarch64"
+      "evra": "0.8.2-1.fc39.aarch64"
     },
     "xz": {
-      "evra": "5.4.1-1.fc38.aarch64"
+      "evra": "5.4.4-1.fc39.aarch64"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc38.aarch64"
+      "evra": "5.4.4-1.fc39.aarch64"
     },
     "yajl": {
-      "evra": "2.1.0-21.fc38.aarch64"
+      "evra": "2.1.0-22.fc39.aarch64"
     },
     "zchunk-libs": {
-      "evra": "1.3.2-1.fc38.aarch64"
+      "evra": "1.3.2-1.fc39.aarch64"
     },
     "zincati": {
-      "evra": "0.0.26-2.fc38.aarch64"
+      "evra": "0.0.26-2.fc39.aarch64"
     },
     "zlib": {
-      "evra": "1.2.13-3.fc38.aarch64"
+      "evra": "1.2.13-4.fc39.aarch64"
     },
     "zram-generator": {
-      "evra": "1.1.2-4.fc38.aarch64"
+      "evra": "1.1.2-8.fc39.aarch64"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc38.aarch64"
+      "evra": "1.5.5-4.fc39.aarch64"
     }
   },
   "metadata": {
-    "generated": "2023-11-04T00:00:00Z",
+    "generated": "2023-11-06T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-04-13T20:36:48Z"
+      "fedora-candidate-compose": {
+        "generated": "2023-11-01T00:12:29Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-04T02:16:19Z"
+        "generated": "2023-11-05T01:43:40Z"
       },
-      "fedora-updates": {
-        "generated": "2023-11-04T03:32:31Z"
+      "fedora-next": {
+        "generated": "2023-11-03T02:50:15Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-11-06T01:22:21Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,8 +9,8 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  moby-engine:
-    evr: 20.10.23-1.fc38
+  containerd:
+    evr: 1.6.19-2.fc39
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1476
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,1298 +1,1301 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.42.8-1.fc38.ppc64le"
+      "evra": "1:1.44.2-1.fc39.ppc64le"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.42.8-1.fc38.ppc64le"
+      "evra": "1:1.44.2-1.fc39.ppc64le"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.42.8-1.fc38.ppc64le"
+      "evra": "1:1.44.2-1.fc39.ppc64le"
     },
     "NetworkManager-team": {
-      "evra": "1:1.42.8-1.fc38.ppc64le"
+      "evra": "1:1.44.2-1.fc39.ppc64le"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.42.8-1.fc38.ppc64le"
+      "evra": "1:1.44.2-1.fc39.ppc64le"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.0.4-1.fc38.noarch"
+      "evra": "2.9.1.1-1.fc39.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.8.0-1.fc38.ppc64le"
+      "evra": "1.8.0-1.fc39.ppc64le"
     },
     "acl": {
-      "evra": "2.3.1-6.fc38.ppc64le"
+      "evra": "2.3.1-8.fc39.ppc64le"
     },
     "adcli": {
-      "evra": "0.9.2-2.fc38.ppc64le"
+      "evra": "0.9.2-3.fc39.ppc64le"
     },
     "afterburn": {
-      "evra": "5.4.2-1.fc38.ppc64le"
+      "evra": "5.4.2-2.fc39.ppc64le"
     },
     "afterburn-dracut": {
-      "evra": "5.4.2-1.fc38.ppc64le"
+      "evra": "5.4.2-2.fc39.ppc64le"
     },
     "alternatives": {
-      "evra": "1.25-1.fc38.ppc64le"
+      "evra": "1.25-1.fc39.ppc64le"
     },
     "amd-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "atheros-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "attr": {
-      "evra": "2.5.1-6.fc38.ppc64le"
+      "evra": "2.5.1-8.fc39.ppc64le"
+    },
+    "audit": {
+      "evra": "3.1.2-4.fc39.ppc64le"
     },
     "audit-libs": {
-      "evra": "3.1.2-1.fc38.ppc64le"
+      "evra": "3.1.2-4.fc39.ppc64le"
     },
     "authselect": {
-      "evra": "1.4.3-1.fc38.ppc64le"
+      "evra": "1.4.3-1.fc39.ppc64le"
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc38.ppc64le"
+      "evra": "1.4.3-1.fc39.ppc64le"
     },
     "avahi-libs": {
-      "evra": "0.8-22.fc38.ppc64le"
+      "evra": "0.8-24.fc39.ppc64le"
     },
     "basesystem": {
-      "evra": "11-15.fc38.noarch"
+      "evra": "11-18.fc39.noarch"
     },
     "bash": {
-      "evra": "5.2.15-3.fc38.ppc64le"
+      "evra": "5.2.15-5.fc39.ppc64le"
+    },
+    "bash-color-prompt": {
+      "evra": "0.1-6.fc39.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.11-9.fc38.noarch"
+      "evra": "1:2.11-12.fc39.noarch"
     },
     "bc": {
-      "evra": "1.07.1-17.fc38.ppc64le"
+      "evra": "1.07.1-19.fc39.ppc64le"
     },
     "bind-libs": {
-      "evra": "32:9.18.19-1.fc38.ppc64le"
+      "evra": "32:9.18.19-1.fc39.ppc64le"
     },
     "bind-license": {
-      "evra": "32:9.18.19-1.fc38.noarch"
+      "evra": "32:9.18.19-1.fc39.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.19-1.fc38.ppc64le"
+      "evra": "32:9.18.19-1.fc39.ppc64le"
     },
     "brcmfmac-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "bsdtar": {
-      "evra": "3.6.1-4.fc38.ppc64le"
+      "evra": "3.7.1-1.fc39.ppc64le"
     },
     "btrfs-progs": {
-      "evra": "6.5.1-1.fc38.ppc64le"
+      "evra": "6.5.1-1.fc39.ppc64le"
     },
     "bubblewrap": {
-      "evra": "0.7.0-1.fc38.ppc64le"
+      "evra": "0.7.0-2.fc39.ppc64le"
     },
     "bzip2": {
-      "evra": "1.0.8-13.fc38.ppc64le"
+      "evra": "1.0.8-16.fc39.ppc64le"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-13.fc38.ppc64le"
+      "evra": "1.0.8-16.fc39.ppc64le"
     },
     "c-ares": {
-      "evra": "1.19.1-1.fc38.ppc64le"
+      "evra": "1.19.1-1.fc39.ppc64le"
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-1.0.fc38.noarch"
+      "evra": "2023.2.60_v7.0.306-2.fc39.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-14.fc38.ppc64le"
+      "evra": "0.1.7-18.fc39.ppc64le"
     },
     "chrony": {
-      "evra": "4.4-1.fc38.ppc64le"
+      "evra": "4.4-1.fc39.ppc64le"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc38.ppc64le"
+      "evra": "7.0-2.fc39.ppc64le"
     },
     "clevis": {
-      "evra": "19-2.fc38.ppc64le"
+      "evra": "19-4.fc39.ppc64le"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc38.ppc64le"
+      "evra": "19-4.fc39.ppc64le"
     },
     "clevis-luks": {
-      "evra": "19-2.fc38.ppc64le"
+      "evra": "19-4.fc39.ppc64le"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc38.ppc64le"
+      "evra": "19-4.fc39.ppc64le"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc38.noarch"
+      "evra": "0.33-3.fc39.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc38.ppc64le"
+      "evra": "2:2.1.7-3.fc39.ppc64le"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.224.0-1.fc38.noarch"
+      "evra": "2:2.224.0-1.fc39.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc38.ppc64le"
+      "evra": "1.6.19-2.fc39.ppc64le"
     },
     "containernetworking-plugins": {
-      "evra": "1.3.0-2.fc38.ppc64le"
+      "evra": "1.3.0-3.fc39.ppc64le"
     },
     "containers-common": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "coreos-installer": {
-      "evra": "0.18.0-1.fc38.ppc64le"
+      "evra": "0.18.0-1.fc39.ppc64le"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.18.0-1.fc38.ppc64le"
+      "evra": "0.18.0-1.fc39.ppc64le"
     },
     "coreutils": {
-      "evra": "9.1-12.fc38.ppc64le"
+      "evra": "9.3-4.fc39.ppc64le"
     },
     "coreutils-common": {
-      "evra": "9.1-12.fc38.ppc64le"
+      "evra": "9.3-4.fc39.ppc64le"
     },
     "cpio": {
-      "evra": "2.13-14.fc38.ppc64le"
+      "evra": "2.14-4.fc39.ppc64le"
     },
     "cracklib": {
-      "evra": "2.9.11-1.fc38.ppc64le"
+      "evra": "2.9.11-2.fc39.ppc64le"
     },
     "criu": {
-      "evra": "3.18-1.fc38.ppc64le"
+      "evra": "3.18-3.fc39.ppc64le"
     },
     "criu-libs": {
-      "evra": "3.18-1.fc38.ppc64le"
+      "evra": "3.18-3.fc39.ppc64le"
     },
     "crun": {
-      "evra": "1.11-1.fc38.ppc64le"
+      "evra": "1.11.1-1.fc39.ppc64le"
     },
     "crypto-policies": {
-      "evra": "20230301-1.gita12f7b2.fc38.noarch"
+      "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc38.ppc64le"
+      "evra": "2.6.1-3.fc39.ppc64le"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc38.ppc64le"
+      "evra": "2.6.1-3.fc39.ppc64le"
     },
     "curl": {
-      "evra": "8.0.1-5.fc38.ppc64le"
+      "evra": "8.2.1-3.fc39.ppc64le"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-9.fc38.ppc64le"
+      "evra": "2.1.28-11.fc39.ppc64le"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-9.fc38.ppc64le"
+      "evra": "2.1.28-11.fc39.ppc64le"
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc38.ppc64le"
+      "evra": "1:1.14.10-1.fc39.ppc64le"
     },
     "dbus-broker": {
-      "evra": "33-1.fc38.ppc64le"
+      "evra": "33-2.fc39.ppc64le"
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc38.noarch"
+      "evra": "1:1.14.10-1.fc39.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc38.ppc64le"
+      "evra": "1:1.14.10-1.fc39.ppc64le"
     },
     "device-mapper": {
-      "evra": "1.02.189-2.fc38.ppc64le"
+      "evra": "1.02.196-1.fc39.ppc64le"
     },
     "device-mapper-event": {
-      "evra": "1.02.189-2.fc38.ppc64le"
+      "evra": "1.02.196-1.fc39.ppc64le"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.189-2.fc38.ppc64le"
+      "evra": "1.02.196-1.fc39.ppc64le"
     },
     "device-mapper-libs": {
-      "evra": "1.02.189-2.fc38.ppc64le"
+      "evra": "1.02.196-1.fc39.ppc64le"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.4-2.fc38.ppc64le"
+      "evra": "0.9.5-2.fc39.ppc64le"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.4-2.fc38.ppc64le"
+      "evra": "0.9.5-2.fc39.ppc64le"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-10.fc38.ppc64le"
+      "evra": "1.0.6-2.fc39.ppc64le"
     },
     "diffutils": {
-      "evra": "3.10-1.fc38.ppc64le"
+      "evra": "3.10-3.fc39.ppc64le"
     },
     "dnsmasq": {
-      "evra": "2.89-5.fc38.ppc64le"
+      "evra": "2.89-6.fc39.ppc64le"
     },
     "dosfstools": {
-      "evra": "4.2-6.fc38.ppc64le"
+      "evra": "4.2-7.fc39.ppc64le"
     },
     "dracut": {
-      "evra": "059-4.fc38.ppc64le"
+      "evra": "059-15.fc39.ppc64le"
     },
     "dracut-network": {
-      "evra": "059-4.fc38.ppc64le"
+      "evra": "059-15.fc39.ppc64le"
     },
     "dracut-squash": {
-      "evra": "059-4.fc38.ppc64le"
+      "evra": "059-15.fc39.ppc64le"
     },
     "duktape": {
-      "evra": "2.7.0-2.fc38.ppc64le"
+      "evra": "2.7.0-5.fc39.ppc64le"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-4.fc38.ppc64le"
+      "evra": "1.47.0-2.fc39.ppc64le"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-4.fc38.ppc64le"
+      "evra": "1.47.0-2.fc39.ppc64le"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-3.fc38.noarch"
+      "evra": "0.189-4.fc39.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-3.fc38.ppc64le"
+      "evra": "0.189-4.fc39.ppc64le"
     },
     "elfutils-libs": {
-      "evra": "0.189-3.fc38.ppc64le"
+      "evra": "0.189-4.fc39.ppc64le"
     },
     "ethtool": {
-      "evra": "2:6.5-1.fc38.ppc64le"
+      "evra": "2:6.5-1.fc39.ppc64le"
     },
     "expat": {
-      "evra": "2.5.0-2.fc38.ppc64le"
+      "evra": "2.5.0-3.fc39.ppc64le"
     },
     "fedora-gpg-keys": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-repos": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-1.noarch"
-    },
-    "fedora-repos-modular": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "file": {
-      "evra": "5.44-3.fc38.ppc64le"
+      "evra": "5.44-5.fc39.ppc64le"
     },
     "file-libs": {
-      "evra": "5.44-3.fc38.ppc64le"
+      "evra": "5.44-5.fc39.ppc64le"
     },
     "filesystem": {
-      "evra": "3.18-3.fc38.ppc64le"
+      "evra": "3.18-6.fc39.ppc64le"
     },
     "findutils": {
-      "evra": "1:4.9.0-3.fc38.ppc64le"
+      "evra": "1:4.9.0-5.fc39.ppc64le"
     },
     "flatpak-session-helper": {
-      "evra": "1.15.4-1.fc38.ppc64le"
+      "evra": "1.15.4-3.fc39.ppc64le"
     },
     "fstrm": {
-      "evra": "0.6.1-6.fc38.ppc64le"
+      "evra": "0.6.1-8.fc39.ppc64le"
     },
     "fuse": {
-      "evra": "2.9.9-16.fc38.ppc64le"
+      "evra": "2.9.9-17.fc39.ppc64le"
     },
     "fuse-common": {
-      "evra": "3.14.1-1.fc38.ppc64le"
+      "evra": "3.16.1-1.fc39.ppc64le"
     },
     "fuse-libs": {
-      "evra": "2.9.9-16.fc38.ppc64le"
+      "evra": "2.9.9-17.fc39.ppc64le"
     },
     "fuse-overlayfs": {
-      "evra": "1.12-1.fc38.ppc64le"
+      "evra": "1.12-2.fc39.ppc64le"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-3.fc38.ppc64le"
+      "evra": "3.7.3-4.fc39.ppc64le"
     },
     "fuse3": {
-      "evra": "3.14.1-1.fc38.ppc64le"
+      "evra": "3.16.1-1.fc39.ppc64le"
     },
     "fuse3-libs": {
-      "evra": "3.14.1-1.fc38.ppc64le"
+      "evra": "3.16.1-1.fc39.ppc64le"
     },
     "fwupd": {
-      "evra": "1.9.7-1.fc38.ppc64le"
+      "evra": "1.9.7-1.fc39.ppc64le"
     },
     "gawk": {
-      "evra": "5.1.1-5.fc38.ppc64le"
+      "evra": "5.2.2-2.fc39.ppc64le"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-3.fc38.ppc64le"
+      "evra": "1:1.23-4.fc39.ppc64le"
     },
     "gdisk": {
-      "evra": "1.0.9-5.fc38.ppc64le"
+      "evra": "1.0.9-6.fc39.ppc64le"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-2.fc38.ppc64le"
+      "evra": "0.22-2.fc39.ppc64le"
     },
     "gettext-libs": {
-      "evra": "0.21.1-2.fc38.ppc64le"
+      "evra": "0.22-2.fc39.ppc64le"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-2.fc38.ppc64le"
+      "evra": "0.22-2.fc39.ppc64le"
     },
     "git-core": {
-      "evra": "2.41.0-1.fc38.ppc64le"
+      "evra": "2.41.0-2.fc39.ppc64le"
     },
     "glib2": {
-      "evra": "2.76.5-2.fc38.ppc64le"
+      "evra": "2.78.1-1.fc39.ppc64le"
     },
     "glibc": {
-      "evra": "2.37-13.fc38.ppc64le"
+      "evra": "2.38-10.fc39.ppc64le"
     },
     "glibc-common": {
-      "evra": "2.37-13.fc38.ppc64le"
+      "evra": "2.38-10.fc39.ppc64le"
     },
     "glibc-gconv-extra": {
-      "evra": "2.37-13.fc38.ppc64le"
+      "evra": "2.38-10.fc39.ppc64le"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.37-13.fc38.ppc64le"
+      "evra": "2.38-10.fc39.ppc64le"
     },
     "gmp": {
-      "evra": "1:6.2.1-4.fc38.ppc64le"
+      "evra": "1:6.2.1-5.fc39.ppc64le"
     },
     "gnupg2": {
-      "evra": "2.4.0-3.fc38.ppc64le"
+      "evra": "2.4.3-2.fc39.ppc64le"
     },
     "gnutls": {
-      "evra": "3.8.1-1.fc38.ppc64le"
+      "evra": "3.8.1-1.fc39.ppc64le"
     },
     "gpgme": {
-      "evra": "1.17.1-5.fc38.ppc64le"
+      "evra": "1.20.0-5.fc39.ppc64le"
     },
     "grep": {
-      "evra": "3.8-3.fc38.ppc64le"
+      "evra": "3.11-3.fc39.ppc64le"
     },
     "grub2-common": {
-      "evra": "1:2.06-102.fc38.noarch"
+      "evra": "1:2.06-104.fc39.noarch"
     },
     "grub2-ppc64le": {
-      "evra": "1:2.06-102.fc38.ppc64le"
+      "evra": "1:2.06-104.fc39.ppc64le"
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.06-102.fc38.noarch"
+      "evra": "1:2.06-104.fc39.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-102.fc38.ppc64le"
+      "evra": "1:2.06-104.fc39.ppc64le"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-102.fc38.ppc64le"
+      "evra": "1:2.06-104.fc39.ppc64le"
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.1-1.fc38.ppc64le"
+      "evra": "6:0.7.1-1.fc39.ppc64le"
     },
     "gzip": {
-      "evra": "1.12-3.fc38.ppc64le"
+      "evra": "1.12-6.fc39.ppc64le"
     },
     "hostname": {
-      "evra": "3.23-8.fc38.ppc64le"
+      "evra": "3.23-9.fc39.ppc64le"
     },
     "ignition": {
-      "evra": "2.16.2-1.fc38.ppc64le"
+      "evra": "2.16.2-2.fc39.ppc64le"
     },
     "inih": {
-      "evra": "57-1.fc38.ppc64le"
+      "evra": "57-2.fc39.ppc64le"
     },
     "intel-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-1.fc38.ppc64le"
+      "evra": "1.0.3-2.fc39.ppc64le"
     },
     "iproute": {
-      "evra": "6.4.0-1.fc38.ppc64le"
+      "evra": "6.4.0-2.fc39.ppc64le"
     },
     "iproute-tc": {
-      "evra": "6.4.0-1.fc38.ppc64le"
+      "evra": "6.4.0-2.fc39.ppc64le"
     },
     "iptables-legacy": {
-      "evra": "1.8.9-4.fc38.1.ppc64le"
+      "evra": "1.8.9-5.fc39.ppc64le"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-4.fc38.1.ppc64le"
+      "evra": "1.8.9-5.fc39.ppc64le"
     },
     "iptables-libs": {
-      "evra": "1.8.9-4.fc38.1.ppc64le"
+      "evra": "1.8.9-5.fc39.ppc64le"
     },
     "iptables-nft": {
-      "evra": "1.8.9-4.fc38.1.ppc64le"
+      "evra": "1.8.9-5.fc39.ppc64le"
     },
     "iptables-services": {
-      "evra": "1.8.9-4.fc38.1.noarch"
+      "evra": "1.8.9-5.fc39.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.9-4.fc38.1.ppc64le"
+      "evra": "1.8.9-5.fc39.ppc64le"
     },
     "iputils": {
-      "evra": "20221126-2.fc38.ppc64le"
+      "evra": "20221126-4.fc39.ppc64le"
     },
     "irqbalance": {
-      "evra": "2:1.9.2-1.fc38.ppc64le"
+      "evra": "2:1.9.2-2.fc39.ppc64le"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.ppc64le"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.ppc64le"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.ppc64le"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.ppc64le"
     },
     "isns-utils-libs": {
-      "evra": "0.101-6.fc38.ppc64le"
+      "evra": "0.101-7.fc39.ppc64le"
     },
     "jansson": {
-      "evra": "2.13.1-6.fc38.ppc64le"
+      "evra": "2.13.1-7.fc39.ppc64le"
     },
     "jemalloc": {
-      "evra": "5.3.0-3.fc38.ppc64le"
+      "evra": "5.3.0-4.fc39.ppc64le"
     },
     "jose": {
-      "evra": "11-7.fc38.ppc64le"
+      "evra": "11-8.fc39.ppc64le"
     },
     "jq": {
-      "evra": "1.6-16.fc38.ppc64le"
+      "evra": "1.6-17.fc39.ppc64le"
     },
     "json-c": {
-      "evra": "0.17-1.fc38.ppc64le"
+      "evra": "0.17-1.fc39.ppc64le"
     },
     "json-glib": {
-      "evra": "1.6.6-4.fc38.ppc64le"
+      "evra": "1.8.0-1.fc39.ppc64le"
     },
     "kbd": {
-      "evra": "2.5.1-5.fc38.ppc64le"
+      "evra": "2.6.3-1.fc39.ppc64le"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kernel": {
-      "evra": "6.5.9-200.fc38.ppc64le"
+      "evra": "6.5.9-300.fc39.ppc64le"
     },
     "kernel-core": {
-      "evra": "6.5.9-200.fc38.ppc64le"
+      "evra": "6.5.9-300.fc39.ppc64le"
     },
     "kernel-modules": {
-      "evra": "6.5.9-200.fc38.ppc64le"
+      "evra": "6.5.9-300.fc39.ppc64le"
     },
     "kernel-modules-core": {
-      "evra": "6.5.9-200.fc38.ppc64le"
+      "evra": "6.5.9-300.fc39.ppc64le"
     },
     "kexec-tools": {
-      "evra": "2.0.26-3.fc38.ppc64le"
+      "evra": "2.0.27-2.fc39.ppc64le"
     },
     "keyutils": {
-      "evra": "1.6.1-6.fc38.ppc64le"
+      "evra": "1.6.1-7.fc39.ppc64le"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-6.fc38.ppc64le"
+      "evra": "1.6.1-7.fc39.ppc64le"
     },
     "kmod": {
-      "evra": "30-4.fc38.ppc64le"
+      "evra": "30-6.fc39.ppc64le"
     },
     "kmod-libs": {
-      "evra": "30-4.fc38.ppc64le"
+      "evra": "30-6.fc39.ppc64le"
     },
     "kpartx": {
-      "evra": "0.9.4-2.fc38.ppc64le"
+      "evra": "0.9.5-2.fc39.ppc64le"
     },
     "krb5-libs": {
-      "evra": "1.21-3.fc38.ppc64le"
+      "evra": "1.21.2-2.fc39.ppc64le"
     },
     "less": {
-      "evra": "633-1.fc38.ppc64le"
+      "evra": "633-2.fc39.ppc64le"
     },
     "libacl": {
-      "evra": "2.3.1-6.fc38.ppc64le"
+      "evra": "2.3.1-8.fc39.ppc64le"
     },
     "libaio": {
-      "evra": "0.3.111-15.fc38.ppc64le"
+      "evra": "0.3.111-16.fc39.ppc64le"
     },
     "libarchive": {
-      "evra": "3.6.1-4.fc38.ppc64le"
+      "evra": "3.7.1-1.fc39.ppc64le"
     },
     "libargon2": {
-      "evra": "20190702-2.fc38.ppc64le"
+      "evra": "20190702-3.fc39.ppc64le"
     },
     "libassuan": {
-      "evra": "2.5.6-1.fc38.ppc64le"
+      "evra": "2.5.6-2.fc39.ppc64le"
     },
     "libatomic": {
-      "evra": "13.2.1-4.fc38.ppc64le"
+      "evra": "13.2.1-4.fc39.ppc64le"
     },
     "libattr": {
-      "evra": "2.5.1-6.fc38.ppc64le"
+      "evra": "2.5.1-8.fc39.ppc64le"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-53.fc38.ppc64le"
+      "evra": "0.1.1-54.fc39.ppc64le"
     },
     "libblkid": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "libbpf": {
-      "evra": "2:1.1.0-2.fc38.ppc64le"
+      "evra": "2:1.1.0-4.fc39.ppc64le"
     },
     "libbsd": {
-      "evra": "0.11.7-4.fc38.ppc64le"
+      "evra": "0.11.7-5.fc39.ppc64le"
     },
     "libcap": {
-      "evra": "2.48-6.fc38.ppc64le"
+      "evra": "2.48-7.fc39.ppc64le"
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc38.ppc64le"
+      "evra": "0.8.3-8.fc39.ppc64le"
     },
     "libcbor": {
-      "evra": "0.7.0-9.fc38.ppc64le"
+      "evra": "0.10.2-2.fc39.ppc64le"
     },
     "libcollection": {
-      "evra": "0.7.0-53.fc38.ppc64le"
+      "evra": "0.7.0-54.fc39.ppc64le"
     },
     "libcom_err": {
-      "evra": "1.46.5-4.fc38.ppc64le"
+      "evra": "1.47.0-2.fc39.ppc64le"
     },
     "libcurl-minimal": {
-      "evra": "8.0.1-5.fc38.ppc64le"
+      "evra": "8.2.1-3.fc39.ppc64le"
     },
     "libdaemon": {
-      "evra": "0.14-25.fc38.ppc64le"
+      "evra": "0.14-26.fc39.ppc64le"
     },
     "libdb": {
-      "evra": "5.3.28-55.fc38.ppc64le"
+      "evra": "5.3.28-56.fc39.ppc64le"
     },
     "libdhash": {
-      "evra": "0.5.0-53.fc38.ppc64le"
+      "evra": "0.5.0-54.fc39.ppc64le"
     },
     "libeconf": {
-      "evra": "0.5.2-1.fc38.ppc64le"
+      "evra": "0.5.2-1.fc39.ppc64le"
     },
     "libedit": {
-      "evra": "3.1-45.20221030cvs.fc38.ppc64le"
+      "evra": "3.1-48.20230828cvs.fc39.ppc64le"
     },
     "libevent": {
-      "evra": "2.1.12-8.fc38.ppc64le"
+      "evra": "2.1.12-9.fc39.ppc64le"
     },
     "libfdisk": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "libffi": {
-      "evra": "3.4.4-2.fc38.ppc64le"
+      "evra": "3.4.4-4.fc39.ppc64le"
     },
     "libfido2": {
-      "evra": "1.12.0-3.fc38.ppc64le"
+      "evra": "1.13.0-3.fc39.ppc64le"
     },
     "libgcc": {
-      "evra": "13.2.1-4.fc38.ppc64le"
+      "evra": "13.2.1-4.fc39.ppc64le"
     },
     "libgcrypt": {
-      "evra": "1.10.2-1.fc38.ppc64le"
+      "evra": "1.10.2-2.fc39.ppc64le"
     },
     "libgpg-error": {
-      "evra": "1.47-1.fc38.ppc64le"
+      "evra": "1.47-2.fc39.ppc64le"
     },
     "libgudev": {
-      "evra": "237-4.fc38.ppc64le"
+      "evra": "238-2.fc39.ppc64le"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc38.ppc64le"
+      "evra": "0.4.7-1.fc39.ppc64le"
     },
     "libibverbs": {
-      "evra": "44.0-3.fc38.ppc64le"
+      "evra": "46.0-4.fc39.ppc64le"
     },
     "libicu": {
-      "evra": "72.1-2.fc38.ppc64le"
+      "evra": "73.2-2.fc39.ppc64le"
     },
     "libidn2": {
-      "evra": "2.3.4-2.fc38.ppc64le"
+      "evra": "2.3.4-3.fc39.ppc64le"
     },
     "libini_config": {
-      "evra": "1.3.1-53.fc38.ppc64le"
+      "evra": "1.3.1-54.fc39.ppc64le"
     },
     "libipa_hbac": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc38.ppc64le"
+      "evra": "0.1.14-2.fc39.ppc64le"
     },
     "libjose": {
-      "evra": "11-7.fc38.ppc64le"
+      "evra": "11-8.fc39.ppc64le"
     },
     "libkcapi": {
-      "evra": "1.4.0-5.fc38.ppc64le"
+      "evra": "1.4.0-7.fc39.ppc64le"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-5.fc38.ppc64le"
+      "evra": "1.4.0-7.fc39.ppc64le"
     },
     "libksba": {
-      "evra": "1.6.4-1.fc38.ppc64le"
+      "evra": "1.6.4-2.fc39.ppc64le"
     },
     "libldb": {
-      "evra": "2.7.2-1.fc38.ppc64le"
+      "evra": "2.8.0-1.fc39.ppc64le"
     },
     "libluksmeta": {
-      "evra": "9-15.fc38.ppc64le"
+      "evra": "9-16.fc39.ppc64le"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-2.fc38.ppc64le"
+      "evra": "1.7.1-3.fc39.ppc64le"
     },
     "libmd": {
-      "evra": "1.1.0-1.fc38.ppc64le"
+      "evra": "1.1.0-2.fc39.ppc64le"
     },
     "libmnl": {
-      "evra": "1.0.5-2.fc38.ppc64le"
+      "evra": "1.0.5-3.fc39.ppc64le"
     },
     "libmodulemd": {
-      "evra": "2.15.0-2.fc38.ppc64le"
+      "evra": "2.15.0-5.fc39.ppc64le"
     },
     "libmount": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "libndp": {
-      "evra": "1.8-5.fc38.ppc64le"
+      "evra": "1.8-6.fc39.ppc64le"
     },
     "libnet": {
-      "evra": "1.3-1.fc38.ppc64le"
+      "evra": "1.3-1.fc39.ppc64le"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-1.fc38.ppc64le"
+      "evra": "1.0.9-2.fc39.ppc64le"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-23.fc38.ppc64le"
+      "evra": "1.0.1-24.fc39.ppc64le"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.3-1.rc3.fc38.ppc64le"
+      "evra": "1:2.6.3-2.rc3.fc39.ppc64le"
     },
     "libnftnl": {
-      "evra": "1.2.4-2.fc38.ppc64le"
+      "evra": "1.2.6-2.fc39.ppc64le"
     },
     "libnghttp2": {
-      "evra": "1.52.0-2.fc38.ppc64le"
+      "evra": "1.55.1-4.fc39.ppc64le"
     },
     "libnl3": {
-      "evra": "3.7.0-3.fc38.ppc64le"
+      "evra": "3.8.0-1.fc39.ppc64le"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-3.fc38.ppc64le"
+      "evra": "3.8.0-1.fc39.ppc64le"
     },
     "libnsl2": {
-      "evra": "2.0.0-5.fc38.ppc64le"
+      "evra": "2.0.0-6.fc39.ppc64le"
     },
     "libnvme": {
-      "evra": "1.4-2.fc38.ppc64le"
+      "evra": "1.6-2.fc39.ppc64le"
     },
     "libpath_utils": {
-      "evra": "0.2.1-53.fc38.ppc64le"
+      "evra": "0.2.1-54.fc39.ppc64le"
     },
     "libpcap": {
-      "evra": "14:1.10.4-1.fc38.ppc64le"
+      "evra": "14:1.10.4-2.fc39.ppc64le"
     },
     "libpkgconf": {
-      "evra": "1.8.0-6.fc38.ppc64le"
+      "evra": "1.9.5-2.fc39.ppc64le"
     },
     "libpsl": {
-      "evra": "0.21.2-2.fc38.ppc64le"
+      "evra": "0.21.2-4.fc39.ppc64le"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc38.ppc64le"
+      "evra": "1.4.5-6.fc39.ppc64le"
     },
     "libref_array": {
-      "evra": "0.1.5-53.fc38.ppc64le"
+      "evra": "0.1.5-54.fc39.ppc64le"
     },
     "librepo": {
-      "evra": "1.17.0-1.fc38.ppc64le"
+      "evra": "1.17.0-1.fc39.ppc64le"
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-1.fc38.noarch"
+      "evra": "2.17.11-3.fc39.noarch"
     },
     "librtas": {
-      "evra": "2.0.4-1.fc38.ppc64le"
+      "evra": "2.0.4-3.fc39.ppc64le"
     },
     "libseccomp": {
-      "evra": "2.5.3-4.fc38.ppc64le"
+      "evra": "2.5.3-6.fc39.ppc64le"
     },
     "libselinux": {
-      "evra": "3.5-1.fc38.ppc64le"
+      "evra": "3.5-5.fc39.ppc64le"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc38.ppc64le"
+      "evra": "3.5-5.fc39.ppc64le"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc38.ppc64le"
+      "evra": "3.5-4.fc39.ppc64le"
     },
     "libsepol": {
-      "evra": "3.5-1.fc38.ppc64le"
+      "evra": "3.5-2.fc39.ppc64le"
     },
     "libservicelog": {
-      "evra": "1.1.19-5.fc38.ppc64le"
+      "evra": "1.1.19-8.fc39.ppc64le"
     },
     "libsigsegv": {
-      "evra": "2.14-4.fc38.ppc64le"
+      "evra": "2.14-5.fc39.ppc64le"
     },
     "libslirp": {
-      "evra": "4.7.0-3.fc38.ppc64le"
+      "evra": "4.7.0-4.fc39.ppc64le"
     },
     "libsmartcols": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "libsmbclient": {
-      "evra": "2:4.18.8-1.fc38.ppc64le"
+      "evra": "2:4.19.2-1.fc39.ppc64le"
     },
     "libsolv": {
-      "evra": "0.7.25-1.fc38.ppc64le"
+      "evra": "0.7.25-1.fc39.ppc64le"
     },
     "libss": {
-      "evra": "1.46.5-4.fc38.ppc64le"
+      "evra": "1.47.0-2.fc39.ppc64le"
     },
     "libsss_certmap": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "libsss_idmap": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "libsss_sudo": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "libstdc++": {
-      "evra": "13.2.1-4.fc38.ppc64le"
+      "evra": "13.2.1-4.fc39.ppc64le"
     },
     "libtalloc": {
-      "evra": "2.4.0-2.fc38.ppc64le"
+      "evra": "2.4.1-1.fc39.ppc64le"
     },
     "libtasn1": {
-      "evra": "4.19.0-2.fc38.ppc64le"
+      "evra": "4.19.0-3.fc39.ppc64le"
     },
     "libtdb": {
-      "evra": "1.4.8-1.fc38.ppc64le"
+      "evra": "1.4.9-1.fc39.ppc64le"
     },
     "libteam": {
-      "evra": "1.31-7.fc38.ppc64le"
+      "evra": "1.32-1.fc39.ppc64le"
     },
     "libtevent": {
-      "evra": "0.14.1-1.fc38.ppc64le"
+      "evra": "0.15.0-1.fc39.ppc64le"
     },
     "libtirpc": {
-      "evra": "1.3.4-0.fc38.ppc64le"
+      "evra": "1.3.4-0.fc39.ppc64le"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-6.fc38.ppc64le"
+      "evra": "2.4.7-7.fc39.ppc64le"
     },
     "libunistring": {
-      "evra": "1.1-3.fc38.ppc64le"
-    },
-    "libunistring1.0": {
-      "evra": "1.0-1.fc38.ppc64le"
+      "evra": "1.1-5.fc39.ppc64le"
     },
     "libusb1": {
-      "evra": "1.0.26-2.fc38.ppc64le"
+      "evra": "1.0.26-3.fc39.ppc64le"
     },
     "libuser": {
-      "evra": "0.64-2.fc38.ppc64le"
+      "evra": "0.64-4.fc39.ppc64le"
     },
     "libutempter": {
-      "evra": "1.2.1-8.fc38.ppc64le"
+      "evra": "1.2.1-10.fc39.ppc64le"
     },
     "libuuid": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "libuv": {
-      "evra": "1:1.46.0-1.fc38.ppc64le"
+      "evra": "1:1.46.0-2.fc39.ppc64le"
     },
     "libverto": {
-      "evra": "0.3.2-5.fc38.ppc64le"
+      "evra": "0.3.2-6.fc39.ppc64le"
     },
     "libwbclient": {
-      "evra": "2:4.18.8-1.fc38.ppc64le"
+      "evra": "2:4.19.2-1.fc39.ppc64le"
     },
     "libxcrypt": {
-      "evra": "4.4.36-1.fc38.ppc64le"
+      "evra": "4.4.36-2.fc39.ppc64le"
     },
     "libxml2": {
-      "evra": "2.10.4-1.fc38.ppc64le"
+      "evra": "2.10.4-3.fc39.ppc64le"
     },
     "libxmlb": {
-      "evra": "0.3.14-1.fc38.ppc64le"
+      "evra": "0.3.14-1.fc39.ppc64le"
     },
     "libyaml": {
-      "evra": "0.2.5-9.fc38.ppc64le"
+      "evra": "0.2.5-12.fc39.ppc64le"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc38.ppc64le"
+      "evra": "1.5.5-4.fc39.ppc64le"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-34.fc38.ppc64le"
+      "evra": "2.5.1-36.fc39.ppc64le"
     },
     "linux-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.31-1.fc38.ppc64le"
+      "evra": "0.9.31-2.fc39.ppc64le"
     },
     "logrotate": {
-      "evra": "3.21.0-2.fc38.ppc64le"
+      "evra": "3.21.0-4.fc39.ppc64le"
     },
     "lsof": {
-      "evra": "4.96.3-3.fc38.ppc64le"
+      "evra": "4.96.3-4.fc39.ppc64le"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc38.ppc64le"
+      "evra": "5.4.6-3.fc39.ppc64le"
     },
     "luksmeta": {
-      "evra": "9-15.fc38.ppc64le"
+      "evra": "9-16.fc39.ppc64le"
     },
     "lvm2": {
-      "evra": "2.03.18-2.fc38.ppc64le"
+      "evra": "2.03.22-1.fc39.ppc64le"
     },
     "lvm2-libs": {
-      "evra": "2.03.18-2.fc38.ppc64le"
+      "evra": "2.03.22-1.fc39.ppc64le"
     },
     "lz4-libs": {
-      "evra": "1.9.4-2.fc38.ppc64le"
+      "evra": "1.9.4-4.fc39.ppc64le"
     },
     "lzo": {
-      "evra": "2.10-8.fc38.ppc64le"
+      "evra": "2.10-9.fc39.ppc64le"
     },
     "mdadm": {
-      "evra": "4.2-4.fc38.ppc64le"
+      "evra": "4.2-6.fc39.ppc64le"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc38.ppc64le"
+      "evra": "24.0.5-1.fc39.ppc64le"
     },
     "mpfr": {
-      "evra": "4.1.1-3.fc38.ppc64le"
+      "evra": "4.2.0-3.fc39.ppc64le"
     },
     "mt7xxx-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nano": {
-      "evra": "7.2-2.fc38.ppc64le"
+      "evra": "7.2-4.fc39.ppc64le"
     },
     "nano-default-editor": {
-      "evra": "7.2-2.fc38.noarch"
+      "evra": "7.2-4.fc39.noarch"
     },
     "ncurses": {
-      "evra": "6.4-3.20230114.fc38.ppc64le"
+      "evra": "6.4-7.20230520.fc39.ppc64le"
     },
     "ncurses-base": {
-      "evra": "6.4-3.20230114.fc38.noarch"
+      "evra": "6.4-7.20230520.fc39.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.4-3.20230114.fc38.ppc64le"
+      "evra": "6.4-7.20230520.fc39.ppc64le"
     },
     "net-tools": {
-      "evra": "2.0-0.65.20160912git.fc38.ppc64le"
+      "evra": "2.0-0.67.20160912git.fc39.ppc64le"
     },
     "netavark": {
-      "evra": "1.8.0-2.fc38.ppc64le"
+      "evra": "1.8.0-2.fc39.ppc64le"
     },
     "nettle": {
-      "evra": "3.8-3.fc38.ppc64le"
+      "evra": "3.9.1-2.fc39.ppc64le"
     },
     "newt": {
-      "evra": "0.52.23-2.fc38.ppc64le"
+      "evra": "0.52.23-4.fc39.ppc64le"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.3-1.rc3.fc38.ppc64le"
+      "evra": "1:2.6.3-2.rc3.fc39.ppc64le"
     },
     "nftables": {
-      "evra": "1:1.0.5-2.fc38.ppc64le"
+      "evra": "1:1.0.7-3.fc39.ppc64le"
     },
     "nmstate": {
-      "evra": "2.2.15-1.fc38.ppc64le"
+      "evra": "2.2.15-1.fc39.ppc64le"
     },
     "npth": {
-      "evra": "1.6-12.fc38.ppc64le"
+      "evra": "1.6-14.fc39.ppc64le"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-22.fc38.ppc64le"
+      "evra": "2.23.0-1.fc39.ppc64le"
     },
     "numactl-libs": {
-      "evra": "2.0.16-2.fc38.ppc64le"
+      "evra": "2.0.16-3.fc39.ppc64le"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nvme-cli": {
-      "evra": "2.4-3.fc38.ppc64le"
+      "evra": "2.6-1.fc39.ppc64le"
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc38.ppc64le"
+      "evra": "6.9.9-1.fc39.ppc64le"
     },
     "openldap": {
-      "evra": "2.6.6-1.fc38.ppc64le"
+      "evra": "2.6.6-1.fc39.ppc64le"
     },
     "openssh": {
-      "evra": "9.0p1-17.fc38.ppc64le"
+      "evra": "9.3p1-9.fc39.ppc64le"
     },
     "openssh-clients": {
-      "evra": "9.0p1-17.fc38.ppc64le"
+      "evra": "9.3p1-9.fc39.ppc64le"
     },
     "openssh-server": {
-      "evra": "9.0p1-17.fc38.ppc64le"
+      "evra": "9.3p1-9.fc39.ppc64le"
     },
     "openssl": {
-      "evra": "1:3.0.9-2.fc38.ppc64le"
+      "evra": "1:3.1.1-4.fc39.ppc64le"
     },
     "openssl-libs": {
-      "evra": "1:3.0.9-2.fc38.ppc64le"
+      "evra": "1:3.1.1-4.fc39.ppc64le"
     },
     "os-prober": {
-      "evra": "1.81-3.fc38.ppc64le"
+      "evra": "1.81-4.fc39.ppc64le"
     },
     "ostree": {
-      "evra": "2023.6-1.fc38.ppc64le"
+      "evra": "2023.7-2.fc39.ppc64le"
     },
     "ostree-grub2": {
-      "evra": "2023.6-1.fc38.ppc64le"
+      "evra": "2023.7-2.fc39.ppc64le"
     },
     "ostree-libs": {
-      "evra": "2023.6-1.fc38.ppc64le"
+      "evra": "2023.7-2.fc39.ppc64le"
     },
     "p11-kit": {
-      "evra": "0.25.2-1.fc38.ppc64le"
+      "evra": "0.25.2-1.fc39.ppc64le"
     },
     "p11-kit-trust": {
-      "evra": "0.25.2-1.fc38.ppc64le"
+      "evra": "0.25.2-1.fc39.ppc64le"
     },
     "pam": {
-      "evra": "1.5.2-16.fc38.ppc64le"
+      "evra": "1.5.3-3.fc39.ppc64le"
     },
     "pam-libs": {
-      "evra": "1.5.2-16.fc38.ppc64le"
+      "evra": "1.5.3-3.fc39.ppc64le"
     },
     "passt": {
-      "evra": "0^20231004.gf851084-1.fc38.ppc64le"
+      "evra": "0^20231004.gf851084-1.fc39.ppc64le"
     },
     "passt-selinux": {
-      "evra": "0^20231004.gf851084-1.fc38.noarch"
+      "evra": "0^20231004.gf851084-1.fc39.noarch"
     },
     "passwd": {
-      "evra": "0.80-14.fc38.ppc64le"
+      "evra": "0.80-15.fc39.ppc64le"
     },
     "pcre2": {
-      "evra": "10.42-1.fc38.1.ppc64le"
+      "evra": "10.42-1.fc39.2.ppc64le"
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc38.1.noarch"
+      "evra": "10.42-1.fc39.2.noarch"
     },
     "pigz": {
-      "evra": "2.7-3.fc38.ppc64le"
+      "evra": "2.8-2.fc39.ppc64le"
     },
     "pkgconf": {
-      "evra": "1.8.0-6.fc38.ppc64le"
+      "evra": "1.9.5-2.fc39.ppc64le"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-6.fc38.noarch"
+      "evra": "1.9.5-2.fc39.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-6.fc38.ppc64le"
+      "evra": "1.9.5-2.fc39.ppc64le"
     },
     "podman": {
-      "evra": "5:4.7.0-1.fc38.ppc64le"
+      "evra": "5:4.7.0-1.fc39.ppc64le"
     },
     "podman-plugins": {
-      "evra": "5:4.7.0-1.fc38.ppc64le"
+      "evra": "5:4.7.0-1.fc39.ppc64le"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc38.ppc64le"
+      "evra": "3.5-8.fc39.ppc64le"
     },
     "polkit": {
-      "evra": "122-3.fc38.1.ppc64le"
+      "evra": "123-1.fc39.ppc64le"
     },
     "polkit-libs": {
-      "evra": "122-3.fc38.1.ppc64le"
+      "evra": "123-1.fc39.ppc64le"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-23.fc38.ppc64le"
+      "evra": "0.1-26.fc39.ppc64le"
     },
     "popt": {
-      "evra": "1.19-2.fc38.ppc64le"
+      "evra": "1.19-3.fc39.ppc64le"
     },
     "powerpc-utils-core": {
-      "evra": "1.3.11-1.fc38.ppc64le"
+      "evra": "1.3.11-4.fc39.ppc64le"
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.9-2.fc38.ppc64le"
+      "evra": "2.7.9-4.fc39.ppc64le"
     },
     "procps-ng": {
-      "evra": "3.3.17-11.fc38.ppc64le"
+      "evra": "4.0.3-4.fc39.ppc64le"
     },
     "protobuf-c": {
-      "evra": "1.4.1-4.fc38.ppc64le"
+      "evra": "1.4.1-5.fc39.ppc64le"
     },
     "psmisc": {
-      "evra": "23.6-2.fc38.ppc64le"
+      "evra": "23.6-4.fc39.ppc64le"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230812-1.fc38.noarch"
+      "evra": "20230812-1.fc39.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.2.6-1.fc38.ppc64le"
+      "evra": "2:8.1.1-1.fc39.ppc64le"
     },
     "readline": {
-      "evra": "8.2-3.fc38.ppc64le"
+      "evra": "8.2-4.fc39.ppc64le"
     },
     "realtek-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc2.fc38.ppc64le"
+      "evra": "1.2.6-4.rc2.fc39.1.ppc64le"
     },
     "rpm": {
-      "evra": "4.18.1-3.fc38.ppc64le"
+      "evra": "4.19.0-1.fc39.ppc64le"
     },
     "rpm-libs": {
-      "evra": "4.18.1-3.fc38.ppc64le"
+      "evra": "4.19.0-1.fc39.ppc64le"
     },
     "rpm-ostree": {
-      "evra": "2023.8-2.fc38.ppc64le"
+      "evra": "2023.8-2.fc39.ppc64le"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.8-2.fc38.ppc64le"
+      "evra": "2023.8-2.fc39.ppc64le"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.1-3.fc38.ppc64le"
+      "evra": "4.19.0-1.fc39.ppc64le"
     },
     "rpm-sequoia": {
-      "evra": "1.5.0-1.fc38.ppc64le"
+      "evra": "1.5.0-1.fc39.ppc64le"
     },
     "rsync": {
-      "evra": "3.2.7-2.fc38.ppc64le"
+      "evra": "3.2.7-5.fc39.ppc64le"
     },
     "runc": {
-      "evra": "2:1.1.8-1.fc38.ppc64le"
+      "evra": "2:1.1.8-1.fc39.ppc64le"
     },
     "samba-client-libs": {
-      "evra": "2:4.18.8-1.fc38.ppc64le"
+      "evra": "2:4.19.2-1.fc39.ppc64le"
     },
     "samba-common": {
-      "evra": "2:4.18.8-1.fc38.noarch"
+      "evra": "2:4.19.2-1.fc39.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.18.8-1.fc38.ppc64le"
+      "evra": "2:4.19.2-1.fc39.ppc64le"
     },
     "sed": {
-      "evra": "4.8-12.fc38.ppc64le"
+      "evra": "4.8-14.fc39.ppc64le"
     },
     "selinux-policy": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "servicelog": {
-      "evra": "1.1.16-3.fc38.ppc64le"
+      "evra": "1.1.16-5.fc39.ppc64le"
     },
     "setup": {
-      "evra": "2.14.3-2.fc38.noarch"
+      "evra": "2.14.4-1.fc39.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-5.fc38.ppc64le"
+      "evra": "1.46-6.fc39.ppc64le"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-5.fc38.ppc64le"
+      "evra": "1.46-6.fc39.ppc64le"
     },
     "shadow-utils": {
-      "evra": "2:4.13-6.fc38.ppc64le"
+      "evra": "2:4.14.0-2.fc39.ppc64le"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.13-6.fc38.ppc64le"
+      "evra": "2:4.14.0-2.fc39.ppc64le"
     },
     "shared-mime-info": {
-      "evra": "2.2-3.fc38.ppc64le"
+      "evra": "2.2-4.fc39.ppc64le"
     },
     "skopeo": {
-      "evra": "1:1.13.3-1.fc38.ppc64le"
+      "evra": "1:1.13.3-1.fc39.ppc64le"
     },
     "slang": {
-      "evra": "2.3.3-3.fc38.ppc64le"
+      "evra": "2.3.3-4.fc39.ppc64le"
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc38.ppc64le"
+      "evra": "1.2.2-1.fc39.ppc64le"
     },
     "snappy": {
-      "evra": "1.1.9-7.fc38.ppc64le"
+      "evra": "1.1.10-2.fc39.ppc64le"
     },
     "socat": {
-      "evra": "1.7.4.4-2.fc38.ppc64le"
+      "evra": "1.7.4.4-3.fc39.ppc64le"
     },
     "sqlite-libs": {
-      "evra": "3.40.1-2.fc38.ppc64le"
+      "evra": "3.42.0-7.fc39.ppc64le"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-3.fc38.ppc64le"
+      "evra": "4.6.1-2.fc39.ppc64le"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-3.fc38.ppc64le"
+      "evra": "0.1.4-4.fc39.ppc64le"
     },
     "sssd-ad": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-client": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-common": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-common-pac": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-ipa": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-krb5": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-krb5-common": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-ldap": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.1-1.fc38.ppc64le"
+      "evra": "2.9.2-2.fc39.ppc64le"
     },
     "stalld": {
-      "evra": "1.16-3.fc38.ppc64le"
+      "evra": "1.16-4.fc39.ppc64le"
     },
     "sudo": {
-      "evra": "1.9.13-2.p2.fc38.ppc64le"
+      "evra": "1.9.14-1.p3.fc39.ppc64le"
     },
     "systemd": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "systemd-container": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "systemd-libs": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "systemd-pam": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "systemd-resolved": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "systemd-udev": {
-      "evra": "253.12-1.fc38.ppc64le"
+      "evra": "254.5-2.fc39.ppc64le"
     },
     "tar": {
-      "evra": "2:1.34-8.fc38.ppc64le"
+      "evra": "2:1.35-2.fc39.ppc64le"
     },
     "teamd": {
-      "evra": "1.31-7.fc38.ppc64le"
+      "evra": "1.32-1.fc39.ppc64le"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc38.ppc64le"
+      "evra": "0.0.99.4-3.fc39.ppc64le"
     },
     "tpm2-tools": {
-      "evra": "5.5-3.fc38.ppc64le"
+      "evra": "5.5-4.fc39.ppc64le"
     },
     "tpm2-tss": {
-      "evra": "4.0.1-3.fc38.ppc64le"
+      "evra": "4.0.1-4.fc39.ppc64le"
     },
     "tzdata": {
-      "evra": "2023c-1.fc38.noarch"
+      "evra": "2023c-2.fc39.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.2-2.fc38.ppc64le"
+      "evra": "0.14.0-3.fc39.ppc64le"
     },
     "util-linux": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "util-linux-core": {
-      "evra": "2.38.1-4.fc38.ppc64le"
+      "evra": "2.39.2-1.fc39.ppc64le"
     },
     "vim-data": {
-      "evra": "2:9.0.2081-1.fc38.noarch"
+      "evra": "2:9.0.2081-1.fc39.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.2081-1.fc38.ppc64le"
+      "evra": "2:9.0.2081-1.fc39.ppc64le"
     },
     "which": {
-      "evra": "2.21-39.fc38.ppc64le"
+      "evra": "2.21-40.fc39.ppc64le"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-4.fc38.ppc64le"
+      "evra": "1.0.20210914-5.fc39.ppc64le"
     },
     "xfsprogs": {
-      "evra": "6.1.0-3.fc38.ppc64le"
+      "evra": "6.4.0-1.fc39.ppc64le"
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc38.ppc64le"
+      "evra": "0.8.2-1.fc39.ppc64le"
     },
     "xz": {
-      "evra": "5.4.1-1.fc38.ppc64le"
+      "evra": "5.4.4-1.fc39.ppc64le"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc38.ppc64le"
+      "evra": "5.4.4-1.fc39.ppc64le"
     },
     "yajl": {
-      "evra": "2.1.0-21.fc38.ppc64le"
+      "evra": "2.1.0-22.fc39.ppc64le"
     },
     "zchunk-libs": {
-      "evra": "1.3.2-1.fc38.ppc64le"
+      "evra": "1.3.2-1.fc39.ppc64le"
     },
     "zincati": {
-      "evra": "0.0.26-2.fc38.ppc64le"
+      "evra": "0.0.26-2.fc39.ppc64le"
     },
     "zlib": {
-      "evra": "1.2.13-3.fc38.ppc64le"
+      "evra": "1.2.13-4.fc39.ppc64le"
     },
     "zram-generator": {
-      "evra": "1.1.2-4.fc38.ppc64le"
+      "evra": "1.1.2-8.fc39.ppc64le"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc38.ppc64le"
+      "evra": "1.5.5-4.fc39.ppc64le"
     }
   },
   "metadata": {
-    "generated": "2023-11-04T00:00:00Z",
+    "generated": "2023-11-06T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-04-13T20:36:47Z"
+      "fedora-candidate-compose": {
+        "generated": "2023-11-01T00:12:28Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-04T02:14:16Z"
+        "generated": "2023-11-05T01:41:35Z"
       },
-      "fedora-updates": {
-        "generated": "2023-11-04T03:32:39Z"
+      "fedora-next": {
+        "generated": "2023-11-03T02:50:15Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-11-06T01:22:24Z"
       }
     }
   }

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -976,13 +976,13 @@
       "evra": "1.81-3.fc38.ppc64le"
     },
     "ostree": {
-      "evra": "2023.7-2.fc38.ppc64le"
+      "evra": "2023.6-1.fc38.ppc64le"
     },
     "ostree-grub2": {
-      "evra": "2023.7-2.fc38.ppc64le"
+      "evra": "2023.6-1.fc38.ppc64le"
     },
     "ostree-libs": {
-      "evra": "2023.7-2.fc38.ppc64le"
+      "evra": "2023.6-1.fc38.ppc64le"
     },
     "p11-kit": {
       "evra": "0.25.2-1.fc38.ppc64le"
@@ -1024,10 +1024,10 @@
       "evra": "1.8.0-6.fc38.ppc64le"
     },
     "podman": {
-      "evra": "5:4.7.2-1.fc38.ppc64le"
+      "evra": "5:4.7.0-1.fc38.ppc64le"
     },
     "podman-plugins": {
-      "evra": "5:4.7.2-1.fc38.ppc64le"
+      "evra": "5:4.7.0-1.fc38.ppc64le"
     },
     "policycoreutils": {
       "evra": "3.5-1.fc38.ppc64le"
@@ -1283,16 +1283,16 @@
     }
   },
   "metadata": {
-    "generated": "2023-11-07T00:00:00Z",
+    "generated": "2023-11-04T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2023-04-13T20:36:47Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-06T21:09:10Z"
+        "generated": "2023-11-04T02:14:16Z"
       },
       "fedora-updates": {
-        "generated": "2023-11-07T04:06:55Z"
+        "generated": "2023-11-04T03:32:39Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -934,10 +934,10 @@
       "evra": "1:3.0.9-2.fc38.s390x"
     },
     "ostree": {
-      "evra": "2023.7-2.fc38.s390x"
+      "evra": "2023.6-1.fc38.s390x"
     },
     "ostree-libs": {
-      "evra": "2023.7-2.fc38.s390x"
+      "evra": "2023.6-1.fc38.s390x"
     },
     "p11-kit": {
       "evra": "0.25.2-1.fc38.s390x"
@@ -979,10 +979,10 @@
       "evra": "1.8.0-6.fc38.s390x"
     },
     "podman": {
-      "evra": "5:4.7.2-1.fc38.s390x"
+      "evra": "5:4.7.0-1.fc38.s390x"
     },
     "podman-plugins": {
-      "evra": "5:4.7.2-1.fc38.s390x"
+      "evra": "5:4.7.0-1.fc38.s390x"
     },
     "policycoreutils": {
       "evra": "3.5-1.fc38.s390x"
@@ -1235,16 +1235,16 @@
     }
   },
   "metadata": {
-    "generated": "2023-11-07T00:00:00Z",
+    "generated": "2023-11-04T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2023-04-13T20:36:40Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-06T21:08:49Z"
+        "generated": "2023-11-04T02:13:44Z"
       },
       "fedora-updates": {
-        "generated": "2023-11-07T04:07:03Z"
+        "generated": "2023-11-04T03:32:47Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,1250 +1,1253 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.42.8-1.fc38.s390x"
+      "evra": "1:1.44.2-1.fc39.s390x"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.42.8-1.fc38.s390x"
+      "evra": "1:1.44.2-1.fc39.s390x"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.42.8-1.fc38.s390x"
+      "evra": "1:1.44.2-1.fc39.s390x"
     },
     "NetworkManager-team": {
-      "evra": "1:1.42.8-1.fc38.s390x"
+      "evra": "1:1.44.2-1.fc39.s390x"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.42.8-1.fc38.s390x"
+      "evra": "1:1.44.2-1.fc39.s390x"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.0.4-1.fc38.noarch"
+      "evra": "2.9.1.1-1.fc39.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.8.0-1.fc38.s390x"
+      "evra": "1.8.0-1.fc39.s390x"
     },
     "acl": {
-      "evra": "2.3.1-6.fc38.s390x"
+      "evra": "2.3.1-8.fc39.s390x"
     },
     "adcli": {
-      "evra": "0.9.2-2.fc38.s390x"
+      "evra": "0.9.2-3.fc39.s390x"
     },
     "afterburn": {
-      "evra": "5.4.2-1.fc38.s390x"
+      "evra": "5.4.2-2.fc39.s390x"
     },
     "afterburn-dracut": {
-      "evra": "5.4.2-1.fc38.s390x"
+      "evra": "5.4.2-2.fc39.s390x"
     },
     "alternatives": {
-      "evra": "1.25-1.fc38.s390x"
+      "evra": "1.25-1.fc39.s390x"
     },
     "amd-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "atheros-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "attr": {
-      "evra": "2.5.1-6.fc38.s390x"
+      "evra": "2.5.1-8.fc39.s390x"
+    },
+    "audit": {
+      "evra": "3.1.2-4.fc39.s390x"
     },
     "audit-libs": {
-      "evra": "3.1.2-1.fc38.s390x"
+      "evra": "3.1.2-4.fc39.s390x"
     },
     "authselect": {
-      "evra": "1.4.3-1.fc38.s390x"
+      "evra": "1.4.3-1.fc39.s390x"
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc38.s390x"
+      "evra": "1.4.3-1.fc39.s390x"
     },
     "avahi-libs": {
-      "evra": "0.8-22.fc38.s390x"
+      "evra": "0.8-24.fc39.s390x"
     },
     "basesystem": {
-      "evra": "11-15.fc38.noarch"
+      "evra": "11-18.fc39.noarch"
     },
     "bash": {
-      "evra": "5.2.15-3.fc38.s390x"
+      "evra": "5.2.15-5.fc39.s390x"
+    },
+    "bash-color-prompt": {
+      "evra": "0.1-6.fc39.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.11-9.fc38.noarch"
+      "evra": "1:2.11-12.fc39.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.19-1.fc38.s390x"
+      "evra": "32:9.18.19-1.fc39.s390x"
     },
     "bind-license": {
-      "evra": "32:9.18.19-1.fc38.noarch"
+      "evra": "32:9.18.19-1.fc39.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.19-1.fc38.s390x"
+      "evra": "32:9.18.19-1.fc39.s390x"
     },
     "brcmfmac-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "bsdtar": {
-      "evra": "3.6.1-4.fc38.s390x"
+      "evra": "3.7.1-1.fc39.s390x"
     },
     "btrfs-progs": {
-      "evra": "6.5.1-1.fc38.s390x"
+      "evra": "6.5.1-1.fc39.s390x"
     },
     "bubblewrap": {
-      "evra": "0.7.0-1.fc38.s390x"
+      "evra": "0.7.0-2.fc39.s390x"
     },
     "bzip2": {
-      "evra": "1.0.8-13.fc38.s390x"
+      "evra": "1.0.8-16.fc39.s390x"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-13.fc38.s390x"
+      "evra": "1.0.8-16.fc39.s390x"
     },
     "c-ares": {
-      "evra": "1.19.1-1.fc38.s390x"
+      "evra": "1.19.1-1.fc39.s390x"
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-1.0.fc38.noarch"
+      "evra": "2023.2.60_v7.0.306-2.fc39.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-14.fc38.s390x"
+      "evra": "0.1.7-18.fc39.s390x"
     },
     "chrony": {
-      "evra": "4.4-1.fc38.s390x"
+      "evra": "4.4-1.fc39.s390x"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc38.s390x"
+      "evra": "7.0-2.fc39.s390x"
     },
     "clevis": {
-      "evra": "19-2.fc38.s390x"
+      "evra": "19-4.fc39.s390x"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc38.s390x"
+      "evra": "19-4.fc39.s390x"
     },
     "clevis-luks": {
-      "evra": "19-2.fc38.s390x"
+      "evra": "19-4.fc39.s390x"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc38.s390x"
+      "evra": "19-4.fc39.s390x"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc38.noarch"
+      "evra": "0.33-3.fc39.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc38.s390x"
+      "evra": "2:2.1.7-3.fc39.s390x"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.224.0-1.fc38.noarch"
+      "evra": "2:2.224.0-1.fc39.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc38.s390x"
+      "evra": "1.6.19-2.fc39.s390x"
     },
     "containernetworking-plugins": {
-      "evra": "1.3.0-2.fc38.s390x"
+      "evra": "1.3.0-3.fc39.s390x"
     },
     "containers-common": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "coreos-installer": {
-      "evra": "0.18.0-1.fc38.s390x"
+      "evra": "0.18.0-1.fc39.s390x"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.18.0-1.fc38.s390x"
+      "evra": "0.18.0-1.fc39.s390x"
     },
     "coreutils": {
-      "evra": "9.1-12.fc38.s390x"
+      "evra": "9.3-4.fc39.s390x"
     },
     "coreutils-common": {
-      "evra": "9.1-12.fc38.s390x"
+      "evra": "9.3-4.fc39.s390x"
     },
     "cpio": {
-      "evra": "2.13-14.fc38.s390x"
+      "evra": "2.14-4.fc39.s390x"
     },
     "cracklib": {
-      "evra": "2.9.11-1.fc38.s390x"
+      "evra": "2.9.11-2.fc39.s390x"
     },
     "criu": {
-      "evra": "3.18-1.fc38.s390x"
+      "evra": "3.18-3.fc39.s390x"
     },
     "criu-libs": {
-      "evra": "3.18-1.fc38.s390x"
+      "evra": "3.18-3.fc39.s390x"
     },
     "crun": {
-      "evra": "1.11-1.fc38.s390x"
+      "evra": "1.11.1-1.fc39.s390x"
     },
     "crypto-policies": {
-      "evra": "20230301-1.gita12f7b2.fc38.noarch"
+      "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc38.s390x"
+      "evra": "2.6.1-3.fc39.s390x"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc38.s390x"
+      "evra": "2.6.1-3.fc39.s390x"
     },
     "curl": {
-      "evra": "8.0.1-5.fc38.s390x"
+      "evra": "8.2.1-3.fc39.s390x"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-9.fc38.s390x"
+      "evra": "2.1.28-11.fc39.s390x"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-9.fc38.s390x"
+      "evra": "2.1.28-11.fc39.s390x"
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc38.s390x"
+      "evra": "1:1.14.10-1.fc39.s390x"
     },
     "dbus-broker": {
-      "evra": "33-1.fc38.s390x"
+      "evra": "33-2.fc39.s390x"
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc38.noarch"
+      "evra": "1:1.14.10-1.fc39.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc38.s390x"
+      "evra": "1:1.14.10-1.fc39.s390x"
     },
     "device-mapper": {
-      "evra": "1.02.189-2.fc38.s390x"
+      "evra": "1.02.196-1.fc39.s390x"
     },
     "device-mapper-event": {
-      "evra": "1.02.189-2.fc38.s390x"
+      "evra": "1.02.196-1.fc39.s390x"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.189-2.fc38.s390x"
+      "evra": "1.02.196-1.fc39.s390x"
     },
     "device-mapper-libs": {
-      "evra": "1.02.189-2.fc38.s390x"
+      "evra": "1.02.196-1.fc39.s390x"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.4-2.fc38.s390x"
+      "evra": "0.9.5-2.fc39.s390x"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.4-2.fc38.s390x"
+      "evra": "0.9.5-2.fc39.s390x"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-10.fc38.s390x"
+      "evra": "1.0.6-2.fc39.s390x"
     },
     "diffutils": {
-      "evra": "3.10-1.fc38.s390x"
+      "evra": "3.10-3.fc39.s390x"
     },
     "dnsmasq": {
-      "evra": "2.89-5.fc38.s390x"
+      "evra": "2.89-6.fc39.s390x"
     },
     "dosfstools": {
-      "evra": "4.2-6.fc38.s390x"
+      "evra": "4.2-7.fc39.s390x"
     },
     "dracut": {
-      "evra": "059-4.fc38.s390x"
+      "evra": "059-15.fc39.s390x"
     },
     "dracut-network": {
-      "evra": "059-4.fc38.s390x"
+      "evra": "059-15.fc39.s390x"
     },
     "dracut-squash": {
-      "evra": "059-4.fc38.s390x"
+      "evra": "059-15.fc39.s390x"
     },
     "duktape": {
-      "evra": "2.7.0-2.fc38.s390x"
+      "evra": "2.7.0-5.fc39.s390x"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-4.fc38.s390x"
+      "evra": "1.47.0-2.fc39.s390x"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-4.fc38.s390x"
+      "evra": "1.47.0-2.fc39.s390x"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-3.fc38.noarch"
+      "evra": "0.189-4.fc39.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-3.fc38.s390x"
+      "evra": "0.189-4.fc39.s390x"
     },
     "elfutils-libs": {
-      "evra": "0.189-3.fc38.s390x"
+      "evra": "0.189-4.fc39.s390x"
     },
     "ethtool": {
-      "evra": "2:6.5-1.fc38.s390x"
+      "evra": "2:6.5-1.fc39.s390x"
     },
     "expat": {
-      "evra": "2.5.0-2.fc38.s390x"
+      "evra": "2.5.0-3.fc39.s390x"
     },
     "fedora-gpg-keys": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-repos": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-1.noarch"
-    },
-    "fedora-repos-modular": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "file": {
-      "evra": "5.44-3.fc38.s390x"
+      "evra": "5.44-5.fc39.s390x"
     },
     "file-libs": {
-      "evra": "5.44-3.fc38.s390x"
+      "evra": "5.44-5.fc39.s390x"
     },
     "filesystem": {
-      "evra": "3.18-3.fc38.s390x"
+      "evra": "3.18-6.fc39.s390x"
     },
     "findutils": {
-      "evra": "1:4.9.0-3.fc38.s390x"
+      "evra": "1:4.9.0-5.fc39.s390x"
     },
     "flatpak-session-helper": {
-      "evra": "1.15.4-1.fc38.s390x"
+      "evra": "1.15.4-3.fc39.s390x"
     },
     "fstrm": {
-      "evra": "0.6.1-6.fc38.s390x"
+      "evra": "0.6.1-8.fc39.s390x"
     },
     "fuse": {
-      "evra": "2.9.9-16.fc38.s390x"
+      "evra": "2.9.9-17.fc39.s390x"
     },
     "fuse-common": {
-      "evra": "3.14.1-1.fc38.s390x"
+      "evra": "3.16.1-1.fc39.s390x"
     },
     "fuse-libs": {
-      "evra": "2.9.9-16.fc38.s390x"
+      "evra": "2.9.9-17.fc39.s390x"
     },
     "fuse-overlayfs": {
-      "evra": "1.12-1.fc38.s390x"
+      "evra": "1.12-2.fc39.s390x"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-3.fc38.s390x"
+      "evra": "3.7.3-4.fc39.s390x"
     },
     "fuse3": {
-      "evra": "3.14.1-1.fc38.s390x"
+      "evra": "3.16.1-1.fc39.s390x"
     },
     "fuse3-libs": {
-      "evra": "3.14.1-1.fc38.s390x"
+      "evra": "3.16.1-1.fc39.s390x"
     },
     "fwupd": {
-      "evra": "1.9.7-1.fc38.s390x"
+      "evra": "1.9.7-1.fc39.s390x"
     },
     "gawk": {
-      "evra": "5.1.1-5.fc38.s390x"
+      "evra": "5.2.2-2.fc39.s390x"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-3.fc38.s390x"
+      "evra": "1:1.23-4.fc39.s390x"
     },
     "gdisk": {
-      "evra": "1.0.9-5.fc38.s390x"
+      "evra": "1.0.9-6.fc39.s390x"
     },
     "git-core": {
-      "evra": "2.41.0-1.fc38.s390x"
+      "evra": "2.41.0-2.fc39.s390x"
     },
     "glib2": {
-      "evra": "2.76.5-2.fc38.s390x"
+      "evra": "2.78.1-1.fc39.s390x"
     },
     "glibc": {
-      "evra": "2.37-13.fc38.s390x"
+      "evra": "2.38-10.fc39.s390x"
     },
     "glibc-common": {
-      "evra": "2.37-13.fc38.s390x"
+      "evra": "2.38-10.fc39.s390x"
     },
     "glibc-gconv-extra": {
-      "evra": "2.37-13.fc38.s390x"
+      "evra": "2.38-10.fc39.s390x"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.37-13.fc38.s390x"
+      "evra": "2.38-10.fc39.s390x"
     },
     "gmp": {
-      "evra": "1:6.2.1-4.fc38.s390x"
+      "evra": "1:6.2.1-5.fc39.s390x"
     },
     "gnupg2": {
-      "evra": "2.4.0-3.fc38.s390x"
+      "evra": "2.4.3-2.fc39.s390x"
     },
     "gnutls": {
-      "evra": "3.8.1-1.fc38.s390x"
+      "evra": "3.8.1-1.fc39.s390x"
     },
     "gpgme": {
-      "evra": "1.17.1-5.fc38.s390x"
+      "evra": "1.20.0-5.fc39.s390x"
     },
     "grep": {
-      "evra": "3.8-3.fc38.s390x"
+      "evra": "3.11-3.fc39.s390x"
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.1-1.fc38.s390x"
+      "evra": "6:0.7.1-1.fc39.s390x"
     },
     "gzip": {
-      "evra": "1.12-3.fc38.s390x"
+      "evra": "1.12-6.fc39.s390x"
     },
     "hostname": {
-      "evra": "3.23-8.fc38.s390x"
+      "evra": "3.23-9.fc39.s390x"
     },
     "ignition": {
-      "evra": "2.16.2-1.fc38.s390x"
+      "evra": "2.16.2-2.fc39.s390x"
     },
     "inih": {
-      "evra": "57-1.fc38.s390x"
+      "evra": "57-2.fc39.s390x"
     },
     "intel-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-1.fc38.s390x"
+      "evra": "1.0.3-2.fc39.s390x"
     },
     "iproute": {
-      "evra": "6.4.0-1.fc38.s390x"
+      "evra": "6.4.0-2.fc39.s390x"
     },
     "iproute-tc": {
-      "evra": "6.4.0-1.fc38.s390x"
+      "evra": "6.4.0-2.fc39.s390x"
     },
     "iptables-legacy": {
-      "evra": "1.8.9-4.fc38.1.s390x"
+      "evra": "1.8.9-5.fc39.s390x"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-4.fc38.1.s390x"
+      "evra": "1.8.9-5.fc39.s390x"
     },
     "iptables-libs": {
-      "evra": "1.8.9-4.fc38.1.s390x"
+      "evra": "1.8.9-5.fc39.s390x"
     },
     "iptables-nft": {
-      "evra": "1.8.9-4.fc38.1.s390x"
+      "evra": "1.8.9-5.fc39.s390x"
     },
     "iptables-services": {
-      "evra": "1.8.9-4.fc38.1.noarch"
+      "evra": "1.8.9-5.fc39.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.9-4.fc38.1.s390x"
+      "evra": "1.8.9-5.fc39.s390x"
     },
     "iputils": {
-      "evra": "20221126-2.fc38.s390x"
+      "evra": "20221126-4.fc39.s390x"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.s390x"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.s390x"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.s390x"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.s390x"
     },
     "isns-utils-libs": {
-      "evra": "0.101-6.fc38.s390x"
+      "evra": "0.101-7.fc39.s390x"
     },
     "jansson": {
-      "evra": "2.13.1-6.fc38.s390x"
+      "evra": "2.13.1-7.fc39.s390x"
     },
     "jemalloc": {
-      "evra": "5.3.0-3.fc38.s390x"
+      "evra": "5.3.0-4.fc39.s390x"
     },
     "jose": {
-      "evra": "11-7.fc38.s390x"
+      "evra": "11-8.fc39.s390x"
     },
     "jq": {
-      "evra": "1.6-16.fc38.s390x"
+      "evra": "1.6-17.fc39.s390x"
     },
     "json-c": {
-      "evra": "0.17-1.fc38.s390x"
+      "evra": "0.17-1.fc39.s390x"
     },
     "json-glib": {
-      "evra": "1.6.6-4.fc38.s390x"
+      "evra": "1.8.0-1.fc39.s390x"
     },
     "kbd": {
-      "evra": "2.5.1-5.fc38.s390x"
+      "evra": "2.6.3-1.fc39.s390x"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kernel": {
-      "evra": "6.5.9-200.fc38.s390x"
+      "evra": "6.5.9-300.fc39.s390x"
     },
     "kernel-core": {
-      "evra": "6.5.9-200.fc38.s390x"
+      "evra": "6.5.9-300.fc39.s390x"
     },
     "kernel-modules": {
-      "evra": "6.5.9-200.fc38.s390x"
+      "evra": "6.5.9-300.fc39.s390x"
     },
     "kernel-modules-core": {
-      "evra": "6.5.9-200.fc38.s390x"
+      "evra": "6.5.9-300.fc39.s390x"
     },
     "kexec-tools": {
-      "evra": "2.0.26-3.fc38.s390x"
+      "evra": "2.0.27-2.fc39.s390x"
     },
     "keyutils": {
-      "evra": "1.6.1-6.fc38.s390x"
+      "evra": "1.6.1-7.fc39.s390x"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-6.fc38.s390x"
+      "evra": "1.6.1-7.fc39.s390x"
     },
     "kmod": {
-      "evra": "30-4.fc38.s390x"
+      "evra": "30-6.fc39.s390x"
     },
     "kmod-libs": {
-      "evra": "30-4.fc38.s390x"
+      "evra": "30-6.fc39.s390x"
     },
     "kpartx": {
-      "evra": "0.9.4-2.fc38.s390x"
+      "evra": "0.9.5-2.fc39.s390x"
     },
     "krb5-libs": {
-      "evra": "1.21-3.fc38.s390x"
+      "evra": "1.21.2-2.fc39.s390x"
     },
     "less": {
-      "evra": "633-1.fc38.s390x"
+      "evra": "633-2.fc39.s390x"
     },
     "libacl": {
-      "evra": "2.3.1-6.fc38.s390x"
+      "evra": "2.3.1-8.fc39.s390x"
     },
     "libaio": {
-      "evra": "0.3.111-15.fc38.s390x"
+      "evra": "0.3.111-16.fc39.s390x"
     },
     "libarchive": {
-      "evra": "3.6.1-4.fc38.s390x"
+      "evra": "3.7.1-1.fc39.s390x"
     },
     "libargon2": {
-      "evra": "20190702-2.fc38.s390x"
+      "evra": "20190702-3.fc39.s390x"
     },
     "libassuan": {
-      "evra": "2.5.6-1.fc38.s390x"
+      "evra": "2.5.6-2.fc39.s390x"
     },
     "libatomic": {
-      "evra": "13.2.1-4.fc38.s390x"
+      "evra": "13.2.1-4.fc39.s390x"
     },
     "libattr": {
-      "evra": "2.5.1-6.fc38.s390x"
+      "evra": "2.5.1-8.fc39.s390x"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-53.fc38.s390x"
+      "evra": "0.1.1-54.fc39.s390x"
     },
     "libblkid": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "libbpf": {
-      "evra": "2:1.1.0-2.fc38.s390x"
+      "evra": "2:1.1.0-4.fc39.s390x"
     },
     "libbsd": {
-      "evra": "0.11.7-4.fc38.s390x"
+      "evra": "0.11.7-5.fc39.s390x"
     },
     "libcap": {
-      "evra": "2.48-6.fc38.s390x"
+      "evra": "2.48-7.fc39.s390x"
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc38.s390x"
+      "evra": "0.8.3-8.fc39.s390x"
     },
     "libcbor": {
-      "evra": "0.7.0-9.fc38.s390x"
+      "evra": "0.10.2-2.fc39.s390x"
     },
     "libcollection": {
-      "evra": "0.7.0-53.fc38.s390x"
+      "evra": "0.7.0-54.fc39.s390x"
     },
     "libcom_err": {
-      "evra": "1.46.5-4.fc38.s390x"
+      "evra": "1.47.0-2.fc39.s390x"
     },
     "libcurl-minimal": {
-      "evra": "8.0.1-5.fc38.s390x"
+      "evra": "8.2.1-3.fc39.s390x"
     },
     "libdaemon": {
-      "evra": "0.14-25.fc38.s390x"
+      "evra": "0.14-26.fc39.s390x"
     },
     "libdb": {
-      "evra": "5.3.28-55.fc38.s390x"
+      "evra": "5.3.28-56.fc39.s390x"
     },
     "libdhash": {
-      "evra": "0.5.0-53.fc38.s390x"
+      "evra": "0.5.0-54.fc39.s390x"
     },
     "libeconf": {
-      "evra": "0.5.2-1.fc38.s390x"
+      "evra": "0.5.2-1.fc39.s390x"
     },
     "libedit": {
-      "evra": "3.1-45.20221030cvs.fc38.s390x"
+      "evra": "3.1-48.20230828cvs.fc39.s390x"
     },
     "libevent": {
-      "evra": "2.1.12-8.fc38.s390x"
+      "evra": "2.1.12-9.fc39.s390x"
     },
     "libfdisk": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "libffi": {
-      "evra": "3.4.4-2.fc38.s390x"
+      "evra": "3.4.4-4.fc39.s390x"
     },
     "libfido2": {
-      "evra": "1.12.0-3.fc38.s390x"
+      "evra": "1.13.0-3.fc39.s390x"
     },
     "libgcc": {
-      "evra": "13.2.1-4.fc38.s390x"
+      "evra": "13.2.1-4.fc39.s390x"
     },
     "libgcrypt": {
-      "evra": "1.10.2-1.fc38.s390x"
+      "evra": "1.10.2-2.fc39.s390x"
     },
     "libgpg-error": {
-      "evra": "1.47-1.fc38.s390x"
+      "evra": "1.47-2.fc39.s390x"
     },
     "libgudev": {
-      "evra": "237-4.fc38.s390x"
+      "evra": "238-2.fc39.s390x"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc38.s390x"
+      "evra": "0.4.7-1.fc39.s390x"
     },
     "libibverbs": {
-      "evra": "44.0-3.fc38.s390x"
+      "evra": "46.0-4.fc39.s390x"
     },
     "libicu": {
-      "evra": "72.1-2.fc38.s390x"
+      "evra": "73.2-2.fc39.s390x"
     },
     "libidn2": {
-      "evra": "2.3.4-2.fc38.s390x"
+      "evra": "2.3.4-3.fc39.s390x"
     },
     "libini_config": {
-      "evra": "1.3.1-53.fc38.s390x"
+      "evra": "1.3.1-54.fc39.s390x"
     },
     "libipa_hbac": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc38.s390x"
+      "evra": "0.1.14-2.fc39.s390x"
     },
     "libjose": {
-      "evra": "11-7.fc38.s390x"
+      "evra": "11-8.fc39.s390x"
     },
     "libkcapi": {
-      "evra": "1.4.0-5.fc38.s390x"
+      "evra": "1.4.0-7.fc39.s390x"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-5.fc38.s390x"
+      "evra": "1.4.0-7.fc39.s390x"
     },
     "libksba": {
-      "evra": "1.6.4-1.fc38.s390x"
+      "evra": "1.6.4-2.fc39.s390x"
     },
     "libldb": {
-      "evra": "2.7.2-1.fc38.s390x"
+      "evra": "2.8.0-1.fc39.s390x"
     },
     "libluksmeta": {
-      "evra": "9-15.fc38.s390x"
+      "evra": "9-16.fc39.s390x"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-2.fc38.s390x"
+      "evra": "1.7.1-3.fc39.s390x"
     },
     "libmd": {
-      "evra": "1.1.0-1.fc38.s390x"
+      "evra": "1.1.0-2.fc39.s390x"
     },
     "libmnl": {
-      "evra": "1.0.5-2.fc38.s390x"
+      "evra": "1.0.5-3.fc39.s390x"
     },
     "libmodulemd": {
-      "evra": "2.15.0-2.fc38.s390x"
+      "evra": "2.15.0-5.fc39.s390x"
     },
     "libmount": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "libndp": {
-      "evra": "1.8-5.fc38.s390x"
+      "evra": "1.8-6.fc39.s390x"
     },
     "libnet": {
-      "evra": "1.3-1.fc38.s390x"
+      "evra": "1.3-1.fc39.s390x"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-1.fc38.s390x"
+      "evra": "1.0.9-2.fc39.s390x"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-23.fc38.s390x"
+      "evra": "1.0.1-24.fc39.s390x"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.3-1.rc3.fc38.s390x"
+      "evra": "1:2.6.3-2.rc3.fc39.s390x"
     },
     "libnftnl": {
-      "evra": "1.2.4-2.fc38.s390x"
+      "evra": "1.2.6-2.fc39.s390x"
     },
     "libnghttp2": {
-      "evra": "1.52.0-2.fc38.s390x"
+      "evra": "1.55.1-4.fc39.s390x"
     },
     "libnl3": {
-      "evra": "3.7.0-3.fc38.s390x"
+      "evra": "3.8.0-1.fc39.s390x"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-3.fc38.s390x"
+      "evra": "3.8.0-1.fc39.s390x"
     },
     "libnsl2": {
-      "evra": "2.0.0-5.fc38.s390x"
+      "evra": "2.0.0-6.fc39.s390x"
     },
     "libnvme": {
-      "evra": "1.4-2.fc38.s390x"
+      "evra": "1.6-2.fc39.s390x"
     },
     "libpath_utils": {
-      "evra": "0.2.1-53.fc38.s390x"
+      "evra": "0.2.1-54.fc39.s390x"
     },
     "libpcap": {
-      "evra": "14:1.10.4-1.fc38.s390x"
+      "evra": "14:1.10.4-2.fc39.s390x"
     },
     "libpkgconf": {
-      "evra": "1.8.0-6.fc38.s390x"
+      "evra": "1.9.5-2.fc39.s390x"
     },
     "libpsl": {
-      "evra": "0.21.2-2.fc38.s390x"
+      "evra": "0.21.2-4.fc39.s390x"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc38.s390x"
+      "evra": "1.4.5-6.fc39.s390x"
     },
     "libref_array": {
-      "evra": "0.1.5-53.fc38.s390x"
+      "evra": "0.1.5-54.fc39.s390x"
     },
     "librepo": {
-      "evra": "1.17.0-1.fc38.s390x"
+      "evra": "1.17.0-1.fc39.s390x"
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-1.fc38.noarch"
+      "evra": "2.17.11-3.fc39.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-4.fc38.s390x"
+      "evra": "2.5.3-6.fc39.s390x"
     },
     "libselinux": {
-      "evra": "3.5-1.fc38.s390x"
+      "evra": "3.5-5.fc39.s390x"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc38.s390x"
+      "evra": "3.5-5.fc39.s390x"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc38.s390x"
+      "evra": "3.5-4.fc39.s390x"
     },
     "libsepol": {
-      "evra": "3.5-1.fc38.s390x"
+      "evra": "3.5-2.fc39.s390x"
     },
     "libsigsegv": {
-      "evra": "2.14-4.fc38.s390x"
+      "evra": "2.14-5.fc39.s390x"
     },
     "libslirp": {
-      "evra": "4.7.0-3.fc38.s390x"
+      "evra": "4.7.0-4.fc39.s390x"
     },
     "libsmartcols": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "libsmbclient": {
-      "evra": "2:4.18.8-1.fc38.s390x"
+      "evra": "2:4.19.2-1.fc39.s390x"
     },
     "libsolv": {
-      "evra": "0.7.25-1.fc38.s390x"
+      "evra": "0.7.25-1.fc39.s390x"
     },
     "libss": {
-      "evra": "1.46.5-4.fc38.s390x"
+      "evra": "1.47.0-2.fc39.s390x"
     },
     "libsss_certmap": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "libsss_idmap": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "libsss_sudo": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "libstdc++": {
-      "evra": "13.2.1-4.fc38.s390x"
+      "evra": "13.2.1-4.fc39.s390x"
     },
     "libtalloc": {
-      "evra": "2.4.0-2.fc38.s390x"
+      "evra": "2.4.1-1.fc39.s390x"
     },
     "libtasn1": {
-      "evra": "4.19.0-2.fc38.s390x"
+      "evra": "4.19.0-3.fc39.s390x"
     },
     "libtdb": {
-      "evra": "1.4.8-1.fc38.s390x"
+      "evra": "1.4.9-1.fc39.s390x"
     },
     "libteam": {
-      "evra": "1.31-7.fc38.s390x"
+      "evra": "1.32-1.fc39.s390x"
     },
     "libtevent": {
-      "evra": "0.14.1-1.fc38.s390x"
+      "evra": "0.15.0-1.fc39.s390x"
     },
     "libtirpc": {
-      "evra": "1.3.4-0.fc38.s390x"
+      "evra": "1.3.4-0.fc39.s390x"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-6.fc38.s390x"
+      "evra": "2.4.7-7.fc39.s390x"
     },
     "libunistring": {
-      "evra": "1.1-3.fc38.s390x"
-    },
-    "libunistring1.0": {
-      "evra": "1.0-1.fc38.s390x"
+      "evra": "1.1-5.fc39.s390x"
     },
     "libusb1": {
-      "evra": "1.0.26-2.fc38.s390x"
+      "evra": "1.0.26-3.fc39.s390x"
     },
     "libuser": {
-      "evra": "0.64-2.fc38.s390x"
+      "evra": "0.64-4.fc39.s390x"
     },
     "libutempter": {
-      "evra": "1.2.1-8.fc38.s390x"
+      "evra": "1.2.1-10.fc39.s390x"
     },
     "libuuid": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "libuv": {
-      "evra": "1:1.46.0-1.fc38.s390x"
+      "evra": "1:1.46.0-2.fc39.s390x"
     },
     "libverto": {
-      "evra": "0.3.2-5.fc38.s390x"
+      "evra": "0.3.2-6.fc39.s390x"
     },
     "libwbclient": {
-      "evra": "2:4.18.8-1.fc38.s390x"
+      "evra": "2:4.19.2-1.fc39.s390x"
     },
     "libxcrypt": {
-      "evra": "4.4.36-1.fc38.s390x"
+      "evra": "4.4.36-2.fc39.s390x"
     },
     "libxml2": {
-      "evra": "2.10.4-1.fc38.s390x"
+      "evra": "2.10.4-3.fc39.s390x"
     },
     "libxmlb": {
-      "evra": "0.3.14-1.fc38.s390x"
+      "evra": "0.3.14-1.fc39.s390x"
     },
     "libyaml": {
-      "evra": "0.2.5-9.fc38.s390x"
+      "evra": "0.2.5-12.fc39.s390x"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc38.s390x"
+      "evra": "1.5.5-4.fc39.s390x"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-34.fc38.s390x"
+      "evra": "2.5.1-36.fc39.s390x"
     },
     "linux-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.31-1.fc38.s390x"
+      "evra": "0.9.31-2.fc39.s390x"
     },
     "logrotate": {
-      "evra": "3.21.0-2.fc38.s390x"
+      "evra": "3.21.0-4.fc39.s390x"
     },
     "lsof": {
-      "evra": "4.96.3-3.fc38.s390x"
+      "evra": "4.96.3-4.fc39.s390x"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc38.s390x"
+      "evra": "5.4.6-3.fc39.s390x"
     },
     "luksmeta": {
-      "evra": "9-15.fc38.s390x"
+      "evra": "9-16.fc39.s390x"
     },
     "lvm2": {
-      "evra": "2.03.18-2.fc38.s390x"
+      "evra": "2.03.22-1.fc39.s390x"
     },
     "lvm2-libs": {
-      "evra": "2.03.18-2.fc38.s390x"
+      "evra": "2.03.22-1.fc39.s390x"
     },
     "lz4-libs": {
-      "evra": "1.9.4-2.fc38.s390x"
+      "evra": "1.9.4-4.fc39.s390x"
     },
     "lzo": {
-      "evra": "2.10-8.fc38.s390x"
+      "evra": "2.10-9.fc39.s390x"
     },
     "mdadm": {
-      "evra": "4.2-4.fc38.s390x"
+      "evra": "4.2-6.fc39.s390x"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc38.s390x"
+      "evra": "24.0.5-1.fc39.s390x"
     },
     "mpfr": {
-      "evra": "4.1.1-3.fc38.s390x"
+      "evra": "4.2.0-3.fc39.s390x"
     },
     "mt7xxx-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nano": {
-      "evra": "7.2-2.fc38.s390x"
+      "evra": "7.2-4.fc39.s390x"
     },
     "nano-default-editor": {
-      "evra": "7.2-2.fc38.noarch"
+      "evra": "7.2-4.fc39.noarch"
     },
     "ncurses": {
-      "evra": "6.4-3.20230114.fc38.s390x"
+      "evra": "6.4-7.20230520.fc39.s390x"
     },
     "ncurses-base": {
-      "evra": "6.4-3.20230114.fc38.noarch"
+      "evra": "6.4-7.20230520.fc39.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.4-3.20230114.fc38.s390x"
+      "evra": "6.4-7.20230520.fc39.s390x"
     },
     "net-tools": {
-      "evra": "2.0-0.65.20160912git.fc38.s390x"
+      "evra": "2.0-0.67.20160912git.fc39.s390x"
     },
     "netavark": {
-      "evra": "1.8.0-2.fc38.s390x"
+      "evra": "1.8.0-2.fc39.s390x"
     },
     "nettle": {
-      "evra": "3.8-3.fc38.s390x"
+      "evra": "3.9.1-2.fc39.s390x"
     },
     "newt": {
-      "evra": "0.52.23-2.fc38.s390x"
+      "evra": "0.52.23-4.fc39.s390x"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.3-1.rc3.fc38.s390x"
+      "evra": "1:2.6.3-2.rc3.fc39.s390x"
     },
     "nftables": {
-      "evra": "1:1.0.5-2.fc38.s390x"
+      "evra": "1:1.0.7-3.fc39.s390x"
     },
     "nmstate": {
-      "evra": "2.2.15-1.fc38.s390x"
+      "evra": "2.2.15-1.fc39.s390x"
     },
     "npth": {
-      "evra": "1.6-12.fc38.s390x"
+      "evra": "1.6-14.fc39.s390x"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-22.fc38.s390x"
+      "evra": "2.23.0-1.fc39.s390x"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nvme-cli": {
-      "evra": "2.4-3.fc38.s390x"
+      "evra": "2.6-1.fc39.s390x"
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc38.s390x"
+      "evra": "6.9.9-1.fc39.s390x"
     },
     "openldap": {
-      "evra": "2.6.6-1.fc38.s390x"
+      "evra": "2.6.6-1.fc39.s390x"
     },
     "openssh": {
-      "evra": "9.0p1-17.fc38.s390x"
+      "evra": "9.3p1-9.fc39.s390x"
     },
     "openssh-clients": {
-      "evra": "9.0p1-17.fc38.s390x"
+      "evra": "9.3p1-9.fc39.s390x"
     },
     "openssh-server": {
-      "evra": "9.0p1-17.fc38.s390x"
+      "evra": "9.3p1-9.fc39.s390x"
     },
     "openssl": {
-      "evra": "1:3.0.9-2.fc38.s390x"
+      "evra": "1:3.1.1-4.fc39.s390x"
     },
     "openssl-libs": {
-      "evra": "1:3.0.9-2.fc38.s390x"
+      "evra": "1:3.1.1-4.fc39.s390x"
     },
     "ostree": {
-      "evra": "2023.6-1.fc38.s390x"
+      "evra": "2023.7-2.fc39.s390x"
     },
     "ostree-libs": {
-      "evra": "2023.6-1.fc38.s390x"
+      "evra": "2023.7-2.fc39.s390x"
     },
     "p11-kit": {
-      "evra": "0.25.2-1.fc38.s390x"
+      "evra": "0.25.2-1.fc39.s390x"
     },
     "p11-kit-trust": {
-      "evra": "0.25.2-1.fc38.s390x"
+      "evra": "0.25.2-1.fc39.s390x"
     },
     "pam": {
-      "evra": "1.5.2-16.fc38.s390x"
+      "evra": "1.5.3-3.fc39.s390x"
     },
     "pam-libs": {
-      "evra": "1.5.2-16.fc38.s390x"
+      "evra": "1.5.3-3.fc39.s390x"
     },
     "passt": {
-      "evra": "0^20231004.gf851084-1.fc38.s390x"
+      "evra": "0^20231004.gf851084-1.fc39.s390x"
     },
     "passt-selinux": {
-      "evra": "0^20231004.gf851084-1.fc38.noarch"
+      "evra": "0^20231004.gf851084-1.fc39.noarch"
     },
     "passwd": {
-      "evra": "0.80-14.fc38.s390x"
+      "evra": "0.80-15.fc39.s390x"
     },
     "pcre2": {
-      "evra": "10.42-1.fc38.1.s390x"
+      "evra": "10.42-1.fc39.2.s390x"
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc38.1.noarch"
+      "evra": "10.42-1.fc39.2.noarch"
     },
     "pigz": {
-      "evra": "2.7-3.fc38.s390x"
+      "evra": "2.8-2.fc39.s390x"
     },
     "pkgconf": {
-      "evra": "1.8.0-6.fc38.s390x"
+      "evra": "1.9.5-2.fc39.s390x"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-6.fc38.noarch"
+      "evra": "1.9.5-2.fc39.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-6.fc38.s390x"
+      "evra": "1.9.5-2.fc39.s390x"
     },
     "podman": {
-      "evra": "5:4.7.0-1.fc38.s390x"
+      "evra": "5:4.7.0-1.fc39.s390x"
     },
     "podman-plugins": {
-      "evra": "5:4.7.0-1.fc38.s390x"
+      "evra": "5:4.7.0-1.fc39.s390x"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc38.s390x"
+      "evra": "3.5-8.fc39.s390x"
     },
     "polkit": {
-      "evra": "122-3.fc38.1.s390x"
+      "evra": "123-1.fc39.s390x"
     },
     "polkit-libs": {
-      "evra": "122-3.fc38.1.s390x"
+      "evra": "123-1.fc39.s390x"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-23.fc38.s390x"
+      "evra": "0.1-26.fc39.s390x"
     },
     "popt": {
-      "evra": "1.19-2.fc38.s390x"
+      "evra": "1.19-3.fc39.s390x"
     },
     "procps-ng": {
-      "evra": "3.3.17-11.fc38.s390x"
+      "evra": "4.0.3-4.fc39.s390x"
     },
     "protobuf-c": {
-      "evra": "1.4.1-4.fc38.s390x"
+      "evra": "1.4.1-5.fc39.s390x"
     },
     "psmisc": {
-      "evra": "23.6-2.fc38.s390x"
+      "evra": "23.6-4.fc39.s390x"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230812-1.fc38.noarch"
+      "evra": "20230812-1.fc39.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:7.2.6-1.fc38.s390x"
+      "evra": "2:8.1.1-1.fc39.s390x"
     },
     "readline": {
-      "evra": "8.2-3.fc38.s390x"
+      "evra": "8.2-4.fc39.s390x"
     },
     "realtek-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc2.fc38.s390x"
+      "evra": "1.2.6-4.rc2.fc39.1.s390x"
     },
     "rpm": {
-      "evra": "4.18.1-3.fc38.s390x"
+      "evra": "4.19.0-1.fc39.s390x"
     },
     "rpm-libs": {
-      "evra": "4.18.1-3.fc38.s390x"
+      "evra": "4.19.0-1.fc39.s390x"
     },
     "rpm-ostree": {
-      "evra": "2023.8-2.fc38.s390x"
+      "evra": "2023.8-2.fc39.s390x"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.8-2.fc38.s390x"
+      "evra": "2023.8-2.fc39.s390x"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.1-3.fc38.s390x"
+      "evra": "4.19.0-1.fc39.s390x"
     },
     "rpm-sequoia": {
-      "evra": "1.5.0-1.fc38.s390x"
+      "evra": "1.5.0-1.fc39.s390x"
     },
     "rsync": {
-      "evra": "3.2.7-2.fc38.s390x"
+      "evra": "3.2.7-5.fc39.s390x"
     },
     "runc": {
-      "evra": "2:1.1.8-1.fc38.s390x"
+      "evra": "2:1.1.8-1.fc39.s390x"
     },
     "s390utils-core": {
-      "evra": "2:2.25.0-4.fc38.s390x"
+      "evra": "2:2.29.0-2.fc39.s390x"
     },
     "samba-client-libs": {
-      "evra": "2:4.18.8-1.fc38.s390x"
+      "evra": "2:4.19.2-1.fc39.s390x"
     },
     "samba-common": {
-      "evra": "2:4.18.8-1.fc38.noarch"
+      "evra": "2:4.19.2-1.fc39.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.18.8-1.fc38.s390x"
+      "evra": "2:4.19.2-1.fc39.s390x"
     },
     "sed": {
-      "evra": "4.8-12.fc38.s390x"
+      "evra": "4.8-14.fc39.s390x"
     },
     "selinux-policy": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "setup": {
-      "evra": "2.14.3-2.fc38.noarch"
+      "evra": "2.14.4-1.fc39.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-5.fc38.s390x"
+      "evra": "1.46-6.fc39.s390x"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-5.fc38.s390x"
+      "evra": "1.46-6.fc39.s390x"
     },
     "shadow-utils": {
-      "evra": "2:4.13-6.fc38.s390x"
+      "evra": "2:4.14.0-2.fc39.s390x"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.13-6.fc38.s390x"
+      "evra": "2:4.14.0-2.fc39.s390x"
     },
     "shared-mime-info": {
-      "evra": "2.2-3.fc38.s390x"
+      "evra": "2.2-4.fc39.s390x"
     },
     "skopeo": {
-      "evra": "1:1.13.3-1.fc38.s390x"
+      "evra": "1:1.13.3-1.fc39.s390x"
     },
     "slang": {
-      "evra": "2.3.3-3.fc38.s390x"
+      "evra": "2.3.3-4.fc39.s390x"
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc38.s390x"
+      "evra": "1.2.2-1.fc39.s390x"
     },
     "snappy": {
-      "evra": "1.1.9-7.fc38.s390x"
+      "evra": "1.1.10-2.fc39.s390x"
     },
     "socat": {
-      "evra": "1.7.4.4-2.fc38.s390x"
+      "evra": "1.7.4.4-3.fc39.s390x"
     },
     "sqlite-libs": {
-      "evra": "3.40.1-2.fc38.s390x"
+      "evra": "3.42.0-7.fc39.s390x"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-3.fc38.s390x"
+      "evra": "4.6.1-2.fc39.s390x"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-3.fc38.s390x"
+      "evra": "0.1.4-4.fc39.s390x"
     },
     "sssd-ad": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-client": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-common": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-common-pac": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-ipa": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-krb5": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-krb5-common": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-ldap": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.1-1.fc38.s390x"
+      "evra": "2.9.2-2.fc39.s390x"
     },
     "stalld": {
-      "evra": "1.16-3.fc38.s390x"
+      "evra": "1.16-4.fc39.s390x"
     },
     "sudo": {
-      "evra": "1.9.13-2.p2.fc38.s390x"
+      "evra": "1.9.14-1.p3.fc39.s390x"
     },
     "systemd": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "systemd-container": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "systemd-libs": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "systemd-pam": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "systemd-resolved": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "systemd-udev": {
-      "evra": "253.12-1.fc38.s390x"
+      "evra": "254.5-2.fc39.s390x"
     },
     "tar": {
-      "evra": "2:1.34-8.fc38.s390x"
+      "evra": "2:1.35-2.fc39.s390x"
     },
     "teamd": {
-      "evra": "1.31-7.fc38.s390x"
+      "evra": "1.32-1.fc39.s390x"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc38.s390x"
+      "evra": "0.0.99.4-3.fc39.s390x"
     },
     "tpm2-tools": {
-      "evra": "5.5-3.fc38.s390x"
+      "evra": "5.5-4.fc39.s390x"
     },
     "tpm2-tss": {
-      "evra": "4.0.1-3.fc38.s390x"
+      "evra": "4.0.1-4.fc39.s390x"
     },
     "tzdata": {
-      "evra": "2023c-1.fc38.noarch"
+      "evra": "2023c-2.fc39.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.2-2.fc38.s390x"
+      "evra": "0.14.0-3.fc39.s390x"
     },
     "util-linux": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "util-linux-core": {
-      "evra": "2.38.1-4.fc38.s390x"
+      "evra": "2.39.2-1.fc39.s390x"
     },
     "veritysetup": {
-      "evra": "2.6.1-1.fc38.s390x"
+      "evra": "2.6.1-3.fc39.s390x"
     },
     "vim-data": {
-      "evra": "2:9.0.2081-1.fc38.noarch"
+      "evra": "2:9.0.2081-1.fc39.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.2081-1.fc38.s390x"
+      "evra": "2:9.0.2081-1.fc39.s390x"
     },
     "which": {
-      "evra": "2.21-39.fc38.s390x"
+      "evra": "2.21-40.fc39.s390x"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-4.fc38.s390x"
+      "evra": "1.0.20210914-5.fc39.s390x"
     },
     "xfsprogs": {
-      "evra": "6.1.0-3.fc38.s390x"
+      "evra": "6.4.0-1.fc39.s390x"
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc38.s390x"
+      "evra": "0.8.2-1.fc39.s390x"
     },
     "xz": {
-      "evra": "5.4.1-1.fc38.s390x"
+      "evra": "5.4.4-1.fc39.s390x"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc38.s390x"
+      "evra": "5.4.4-1.fc39.s390x"
     },
     "yajl": {
-      "evra": "2.1.0-21.fc38.s390x"
+      "evra": "2.1.0-22.fc39.s390x"
     },
     "zchunk-libs": {
-      "evra": "1.3.2-1.fc38.s390x"
+      "evra": "1.3.2-1.fc39.s390x"
     },
     "zincati": {
-      "evra": "0.0.26-2.fc38.s390x"
+      "evra": "0.0.26-2.fc39.s390x"
     },
     "zlib": {
-      "evra": "1.2.13-3.fc38.s390x"
+      "evra": "1.2.13-4.fc39.s390x"
     },
     "zram-generator": {
-      "evra": "1.1.2-4.fc38.s390x"
+      "evra": "1.1.2-8.fc39.s390x"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc38.s390x"
+      "evra": "1.5.5-4.fc39.s390x"
     }
   },
   "metadata": {
-    "generated": "2023-11-04T00:00:00Z",
+    "generated": "2023-11-06T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-04-13T20:36:40Z"
+      "fedora-candidate-compose": {
+        "generated": "2023-11-01T00:12:19Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-04T02:13:44Z"
+        "generated": "2023-11-05T01:41:18Z"
       },
-      "fedora-updates": {
-        "generated": "2023-11-04T03:32:47Z"
+      "fedora-next": {
+        "generated": "2023-11-03T02:50:05Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-11-06T01:22:26Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1298 +1,1313 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.42.8-1.fc38.x86_64"
+      "evra": "1:1.44.2-1.fc39.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.42.8-1.fc38.x86_64"
+      "evra": "1:1.44.2-1.fc39.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.42.8-1.fc38.x86_64"
+      "evra": "1:1.44.2-1.fc39.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.42.8-1.fc38.x86_64"
+      "evra": "1:1.44.2-1.fc39.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.42.8-1.fc38.x86_64"
+      "evra": "1:1.44.2-1.fc39.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.0.4-1.fc38.noarch"
+      "evra": "2.9.1.1-1.fc39.noarch"
     },
     "aardvark-dns": {
-      "evra": "1.8.0-1.fc38.x86_64"
+      "evra": "1.8.0-1.fc39.x86_64"
     },
     "acl": {
-      "evra": "2.3.1-6.fc38.x86_64"
+      "evra": "2.3.1-8.fc39.x86_64"
     },
     "adcli": {
-      "evra": "0.9.2-2.fc38.x86_64"
+      "evra": "0.9.2-3.fc39.x86_64"
     },
     "afterburn": {
-      "evra": "5.4.2-1.fc38.x86_64"
+      "evra": "5.4.2-2.fc39.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.4.2-1.fc38.x86_64"
+      "evra": "5.4.2-2.fc39.x86_64"
     },
     "alternatives": {
-      "evra": "1.25-1.fc38.x86_64"
+      "evra": "1.25-1.fc39.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "atheros-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "attr": {
-      "evra": "2.5.1-6.fc38.x86_64"
+      "evra": "2.5.1-8.fc39.x86_64"
+    },
+    "audit": {
+      "evra": "3.1.2-4.fc39.x86_64"
     },
     "audit-libs": {
-      "evra": "3.1.2-1.fc38.x86_64"
+      "evra": "3.1.2-4.fc39.x86_64"
     },
     "authselect": {
-      "evra": "1.4.3-1.fc38.x86_64"
+      "evra": "1.4.3-1.fc39.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc38.x86_64"
+      "evra": "1.4.3-1.fc39.x86_64"
     },
     "avahi-libs": {
-      "evra": "0.8-22.fc38.x86_64"
+      "evra": "0.8-24.fc39.x86_64"
     },
     "basesystem": {
-      "evra": "11-15.fc38.noarch"
+      "evra": "11-18.fc39.noarch"
     },
     "bash": {
-      "evra": "5.2.15-3.fc38.x86_64"
+      "evra": "5.2.15-5.fc39.x86_64"
+    },
+    "bash-color-prompt": {
+      "evra": "0.1-6.fc39.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.11-9.fc38.noarch"
+      "evra": "1:2.11-12.fc39.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.19-1.fc38.x86_64"
+      "evra": "32:9.18.19-1.fc39.x86_64"
     },
     "bind-license": {
-      "evra": "32:9.18.19-1.fc38.noarch"
+      "evra": "32:9.18.19-1.fc39.noarch"
     },
     "bind-utils": {
-      "evra": "32:9.18.19-1.fc38.x86_64"
+      "evra": "32:9.18.19-1.fc39.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.12-2.fc38.x86_64"
+      "evra": "0.2.12-2.fc39.x86_64"
     },
     "brcmfmac-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "bsdtar": {
-      "evra": "3.6.1-4.fc38.x86_64"
+      "evra": "3.7.1-1.fc39.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.5.1-1.fc38.x86_64"
+      "evra": "6.5.1-1.fc39.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.7.0-1.fc38.x86_64"
+      "evra": "0.7.0-2.fc39.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-13.fc38.x86_64"
+      "evra": "1.0.8-16.fc39.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-13.fc38.x86_64"
+      "evra": "1.0.8-16.fc39.x86_64"
     },
     "c-ares": {
-      "evra": "1.19.1-1.fc38.x86_64"
+      "evra": "1.19.1-1.fc39.x86_64"
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-1.0.fc38.noarch"
+      "evra": "2023.2.60_v7.0.306-2.fc39.noarch"
     },
     "catatonit": {
-      "evra": "0.1.7-14.fc38.x86_64"
+      "evra": "0.1.7-18.fc39.x86_64"
     },
     "chrony": {
-      "evra": "4.4-1.fc38.x86_64"
+      "evra": "4.4-1.fc39.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.0-1.fc38.x86_64"
+      "evra": "7.0-2.fc39.x86_64"
     },
     "clevis": {
-      "evra": "19-2.fc38.x86_64"
+      "evra": "19-4.fc39.x86_64"
     },
     "clevis-dracut": {
-      "evra": "19-2.fc38.x86_64"
+      "evra": "19-4.fc39.x86_64"
     },
     "clevis-luks": {
-      "evra": "19-2.fc38.x86_64"
+      "evra": "19-4.fc39.x86_64"
     },
     "clevis-systemd": {
-      "evra": "19-2.fc38.x86_64"
+      "evra": "19-4.fc39.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc38.noarch"
+      "evra": "0.33-3.fc39.noarch"
     },
     "conmon": {
-      "evra": "2:2.1.7-2.fc38.x86_64"
+      "evra": "2:2.1.7-3.fc39.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-4.fc38.noarch"
+      "evra": "0.21.3-6.fc39.noarch"
     },
     "container-selinux": {
-      "evra": "2:2.224.0-1.fc38.noarch"
+      "evra": "2:2.224.0-1.fc39.noarch"
     },
     "containerd": {
-      "evra": "1.6.19-1.fc38.x86_64"
+      "evra": "1.6.19-2.fc39.x86_64"
     },
     "containernetworking-plugins": {
-      "evra": "1.3.0-2.fc38.x86_64"
+      "evra": "1.3.0-3.fc39.x86_64"
     },
     "containers-common": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "containers-common-extra": {
-      "evra": "4:1-89.fc38.noarch"
+      "evra": "4:1-95.fc39.noarch"
     },
     "coreos-installer": {
-      "evra": "0.18.0-1.fc38.x86_64"
+      "evra": "0.18.0-1.fc39.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.18.0-1.fc38.x86_64"
+      "evra": "0.18.0-1.fc39.x86_64"
     },
     "coreutils": {
-      "evra": "9.1-12.fc38.x86_64"
+      "evra": "9.3-4.fc39.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.1-12.fc38.x86_64"
+      "evra": "9.3-4.fc39.x86_64"
     },
     "cpio": {
-      "evra": "2.13-14.fc38.x86_64"
+      "evra": "2.14-4.fc39.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.11-1.fc38.x86_64"
+      "evra": "2.9.11-2.fc39.x86_64"
     },
     "criu": {
-      "evra": "3.18-1.fc38.x86_64"
+      "evra": "3.18-3.fc39.x86_64"
     },
     "criu-libs": {
-      "evra": "3.18-1.fc38.x86_64"
+      "evra": "3.18-3.fc39.x86_64"
     },
     "crun": {
-      "evra": "1.11-1.fc38.x86_64"
+      "evra": "1.11.1-1.fc39.x86_64"
+    },
+    "crun-wasm": {
+      "evra": "1.11.1-1.fc39.x86_64"
     },
     "crypto-policies": {
-      "evra": "20230301-1.gita12f7b2.fc38.noarch"
+      "evra": "20230731-1.git5ed06e0.fc39.noarch"
     },
     "cryptsetup": {
-      "evra": "2.6.1-1.fc38.x86_64"
+      "evra": "2.6.1-3.fc39.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-1.fc38.x86_64"
+      "evra": "2.6.1-3.fc39.x86_64"
     },
     "curl": {
-      "evra": "8.0.1-5.fc38.x86_64"
+      "evra": "8.2.1-3.fc39.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-9.fc38.x86_64"
+      "evra": "2.1.28-11.fc39.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-9.fc38.x86_64"
+      "evra": "2.1.28-11.fc39.x86_64"
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc38.x86_64"
+      "evra": "1:1.14.10-1.fc39.x86_64"
     },
     "dbus-broker": {
-      "evra": "33-1.fc38.x86_64"
+      "evra": "33-2.fc39.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc38.noarch"
+      "evra": "1:1.14.10-1.fc39.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc38.x86_64"
+      "evra": "1:1.14.10-1.fc39.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.189-2.fc38.x86_64"
+      "evra": "1.02.196-1.fc39.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.189-2.fc38.x86_64"
+      "evra": "1.02.196-1.fc39.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.189-2.fc38.x86_64"
+      "evra": "1.02.196-1.fc39.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.189-2.fc38.x86_64"
+      "evra": "1.02.196-1.fc39.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.9.4-2.fc38.x86_64"
+      "evra": "0.9.5-2.fc39.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.4-2.fc38.x86_64"
+      "evra": "0.9.5-2.fc39.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "0.9.0-10.fc38.x86_64"
+      "evra": "1.0.6-2.fc39.x86_64"
     },
     "diffutils": {
-      "evra": "3.10-1.fc38.x86_64"
+      "evra": "3.10-3.fc39.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.89-5.fc38.x86_64"
+      "evra": "2.89-6.fc39.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-6.fc38.x86_64"
+      "evra": "4.2-7.fc39.x86_64"
     },
     "dracut": {
-      "evra": "059-4.fc38.x86_64"
+      "evra": "059-15.fc39.x86_64"
     },
     "dracut-network": {
-      "evra": "059-4.fc38.x86_64"
+      "evra": "059-15.fc39.x86_64"
     },
     "dracut-squash": {
-      "evra": "059-4.fc38.x86_64"
+      "evra": "059-15.fc39.x86_64"
     },
     "duktape": {
-      "evra": "2.7.0-2.fc38.x86_64"
+      "evra": "2.7.0-5.fc39.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.46.5-4.fc38.x86_64"
+      "evra": "1.47.0-2.fc39.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.46.5-4.fc38.x86_64"
+      "evra": "1.47.0-2.fc39.x86_64"
     },
     "efi-filesystem": {
-      "evra": "5-7.fc38.noarch"
+      "evra": "5-9.fc39.noarch"
     },
     "efibootmgr": {
-      "evra": "18-3.fc38.x86_64"
+      "evra": "18-4.fc39.x86_64"
     },
     "efivar-libs": {
-      "evra": "38-7.fc38.x86_64"
+      "evra": "38-8.fc39.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.189-3.fc38.noarch"
+      "evra": "0.189-4.fc39.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.189-3.fc38.x86_64"
+      "evra": "0.189-4.fc39.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.189-3.fc38.x86_64"
+      "evra": "0.189-4.fc39.x86_64"
     },
     "ethtool": {
-      "evra": "2:6.5-1.fc38.x86_64"
+      "evra": "2:6.5-1.fc39.x86_64"
     },
     "expat": {
-      "evra": "2.5.0-2.fc38.x86_64"
+      "evra": "2.5.0-3.fc39.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "38-36.noarch"
+      "evra": "39-30.noarch"
     },
     "fedora-repos": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "38-1.noarch"
-    },
-    "fedora-repos-modular": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "fedora-repos-ostree": {
-      "evra": "38-1.noarch"
+      "evra": "39-1.noarch"
     },
     "file": {
-      "evra": "5.44-3.fc38.x86_64"
+      "evra": "5.44-5.fc39.x86_64"
     },
     "file-libs": {
-      "evra": "5.44-3.fc38.x86_64"
+      "evra": "5.44-5.fc39.x86_64"
     },
     "filesystem": {
-      "evra": "3.18-3.fc38.x86_64"
+      "evra": "3.18-6.fc39.x86_64"
     },
     "findutils": {
-      "evra": "1:4.9.0-3.fc38.x86_64"
+      "evra": "1:4.9.0-5.fc39.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.15.4-1.fc38.x86_64"
+      "evra": "1.15.4-3.fc39.x86_64"
+    },
+    "fmt": {
+      "evra": "10.0.0-3.fc39.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-6.fc38.x86_64"
+      "evra": "0.6.1-8.fc39.x86_64"
     },
     "fuse": {
-      "evra": "2.9.9-16.fc38.x86_64"
+      "evra": "2.9.9-17.fc39.x86_64"
     },
     "fuse-common": {
-      "evra": "3.14.1-1.fc38.x86_64"
+      "evra": "3.16.1-1.fc39.x86_64"
     },
     "fuse-libs": {
-      "evra": "2.9.9-16.fc38.x86_64"
+      "evra": "2.9.9-17.fc39.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.12-1.fc38.x86_64"
+      "evra": "1.12-2.fc39.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-3.fc38.x86_64"
+      "evra": "3.7.3-4.fc39.x86_64"
     },
     "fuse3": {
-      "evra": "3.14.1-1.fc38.x86_64"
+      "evra": "3.16.1-1.fc39.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.14.1-1.fc38.x86_64"
+      "evra": "3.16.1-1.fc39.x86_64"
     },
     "fwupd": {
-      "evra": "1.9.7-1.fc38.x86_64"
+      "evra": "1.9.7-1.fc39.x86_64"
     },
     "gawk": {
-      "evra": "5.1.1-5.fc38.x86_64"
+      "evra": "5.2.2-2.fc39.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-3.fc38.x86_64"
+      "evra": "1:1.23-4.fc39.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.9-5.fc38.x86_64"
+      "evra": "1.0.9-6.fc39.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.21.1-2.fc38.x86_64"
+      "evra": "0.22-2.fc39.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.21.1-2.fc38.x86_64"
+      "evra": "0.22-2.fc39.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.21.1-2.fc38.x86_64"
+      "evra": "0.22-2.fc39.x86_64"
     },
     "git-core": {
-      "evra": "2.41.0-1.fc38.x86_64"
+      "evra": "2.41.0-2.fc39.x86_64"
     },
     "glib2": {
-      "evra": "2.76.5-2.fc38.x86_64"
+      "evra": "2.78.1-1.fc39.x86_64"
     },
     "glibc": {
-      "evra": "2.37-13.fc38.x86_64"
+      "evra": "2.38-10.fc39.x86_64"
     },
     "glibc-common": {
-      "evra": "2.37-13.fc38.x86_64"
+      "evra": "2.38-10.fc39.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.37-13.fc38.x86_64"
+      "evra": "2.38-10.fc39.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.37-13.fc38.x86_64"
+      "evra": "2.38-10.fc39.x86_64"
     },
     "gmp": {
-      "evra": "1:6.2.1-4.fc38.x86_64"
+      "evra": "1:6.2.1-5.fc39.x86_64"
     },
     "gnupg2": {
-      "evra": "2.4.0-3.fc38.x86_64"
+      "evra": "2.4.3-2.fc39.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.1-1.fc38.x86_64"
+      "evra": "3.8.1-1.fc39.x86_64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20230929.00-1.fc38.noarch"
+      "evra": "20230929.00-1.fc39.noarch"
     },
     "gpgme": {
-      "evra": "1.17.1-5.fc38.x86_64"
+      "evra": "1.20.0-5.fc39.x86_64"
     },
     "grep": {
-      "evra": "3.8-3.fc38.x86_64"
+      "evra": "3.11-3.fc39.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.06-102.fc38.noarch"
+      "evra": "1:2.06-104.fc39.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-102.fc38.x86_64"
+      "evra": "1:2.06-104.fc39.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.06-102.fc38.x86_64"
+      "evra": "1:2.06-104.fc39.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-102.fc38.noarch"
+      "evra": "1:2.06-104.fc39.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.06-102.fc38.x86_64"
+      "evra": "1:2.06-104.fc39.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-102.fc38.x86_64"
+      "evra": "1:2.06-104.fc39.x86_64"
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.1-1.fc38.x86_64"
+      "evra": "6:0.7.1-1.fc39.x86_64"
     },
     "gzip": {
-      "evra": "1.12-3.fc38.x86_64"
+      "evra": "1.12-6.fc39.x86_64"
     },
     "hostname": {
-      "evra": "3.23-8.fc38.x86_64"
+      "evra": "3.23-9.fc39.x86_64"
     },
     "ignition": {
-      "evra": "2.16.2-1.fc38.x86_64"
+      "evra": "2.16.2-2.fc39.x86_64"
     },
     "inih": {
-      "evra": "57-1.fc38.x86_64"
+      "evra": "57-2.fc39.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-1.fc38.x86_64"
+      "evra": "1.0.3-2.fc39.x86_64"
     },
     "iproute": {
-      "evra": "6.4.0-1.fc38.x86_64"
+      "evra": "6.4.0-2.fc39.x86_64"
     },
     "iproute-tc": {
-      "evra": "6.4.0-1.fc38.x86_64"
+      "evra": "6.4.0-2.fc39.x86_64"
     },
     "iptables-legacy": {
-      "evra": "1.8.9-4.fc38.1.x86_64"
+      "evra": "1.8.9-5.fc39.x86_64"
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-4.fc38.1.x86_64"
+      "evra": "1.8.9-5.fc39.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.9-4.fc38.1.x86_64"
+      "evra": "1.8.9-5.fc39.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.9-4.fc38.1.x86_64"
+      "evra": "1.8.9-5.fc39.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.9-4.fc38.1.noarch"
+      "evra": "1.8.9-5.fc39.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.9-4.fc38.1.x86_64"
+      "evra": "1.8.9-5.fc39.x86_64"
     },
     "iputils": {
-      "evra": "20221126-2.fc38.x86_64"
+      "evra": "20221126-4.fc39.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.9.2-1.fc38.x86_64"
+      "evra": "2:1.9.2-2.fc39.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.x86_64"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.4-10.git2a8f9d8.fc38.x86_64"
+      "evra": "6.2.1.9-17.gitc26218d.fc39.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.101-6.fc38.x86_64"
+      "evra": "0.101-7.fc39.x86_64"
     },
     "jansson": {
-      "evra": "2.13.1-6.fc38.x86_64"
+      "evra": "2.13.1-7.fc39.x86_64"
     },
     "jemalloc": {
-      "evra": "5.3.0-3.fc38.x86_64"
+      "evra": "5.3.0-4.fc39.x86_64"
     },
     "jose": {
-      "evra": "11-7.fc38.x86_64"
+      "evra": "11-8.fc39.x86_64"
     },
     "jq": {
-      "evra": "1.6-16.fc38.x86_64"
+      "evra": "1.6-17.fc39.x86_64"
     },
     "json-c": {
-      "evra": "0.17-1.fc38.x86_64"
+      "evra": "0.17-1.fc39.x86_64"
     },
     "json-glib": {
-      "evra": "1.6.6-4.fc38.x86_64"
+      "evra": "1.8.0-1.fc39.x86_64"
     },
     "kbd": {
-      "evra": "2.5.1-5.fc38.x86_64"
+      "evra": "2.6.3-1.fc39.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kbd-misc": {
-      "evra": "2.5.1-5.fc38.noarch"
+      "evra": "2.6.3-1.fc39.noarch"
     },
     "kernel": {
-      "evra": "6.5.9-200.fc38.x86_64"
+      "evra": "6.5.9-300.fc39.x86_64"
     },
     "kernel-core": {
-      "evra": "6.5.9-200.fc38.x86_64"
+      "evra": "6.5.9-300.fc39.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.5.9-200.fc38.x86_64"
+      "evra": "6.5.9-300.fc39.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.5.9-200.fc38.x86_64"
+      "evra": "6.5.9-300.fc39.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.26-3.fc38.x86_64"
+      "evra": "2.0.27-2.fc39.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.1-6.fc38.x86_64"
+      "evra": "1.6.1-7.fc39.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.1-6.fc38.x86_64"
+      "evra": "1.6.1-7.fc39.x86_64"
     },
     "kmod": {
-      "evra": "30-4.fc38.x86_64"
+      "evra": "30-6.fc39.x86_64"
     },
     "kmod-libs": {
-      "evra": "30-4.fc38.x86_64"
+      "evra": "30-6.fc39.x86_64"
     },
     "kpartx": {
-      "evra": "0.9.4-2.fc38.x86_64"
+      "evra": "0.9.5-2.fc39.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.21-3.fc38.x86_64"
+      "evra": "1.21.2-2.fc39.x86_64"
     },
     "less": {
-      "evra": "633-1.fc38.x86_64"
+      "evra": "633-2.fc39.x86_64"
     },
     "libacl": {
-      "evra": "2.3.1-6.fc38.x86_64"
+      "evra": "2.3.1-8.fc39.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-15.fc38.x86_64"
+      "evra": "0.3.111-16.fc39.x86_64"
     },
     "libarchive": {
-      "evra": "3.6.1-4.fc38.x86_64"
+      "evra": "3.7.1-1.fc39.x86_64"
     },
     "libargon2": {
-      "evra": "20190702-2.fc38.x86_64"
+      "evra": "20190702-3.fc39.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.6-1.fc38.x86_64"
+      "evra": "2.5.6-2.fc39.x86_64"
     },
     "libattr": {
-      "evra": "2.5.1-6.fc38.x86_64"
+      "evra": "2.5.1-8.fc39.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-53.fc38.x86_64"
+      "evra": "0.1.1-54.fc39.x86_64"
     },
     "libblkid": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "libbpf": {
-      "evra": "2:1.1.0-2.fc38.x86_64"
+      "evra": "2:1.1.0-4.fc39.x86_64"
     },
     "libbsd": {
-      "evra": "0.11.7-4.fc38.x86_64"
+      "evra": "0.11.7-5.fc39.x86_64"
     },
     "libcap": {
-      "evra": "2.48-6.fc38.x86_64"
+      "evra": "2.48-7.fc39.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc38.x86_64"
+      "evra": "0.8.3-8.fc39.x86_64"
     },
     "libcbor": {
-      "evra": "0.7.0-9.fc38.x86_64"
+      "evra": "0.10.2-2.fc39.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-53.fc38.x86_64"
+      "evra": "0.7.0-54.fc39.x86_64"
     },
     "libcom_err": {
-      "evra": "1.46.5-4.fc38.x86_64"
+      "evra": "1.47.0-2.fc39.x86_64"
     },
     "libcurl-minimal": {
-      "evra": "8.0.1-5.fc38.x86_64"
+      "evra": "8.2.1-3.fc39.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-25.fc38.x86_64"
+      "evra": "0.14-26.fc39.x86_64"
     },
     "libdb": {
-      "evra": "5.3.28-55.fc38.x86_64"
+      "evra": "5.3.28-56.fc39.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-53.fc38.x86_64"
+      "evra": "0.5.0-54.fc39.x86_64"
     },
     "libeconf": {
-      "evra": "0.5.2-1.fc38.x86_64"
+      "evra": "0.5.2-1.fc39.x86_64"
     },
     "libedit": {
-      "evra": "3.1-45.20221030cvs.fc38.x86_64"
+      "evra": "3.1-48.20230828cvs.fc39.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-8.fc38.x86_64"
+      "evra": "2.1.12-9.fc39.x86_64"
     },
     "libfdisk": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "libffi": {
-      "evra": "3.4.4-2.fc38.x86_64"
+      "evra": "3.4.4-4.fc39.x86_64"
     },
     "libfido2": {
-      "evra": "1.12.0-3.fc38.x86_64"
+      "evra": "1.13.0-3.fc39.x86_64"
     },
     "libgcc": {
-      "evra": "13.2.1-4.fc38.x86_64"
+      "evra": "13.2.1-4.fc39.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.10.2-1.fc38.x86_64"
+      "evra": "1.10.2-2.fc39.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.47-1.fc38.x86_64"
+      "evra": "1.47-2.fc39.x86_64"
     },
     "libgudev": {
-      "evra": "237-4.fc38.x86_64"
+      "evra": "238-2.fc39.x86_64"
     },
     "libgusb": {
-      "evra": "0.4.5-1.fc38.x86_64"
+      "evra": "0.4.7-1.fc39.x86_64"
     },
     "libibverbs": {
-      "evra": "44.0-3.fc38.x86_64"
+      "evra": "46.0-4.fc39.x86_64"
     },
     "libicu": {
-      "evra": "72.1-2.fc38.x86_64"
+      "evra": "73.2-2.fc39.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.4-2.fc38.x86_64"
+      "evra": "2.3.4-3.fc39.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-53.fc38.x86_64"
+      "evra": "1.3.1-54.fc39.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "libjcat": {
-      "evra": "0.1.13-1.fc38.x86_64"
+      "evra": "0.1.14-2.fc39.x86_64"
     },
     "libjose": {
-      "evra": "11-7.fc38.x86_64"
+      "evra": "11-8.fc39.x86_64"
     },
     "libkcapi": {
-      "evra": "1.4.0-5.fc38.x86_64"
+      "evra": "1.4.0-7.fc39.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-5.fc38.x86_64"
+      "evra": "1.4.0-7.fc39.x86_64"
     },
     "libksba": {
-      "evra": "1.6.4-1.fc38.x86_64"
+      "evra": "1.6.4-2.fc39.x86_64"
     },
     "libldb": {
-      "evra": "2.7.2-1.fc38.x86_64"
+      "evra": "2.8.0-1.fc39.x86_64"
     },
     "libluksmeta": {
-      "evra": "9-15.fc38.x86_64"
+      "evra": "9-16.fc39.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.7.1-2.fc38.x86_64"
+      "evra": "1.7.1-3.fc39.x86_64"
     },
     "libmd": {
-      "evra": "1.1.0-1.fc38.x86_64"
+      "evra": "1.1.0-2.fc39.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.5-2.fc38.x86_64"
+      "evra": "1.0.5-3.fc39.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.15.0-2.fc38.x86_64"
+      "evra": "2.15.0-5.fc39.x86_64"
     },
     "libmount": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "libndp": {
-      "evra": "1.8-5.fc38.x86_64"
+      "evra": "1.8-6.fc39.x86_64"
     },
     "libnet": {
-      "evra": "1.3-1.fc38.x86_64"
+      "evra": "1.3-1.fc39.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-1.fc38.x86_64"
+      "evra": "1.0.9-2.fc39.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-23.fc38.x86_64"
+      "evra": "1.0.1-24.fc39.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.6.3-1.rc3.fc38.x86_64"
+      "evra": "1:2.6.3-2.rc3.fc39.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.4-2.fc38.x86_64"
+      "evra": "1.2.6-2.fc39.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.52.0-2.fc38.x86_64"
+      "evra": "1.55.1-4.fc39.x86_64"
     },
     "libnl3": {
-      "evra": "3.7.0-3.fc38.x86_64"
+      "evra": "3.8.0-1.fc39.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.7.0-3.fc38.x86_64"
+      "evra": "3.8.0-1.fc39.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.0-5.fc38.x86_64"
+      "evra": "2.0.0-6.fc39.x86_64"
     },
     "libnvme": {
-      "evra": "1.4-2.fc38.x86_64"
+      "evra": "1.6-2.fc39.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-53.fc38.x86_64"
+      "evra": "0.2.1-54.fc39.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.4-1.fc38.x86_64"
+      "evra": "14:1.10.4-2.fc39.x86_64"
     },
     "libpkgconf": {
-      "evra": "1.8.0-6.fc38.x86_64"
+      "evra": "1.9.5-2.fc39.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.2-2.fc38.x86_64"
+      "evra": "0.21.2-4.fc39.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.5-3.fc38.x86_64"
+      "evra": "1.4.5-6.fc39.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-53.fc38.x86_64"
+      "evra": "0.1.5-54.fc39.x86_64"
     },
     "librepo": {
-      "evra": "1.17.0-1.fc38.x86_64"
+      "evra": "1.17.0-1.fc39.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-1.fc38.noarch"
+      "evra": "2.17.11-3.fc39.noarch"
     },
     "libseccomp": {
-      "evra": "2.5.3-4.fc38.x86_64"
+      "evra": "2.5.3-6.fc39.x86_64"
     },
     "libselinux": {
-      "evra": "3.5-1.fc38.x86_64"
+      "evra": "3.5-5.fc39.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.5-1.fc38.x86_64"
+      "evra": "3.5-5.fc39.x86_64"
     },
     "libsemanage": {
-      "evra": "3.5-2.fc38.x86_64"
+      "evra": "3.5-4.fc39.x86_64"
     },
     "libsepol": {
-      "evra": "3.5-1.fc38.x86_64"
+      "evra": "3.5-2.fc39.x86_64"
     },
     "libsigsegv": {
-      "evra": "2.14-4.fc38.x86_64"
+      "evra": "2.14-5.fc39.x86_64"
     },
     "libslirp": {
-      "evra": "4.7.0-3.fc38.x86_64"
+      "evra": "4.7.0-4.fc39.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.18.8-1.fc38.x86_64"
+      "evra": "2:4.19.2-1.fc39.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.25-1.fc38.x86_64"
+      "evra": "0.7.25-1.fc39.x86_64"
     },
     "libss": {
-      "evra": "1.46.5-4.fc38.x86_64"
+      "evra": "1.47.0-2.fc39.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "libstdc++": {
-      "evra": "13.2.1-4.fc38.x86_64"
+      "evra": "13.2.1-4.fc39.x86_64"
     },
     "libtalloc": {
-      "evra": "2.4.0-2.fc38.x86_64"
+      "evra": "2.4.1-1.fc39.x86_64"
     },
     "libtasn1": {
-      "evra": "4.19.0-2.fc38.x86_64"
+      "evra": "4.19.0-3.fc39.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.8-1.fc38.x86_64"
+      "evra": "1.4.9-1.fc39.x86_64"
     },
     "libteam": {
-      "evra": "1.31-7.fc38.x86_64"
+      "evra": "1.32-1.fc39.x86_64"
     },
     "libtevent": {
-      "evra": "0.14.1-1.fc38.x86_64"
+      "evra": "0.15.0-1.fc39.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.4-0.fc38.x86_64"
+      "evra": "1.3.4-0.fc39.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-6.fc38.x86_64"
+      "evra": "2.4.7-7.fc39.x86_64"
     },
     "libunistring": {
-      "evra": "1.1-3.fc38.x86_64"
-    },
-    "libunistring1.0": {
-      "evra": "1.0-1.fc38.x86_64"
+      "evra": "1.1-5.fc39.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.26-2.fc38.x86_64"
+      "evra": "1.0.26-3.fc39.x86_64"
     },
     "libuser": {
-      "evra": "0.64-2.fc38.x86_64"
+      "evra": "0.64-4.fc39.x86_64"
     },
     "libutempter": {
-      "evra": "1.2.1-8.fc38.x86_64"
+      "evra": "1.2.1-10.fc39.x86_64"
     },
     "libuuid": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "libuv": {
-      "evra": "1:1.46.0-1.fc38.x86_64"
+      "evra": "1:1.46.0-2.fc39.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-5.fc38.x86_64"
+      "evra": "0.3.2-6.fc39.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.18.8-1.fc38.x86_64"
+      "evra": "2:4.19.2-1.fc39.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.4.36-1.fc38.x86_64"
+      "evra": "4.4.36-2.fc39.x86_64"
     },
     "libxml2": {
-      "evra": "2.10.4-1.fc38.x86_64"
+      "evra": "2.10.4-3.fc39.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.14-1.fc38.x86_64"
+      "evra": "0.3.14-1.fc39.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-9.fc38.x86_64"
+      "evra": "0.2.5-12.fc39.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.5-1.fc38.x86_64"
+      "evra": "1.5.5-4.fc39.x86_64"
     },
     "linux-atm-libs": {
-      "evra": "2.5.1-34.fc38.x86_64"
+      "evra": "2.5.1-36.fc39.x86_64"
     },
     "linux-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.31-1.fc38.x86_64"
+      "evra": "0.9.31-2.fc39.x86_64"
     },
     "logrotate": {
-      "evra": "3.21.0-2.fc38.x86_64"
+      "evra": "3.21.0-4.fc39.x86_64"
     },
     "lsof": {
-      "evra": "4.96.3-3.fc38.x86_64"
+      "evra": "4.96.3-4.fc39.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.4-9.fc38.x86_64"
+      "evra": "5.4.6-3.fc39.x86_64"
     },
     "luksmeta": {
-      "evra": "9-15.fc38.x86_64"
+      "evra": "9-16.fc39.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.18-2.fc38.x86_64"
+      "evra": "2.03.22-1.fc39.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.18-2.fc38.x86_64"
+      "evra": "2.03.22-1.fc39.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.9.4-2.fc38.x86_64"
+      "evra": "1.9.4-4.fc39.x86_64"
     },
     "lzo": {
-      "evra": "2.10-8.fc38.x86_64"
+      "evra": "2.10-9.fc39.x86_64"
     },
     "mdadm": {
-      "evra": "4.2-4.fc38.x86_64"
+      "evra": "4.2-6.fc39.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-55.1.fc38.x86_64"
+      "evra": "2:2.1-57.fc39.x86_64"
     },
     "moby-engine": {
-      "evra": "20.10.23-1.fc38.x86_64"
+      "evra": "24.0.5-1.fc39.x86_64"
     },
     "mokutil": {
-      "evra": "2:0.6.0-6.fc38.x86_64"
+      "evra": "2:0.6.0-7.fc39.x86_64"
     },
     "mpfr": {
-      "evra": "4.1.1-3.fc38.x86_64"
+      "evra": "4.2.0-3.fc39.x86_64"
     },
     "mt7xxx-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nano": {
-      "evra": "7.2-2.fc38.x86_64"
+      "evra": "7.2-4.fc39.x86_64"
     },
     "nano-default-editor": {
-      "evra": "7.2-2.fc38.noarch"
+      "evra": "7.2-4.fc39.noarch"
     },
     "ncurses": {
-      "evra": "6.4-3.20230114.fc38.x86_64"
+      "evra": "6.4-7.20230520.fc39.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.4-3.20230114.fc38.noarch"
+      "evra": "6.4-7.20230520.fc39.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.4-3.20230114.fc38.x86_64"
+      "evra": "6.4-7.20230520.fc39.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.65.20160912git.fc38.x86_64"
+      "evra": "2.0-0.67.20160912git.fc39.x86_64"
     },
     "netavark": {
-      "evra": "1.8.0-2.fc38.x86_64"
+      "evra": "1.8.0-2.fc39.x86_64"
     },
     "nettle": {
-      "evra": "3.8-3.fc38.x86_64"
+      "evra": "3.9.1-2.fc39.x86_64"
     },
     "newt": {
-      "evra": "0.52.23-2.fc38.x86_64"
+      "evra": "0.52.23-4.fc39.x86_64"
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.3-1.rc3.fc38.x86_64"
+      "evra": "1:2.6.3-2.rc3.fc39.x86_64"
     },
     "nftables": {
-      "evra": "1:1.0.5-2.fc38.x86_64"
+      "evra": "1:1.0.7-3.fc39.x86_64"
     },
     "nmstate": {
-      "evra": "2.2.15-1.fc38.x86_64"
+      "evra": "2.2.15-1.fc39.x86_64"
     },
     "npth": {
-      "evra": "1.6-12.fc38.x86_64"
+      "evra": "1.6-14.fc39.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.18.1-22.fc38.x86_64"
+      "evra": "2.23.0-1.fc39.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.16-2.fc38.x86_64"
+      "evra": "2.0.16-3.fc39.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "nvme-cli": {
-      "evra": "2.4-3.fc38.x86_64"
+      "evra": "2.6-1.fc39.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc38.x86_64"
+      "evra": "6.9.9-1.fc39.x86_64"
     },
     "openldap": {
-      "evra": "2.6.6-1.fc38.x86_64"
+      "evra": "2.6.6-1.fc39.x86_64"
     },
     "openssh": {
-      "evra": "9.0p1-17.fc38.x86_64"
+      "evra": "9.3p1-9.fc39.x86_64"
     },
     "openssh-clients": {
-      "evra": "9.0p1-17.fc38.x86_64"
+      "evra": "9.3p1-9.fc39.x86_64"
     },
     "openssh-server": {
-      "evra": "9.0p1-17.fc38.x86_64"
+      "evra": "9.3p1-9.fc39.x86_64"
     },
     "openssl": {
-      "evra": "1:3.0.9-2.fc38.x86_64"
+      "evra": "1:3.1.1-4.fc39.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.0.9-2.fc38.x86_64"
+      "evra": "1:3.1.1-4.fc39.x86_64"
     },
     "os-prober": {
-      "evra": "1.81-3.fc38.x86_64"
+      "evra": "1.81-4.fc39.x86_64"
     },
     "ostree": {
-      "evra": "2023.6-1.fc38.x86_64"
+      "evra": "2023.7-2.fc39.x86_64"
     },
     "ostree-libs": {
-      "evra": "2023.6-1.fc38.x86_64"
+      "evra": "2023.7-2.fc39.x86_64"
     },
     "p11-kit": {
-      "evra": "0.25.2-1.fc38.x86_64"
+      "evra": "0.25.2-1.fc39.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.25.2-1.fc38.x86_64"
+      "evra": "0.25.2-1.fc39.x86_64"
     },
     "pam": {
-      "evra": "1.5.2-16.fc38.x86_64"
+      "evra": "1.5.3-3.fc39.x86_64"
     },
     "pam-libs": {
-      "evra": "1.5.2-16.fc38.x86_64"
+      "evra": "1.5.3-3.fc39.x86_64"
     },
     "passt": {
-      "evra": "0^20231004.gf851084-1.fc38.x86_64"
+      "evra": "0^20231004.gf851084-1.fc39.x86_64"
     },
     "passt-selinux": {
-      "evra": "0^20231004.gf851084-1.fc38.noarch"
+      "evra": "0^20231004.gf851084-1.fc39.noarch"
     },
     "passwd": {
-      "evra": "0.80-14.fc38.x86_64"
+      "evra": "0.80-15.fc39.x86_64"
     },
     "pcre2": {
-      "evra": "10.42-1.fc38.1.x86_64"
+      "evra": "10.42-1.fc39.2.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc38.1.noarch"
+      "evra": "10.42-1.fc39.2.noarch"
     },
     "pigz": {
-      "evra": "2.7-3.fc38.x86_64"
+      "evra": "2.8-2.fc39.x86_64"
     },
     "pkgconf": {
-      "evra": "1.8.0-6.fc38.x86_64"
+      "evra": "1.9.5-2.fc39.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "1.8.0-6.fc38.noarch"
+      "evra": "1.9.5-2.fc39.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "1.8.0-6.fc38.x86_64"
+      "evra": "1.9.5-2.fc39.x86_64"
     },
     "podman": {
-      "evra": "5:4.7.0-1.fc38.x86_64"
+      "evra": "5:4.7.0-1.fc39.x86_64"
     },
     "podman-plugins": {
-      "evra": "5:4.7.0-1.fc38.x86_64"
+      "evra": "5:4.7.0-1.fc39.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.5-1.fc38.x86_64"
+      "evra": "3.5-8.fc39.x86_64"
     },
     "polkit": {
-      "evra": "122-3.fc38.1.x86_64"
+      "evra": "123-1.fc39.x86_64"
     },
     "polkit-libs": {
-      "evra": "122-3.fc38.1.x86_64"
+      "evra": "123-1.fc39.x86_64"
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-23.fc38.x86_64"
+      "evra": "0.1-26.fc39.x86_64"
     },
     "popt": {
-      "evra": "1.19-2.fc38.x86_64"
+      "evra": "1.19-3.fc39.x86_64"
     },
     "procps-ng": {
-      "evra": "3.3.17-11.fc38.x86_64"
+      "evra": "4.0.3-4.fc39.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.4.1-4.fc38.x86_64"
+      "evra": "1.4.1-5.fc39.x86_64"
     },
     "psmisc": {
-      "evra": "23.6-2.fc38.x86_64"
+      "evra": "23.6-4.fc39.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20230812-1.fc38.noarch"
+      "evra": "20230812-1.fc39.noarch"
     },
     "readline": {
-      "evra": "8.2-3.fc38.x86_64"
+      "evra": "8.2-4.fc39.x86_64"
     },
     "realtek-firmware": {
-      "evra": "20231030-1.fc38.noarch"
+      "evra": "20231030-1.fc39.noarch"
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc2.fc38.x86_64"
+      "evra": "1.2.6-4.rc2.fc39.1.x86_64"
     },
     "rpm": {
-      "evra": "4.18.1-3.fc38.x86_64"
+      "evra": "4.19.0-1.fc39.x86_64"
     },
     "rpm-libs": {
-      "evra": "4.18.1-3.fc38.x86_64"
+      "evra": "4.19.0-1.fc39.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2023.8-2.fc38.x86_64"
+      "evra": "2023.8-2.fc39.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2023.8-2.fc38.x86_64"
+      "evra": "2023.8-2.fc39.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "4.18.1-3.fc38.x86_64"
+      "evra": "4.19.0-1.fc39.x86_64"
     },
     "rpm-sequoia": {
-      "evra": "1.5.0-1.fc38.x86_64"
+      "evra": "1.5.0-1.fc39.x86_64"
     },
     "rsync": {
-      "evra": "3.2.7-2.fc38.x86_64"
+      "evra": "3.2.7-5.fc39.x86_64"
     },
     "runc": {
-      "evra": "2:1.1.8-1.fc38.x86_64"
+      "evra": "2:1.1.8-1.fc39.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.18.8-1.fc38.x86_64"
+      "evra": "2:4.19.2-1.fc39.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.18.8-1.fc38.noarch"
+      "evra": "2:4.19.2-1.fc39.noarch"
     },
     "samba-common-libs": {
-      "evra": "2:4.18.8-1.fc38.x86_64"
+      "evra": "2:4.19.2-1.fc39.x86_64"
     },
     "sed": {
-      "evra": "4.8-12.fc38.x86_64"
+      "evra": "4.8-14.fc39.x86_64"
     },
     "selinux-policy": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "38.30-1.fc38.noarch"
+      "evra": "39.1-1.fc39.noarch"
     },
     "setup": {
-      "evra": "2.14.3-2.fc38.noarch"
+      "evra": "2.14.4-1.fc39.noarch"
     },
     "sg3_utils": {
-      "evra": "1.46-5.fc38.x86_64"
+      "evra": "1.46-6.fc39.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.46-5.fc38.x86_64"
+      "evra": "1.46-6.fc39.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.13-6.fc38.x86_64"
+      "evra": "2:4.14.0-2.fc39.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.13-6.fc38.x86_64"
+      "evra": "2:4.14.0-2.fc39.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.2-3.fc38.x86_64"
+      "evra": "2.2-4.fc39.x86_64"
     },
     "shim-x64": {
       "evra": "15.6-2.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.13.3-1.fc38.x86_64"
+      "evra": "1:1.13.3-1.fc39.x86_64"
     },
     "slang": {
-      "evra": "2.3.3-3.fc38.x86_64"
+      "evra": "2.3.3-4.fc39.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc38.x86_64"
+      "evra": "1.2.2-1.fc39.x86_64"
     },
     "snappy": {
-      "evra": "1.1.9-7.fc38.x86_64"
+      "evra": "1.1.10-2.fc39.x86_64"
     },
     "socat": {
-      "evra": "1.7.4.4-2.fc38.x86_64"
+      "evra": "1.7.4.4-3.fc39.x86_64"
+    },
+    "spdlog": {
+      "evra": "1.12.0-2.fc39.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.40.1-2.fc38.x86_64"
+      "evra": "3.42.0-7.fc39.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.5.1-3.fc38.x86_64"
+      "evra": "4.6.1-2.fc39.x86_64"
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-3.fc38.x86_64"
+      "evra": "0.1.4-4.fc39.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-client": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-common": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.1-1.fc38.x86_64"
+      "evra": "2.9.2-2.fc39.x86_64"
     },
     "stalld": {
-      "evra": "1.16-3.fc38.x86_64"
+      "evra": "1.16-4.fc39.x86_64"
     },
     "sudo": {
-      "evra": "1.9.13-2.p2.fc38.x86_64"
+      "evra": "1.9.14-1.p3.fc39.x86_64"
     },
     "systemd": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "systemd-container": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "systemd-libs": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "systemd-pam": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "systemd-resolved": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "systemd-udev": {
-      "evra": "253.12-1.fc38.x86_64"
+      "evra": "254.5-2.fc39.x86_64"
     },
     "tar": {
-      "evra": "2:1.34-8.fc38.x86_64"
+      "evra": "2:1.35-2.fc39.x86_64"
     },
     "teamd": {
-      "evra": "1.31-7.fc38.x86_64"
+      "evra": "1.32-1.fc39.x86_64"
     },
     "toolbox": {
-      "evra": "0.0.99.4-1.fc38.x86_64"
+      "evra": "0.0.99.4-3.fc39.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.5-3.fc38.x86_64"
+      "evra": "5.5-4.fc39.x86_64"
     },
     "tpm2-tss": {
-      "evra": "4.0.1-3.fc38.x86_64"
+      "evra": "4.0.1-4.fc39.x86_64"
     },
     "tzdata": {
-      "evra": "2023c-1.fc38.noarch"
+      "evra": "2023c-2.fc39.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.13.2-2.fc38.x86_64"
+      "evra": "0.14.0-3.fc39.x86_64"
     },
     "util-linux": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.38.1-4.fc38.x86_64"
+      "evra": "2.39.2-1.fc39.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.0.2081-1.fc38.noarch"
+      "evra": "2:9.0.2081-1.fc39.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.0.2081-1.fc38.x86_64"
+      "evra": "2:9.0.2081-1.fc39.x86_64"
+    },
+    "wasmedge-rt": {
+      "evra": "0.13.4-1.fc39.x86_64"
     },
     "which": {
-      "evra": "2.21-39.fc38.x86_64"
+      "evra": "2.21-40.fc39.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-4.fc38.x86_64"
+      "evra": "1.0.20210914-5.fc39.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.1.0-3.fc38.x86_64"
+      "evra": "6.4.0-1.fc39.x86_64"
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc38.x86_64"
+      "evra": "0.8.2-1.fc39.x86_64"
     },
     "xz": {
-      "evra": "5.4.1-1.fc38.x86_64"
+      "evra": "5.4.4-1.fc39.x86_64"
     },
     "xz-libs": {
-      "evra": "5.4.1-1.fc38.x86_64"
+      "evra": "5.4.4-1.fc39.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-21.fc38.x86_64"
+      "evra": "2.1.0-22.fc39.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.3.2-1.fc38.x86_64"
+      "evra": "1.3.2-1.fc39.x86_64"
     },
     "zincati": {
-      "evra": "0.0.26-2.fc38.x86_64"
+      "evra": "0.0.26-2.fc39.x86_64"
     },
     "zlib": {
-      "evra": "1.2.13-3.fc38.x86_64"
+      "evra": "1.2.13-4.fc39.x86_64"
     },
     "zram-generator": {
-      "evra": "1.1.2-4.fc38.x86_64"
+      "evra": "1.1.2-8.fc39.x86_64"
     },
     "zstd": {
-      "evra": "1.5.5-1.fc38.x86_64"
+      "evra": "1.5.5-4.fc39.x86_64"
     }
   },
   "metadata": {
-    "generated": "2023-11-04T00:00:00Z",
+    "generated": "2023-11-06T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-04-13T20:37:10Z"
+      "fedora-candidate-compose": {
+        "generated": "2023-11-01T00:12:39Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-04T02:15:15Z"
+        "generated": "2023-11-05T01:43:59Z"
       },
-      "fedora-updates": {
-        "generated": "2023-11-04T03:32:55Z"
+      "fedora-next": {
+        "generated": "2023-11-03T02:50:25Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2023-11-06T01:22:29Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -988,10 +988,10 @@
       "evra": "1.81-3.fc38.x86_64"
     },
     "ostree": {
-      "evra": "2023.7-2.fc38.x86_64"
+      "evra": "2023.6-1.fc38.x86_64"
     },
     "ostree-libs": {
-      "evra": "2023.7-2.fc38.x86_64"
+      "evra": "2023.6-1.fc38.x86_64"
     },
     "p11-kit": {
       "evra": "0.25.2-1.fc38.x86_64"
@@ -1033,10 +1033,10 @@
       "evra": "1.8.0-6.fc38.x86_64"
     },
     "podman": {
-      "evra": "5:4.7.2-1.fc38.x86_64"
+      "evra": "5:4.7.0-1.fc38.x86_64"
     },
     "podman-plugins": {
-      "evra": "5:4.7.2-1.fc38.x86_64"
+      "evra": "5:4.7.0-1.fc38.x86_64"
     },
     "policycoreutils": {
       "evra": "3.5-1.fc38.x86_64"
@@ -1283,16 +1283,16 @@
     }
   },
   "metadata": {
-    "generated": "2023-11-07T00:00:00Z",
+    "generated": "2023-11-04T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2023-04-13T20:37:10Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2023-11-06T21:11:40Z"
+        "generated": "2023-11-04T02:15:15Z"
       },
       "fedora-updates": {
-        "generated": "2023-11-07T04:07:11Z"
+        "generated": "2023-11-04T03:32:55Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: testing-devel
   prod: false
 
-releasever: 38
+releasever: 39
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -20,7 +20,7 @@ set -xeuo pipefail
 
 case "$(arch)" in
     aarch64|ppc64le|s390x)
-        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:38 arch)
+        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:39 arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"
         fi

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -13,6 +13,6 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-docker run --rm quay.io/fedora/fedora:38 true
+docker run --rm quay.io/fedora/fedora:39 true
 
 ok "basic docker run successfully"

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,7 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:38
+FROM quay.io/fedora/fedora:39
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -23,7 +23,7 @@ runascoreuserscript='
 set -euxo pipefail
 
 podman network create testnetwork
-podman run --rm -t --network=testnetwork quay.io/fedora/fedora:38 getent hosts google.com
+podman run --rm -t --network=testnetwork quay.io/fedora/fedora:39 getent hosts google.com
 podman network rm testnetwork
 '
 

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -20,7 +20,7 @@ set -xeuo pipefail
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:38 bash <<"EOF"
+podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:39 bash <<"EOF"
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,7 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:38
+FROM quay.io/fedora/fedora:39
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora:38 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora:39 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
This PR, [detailed in Issue]( https://github.com/coreos/fedora-coreos-tracker/issues/1490) , follows the necessary steps to prepares for the upcoming Fedora CoreOS 39 GA release by updating fedora-coreos-config.

FYI: Previously, there was another branch, but I set it as a draft and started working on this new one after running into some issues with the rebase. If you'd like to review the discussion on t[hat pull request,](https://github.com/coreos/fedora-coreos-config/pull/2693) please feel free to do so.