### PR TITLE
denylist: extend snooze for `coreos.ignition.ssh.key`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-02-26
+  snooze: 2024-03-29
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
Extend the snooze while we continue to investigate https://github.com/coreos/fedora-coreos-tracker/issues/1553