### PR TITLE
[next-devel] overrides: fast-track passt-0^20240326.g4988e2b-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -15,6 +15,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d736bf394f
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  passt:
+    evr: 0^20240326.g4988e2b-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-4d3ddadf4d
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1704
+      type: fast-track
+  passt-selinux:
+    evra: 0^20240326.g4988e2b-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-4d3ddadf4d
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1704
+      type: fast-track
   rpm-ostree:
     evr: 2024.4-3.fc40
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).