### PR TITLE
[branched] overrides: pin authselect-1.5.0-3.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,15 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  authselect:
+    evr: 1.5.0-3.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1680
+      type: pin
+  authselect-libs:
+    evr: 1.5.0-3.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1680
+      type: pin
+


### PR DESCRIPTION
manual version of #2881 to rebase it.