### PR TITLE
[rawhide] overrides: pin kernel-6.8.0-0.rc5.41.fc41 on aarch64

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,22 +10,22 @@
 
 packages:
   kernel:
-    evr: 6.8.0-0.rc2.19.fc40
+    evr: 6.8.0-0.rc5.41.fc41
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
       type: pin
   kernel-core:
-    evr: 6.8.0-0.rc2.19.fc40
+    evr: 6.8.0-0.rc5.41.fc41
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
       type: pin
   kernel-modules:
-    evr: 6.8.0-0.rc2.19.fc40
+    evr: 6.8.0-0.rc5.41.fc41
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
       type: pin
   kernel-modules-core:
-    evr: 6.8.0-0.rc2.19.fc40
+    evr: 6.8.0-0.rc5.41.fc41
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
       type: pin


### PR DESCRIPTION
The kola basic test seem to PASS with the latest kernel version kernel-6.8.0-0.rc5.41.fc41 but the investigation on why it failed is still ongoing. So let's pin it to kernel-6.8.0-0.rc5.41.fc41 for now.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1647