### PR TITLE
[rawhide] denylist: add ext.config.kdump.crash

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,3 +23,9 @@
 - pattern: coreos.boot-mirror*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1659
   warn: true
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1698
+  snooze: 2024-04-07
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
kdump currently fails on kernel-next for ppc64le
This is a known upstream bug
Ref: coreos/fedora-coreos-tracker#1698
Also see upstream bug : https://bugzilla.redhat.com/show_bug.cgi?id=2269991