### PR TITLE
Reapply "manifests: enable cliwrap on Fedora 40+"

### DIFF
--- a/manifests/cliwrap.yaml
+++ b/manifests/cliwrap.yaml
@@ -1,2 +1,5 @@
 # https://github.com/coreos/fedora-coreos-tracker/issues/730
-cliwrap: true
+cliwrap-binaries:
+  - dnf
+  # until https://github.com/coreos/rpm-ostree/issues/4726
+  - kernel-install

--- a/manifests/cliwrap.yaml
+++ b/manifests/cliwrap.yaml
@@ -1,0 +1,2 @@
+# https://github.com/coreos/fedora-coreos-tracker/issues/730
+cliwrap: true

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -36,6 +36,8 @@ conditional-include:
   - if: releasever == 39
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
+  - if: releasever >= 40
+    include: cliwrap.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -52,3 +52,9 @@ if [[ -n "${failed}" ]]; then
   fatal "could not install: ${failed}"
 fi
 ok "successfully installed os rpm package extensions"
+
+# also try the wrapped dnf
+if jq -e .cliwrap /usr/share/rpm-ostree/treefile.json; then
+  dnf install -y 'ltrace'
+  ok "dnf cliwrap"
+fi

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -87,7 +87,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     version=$(rpm-ostree --version | grep Version)
 cat > Dockerfile << EOF
 FROM localhost/fcos
-RUN rpm-ostree cliwrap install-to-root /
+# until we have https://github.com/coreos/rpm-ostree/pull/4848
+RUN if test ! -d /usr/libexec/rpm-ostree/wrapped; then rpm-ostree cliwrap install-to-root /; fi
 RUN rpm-ostree override replace \
     https://koji.fedoraproject.org/koji/buildinfo?buildID=2178613 && \
     ostree container commit


### PR DESCRIPTION
This reverts commit 3789b068627af980a3914fbab42153adc2df5815.

The reported issue that motivated the revert[[1]] is due to an rpm-ostree bug[[2]].

We can trivially work around this bug until the rpm-ostree fix lands in FCOS, so let's do that and re-enable cliwrap.

[1]: https://github.com/coreos/fedora-coreos-tracker/issues/1679
[2]: https://github.com/coreos/rpm-ostree/pull/4848