### PR TITLE
tests/root-reprovision: Query `/sysroot`, not `/`

### DIFF
--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -14,7 +14,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-fstype=$(findmnt -nvr / -o FSTYPE)
+fstype=$(findmnt -nvr /sysroot -o FSTYPE)
 [[ $fstype == ext4 ]]
 ok "source is ext4"
 

--- a/tests/kola/root-reprovision/linear/test.sh
+++ b/tests/kola/root-reprovision/linear/test.sh
@@ -18,13 +18,13 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-srcdev=$(findmnt -nvr / -o SOURCE)
+srcdev=$(findmnt -nvr /sysroot -o SOURCE)
 [[ ${srcdev} == $(realpath /dev/md/foobar) ]]
 
 blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
 [[ ${blktype} == linear ]]
 
-fstype=$(findmnt -nvr / -o FSTYPE)
+fstype=$(findmnt -nvr /sysroot -o FSTYPE)
 [[ ${fstype} == xfs ]]
 ok "source is XFS on linear device"
 

--- a/tests/kola/root-reprovision/luks/data/luks-test.sh
+++ b/tests/kola/root-reprovision/luks/data/luks-test.sh
@@ -4,13 +4,13 @@
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-srcdev=$(findmnt -nvr / -o SOURCE)
+srcdev=$(findmnt -nvr /sysroot -o SOURCE)
 [[ ${srcdev} == /dev/mapper/myluksdev ]]
 
 blktype=$(lsblk -o TYPE "${srcdev}" --noheadings)
 [[ ${blktype} == crypt ]]
 
-fstype=$(findmnt -nvr / -o FSTYPE)
+fstype=$(findmnt -nvr /sysroot -o FSTYPE)
 [[ ${fstype} == xfs ]]
 ok "source is XFS on LUKS device"
 

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -23,7 +23,7 @@ swapstatus=$(systemctl is-active dev-disk-by\\x2dpartlabel-swap.swap)
 [[ ${swapstatus} == active ]]
 ok "swap is active"
 
-fstype=$(findmnt -nvr / -o FSTYPE)
+fstype=$(findmnt -nvr /sysroot -o FSTYPE)
 [[ ${fstype} == xfs ]]
 ok "source is xfs"
 


### PR DESCRIPTION
Prep for enabling composefs.  This is the same issue as https://github.com/coreos/coreos-installer/pull/1203