### PR TITLE
denylist: remove linear entry and bump ssh.key snooze

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-02-05
+  snooze: 2024-02-26
   warn: true
   platforms:
     - azure

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,12 +13,6 @@
     - azure
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
-- pattern: ext.config.root-reprovision.linear
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1648
-  snooze: 2024-02-05
-  warn: true  
-  streams:
-    - rawhide
 - pattern: ext.config.files.console-config
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1654
   streams:


### PR DESCRIPTION
```
commit 111ccfbfb063ca7bea59be2065ed6ac544074e2e
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Feb 5 10:08:41 2024 -0700

    denylist: remove `root-reprovision.linear` entry
    
    md.linear was removed from the 6.8 kernel and as a result
    we removed the test from FCOS and RHCOS in:
    https://github.com/coreos/fedora-coreos-config/pull/2830.
    Remove the entry to clean up the denylist.

commit dc6ea50c98ec7f17608eb0e5115dbd89fda00515
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Feb 5 10:07:23 2024 -0700

    denylist: extend snooze for `coreos.ignition.ssh.key`
    
    This test is still failing. Let's bump the snooze while we
    continue to investigate:
    https://github.com/coreos/fedora-coreos-tracker/issues/1553
```