### PR TITLE
[branched] overrides: pin authselect-1.5.0-3.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  authselect:
+    evr: 1.5.0-3.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1680
+      type: pin
+  authselect-libs:
+    evr: 1.5.0-3.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1680
+      type: pin


### PR DESCRIPTION
Requested by @jmarrero via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).