### PR TITLE
[testing] overrides: pin podman-4.7.2-1.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,16 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1578
       type: pin
+  podman:
+    evr: 5:4.7.2-1.fc39
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2252000
+      type: pin
+  podman-plugins:
+    evr: 5:4.7.2-1.fc39
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2252000
+      type: pin
   zincati:
     evr: 0.0.25-6.fc39
     metadata:


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).