### PR TITLE
tests: use `/dev/disk/by-id/coreos-boot-disk` instead of `/dev/vda`

### DIFF
--- a/tests/kola/root-reprovision/swap-before-root/config.bu
+++ b/tests/kola/root-reprovision/swap-before-root/config.bu
@@ -3,7 +3,7 @@ version: 1.4.0
 
 storage:
   disks:
-    - device: /dev/vda
+    - device: /dev/disk/by-id/coreos-boot-disk
       partitions:
         - number: 4
           label: swap

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test's config manually references /dev/vda and is thus QEMU only
-##   platforms: qemu
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher
@@ -11,7 +9,7 @@
 ##   # legal but usually not intended, so Butane warns about it.
 ##   allowConfigWarnings: true
 ##   # This test reprovisions the rootfs.
-##   tags: reprovision
+##   tags: reprovision platform-independent
 ##   description: Verify the root reprovision and swap enabled are supported.
 
 set -xeuo pipefail

--- a/tests/kola/var-mount/luks/config.bu
+++ b/tests/kola/var-mount/luks/config.bu
@@ -2,7 +2,7 @@ variant: fcos
 version: 1.3.0
 storage:
   disks:
-    - device: /dev/vda
+    - device: /dev/disk/by-id/coreos-boot-disk
       partitions:
         - label: var
           size_mib: 1000

--- a/tests/kola/var-mount/luks/test.sh
+++ b/tests/kola/var-mount/luks/test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 ## kola:
-##   # Restrict to qemu for now because the primary disk path is platform-dependent
-##   platforms: qemu
 ##   architectures: "! s390x"
 ##   description: Verify that reprovision disk with luks works.
+##   tags: platform-independent
 
 set -xeuo pipefail
 

--- a/tests/kola/var-mount/simple/config.bu
+++ b/tests/kola/var-mount/simple/config.bu
@@ -2,7 +2,7 @@ variant: fcos
 version: 1.3.0
 storage:
   disks:
-    - device: /dev/vda
+    - device: /dev/disk/by-id/coreos-boot-disk
       partitions:
         - label: var
           guid: 63194b49-e4b7-43f9-9a8b-df0fd8279bb7

--- a/tests/kola/var-mount/simple/test.sh
+++ b/tests/kola/var-mount/simple/test.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 ## kola:
-##   platforms: qemu
 ##   description: Verify that provision disk with guid works.
-#
-# Restrict to qemu for now because the primary disk path is platform-dependent
+##   tags: platform-independent
 
 set -xeuo pipefail
 


### PR DESCRIPTION
Hardcoding `/dev/vda` will break if there are more than one block device may be attached (like on s390x where we attach another disk to pass in Ignition). This is why the `/dev/disk/by-id/coreos-boot-disk` symlink was added. Use it.

While we're here, switch from `platform: qemu` to
`tags: platform-independent` since they should theoretically work on any platform now (though they are equivalent today).

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1683