### PR TITLE
overrides: fast-track rust-bootupd-0.2.16-2.fc39

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,7 @@
 
 packages:
   bootupd:
-    evr: 0.2.15-2.fc39
+    evr: 0.2.16-2.fc39
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-7d001fa064
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2023-5705e05f53
       type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).