### PR TITLE
[next] remove wasm includes in manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,11 +5,3 @@ variables:
 releasever: 39
 
 include: manifests/fedora-coreos.yaml
-
-conditional-include:
-  # we only want these in next for now; see
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1375
-  - if: basearch == "x86_64"
-    include: manifests/crun-wasm.yaml
-  - if: basearch == "aarch64"
-    include: manifests/crun-wasm.yaml


### PR DESCRIPTION
If https://github.com/coreos/fedora-coreos-config/pull/2690 merges we won't need this stream specific configuration.

(cherry picked from commit 28d7b0e9a538684fe123beffc947f9943e84a5a9)