### PR TITLE
manifest: drop `containernetworking-plugins` and `podman-plugins`

### DIFF
--- a/manifests/cni-plugins.yaml
+++ b/manifests/cni-plugins.yaml
@@ -1,0 +1,5 @@
+# Issue: https://github.com/coreos/fedora-coreos-config/pull/2818
+# Delete this file once we are on Podman v5 everywhere.
+# i.e. We have moved past F39.
+packages:
+  - containernetworking-plugins podman-plugins

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -104,11 +104,10 @@ packages:
   # Containers
   - systemd-container catatonit
   - fuse-overlayfs slirp4netns
-  # support for old style CNI networks and name resolution for
-  # podman containers with CNI networks
+  # Some host applications(i.e. NetworkManager) use dnsmasq
+  # as the binary for some various utility operations.
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071338097
-  - containernetworking-plugins podman-plugins dnsmasq
+  - dnsmasq
   # For podman v4 netavark gets pulled in but it only recommends
   # aardvark-dns (which provides name resolution based on container
   # names). This functionality was previously provided by dnsname from

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -27,6 +27,12 @@ conditional-include:
     # passwd RPM was obsoleted by shadow-utils in F40+, but we need to keep
     # including it in F39. Remove this when we are on F40+ on all streams.
     include: passwd.yaml
+  - if: releasever == 39
+    # No longer need CNI plugins in f40 since Podman dropped
+    # support for CNI networking entirely in Podmanv5
+    # Remove this once we have Podman v5 in f39.
+    # xref: https://github.com/coreos/fedora-coreos-tracker/issues/1629
+    include: cni-plugins.yaml
 
 ostree-layers:
   - overlay/15fcos


### PR DESCRIPTION
Since podman is dropping support for CNI networking entirely we can drop `containernetworking-plugins` and  `podman-plugins`. Podman stopped shipping `podman-plugins` rpm with the Podmanv5. Subsequently, we wouldn't need `containernetworking-plugins` as it is just libraries for writing CNI plugins.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1629#issuecomment-1939353789