### PR TITLE
[stable] overrides: pin rust-zincati-0.0.25-4.fc38

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,8 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1476
       type: pin
+  zincati:
+    evr: 0.0.25-4.fc38
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1608
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).