### PR TITLE
denylist: extend expired snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,19 +7,19 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2023-11-30
+  snooze: 2023-12-14
   warn: true
   platforms:
     - azure
 - pattern: ext.config.docker.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1578
-  snooze: 2023-11-30
+  snooze: 2023-12-14
   warn: true
   streams:
     - rawhide
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1588
-  snooze: 2023-11-30
+  snooze: 2023-12-14
   warn: true
   arches:
     - ppc64le


### PR DESCRIPTION
The following tests are still failing as of today:
- `coreos.ignition.ssh.key`
- `ext.config.docker.basic`
- `ext.config.kdump.crash`

Extend the snooze on these tests for another two weeks while we wait for a fix on them.