### PR TITLE
overlay.d/40grub: delete 30_console.cfg file

### DIFF
--- a/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/30_console.cfg
+++ b/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/30_console.cfg
@@ -1,4 +1,0 @@
-
-# Any non-default console settings will be inserted here.
-# CONSOLE-SETTINGS-START
-# CONSOLE-SETTINGS-END

--- a/tests/kola/files/console-config
+++ b/tests/kola/files/console-config
@@ -47,11 +47,16 @@ ok "platforms.json exists!"
 platform=$(cmdline_arg ignition.platform.id)
 expected_kargs=$(platform_json_kargs "$platform")
 expected_grub_cmds=$(platform_json_grub_cmds "$platform")
+if [ -f /boot/grub2/console.cfg ]; then
+    grub_console_cfg_file=/boot/grub2/console.cfg
+else
+    grub_console_cfg_file=/boot/grub2/grub.cfg
+fi
 if [ -n "$expected_kargs" ] && ! grep -Eq " ${expected_kargs}( |$)" /proc/cmdline; then
     fatal "Didn't find $expected_kargs in $(cat /proc/cmdline)"
 fi
-if [ -n "$expected_grub_cmds" ] && ! grep -qzP "\n${expected_grub_cmds}\n" /boot/grub2/grub.cfg; then
-    fatal "Didn't find platform grub commands in /boot/grub2/grub.cfg"
+if [ -n "$expected_grub_cmds" ] && ! grep -qzP "\n${expected_grub_cmds}\n" $grub_console_cfg_file; then
+    fatal "Didn't find platform grub commands in ${grub_console_cfg_file}"
 fi
 ok "platforms.json matches grub.cfg and kargs"
 


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1671 where we discovered that having this be a static config delivered by bootupd was a bad idea.

Instead we'll have something else create a file in /boot/grub2/console.cfg (most likely https://github.com/osbuild/osbuild/pull/1589) and we'll have the bootupd static grub configs source it (https://github.com/coreos/bootupd/pull/619).