### PR TITLE
[next-devel]: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,12 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  gnutls:
+    evr: 3.8.4-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d736bf394f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   libnfsidmap:
     evr: 1:2.6.4-0.rc5.fc40
     metadata:


### PR DESCRIPTION
F40 is now in final freeze. This means some packages in F39 will sort as newer than packages in F40. We'll prevent downgrades by fast-tracking any packages that would violoate this "no downgrade" rule.

Today they are: `gnutls`

See: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582