### PR TITLE
denylist: remove ext.config.kdump.crash

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,14 +17,6 @@
   warn: true
   streams:
     - rawhide
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1588
-  snooze: 2023-12-14
-  warn: true
-  arches:
-    - ppc64le
-  streams:
-    - rawhide
 - pattern: coreos.unique.boot.failure
   tracker: https://github.com/coreos/coreos-assembler/issues/3669
   snooze: 2023-12-12


### PR DESCRIPTION
The fix for https://github.com/coreos/fedora-coreos-tracker/issues/1588 landed upstream and this test is now passing so let's remove it from the denylist.