### PR TITLE
overrides: fast-track ostree-2023.8-3.fc38

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.8-3.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track
+  ostree-libs:
+    evra: 2023.8-3.fc39.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,29 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.8-3.fc39.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track
+  ostree-libs:
+    evra: 2023.8-3.fc39.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track
+  ostree-grub2:
+    evra: 2023.8-3.fc39.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track

--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.8-3.fc39.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track
+  ostree-libs:
+    evra: 2023.8-3.fc39.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  ostree:
+    evra: 2023.8-3.fc39.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track
+  ostree-libs:
+    evra: 2023.8-3.fc39.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-450e7cc057
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1637
+      type: fast-track


### PR DESCRIPTION
Contains the fix for the corner case issue described in https://github.com/coreos/fedora-coreos-tracker/issues/1637