### PR TITLE
[rawhide] denylist: add ext.config.dump.crash

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -20,3 +20,9 @@
     - branched
     - next
     - next-devel
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1698 
+  snooze: 2024-04-07
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
~~Kdump currently fails on kernel-next. This have been fixed in kexec-tools-2.0.28-6.fc41~~

~~https://bodhi.fedoraproject.org/updates/FEDORA-2024-0582ec516b~~
~~It looks like this package should be in rawhide already, not sure if this PR is necessary really ?~~

Kdump currently fails on kernel-next, for ppc64le
This is a known upstream bug
See coreos/fedora-coreos-tracker#1698
Also see upstream bug : https://bugzilla.redhat.com/show_bug.cgi?id=2269991
