### PR TITLE
[branched] overrides: fast-track rust-coreos-installer-0.21.0-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,4 +19,15 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1680
       type: pin
-
+  coreos-installer:
+    evr: 0.21.0-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a610b3508f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.21.0-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a610b3508f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).