### PR TITLE
05core: order boot UUID restamp before ignition-kargs.service

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-boot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-uuid-boot.service
@@ -6,7 +6,9 @@ ConditionPathExists=!/run/ostree-live
 # Any services looking at mounts need to order after this
 # because it causes device re-probing.
 After=coreos-gpt-setup.service
-Before=ignition-disks.service
+# This could mount the bootfs rw and the ext4 in el9 at least doesn't seem to
+# like doing that in parallel with restamping the UUID
+Before=ignition-kargs.service
 
 # If we're going to reprovision the bootfs, then there's no need to restamp
 ConditionKernelCommandLine=!bootfs.roothash


### PR DESCRIPTION
It seems like the ext4 in el9 at least has an issue where the filesystem
can become corrupted if doing the UUID restamp at the same time as kargs
are being written to the BLS. It's better anyway to make these kinds of
invasive changes offline, so enforce that.

Follow-up to 5fb5b4fa ("05core: run `coreos-gpt-setup` and
`ignition-ostree-uuid-boot` later").