### PR TITLE
05core: drop duplicate sysctl dropin to lower printk level

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator
@@ -20,17 +20,6 @@ ExecStart=-/sbin/agetty --autologin core -o '-p -f core' ${args} %I \$TERM
 EOF
 }
 
-quiet_kernel_console_messages() {
-    cat <<'EOF' > /etc/sysctl.d/20-coreos-autologin-kernel-printk.conf
-# Raise console message logging level from DEBUG (7) to WARNING (4)
-# so that kernel debug message don't get interspersed on the console
-# that
-# may frustrate a user trying to interactively do an install with
-# nmtui and coreos-installer.
-kernel.printk=4
-EOF
-}
-
 write_interactive_live_motd() {
     # Write motd to a tmp file and not directly to /etc/motd because
     # SELinux denies write from init_t to etc_t
@@ -92,13 +81,6 @@ fi
 write_dropin "getty@.service"        "--noclear"
 # Also autologin on serial console if someone enables that
 write_dropin "serial-getty@.service" "--keep-baud 115200,38400,9600"
-
-# When the installer runs a lot of things happen on the system (audit
-# messages from running via sudo, re-reading partition table messages,
-# mounting filesystem messages, etc.). Quieting the verbosity of the
-# kernel console will help us keep our sanity.
-quiet_kernel_console_messages
-
 
 # Write an motd that will let the user know about the live environment
 # and what is possible.


### PR DESCRIPTION
This doesn't work anymore since systemd locked down where generators can write files:

    [    9.246494] /usr/lib/systemd/system-generators/coreos-liveiso-autologin-generator: line 24: /etc/sysctl.d/20-coreos-autologin-kernel-printk.conf: Read-only file system

But anyway, nowadays this duplicates `coreos-printk-quiet.service` which was added two years after this code was written (#1840).

Noticed by Colin in
https://github.com/ostreedev/ostree/pull/3158#issuecomment-1930494055.