### PR TITLE
tests: check default dropins file permissions

### DIFF
--- a/tests/kola/ignition/delete-config/test.sh
+++ b/tests/kola/ignition/delete-config/test.sh
@@ -29,6 +29,10 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")
     # Ignition boot
 
+    # https://github.com/coreos/ignition/issues/1833
+    if [ $(stat --format="%a" /etc/systemd/system/ignition-delete-config.service.d/50-kola.conf) != "644" ]; then
+        fatal "dropin file permission should be 644"
+    fi
     if [ ! -e /run/ignition-rmcfg-ran ]; then
         fatal "mocked ignition-rmcfg did not run on first boot"
     fi


### PR DESCRIPTION
Add check in existing case, xerf to https://github.com/coreos/ignition/issues/1833