### PR TITLE
ci/overrides.py: add podman to trivial fast tracks

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -22,6 +22,7 @@ TRIVIAL_FAST_TRACKS = [
     'console-login-helper-messages',
     'ignition',
     'ostree',
+    'podman',
     'rpm-ostree',
     'rust-afterburn',
     'rust-bootupd',


### PR DESCRIPTION
I'd say it's routine that we want to pick up the newest version of podman before it is stable in Fedora (especially if it has passed tests).