### PR TITLE
denylist: extend snooze for var-mount.scsi-id test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,7 +17,7 @@
     - rawhide
 - pattern: ext.config.var-mount.scsi-id
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
-  snooze: 2024-02-21
+  snooze: 2024-02-29
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
This is still outstanding. Let's snooze it so we don't keep getting warnings from builds.