### PR TITLE
[Rawhide] overrides: pin `selinux-policy-40.5-1.fc40` and `container-selinux-2.224.0-1.fc40`

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  container-selinux:
+    evra: 2:2.224.0-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
+      type: pin
+  selinux-policy:
+    evra: 40.5-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
+      type: pin
+  selinux-policy-targeted:
+    evra: 40.5-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
+      type: pin


### PR DESCRIPTION
Pin selinux-policy-40.5-1.fc40 and container-selinux-2.224.0-1.fc40
Ref Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1630