### PR TITLE
denylist: extend snooze for var-mount.scsi-id

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,7 +13,7 @@
     - azure
 - pattern: ext.config.var-mount.scsi-id
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
-  snooze: 2024-03-18
+  snooze: 2024-04-01
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
This test is still failing. Let's extend the snooze while we continue to investigate coreos/fedora-coreos-tracker#1670