### PR TITLE
[rawhide] overrides: pin util-linux-2.39.3-4.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,31 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
       type: pin
+  libblkid:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
+  libfdisk:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
+  libmount:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
+  libsmartcols:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
+  libuuid:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
   selinux-policy:
     evra: 40.5-1.fc40.noarch
     metadata:
@@ -23,4 +48,14 @@ packages:
     evra: 40.5-1.fc40.noarch
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1630
+      type: pin
+  util-linux:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
+      type: pin
+  util-linux-core:
+    evr: 2.39.3-4.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
       type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).