### PR TITLE
Revert "denylist: skip PXE tests on ppc64le"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,8 +25,3 @@
     - ppc64le
   streams:
     - rawhide
-- pattern: pxe-*.ppcfw
-  tracker: https://github.com/coreos/coreos-assembler/issues/3370
-  # nb: testiso doesn't read this, so it's just for consistency
-  arches:
-    - ppc64le


### PR DESCRIPTION
This reverts commit 077d4188c2dabb49d3d0e7dfe22b3944502ad323.

Those tests should work now with the workaround added in https://github.com/coreos/coreos-assembler/pull/3661.