### PR TITLE
[rawhide] manifest: Add bootc

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,3 +8,8 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
+
+# Ship this in rawhide because we want to enable it in the future, also
+# to shake out any integration issues.
+packages:
+  - bootc


### PR DESCRIPTION
Because we want to enable it instead of rpm-ostree in the future.