### PR TITLE
Add Podman v5 breaking changes checks.

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -33,6 +33,9 @@ conditional-include:
     # Remove this once we have Podman v5 in f39.
     # xref: https://github.com/coreos/fedora-coreos-tracker/issues/1629
     include: cni-plugins.yaml
+  - if: releasever == 39
+    # Checks for breaking changes that came with Podman v5.
+    include: podman-v5.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/podman-v5.yaml
+++ b/manifests/podman-v5.yaml
@@ -1,0 +1,5 @@
+# https://github.com/coreos/fedora-coreos-tracker/issues/1629
+# Delete this file once we are on Podman v5 everywhere.
+# i.e. We have moved past F39.
+ostree-layers:
+  - overlay/14podman-v5

--- a/overlay.d/14podman-v5/usr/lib/systemd/system-preset/14-fcos.preset
+++ b/overlay.d/14podman-v5/usr/lib/systemd/system-preset/14-fcos.preset
@@ -1,0 +1,1 @@
+enable coreos-cni-networking-check.service

--- a/overlay.d/14podman-v5/usr/lib/systemd/system/coreos-cni-networking-check.service
+++ b/overlay.d/14podman-v5/usr/lib/systemd/system/coreos-cni-networking-check.service
@@ -1,0 +1,11 @@
+# This service checks if the system nodes are still using
+# CNI networking. If so, they will be warned to move
+# their nodes to netavark respectively.
+[Unit]
+Description=Check If Podman Is Still Using CNI Networking
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-cni-networking-check
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/14podman-v5/usr/libexec/coreos-cni-networking-check
+++ b/overlay.d/14podman-v5/usr/libexec/coreos-cni-networking-check
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+set -euo pipefail
+# Podman is dropping support for CNI networking.
+# Podman 5 changes: https://fedoraproject.org/wiki/Changes/Podman5
+# This script checks if the system nodes are still using CNI
+# networking. If so, they will warned to move their nodes to Netavark.
+
+# Change the output color to yellow
+warn=$(echo -e '\033[0;33m')
+# No color
+nc=$(echo -e '\033[0m')
+
+# Podman supports two network backends Netavark and CNI.
+# Netavark is the default network backend and was added in
+# Podman version 4.0. CNI is deprecated and is removed
+# in Podman version 5.0, in preference of Netavark.
+podmanBackend=$(podman info --format "{{.Host.NetworkBackend}}")
+
+if [[ $podmanBackend != "netavark" ]]; then
+    motd_path=/run/motd.d/35_cni_warning.motd
+
+    cat << EOF > "${motd_path}"
+${warn}
+##############################################################################
+WARNING: Podman is using CNI networking. CNI is deprecated and will be
+removed in the upcoming Podman v5.0, in preference of Netavark. To switch
+from CNI networking to Netavark, you must run 'podman system reset --force'.
+This will delete all of your images, containers, and custom networks.
+Depending on your setup it may be preferable to reprovision the whole machine
+from the latest images.
+
+To disable this warning, use:
+sudo systemctl disable coreos-cni-networking-check.service
+##############################################################################
+${nc}
+EOF
+fi

--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -1,5 +1,5 @@
 enable coreos-check-ssh-keys.service
 # Check if cgroupsv1 is still being used
-enable coreos-check-cgroups.service
+enable coreos-check-cgroups-version.service
 # https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
 enable fwupd-refresh.timer

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-cgroups-version.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-cgroups-version.service
@@ -5,7 +5,7 @@ Description=Check if cgroupsv1 Is Still Being Used
 ConditionControlGroupController=v1
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/coreos-check-cgroups
+ExecStart=/usr/libexec/coreos-check-cgroups-version
 RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-check-cgroups-version
+++ b/overlay.d/15fcos/usr/libexec/coreos-check-cgroups-version
@@ -11,15 +11,16 @@ motd_path=/run/motd.d/30_cgroupsv1_warning.motd
 
 cat << EOF > "${motd_path}"
 ${warn}
-############################################################################
+##########################################################################
 WARNING: This system is using cgroups v1. For increased reliability
 it is strongly recommended to migrate this system and your workloads
-to use cgroups v2. For instructions on how to adjust kernel arguments
+to use cgroups v2. A future version of Podman will also drop support
+for cgroups v1. For instructions on how to adjust kernel arguments
 to use cgroups v2, see:
 https://docs.fedoraproject.org/en-US/fedora-coreos/kernel-args/
 
 To disable this warning, use:
-sudo systemctl disable coreos-check-cgroups.service
-############################################################################
+sudo systemctl disable coreos-check-cgroups-version.service
+##########################################################################
 ${nc}
 EOF

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -24,6 +24,14 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1700056
 
 Warning about `/etc/sysconfig`.
 
+14podman-v5
+------
+
+Warn about breaking changes [1] with Podman v5 and link the
+users to how they can adapt their existing nodes.
+
+[1] https://github.com/coreos/fedora-coreos-tracker/issues/1629
+
 15fcos
 ------
 


### PR DESCRIPTION
Podman 5 will come with breaking changes affecting upgradability. CGroups v1 environments will be required to switch to CGroups v2 and CNI plugin environemnts will need to switch to netavark. In the above script we added the CLHM helpers to notifiy people of the incoming changes.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1629