### PR TITLE
tests/var-mount/scsi-id: simplify bootloader entry finding

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -64,7 +64,7 @@ is_rhcos9() {
 # scos
 is_scos() {
     source /etc/os-release
-    [ "${ID}" == "scos" ] && [ "${VARIANT_ID}" == "coreos" ]
+    { [ "${ID}" == "scos" ] || [ "${ID}" == "centos" ]; } && [ "${VARIANT_ID}" == "coreos" ]
 }
 
 IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -18,15 +18,7 @@ if [ $fstype != xfs ]; then
     fatal "Error: /var fstype is $fstype, expected is xfs"
 fi
 
-source /etc/os-release
-ostree_conf=""
-if [ "$ID" == "fedora" ]; then
-    ostree_conf="/boot/loader.1/entries/ostree-1-fedora-coreos.conf"
-elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
-    ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"
-else
-    fatal "fail: not operating on expected OS"
-fi
+ostree_conf=$(ls /boot/loader/entries/*.conf)
 
 initramfs=/boot$(grep initrd ${ostree_conf} | sed 's/initrd //g')
 tempfile=$(mktemp)


### PR DESCRIPTION
We don't have to be super strict here in how we find the bootloader
entry. There should only be one, so simplify the logic using a glob
instead.

Motivated by the fact that this will break otherwise as part of
openshift/os#1445 where the `ID` will be
`centos`, but the stateroot will still be `scos`.