### PR TITLE
manifests: update qcom dtb hack on aarch64

### DIFF
--- a/manifests/aarch64-drop-qcom-dtb-files.yaml
+++ b/manifests/aarch64-drop-qcom-dtb-files.yaml
@@ -1,6 +1,6 @@
 # Short term hack to avoid running out of space on aarch64. This should
-# save us about 14M. https://github.com/coreos/fedora-coreos-tracker/issues/1464
-# This can be removed once we are on F39+.
+# save us about 14M. https://github.com/coreos/fedora-coreos-tracker/issues/1637
+# This can be removed once we have added a barrier release.
 postprocess:
   - |
     #!/usr/bin/env bash

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -28,8 +28,7 @@ conditional-include:
     include: ostree-bls.yaml
   - if:
       - basearch == "aarch64"
-      - releasever == 38
-    # Remove qcom dtb on F38 files since autopruning isn't in place yet
+    # Remove qcom dtb to help us overcome https://github.com/coreos/fedora-coreos-tracker/issues/1637
     include: aarch64-drop-qcom-dtb-files.yaml
   - if:
       - releasever == 38


### PR DESCRIPTION
We need this hack again to work around a new corner case in the /boot ENOSPC wars.

See https://github.com/coreos/fedora-coreos-tracker/issues/1637