### PR TITLE
tests/kola/networking: adapt to new link file names

### DIFF
--- a/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
+++ b/tests/kola/networking/ifname-karg/everyboot-systemd-link-file/test.sh
@@ -20,7 +20,7 @@ run_tests() {
     # Make sure nothing was persisted from the initramfs
     check_file_not_exists '/etc/udev/rules.d/80-ifname.rules'
     # Make sure systemd-network-generator ran (from the real root)
-    check_file_exists "/run/systemd/network/90-${nicname}.link"
+    check_file_exists "/run/systemd/network/*-${nicname}.link"
     # Make sure the NIC is in use and got the expected IP address
     check_ip "${nicname}"
 }

--- a/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
+++ b/tests/kola/networking/ifname-karg/udev-rule-firstboot-propagation
@@ -24,7 +24,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
         check_file_exists '/etc/udev/rules.d/80-ifname.rules'
         # On first boot we expect systemd-network-generator to run too
         # because the ifname= karg was present, but only for first boot
-        check_file_exists "/run/systemd/network/90-${nicname}.link"
+        check_file_exists "/run/systemd/network/*-${nicname}.link"
         # Make sure the NIC is in use and got the expected IP address
         check_ip "${nicname}"
         /tmp/autopkgtest-reboot rebooted
@@ -36,7 +36,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
         check_file_exists '/etc/udev/rules.d/80-ifname.rules'
         # On second boot the ifname= karg isn't there so the file
         # created by systemd-network-generator shouldn't exist.
-        check_file_not_exists "/run/systemd/network/90-${nicname}.link"
+        check_file_not_exists "/run/systemd/network/*-${nicname}.link"
         # Make sure the NIC is in use and got the expected IP address
         check_ip "${nicname}"
       ;;


### PR DESCRIPTION
In systemd commit b94f59b9d56 (part of v255+), the priority of the link file generated from the `ifname` karg was changed from 90 to 70. We don't really care about the priority here so just use a glob instead.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1620