### PR TITLE
[next-devel]: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,10 +9,46 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  expat:
+    evr: 2.6.2-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b05fbc1127
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  fuse-sshfs:
+    evr: 3.7.3-9.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-029efc3056
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  fwupd:
+    evr: 1.9.16-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a960990153
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   gnutls:
     evr: 3.8.4-1.fc40
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d736bf394f
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  librepo:
+    evr: 1.17.1-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-69431d58c2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libxmlb:
+    evr: 0.3.17-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a960990153
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libzstd:
+    evr: 1.5.6-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1e8a70c30e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
   passt:
@@ -55,5 +91,11 @@ packages:
     evr: 2:9.1.181-1.fc40
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-918ccf84c1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  zstd:
+    evr: 1.5.6-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1e8a70c30e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track


### PR DESCRIPTION
F40 is now in final freeze. This means some packages in F39 will sort as newer than packages in F40. We'll prevent downgrades by fast-tracking any packages that would violate this "no downgrade" rule.

```
Downgraded:
  expat 2.6.2-1.fc39 -> 2.6.0-1.fc40
  fuse-sshfs 3.7.3-9.fc39 -> 3.7.3-7.fc40
  fwupd 1.9.16-1.fc39 -> 1.9.15-1.fc40
  librepo 1.17.1-1.fc39 -> 1.17.0-3.fc40
  libxmlb 0.3.17-1.fc39 -> 0.3.15-3.fc40
  libzstd 1.5.6-1.fc39 -> 1.5.5-5.fc40
  zstd 1.5.6-1.fc39 -> 1.5.5-5.fc40

```
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582