### PR TITLE
denylist: skip PXE tests on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,3 +25,8 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: pxe-*.ppcfw
+  tracker: https://github.com/coreos/coreos-assembler/issues/3370
+  # nb: testiso doesn't read this, so it's just for consistency
+  arches:
+    - ppc64le


### PR DESCRIPTION
These tests are broken with the latest GRUB BOOTP binaries in cosa, which is now on f39.