### PR TITLE
platforms: [qemu] Also use hvc0 for x86_64/aarch64

### DIFF
--- a/platforms.yaml
+++ b/platforms.yaml
@@ -52,6 +52,9 @@ aarch64:
     kernel_arguments:
       - console=ttyAMA0,115200
   qemu:
+    kernel_arguments:
+      - console=hvc0
+      - console=ttyAMA0,115200
     # The kernel successfully autodetects a serial console, but we still
     # want GRUB to use one
     grub_commands:
@@ -153,6 +156,7 @@ x86_64:
       - terminal_input serial console
       - terminal_output serial console
     kernel_arguments:
+      - console=hvc0
       - console=tty0
       - console=ttyS0,115200n8
   virtualbox:


### PR DESCRIPTION
Pairs with https://github.com/coreos/coreos-assembler/pull/3689

Basically hvc0 is faster and more modern, but requires us to opt-in specifically.  We already had a few usages of hvc0 from cloud providers that default to this, no reason for us not to do it for our own qemu provider.

(One thing TODO here: I believe s390x qemu could do this too;
 as of right now we don't have any references to s390x here)