### PR TITLE
 denylist: drop `ext.config.files.console-config` snooze

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,10 +11,6 @@
   warn: true
   platforms:
     - azure
-- pattern: ext.config.files.console-config
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1654
-  streams:
-    - rawhide
 - pattern: ext.config.var-mount.scsi-id
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
   snooze: 2024-02-29


### PR DESCRIPTION
In reference to https://github.com/coreos/coreos-assembler/pull/3742 this test should be passing now. Updating the denylist accordingly.