### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -10,10 +10,10 @@
 
 packages:
   shim-aa64:
-    evr: 15.6-2
+    evra: 15.8-3.aarch64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1694
-      type: pin
+      type: fast-track
   crun-wasm:
     evra: 1.14.4-1.fc40.aarch64
     metadata:

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -14,3 +14,9 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1694
       type: pin
+  crun-wasm:
+    evra: 1.14.4-1.fc40.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1aeb8ef84c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -11,10 +11,10 @@
 
 packages:
   shim-x64:
-    evr: 15.6-2
+    evra: 15.8-3.x86_64
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1694
-      type: pin
+      type: fast-track
   amd-ucode-firmware:
     evra: 20240312-1.fc40.noarch
     metadata:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,3 +15,15 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1694
       type: pin
+  amd-ucode-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  crun-wasm:
+    evra: 1.14.4-1.fc40.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1aeb8ef84c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,54 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  amd-gpu-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  atheros-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  bind-libs:
+    evr: 32:9.18.24-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-5f7bde89d6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  bind-license:
+    evra: 32:9.18.24-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-5f7bde89d6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  bind-utils:
+    evr: 32:9.18.24-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-5f7bde89d6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  brcmfmac-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  conmon:
+    evr: 2:2.1.10-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a37718c58a
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  container-selinux:
+    evra: 2:2.230.0-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f6264c56f0
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   coreos-installer:
     evr: 0.21.0-1.fc40
     metadata:
@@ -21,8 +69,128 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a610b3508f
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1671
       type: fast-track
+  crun:
+    evr: 1.14.4-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1aeb8ef84c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  device-mapper-persistent-data:
+    evr: 1.0.12-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f4e790d8eb
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  elfutils-default-yama-scope:
+    evra: 0.191-4.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ee960af4b7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  elfutils-libelf:
+    evr: 0.191-4.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ee960af4b7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  elfutils-libs:
+    evr: 0.191-4.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ee960af4b7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  fwupd:
+    evr: 1.9.15-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-da8704c071
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   ignition:
     evr: 2.18.0-1.fc40
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ad734e1656
+      type: fast-track
+  intel-gpu-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libnfsidmap:
+    evr: 1:2.6.4-0.rc5.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3d80a949c6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libusb1:
+    evr: 1.0.27-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a38ed1fb15
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  linux-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  linux-firmware-whence:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  mt7xxx-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  nfs-utils-coreos:
+    evr: 1:2.6.4-0.rc5.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3d80a949c6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  nvidia-gpu-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  realtek-firmware:
+    evra: 20240312-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree:
+    evr: 2024.4-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-95b6bafb8b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2024.4-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-95b6bafb8b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  socat:
+    evr: 1.8.0.0-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e3c9a5a3c8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  vim-data:
+    evra: 2:9.1.181-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-918ccf84c1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  vim-minimal:
+    evr: 2:9.1.181-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-918ccf84c1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track


### PR DESCRIPTION
F40 is now in final freeze. This means some packages in F39 will sort as newer than packages in F39. We'll prevent downgrades by fast-tracking any packages that would violoate this "no downgrade" rule.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582


```
Downgraded:
  amd-gpu-firmware 20240312-1.fc39 -> 20240220-1.fc40
  amd-ucode-firmware 20240312-1.fc39 -> 20240220-1.fc40
  atheros-firmware 20240312-1.fc39 -> 20240220-1.fc40
  bind-libs 32:9.18.24-1.fc39 -> 32:9.18.21-4.fc40
  bind-license 32:9.18.24-1.fc39 -> 32:9.18.21-4.fc40
  bind-utils 32:9.18.24-1.fc39 -> 32:9.18.21-4.fc40
  brcmfmac-firmware 20240312-1.fc39 -> 20240220-1.fc40
  conmon 2:2.1.10-1.fc39 -> 2:2.1.8-4.fc40
  container-selinux 2:2.230.0-1.fc39 -> 2:2.229.0-2.fc40
  crun 1.14.4-1.fc39 -> 1.14.3-1.fc40
  crun-wasm 1.14.4-1.fc39 -> 1.14.3-1.fc40
  device-mapper-persistent-data 1.0.12-1.fc39 -> 1.0.11-3.fc40
  elfutils-default-yama-scope 0.191-2.fc39 -> 0.190-6.fc40
  elfutils-libelf 0.191-2.fc39 -> 0.190-6.fc40
  elfutils-libs 0.191-2.fc39 -> 0.190-6.fc40
  fwupd 1.9.15-1.fc39 -> 1.9.14-1.fc40
  intel-gpu-firmware 20240312-1.fc39 -> 20240220-1.fc40
  libnfsidmap 1:2.6.4-0.rc5.fc39 -> 1:2.6.4-0.rc4.fc40
  libusb1 1.0.27-1.fc39 -> 1.0.26-6.fc40
  linux-firmware 20240312-1.fc39 -> 20240220-1.fc40
  linux-firmware-whence 20240312-1.fc39 -> 20240220-1.fc40
  mt7xxx-firmware 20240312-1.fc39 -> 20240220-1.fc40
  nfs-utils-coreos 1:2.6.4-0.rc5.fc39 -> 1:2.6.4-0.rc4.fc40
  nvidia-gpu-firmware 20240312-1.fc39 -> 20240220-1.fc40
  realtek-firmware 20240312-1.fc39 -> 20240220-1.fc40
  rpm-ostree 2024.3-3.fc39 -> 2024.3-2.fc40
  rpm-ostree-libs 2024.3-3.fc39 -> 2024.3-2.fc40
  socat 1.8.0.0-2.fc39 -> 1.7.4.4-5.fc40
  vim-data 2:9.1.181-1.fc39 -> 2:9.1.113-1.fc40
  vim-minimal 2:9.1.181-1.fc39 -> 2:9.1.113-1.fc40
```
