### PR TITLE
[next-devel] overrides: fast-track rust-zincati-0.0.27-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,9 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
+  zincati:
+    evr: 0.0.27-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7699739559
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1608
+      type: fast-track


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).