### PR TITLE
Add `dnf5` on Fedora 41+

### DIFF
--- a/manifests/exclude-dnf.yaml
+++ b/manifests/exclude-dnf.yaml
@@ -1,0 +1,3 @@
+exclude-packages:
+  - dnf
+  - dnf5

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -36,6 +36,13 @@ conditional-include:
   - if: releasever >= 41
     # Include makedumpfile subpackage from kexec-tools (new in F41+)
     include: makedumpfile.yaml
+  # On <41, we want to keep making sure dnf doesn't slip in somehow
+  # On 41+, we do want it
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1687
+  - if: releasever < 41
+    include: exclude-dnf.yaml
+  - if: releasever >= 41
+    include: include-dnf.yaml
 
 ostree-layers:
   - overlay/15fcos
@@ -163,7 +170,6 @@ exclude-packages:
   - perl
   - perl-interpreter
   - nodejs
-  - dnf
   - grubby
   - cowsay  # Just in case
   # Let's make sure initscripts doesn't get pulled back in

--- a/manifests/include-dnf.yaml
+++ b/manifests/include-dnf.yaml
@@ -1,0 +1,13 @@
+packages:
+  - dnf5
+
+# until dnf5 becomes the default, manually symlink dnf to it
+postprocess:
+  - |
+    #!/usr/bin/bash
+    set -euo pipefail
+    if command -v dnf; then
+      echo 'dnf5 is now the default, remove this postprocess script!' >&2
+      exit 1
+    fi
+    ln -s dnf5 /usr/bin/dnf


### PR DESCRIPTION
As per https://github.com/coreos/fedora-coreos-tracker/issues/1687, we will for now add `dnf5` to the rawhide stream to test it out and re-evaluate at branching.