### PR TITLE
[stable] The test for iscsi boot fails on somes arches

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,3 +31,6 @@
   # warn: true (disabled on promotion)
   arches:
     - aarch64
+- pattern: iso-offline-install-iscsi.bios
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
+  snooze: 2024-01-20


### PR DESCRIPTION
let's disable while we build images for all the arches and create a repo centralizing images that kola needs for the tests.