### PR TITLE
 Add bootupd package for ppc64le

### DIFF
--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -174,6 +174,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootupd": {
+      "evra": "0.2.16-2.fc39.ppc64le",
+      "metadata": {
+        "sourcerpm": "rust-bootupd"
+      }
+    },
     "brcmfmac-firmware": {
       "evra": "20231211-1.fc39.noarch",
       "metadata": {

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -205,8 +205,9 @@ packages-s390x:
 
 # See https://github.com/coreos/bootupd
 arch-include:
-  x86_64: bootupd.yaml
   aarch64: bootupd.yaml
+  ppc64le: bootupd.yaml
+  x86_64: bootupd.yaml
 
 remove-from-packages:
   # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -13,7 +13,7 @@ set -xeuo pipefail
 . "$KOLA_EXT_DATA/commonlib.sh"
 
 case "$(arch)" in
-    x86_64|aarch64)
+    aarch64|ppc64le|x86_64)
         bootupctl status
         ok bootupctl
         ;;


### PR DESCRIPTION
- Bootupd is now available for ppc64le as part of our ongoing efforts to
integrate osbuild. Let's include it

- Let's also enable the existing test to check it.