### PR TITLE
[rawhide] overrides: fast-track `coreos-installer` and `bootupd`, drop `util-linux`

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,39 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  libblkid:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  libfdisk:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  libmount:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  libsmartcols:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  libuuid:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  util-linux:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
-  util-linux-core:
-    evr: 2.39.3-4.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1666
-      type: pin
+packages: {}

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,3 +15,15 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b94ef03275
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
       type: fast-track
+  coreos-installer:
+    evr: 0.21.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f5da825190
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-1954790135
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.21.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f5da825190
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-1954790135
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,10 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  bootupd:
+    evr: 0.2.18-2.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b94ef03275
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
+      type: fast-track


### PR DESCRIPTION
A new util-linux package was released with a fix for the issue, let's remove the pin to pick up the latest rpm.
See: https://github.com/coreos/fedora-coreos-tracker/issues/1666