### PR TITLE
tests/quadlet: update fedora-minimal image tag

### DIFF
--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=quay.io/fedora/fedora-minimal
+          Image=quay.io/fedora/fedora-minimal:39
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -17,7 +17,7 @@ if [[ "$(podman network inspect systemd-test | jq -r '.[0].labels."org.test.Key"
     fatal "Network not correctly created"
 fi
 
-if [[ "$(podman inspect systemd-test | jq -r '.[0].ImageName')" != "quay.io/fedora/fedora-minimal:latest" ]]; then
+if [[ "$(podman inspect systemd-test | jq -r '.[0].ImageName')" != "quay.io/fedora/fedora-minimal:39" ]]; then
     fatal "Container not using the correct image"
 fi
 


### PR DESCRIPTION
For a brief period of time during the release of a new Fedora version, the latest tag may not point to a proper version and this test will fail. Update the fedora-minimal image tag to be version specific instead of latest to prevent test failures.

Here is the output from a recent RHCOS test failure on `aarch64`:
``` text
Nov 07 00:42:27 qemu0 systemd[1]: Started kola-runext.service.
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + . /var/opt/kola/extdata/commonlib.sh
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: ++ IFS=' '
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: ++ read -r -a cmdline
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2075]: ++ jq -r '.[0].Labels."org.test.Key"'
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2074]: ++ podman volume inspect systemd-test
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + [[ quadlet-test-volume != \q\u\a\d\l\e\t\-\t\e\s\t\-\v\o\l\u\m\e ]]
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2082]: ++ jq -r '.[0].labels."org.test.Key"'
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2081]: ++ podman network inspect systemd-test
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + [[ quadlet-test-network != \q\u\a\d\l\e\t\-\t\e\s\t\-\n\e\t\w\o\r\k ]]
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2119]: ++ jq -r '.[0].ImageName'
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2118]: ++ podman inspect systemd-test
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + [[ null != \q\u\a\y\.\i\o\/\f\e\d\o\r\a\/\f\e\d\o\r\a\-\m\i\n\i\m\a\l\:\l\a\t\e\s\t ]]
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + fatal 'Container not using the correct image'
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + echo 'Container not using the correct image'
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: Container not using the correct image
Nov 07 00:42:27 qemu0 kola-runext-test.sh[2071]: + exit 1
Nov 07 00:42:27 qemu0 systemd[1]: kola-runext.service: Main process exited, code=exited, status=1/FAILURE
Nov 07 00:42:27 qemu0 systemd[1]: kola-runext.service: Failed with result 'exit-code'.
--- FAIL: ext.config.shared.containers.quadlet (39.98s)
```