### PR TITLE
[rawhide] overrides: pin kernel-6.7.0-68.fc40 on aarch64 only

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,32 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  kernel:
+    evr: 6.7.0-68.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-core:
+    evr: 6.7.0-68.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-modules:
+    evr: 6.7.0-68.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-modules-core:
+    evr: 6.7.0-68.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+


### PR DESCRIPTION
For some reason it just won't boot on aarch64.
See https://github.com/coreos/fedora-coreos-tracker/issues/1647