### PR TITLE
denylist: remove ext.config.rpm-ostree.kernel-replace

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,12 +13,6 @@
     - azure
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
-- pattern: ext.config.rpm-ostree.kernel-replace
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1642
-  snooze: 2024-02-05
-  warn: true
-  streams:
-    - rawhide
 - pattern: ext.config.root-reprovision.linear
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1648
   snooze: 2024-02-05


### PR DESCRIPTION
The test passes with the latest kernel build `kernel-6.8.0-0.rc2.19.fc40`
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1642