### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  coreos-installer:
-    evr: 0.21.0-1.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f5da825190
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-1954790135
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.21.0-1.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f5da825190
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-1954790135
-      type: fast-track
   authselect:
     evr: 1.5.0-3.fc40
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).