### PR TITLE
[next-devel] overrides: fast-track ignition-2.18.0-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,8 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a610b3508f
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
       type: fast-track
+  ignition:
+    evr: 2.18.0-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ad734e1656
+      type: fast-track


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).