### PR TITLE
[next-devel] overrides: fast-track containers-common-0.58.0-2.fc40, netavark-1.10.3-3.fc40, podman-5.0.0-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -134,6 +134,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3d80a949c6
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  libtirpc:
+    evr: 1.3.4-1.rc3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-32d78ca745
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   libusb1:
     evr: 1.0.27-1.fc40
     metadata:
@@ -186,6 +192,12 @@ packages:
     evra: 20240312-1.fc40.noarch
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpcbind:
+    evr: 1.2.6-4.rc3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d7ac14a9b7
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
   rpm-ostree:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -57,6 +57,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f6264c56f0
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  containers-common:
+    evra: 5:0.58.0-2.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a267e93f8c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2015837258
+      type: fast-track
+  containers-common-extra:
+    evra: 5:0.58.0-2.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a267e93f8c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2015837258
+      type: fast-track
   coreos-installer:
     evr: 0.21.0-1.fc40
     metadata:
@@ -146,6 +158,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  netavark:
+    evr: 0:1.10.3-3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a267e93f8c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2015837258
+      type: fast-track
   nfs-utils-coreos:
     evr: 1:2.6.4-0.rc5.fc40
     metadata:
@@ -157,6 +175,12 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e62bcaf172
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  podman:
+    evr: 5:5.0.0-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a267e93f8c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2015837258
       type: fast-track
   realtek-firmware:
     evra: 20240312-1.fc40.noarch


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).