### PR TITLE
tests/bootupd: check for `/boot/bootupd-state.json`

### DIFF
--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -27,5 +27,10 @@ case "$(arch)" in
         ;;
 esac
 
+state_file=/boot/bootupd-state.json
+if [ ! -f "${state_file}" ]; then
+    fatal "${state_file} not present"
+fi
+
 bootupctl status
 ok bootupctl


### PR DESCRIPTION
`bootupctl status` will still be happy even if that file doesn't exist, so let's check for it explicitly to make sure that `bootupctl backend install` ran correctly at disk image generation time.