### PR TITLE
Manifests: move zram to system-configuration

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -150,9 +150,6 @@ packages:
   - console-login-helper-messages-motdgen
   # i18n
   - kbd
-  # zram-generator (but not zram-generator-defaults) for F33 change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/509
-  - zram-generator
   # resolved was broken out to its own package in rawhide/f35
   - systemd-resolved
   # In F35+ need `iptables-legacy` package

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -43,6 +43,9 @@ packages:
   - ssh-key-dir
   # Allow for configuring different timezones
   - tzdata
+  # zram-generator (but not zram-generator-defaults) for F33 change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/509
+  - zram-generator
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first


### PR DESCRIPTION
Kubernetes 1.28 now supports swap on zram as beta, so we need to ship this package in RHCOS.
Moving zram to a separate manifest that could be optionnaly enabled for k8s use ?

See https://github.com/coreos/fedora-coreos-docs/issues/530