### PR TITLE
denylist: update arch for `coreos.boot-mirror*` and extend snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,6 +23,8 @@
 - pattern: coreos.boot-mirror*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1659
   warn: true
+  arches:
+    - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1698
   snooze: 2024-04-07

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,13 +7,13 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-03-29
+  snooze: 2024-04-15
   warn: true
   platforms:
     - azure
 - pattern: ext.config.var-mount.scsi-id
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
-  snooze: 2024-04-01
+  snooze: 2024-04-15
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
```
commit 16abd410c83e331c045e346b2272736698d6ff13
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Apr 1 10:49:24 2024 -0600

    denylist: only denylist `coreos.boot-mirror*` on ppc64le
    
    This test is only failing on ppc64le so update the denylist
    entry to skip the test only on that arch.

commit f511a0d030b6a4e67965565329c925537613204c
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Apr 1 10:47:09 2024 -0600

    denylist: extend snooze for two tests
    
    The snooze expired on `coreos.ignition.ssh.key` and
    `ext.config.var-mount.scsi-id`, but the tests are still failing.
    Let's extend the snoozes while we continue to investigate.
```