### PR TITLE
[rawhide] image.yaml: use zstd compression

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -9,3 +9,7 @@ include: image-base.yaml
 # and enable it by default for rawhide!
 deploy-via-container: true
 container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:rawhide"
+
+# Experiment with using zstd compression in rawhide
+compressor: zstd
+


### PR DESCRIPTION
We'll experiment with this in `rawhide` to see what kind of real world gains we get from using zstd compression. Also see if there are any bugs that crop up. This is to further the discussion in https://github.com/coreos/fedora-coreos-tracker/issues/1660