### PR TITLE
denylist: snooze ext.config.var-mount.scsi-id on next & next-devel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,3 +18,5 @@
   streams:
     - rawhide
     - branched
+    - next
+    - next-devel


### PR DESCRIPTION
Let's also snooze `ext.config.var-mount.scsi-id` on `next` & `next-devel` since it's been failing on F40.
Ref: https://github.com/coreos/fedora-coreos-config/pull/2901