### PR TITLE
[next] overrides: fast-track rust-zincati-0.0.27-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -26,3 +26,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-24872e50a0
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1490#issuecomment-1720020468
       type: fast-track
+  zincati:
+    evr: 0.0.27-1.fc39
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7699739559
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1608
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).