### PR TITLE
[next-devel] disable candidate-compose repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,6 +11,6 @@ repos:
   # GitHub Action.
   - fedora-next
   - fedora-next-updates
-  - fedora-candidate-compose
+# - fedora-candidate-compose
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
We are not in a period where there are RC candidates being created.