### PR TITLE
tests/kola/files/amd-ucode-firmware: limit to x86_64

### DIFF
--- a/tests/kola/files/amd-ucode-firmware
+++ b/tests/kola/files/amd-ucode-firmware
@@ -2,6 +2,7 @@
 ## kola:
 ##   exclusive: false
 ##   description: Verify that the host ships AMD microcode updates.
+##   architectures: x86_64
 
 # This will allow us to detect when the amd-ucode-firmware split happens in RHCOS:
 # https://github.com/coreos/fedora-coreos-tracker/issues/1618


### PR DESCRIPTION
This test is only relevant on x86_64.

Fixes 76362abe ("manifests: move `amd-ucode-firmware` to FCOS-specific manifest").