### PR TITLE
Revert "manifests: enable cliwrap on Fedora 40+"

### DIFF
--- a/manifests/cliwrap.yaml
+++ b/manifests/cliwrap.yaml
@@ -1,2 +1,0 @@
-# https://github.com/coreos/fedora-coreos-tracker/issues/730
-cliwrap: true

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -36,8 +36,6 @@ conditional-include:
   - if: releasever == 39
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
-  - if: releasever >= 40
-    include: cliwrap.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -52,9 +52,3 @@ if [[ -n "${failed}" ]]; then
   fatal "could not install: ${failed}"
 fi
 ok "successfully installed os rpm package extensions"
-
-# also try the wrapped dnf
-if jq -e .cliwrap /usr/share/rpm-ostree/treefile.json; then
-  dnf install -y 'ltrace'
-  ok "dnf cliwrap"
-fi


### PR DESCRIPTION
This reverts commit 1cfbd773ce3137febe43d651fba48d5eeb81a79e.

This seems to be breaking `ext.config.rpm-ostree.kernel-replace` at least:

https://github.com/coreos/fedora-coreos-tracker/issues/1679