### PR TITLE
[next-devel] overrides: fast-track downgraded F40 packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,6 +15,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d736bf394f
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  rpm-ostree:
+    evr: 2024.4-3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-049d306b11
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2024.4-3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-049d306b11
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   socat:
     evr: 1.8.0.0-2.fc40
     metadata:


### PR DESCRIPTION
 F40 is now in final freeze. This means some packages in F39 will
 sort as newer than packages in F40. We'll prevent downgrades by
 fast-tracking any packages that would violoate this "no downgrade"
 rule.

Today they are: `rpm-ostree`, `rpm-ostree-libs`