### PR TITLE
[rawhide] overrides: pin to shim-15.6-2

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -9,28 +9,8 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  shim-aa64:
+  shim-x64:
     evr: 15.6-2
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1694
-      type: pin
-  kernel:
-    evr: 6.8.0-63.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
-      type: pin
-  kernel-core:
-    evr: 6.8.0-63.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
-      type: pin
-  kernel-modules:
-    evr: 6.8.0-63.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
-      type: pin
-  kernel-modules-core:
-    evr: 6.8.0-63.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1647
       type: pin


### PR DESCRIPTION
The new shim-15.8-2 seems to not work for secure boot: https://github.com/coreos/fedora-coreos-tracker/issues/1694