### PR TITLE
manifests: Add back more wireless card firmwares

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -161,7 +161,7 @@ packages:
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
   # Wifi/BT firmware files https://github.com/coreos/fedora-coreos-tracker/issues/1575
-  - atheros-firmware brcmfmac-firmware mt7xxx-firmware realtek-firmware
+  - atheros-firmware brcmfmac-firmware mt7xxx-firmware realtek-firmware nxpwireless-firmware tiwilink-firmware
 
 
 # - irqbalance


### PR DESCRIPTION
Temporarily add back more wireless card firmwares until we announce their removal and add a CLHM module to warn users about it.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1575