### PR TITLE
denylist: add denial for files.console-config on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,3 +19,7 @@
   warn: true  
   streams:
     - rawhide
+- pattern: ext.config.files.console-config
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1654
+  streams:
+    - rawhide


### PR DESCRIPTION
When we switch to using OSBuild this test will start failing. See https://github.com/coreos/fedora-coreos-tracker/issues/1654