### PR TITLE
Re enabling iiso-offline-install-iscsi.bios

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,9 +23,6 @@
   warn: true
   arches:
     - aarch64
-- pattern: iso-offline-install-iscsi.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
-  snooze: 2024-01-20
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1642
   snooze: 2024-01-22


### PR DESCRIPTION
Multi arch images are available now at quay.io/jbtrystram/targetcli so we can re-enable this test.

This requires further work still, tracked in https://github.com/coreos/fedora-coreos-tracker/issues/1639 Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1638