### PR TITLE
manifests: Explicitely include amd-ucode-firmware

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -39,6 +39,9 @@
     "amd-gpu-firmware": {
       "evra": "20231111-1.fc39.noarch"
     },
+    "amd-ucode-firmware": {
+      "evra": "20231111-1.fc39.noarch"
+    },
     "atheros-firmware": {
       "evra": "20231111-1.fc39.noarch"
     },

--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -29,6 +29,7 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
+  - amd-ucode-firmware
 
 exclude-packages:
   # Exclude kernel-debug-core to make sure that it doesn't somehow get


### PR DESCRIPTION
manifests: Explicitly include amd-ucode-firmware

Explicitly include this sub package as we want to make sure that AMD CPU microcode firmwares are included in FCOS, just like we include the ones for Intel CPU.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2251053
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1618