### PR TITLE
manifests: Split container engines and deps into sub manifests

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -54,7 +54,6 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -xeuo pipefail
-    setsebool -P -N container_use_cephfs on  # RHBZ#1692369
     setsebool -P -N virt_use_samba on  # RHBZ#1754825
 
   # Mask dnsmasq. We include dnsmasq for host services that use the dnsmasq
@@ -103,23 +102,10 @@ packages:
   - polkit
   # Containers
   - systemd-container catatonit
-  - fuse-overlayfs slirp4netns
   # Some host applications(i.e. NetworkManager) use dnsmasq
   # as the binary for some various utility operations.
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
   - dnsmasq
-  # For podman v4 netavark gets pulled in but it only recommends
-  # aardvark-dns (which provides name resolution based on container
-  # names). This functionality was previously provided by dnsname from
-  # podman-plugins in the podman v3 stack.
-  # See https://github.com/containers/netavark/pull/217
-  - aardvark-dns
-  # Since we need `containernetworking-plugins` installed to continue
-  # to support CNI networks we need to also explicitly install
-  # `netavark` so we get both of them installed since both of them
-  # provide `container-network-stack`.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071458717
-  - netavark
   # Minimal NFS client
   - nfs-utils-coreos
   # Active Directory support
@@ -179,12 +165,9 @@ packages:
 #   - Add this package on x86_64 and aarch64 (the two architectures
 #     GCP supports. https://github.com/coreos/fedora-coreos-tracker/issues/1494
 #     This should be moved to a shared manifest when RHEL has this package.
-# - crun-wasm wasmedge-rt
-#   - Support for wasm runtime: https://github.com/coreos/fedora-coreos-tracker/issues/1375
 packages-x86_64:
   - irqbalance
   - google-compute-engine-guest-configs-udev
-  - crun-wasm wasmedge-rt
   # Include AMD microcode updates, see https://github.com/coreos/fedora-coreos-tracker/issues/1618.
   # This normally should belong in bootable-rpm-ostree.yaml (alongside
   # `microcode_ctl`), but this change hasn't hit RHCOS yet.
@@ -199,7 +182,6 @@ packages-aarch64:
   - irqbalance
   - qemu-user-static-x86
   - google-compute-engine-guest-configs-udev
-  - crun-wasm wasmedge-rt
 packages-s390x:
   - qemu-user-static-x86
 

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -11,6 +11,9 @@ rojig:
 add-commit-metadata:
   fedora-coreos.stream: ${stream}
 
+# Include all container engines by default
+variables:
+  container_engines: true
 
 include: fedora-coreos-base.yaml
 conditional-include:
@@ -27,17 +30,25 @@ conditional-include:
     # passwd RPM was obsoleted by shadow-utils in F40+, but we need to keep
     # including it in F39. Remove this when we are on F40+ on all streams.
     include: passwd.yaml
-  - if: releasever == 39
+  - if:
+      - releasever == 39
+      - container_engines == true
     # No longer need CNI plugins in f40 since Podman dropped
     # support for CNI networking entirely in Podmanv5
     # Remove this once we have Podman v5 in f39.
     # xref: https://github.com/coreos/fedora-coreos-tracker/issues/1629
     include: cni-plugins.yaml
-  - if: releasever == 39
+  - if:
+      - releasever == 39
+      - container_engines == true
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
   - if: releasever >= 40
     include: cliwrap.yaml
+  - if: container_engines == true
+    include:
+      - podman.yaml
+      - moby-engine.yaml
 
 ostree-layers:
   - overlay/15fcos
@@ -55,10 +66,6 @@ packages:
   # the archive repo for more reliable package layering
   # https://github.com/coreos/fedora-coreos-tracker/issues/400
   - fedora-repos-archive
-  # CL ships this.
-  - moby-engine
-  # Already pulled in by moby-engine, but let's be explicit. Typhoon uses it.
-  - containerd
   # Updates
   - zincati
   # Include and set the default editor

--- a/manifests/moby-engine.yaml
+++ b/manifests/moby-engine.yaml
@@ -1,0 +1,8 @@
+# This manifest is Fedora CoreOS only (not included in SCOS or RHCOS)
+
+packages:
+  # CL shipped this
+  - moby-engine
+  # Already pulled in by moby-engine, but let's be explicit. Typhoon uses it.
+  - containerd
+  - runc

--- a/manifests/podman.yaml
+++ b/manifests/podman.yaml
@@ -1,0 +1,34 @@
+# This manifest is Fedora CoreOS only (not included in SCOS or RHCOS)
+
+packages:
+  - podman
+  - crun
+  # Include toolbox here as it pulls podman
+  - toolbox
+  - fuse-overlayfs slirp4netns
+  # For podman v4 netavark gets pulled in but it only recommends
+  # aardvark-dns (which provides name resolution based on container
+  # names). This functionality was previously provided by dnsname from
+  # podman-plugins in the podman v3 stack.
+  # See https://github.com/containers/netavark/pull/217
+  - aardvark-dns
+  # Since we need `containernetworking-plugins` installed to continue
+  # to support CNI networks we need to also explicitly install
+  # `netavark` so we get both of them installed since both of them
+  # provide `container-network-stack`.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071458717
+  - netavark
+
+# Support for wasm runtime: https://github.com/coreos/fedora-coreos-tracker/issues/1375
+packages-x86_64:
+  - crun-wasm wasmedge-rt
+packages-aarch64:
+  - crun-wasm wasmedge-rt
+
+postprocess:
+  # Enable SELinux booleans used by OpenShift
+  # https://github.com/coreos/fedora-coreos-tracker/issues/284
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    setsebool -P -N container_use_cephfs on  # RHBZ#1692369

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -37,13 +37,10 @@ packages:
   # Remote Access
   - openssh-clients openssh-server
   # Container tooling
-  ## crun recommends but doesn't require criu and criu-libs. We want them for
-  ## checkpoint/restore. https://github.com/coreos/fedora-coreos-tracker/issues/1370
-  - crun criu criu-libs
-  - podman
-  - runc
   - skopeo
-  - toolbox
+  # crun recommends but doesn't require criu and criu-libs. We want them for
+  # checkpoint/restore. https://github.com/coreos/fedora-coreos-tracker/issues/1370
+  - criu criu-libs
   # passt provides user-mode networking daemons for namespaces
   - passt
   # nvme-cli for managing nvme disks


### PR DESCRIPTION
manifests: Split container engines into sub-manifests

- Split podman, moby-engine and related packages into distinct
  sub-manifests
- Include both container engines by default
- Ensure that they are excluded if specified as such