### PR TITLE
re-enable iscsi install and boot tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,6 +23,3 @@
   warn: true
   arches:
     - aarch64
-- pattern: iso-offline-install-iscsi.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
-  snooze: 2024-01-20


### PR DESCRIPTION
I added multi arch images, so the tests should work now