### PR TITLE
manifests: add makedumpfile RPM on F41+

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -36,6 +36,9 @@ conditional-include:
   - if: releasever == 39
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
+  - if: releasever >= 41
+    # Include makedumpfile subpackage from kexec-tools (new in F41+)
+    include: makedumpfile.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/makedumpfile.yaml
+++ b/manifests/makedumpfile.yaml
@@ -1,0 +1,4 @@
+# makedumpfile is needed for kdump and was broken out to a subpackage
+# in F41+. Drop this when we no longer support <F41.
+packages:
+  - makedumpfile


### PR DESCRIPTION
This was made into a subpackage, but is required for kdump to work. See https://github.com/coreos/fedora-coreos-tracker/issues/1692