### PR TITLE
denylist: skip `coreos.unique.boot.failure` on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,3 +25,9 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: coreos.unique.boot.failure
+  tracker: https://github.com/coreos/coreos-assembler/issues/3669
+  snooze: 2023-12-12
+  warn: true
+  arches:
+    - aarch64


### PR DESCRIPTION
This test has been failing on aarch64 builds. Let's denylist the test while we work to find a fix for:
https://github.com/coreos/coreos-assembler/issues/3669