### PR TITLE
denylist: snooze `rpm-ostree.kernel-replace`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -26,3 +26,8 @@
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
   snooze: 2024-01-20
+- pattern: ext.config.rpm-ostree.kernel-replace
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1642
+  snooze: 2024-01-22
+  streams:
+    - rawhide


### PR DESCRIPTION
Recent rawhide runs fails in `ext.config.rpm-ostree.kernel-replace` test because the `ostree container encapsulate command` just seems to hang forever. Snoozing till we fix it