### PR TITLE
tests/timesyncd: fix NM dispatcher URL

### DIFF
--- a/tests/kola/ntp/timesyncd/dhcp-propagation/config.bu
+++ b/tests/kola/ntp/timesyncd/dhcp-propagation/config.bu
@@ -13,5 +13,5 @@ storage:
   files:
     - path: /etc/NetworkManager/dispatcher.d/30-timesyncd
       contents:
-        source: "https://github.com/eworm-de/networkmanager-dispatcher-timesyncd/raw/master/30-timesyncd"
+        source: "https://github.com/eworm-de/networkmanager-dispatcher-timesyncd/raw/main/30-timesyncd"
       mode: 0755


### PR DESCRIPTION
Apparently the `master` branch got deleted in favor of `main` so we need to update the URL here.