### PR TITLE
[rawhide] overrides: pin kernel-6.8.0-0.rc2.19.fc40 on aarch64

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 6.8.0-0.rc2.19.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-core:
+    evr: 6.8.0-0.rc2.19.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-modules:
+    evr: 6.8.0-0.rc2.19.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin
+  kernel-modules-core:
+    evr: 6.8.0-0.rc2.19.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,30 +14,6 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
       type: pin
-  kernel:
-    evr: 6.8.0-0.rc2.20240130git861c0981648f.20.fc40
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-cba88e0da6
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2824#issuecomment-1917926476
-      type: fast-track
-  kernel-core:
-    evr: 6.8.0-0.rc2.20240130git861c0981648f.20.fc40
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-cba88e0da6
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2824#issuecomment-1917926476
-      type: fast-track
-  kernel-modules:
-    evr: 6.8.0-0.rc2.20240130git861c0981648f.20.fc40
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-cba88e0da6
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2824#issuecomment-1917926476
-      type: fast-track
-  kernel-modules-core:
-    evr: 6.8.0-0.rc2.20240130git861c0981648f.20.fc40
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-cba88e0da6
-      reason: https://github.com/coreos/fedora-coreos-config/pull/2824#issuecomment-1917926476
-      type: fast-track
   selinux-policy:
     evra: 40.5-1.fc40.noarch
     metadata:


### PR DESCRIPTION
Since we are still seeing the booting [error](https://github.com/coreos/fedora-coreos-tracker/issues/1647) on aarch64 using the latest kernel, let's pin it to `6.8.0-0.rc2.19.fc40`