### PR TITLE
Add bootupd package for s390x

### DIFF
--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -168,6 +168,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootupd": {
+      "evra": "0.2.17-2.fc39.s390x",
+      "metadata": {
+        "sourcerpm": "rust-bootupd"
+      }
+    },
     "brcmfmac-firmware": {
       "evra": "20231211-1.fc39.noarch",
       "metadata": {

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -10,7 +10,8 @@ include:
   - networking-tools.yaml
   - user-experience.yaml
   - shared-workarounds.yaml
-
+  # See https://github.com/coreos/bootupd
+  - bootupd.yaml
 ostree-layers:
   - overlay/05core
   - overlay/08nouveau
@@ -202,12 +203,6 @@ packages-aarch64:
   - crun-wasm wasmedge-rt
 packages-s390x:
   - qemu-user-static-x86
-
-# See https://github.com/coreos/bootupd
-arch-include:
-  aarch64: bootupd.yaml
-  ppc64le: bootupd.yaml
-  x86_64: bootupd.yaml
 
 remove-from-packages:
   # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -12,9 +12,5 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-case "$(arch)" in
-    aarch64|ppc64le|x86_64)
-        bootupctl status
-        ok bootupctl
-        ;;
-esac
+bootupctl status
+ok bootupctl


### PR DESCRIPTION
- Bootupd is now available for s390x as part of our ongoing efforts to
integrate osbuild. Let's include it

- Let's also enable the existing test to check it.