### PR TITLE
[branched] manifest: bump to F40

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 39
+releasever: 40
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 40 has now been branched from rawhide, 