### PR TITLE
[next-devel] overrides: fast-track rpm-ostree-2024.4-5.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -64,16 +64,16 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1704
       type: fast-track
   rpm-ostree:
-    evr: 2024.4-3.fc40
+    evr: 2024.4-5.fc40
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-049d306b11
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-589189d414
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1705
       type: fast-track
   rpm-ostree-libs:
-    evr: 2024.4-3.fc40
+    evr: 2024.4-5.fc40
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-049d306b11
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-589189d414
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1705
       type: fast-track
   socat:
     evr: 1.8.0.0-2.fc40


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).