### PR TITLE
denylist: extend expired snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,12 +15,13 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1642
-  snooze: 2024-01-22
+  snooze: 2024-02-05
+  warn: true
   streams:
     - rawhide
 - pattern: ext.config.root-reprovision.linear
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1648
-  snooze: 2024-01-22
+  snooze: 2024-02-05
   warn: true  
   streams:
     - rawhide


### PR DESCRIPTION
`ext.config.rpm-ostree.kernel-replace` and `ext.config.root-reprovision.linear` are still failing.
Let's extend the snooze while we continue to investigate.