### PR TITLE
manifests: enable cliwrap on Fedora 40+

### DIFF
--- a/manifests/cliwrap.yaml
+++ b/manifests/cliwrap.yaml
@@ -1,0 +1,2 @@
+# https://github.com/coreos/fedora-coreos-tracker/issues/730
+cliwrap: true

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -36,6 +36,8 @@ conditional-include:
   - if: releasever == 39
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
+  - if: releasever >= 40
+    include: cliwrap.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -52,3 +52,9 @@ if [[ -n "${failed}" ]]; then
   fatal "could not install: ${failed}"
 fi
 ok "successfully installed os rpm package extensions"
+
+# also try the wrapped dnf
+if jq -e .cliwrap /usr/share/rpm-ostree/treefile.json; then
+  dnf install -y 'ltrace'
+  ok "dnf cliwrap"
+fi


### PR DESCRIPTION
As part of the bootable containers effort, we want to put emphasis on a consistent experience when deriving images. A big part of that is being able to type `dnf install -y ...` in one's `Containerfile`.

Let's turn on cliwrap for this. This was previously agreed[[1]], but we ended never shipping it since there was a less invasive way to test it.[[2]] Here, we bundle it as part of the Fedora 40 rebase. This will naturally allow it to bake in `branched` and `next` for a while before making it to `stable`.

Eventually, once dnf5 is ready, it could take on this role (including package layering on the client-side), at which point we will no longer need to wrap it.

[1]: https://github.com/coreos/fedora-coreos-config/pull/830#issuecomment-780840462
[2]: https://github.com/coreos/fedora-coreos-config/pull/830#issuecomment-789806308