### PR TITLE
manifests/bootupd: Remove 'mkdir -p /run' workaround

### DIFF
--- a/manifests/bootupd.yaml
+++ b/manifests/bootupd.yaml
@@ -7,7 +7,5 @@ postprocess:
   - |
     #!/bin/bash
     set -xeuo pipefail
-    # Until we have https://github.com/coreos/rpm-ostree/pull/2275
-    mkdir -p /run
     # Transforms /usr/lib/ostree-boot into a bootupd-compatible update payload
     /usr/bin/bootupctl backend generate-update-metadata


### PR DESCRIPTION
This was added a while back as a fast-track for a fix in rpm-ostree and we don't need it anymore.

Reverts: https://github.com/coreos/fedora-coreos-config/commit/cb300804dbb0ffea4e04b84cfb1109b4585c29c5