### PR TITLE
denylist: snooze var-mount.scsi-id test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -15,3 +15,9 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1654
   streams:
     - rawhide
+- pattern: ext.config.var-mount.scsi-id
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
+  snooze: 2024-02-21
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
This started failing in rawhide and we haven't had time to fully investigate yet.

https://github.com/coreos/fedora-coreos-tracker/issues/1670