### PR TITLE
denylist: snooze `ext.config.root-reprovision.linear`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,3 +19,9 @@
   snooze: 2024-01-22
   streams:
     - rawhide
+- pattern: ext.config.root-reprovision.linear
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1648
+  snooze: 2024-01-22
+  warn: true  
+  streams:
+    - rawhide


### PR DESCRIPTION
Most recent rawhide build fails `ext.config.root-reprovision.linear' kola test with the latest kernel release. Snoozing till it gets fixed.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1648