### PR TITLE
overlay.d: add 40grub overlay

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -18,6 +18,7 @@ ostree-layers:
   - overlay/20platform-chrony
   - overlay/25azure-udev-rules
   - overlay/30lvmdevices
+  - overlay/40grub
 
 # Be minimal
 recommends: false

--- a/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/30_console.cfg
+++ b/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/30_console.cfg
@@ -1,0 +1,4 @@
+
+# Any non-default console settings will be inserted here.
+# CONSOLE-SETTINGS-START
+# CONSOLE-SETTINGS-END

--- a/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/40_coreos-ignition.cfg
+++ b/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/40_coreos-ignition.cfg
@@ -1,0 +1,18 @@
+# Remove soon when Ignition is providing this:
+# https://github.com/coreos/fedora-coreos-config/pull/2769#discussion_r1428152480
+#
+# Determine if this is a first boot and set the ${ignition_firstboot} variable
+# which is used in the kernel command line.
+set ignition_firstboot=""
+if [ -f "/ignition.firstboot" ]; then
+    # Default networking parameters to be used with ignition.
+    set ignition_network_kcmdline=''
+
+    # Source in the `ignition.firstboot` file which could override the
+    # above $ignition_network_kcmdline with static networking config.
+    # This override feature is also by coreos-installer to persist static
+    # networking config provided during install to the first boot of the machine.
+    source "/ignition.firstboot"
+
+    set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"
+fi

--- a/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/70_coreos-user.cfg
+++ b/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/70_coreos-user.cfg
@@ -1,0 +1,6 @@
+
+# Import user defined configuration
+# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
+if [ -f $prefix/user.cfg ]; then
+  source $prefix/user.cfg
+fi

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -93,3 +93,9 @@ pre-existing LVM devices attached. See the tracker issue [1] for more
 information.
 
 [1] https://github.com/coreos/fedora-coreos-tracker/issues/1517
+
+40grub
+------
+
+Add in static grub configs that will be leveraged by bootupd when
+managing bootloaders. See https://github.com/coreos/bootupd/pull/543


### PR DESCRIPTION
bootupd upstream was modified to store default static grub configs and allow for OS integrators to add their own snippets by placing files in /usr/lib/bootupd/grub2-static/configs.d/ [1] When we move to building with osbuild we will start taking advantage of this functionality and calling bootupd with --with-static-configs. Let's go ahead and add our snippets here so they can be leveraged when we start calling bootupd with --with-static-configs.

The snippets added here come from the parts of the config currently defined in coreos-assembler that weren't lifted into bootupd [2][3][4].

[1] https://github.com/coreos/bootupd/pull/543
[2] https://github.com/coreos/coreos-assembler/blob/4636b1a5c6dc00b1d6a58b1bfbb199431444336b/src/grub.cfg#L58-L60
[3] https://github.com/coreos/coreos-assembler/blob/4636b1a5c6dc00b1d6a58b1bfbb199431444336b/src/grub.cfg#L71-L85
[4] https://github.com/coreos/coreos-assembler/blob/4636b1a5c6dc00b1d6a58b1bfbb199431444336b/src/grub.cfg#L87-L91