### PR TITLE
ext-tests/ext Fix var-mount/scsi-id failure on rawhide

### DIFF
--- a/tests/kola/var-mount/scsi-id/config.bu
+++ b/tests/kola/var-mount/scsi-id/config.bu
@@ -2,7 +2,8 @@ variant: fcos
 version: 1.4.0
 storage:
   disks:
-    - device: /dev/disk/by-id/scsi-0NVME_VirtualMultipath_disk1
+    # the symlink is from wwn=123456789 converted to hexadecimal (base16)
+    - device: /dev/disk/by-id/scsi-300000000075bcd15
       wipe_table: true
       partitions:
         - number: 1

--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -2,7 +2,7 @@
 ## kola:
 ##   # additionalDisks is only supported on QEMU
 ##   platforms: qemu
-##   additionalDisks: ["5G:mpath"]
+##   additionalDisks: ["5G:channel=scsi,wwn=123456789"]
 ##   description: Verify udev rules /dev/disk/by-id/scsi-* symlinks exist
 ##     in initramfs.
 


### PR DESCRIPTION
Update the scsci-id test to set a WWN for the disk, and use reliable udev symlinks to adjust for a change in sg3_utils [1]

Note that the `wwn` value set is converted to base 16 by QEMU, so the symlink in the ignition config must reflects it.

This requires https://github.com/coreos/coreos-assembler/pull/3772 See https://github.com/coreos/fedora-coreos-tracker/issues/1670

[1] https://listman.redhat.com/archives/dm-devel/2023-March/053645.html