### PR TITLE
Re enabling iiso-offline-install-iscsi.bios

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,8 +11,6 @@
   warn: true
   platforms:
     - azure
-- pattern: iso-offline-install-iscsi.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
 - pattern: ext.config.files.console-config
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1654
   streams:


### PR DESCRIPTION
Following the merge of https://github.com/coreos/coreos-assembler/pull/3702

