### PR TITLE
manifests: move `amd-ucode-firmware` to FCOS-specific manifest

### DIFF
--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -29,7 +29,6 @@ packages-s390x:
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl
-  - amd-ucode-firmware
 
 exclude-packages:
   # Exclude kernel-debug-core to make sure that it doesn't somehow get

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -184,6 +184,10 @@ packages-x86_64:
   - irqbalance
   - google-compute-engine-guest-configs-udev
   - crun-wasm wasmedge-rt
+  # Include AMD microcode updates, see https://github.com/coreos/fedora-coreos-tracker/issues/1618.
+  # This normally should belong in bootable-rpm-ostree.yaml (alongside
+  # `microcode_ctl`), but this change hasn't hit RHCOS yet.
+  - amd-ucode-firmware
 packages-ppc64le:
   - irqbalance
   - librtas

--- a/tests/kola/files/amd-ucode-firmware
+++ b/tests/kola/files/amd-ucode-firmware
@@ -1,0 +1,17 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Verify that the host ships AMD microcode updates.
+
+# This will allow us to detect when the amd-ucode-firmware split happens in RHCOS:
+# https://github.com/coreos/fedora-coreos-tracker/issues/1618
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if ! ls /usr/lib/firmware/amd-ucode/microcode*; then
+    fatal "no AMD microcode found on host"
+fi
+ok "found AMD microcode files"


### PR DESCRIPTION
This change hasn't hit RHCOS/C9S yet so we can't put it in a shared manifest.

Add a test so we know when RHCOS gets it.

Fixes 898bf23a ("manifests: Explicitly include amd-ucode-firmware").