### PR TITLE
[rawhide] overrides: pin google-compute-engine-guest-configs-udev

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  google-compute-engine-guest-configs-udev:
+    evra: 20240119.00-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1702
+      type: pin


### PR DESCRIPTION
The package was retired but if we pin it we can still pull it from the coreos-pool repo for FCOS in rawhide for now while we try to find a new maintainer.

Follow https://github.com/coreos/fedora-coreos-tracker/issues/1702