### PR TITLE
40ignition-ostree: avoid jq try-catch

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-transposefs.sh
@@ -36,7 +36,7 @@ query_fslabel() {
 
 # Print jq query string for partitions with type GUID $1
 query_parttype() {
-    echo ".storage?.disks? // [] | map(.partitions?) | flatten | map(select(try .typeGuid catch \"\" | ascii_downcase == \"$1\"))"
+    echo ".storage?.disks? // [] | map(.partitions?) | flatten | map(select(has(\"typeGuid\") and (.typeGuid | ascii_downcase == \"$1\")))"
 }
 
 # Print partition labels for partitions with type GUID $1


### PR DESCRIPTION
There seems to be a bug in jq 1.7 where `try .foo catch "" | ascii_downcase` now fails.

It seems like jq implements short-circuiting boolean operators, so we can rework this to instead just use a simpler `and` operator.

BZ issue: https://bugzilla.redhat.com/show_bug.cgi?id=2258285

Reported-by: Gursewak Mangat <gursmangat@gmail.com>