### PR TITLE
denylist: snooze tests on branched stream

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,3 +21,4 @@
   warn: true
   streams:
     - rawhide
+    - branched


### PR DESCRIPTION
F40 has branched from rawhide, so we'll be tracking it in the branched stream once enabled: https://github.com/coreos/fedora-coreos-pipeline/pull/962.
Let's also snooze `ext.config.var-mount.scsi-id` on branched since it's been failing on F40.

EDIT: removed `ext.config.files.console-config`