### PR TITLE
workflows/openshift-os: Add NO-JIRA to PR title

### DIFF
--- a/.github/workflows/openshift-os.yml
+++ b/.github/workflows/openshift-os.yml
@@ -72,7 +72,7 @@ jobs:
             Bump fedora-coreos-config
 
             ${{ env.SHORTLOG }}
-          title: Bump fedora-coreos-config
+          title: "NO-JIRA: Bump fedora-coreos-config"
           body: |
             Created by [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/openshift-os.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/testing-devel/.github/workflows/openshift-os.yml)).
 


### PR DESCRIPTION
openshift/os main PRs require either a valid Jira issue reference or NO-JIRA prepended to the title. This is automated fedora-coreos-config bump so lets use NO-JIRA.