### PR TITLE
Manifests: disable default ZRAM config

### DIFF
--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -54,3 +54,8 @@ postprocess:
   - |
     #!/usr/bin/env bash
     systemctl mask systemd-repart.service
+  # zram-generator-0.3.2 (shipped in centOS 9) provides a default
+  # zram-generator config, we want to disable it
+  - |
+    #!/usr/bin/env bash
+    rm -f /usr/lib/systemd/zram-generator.conf


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-config/pull/2937 we moved zram-generator to the system-configuration.yaml manifest so it's shared with RHCOS.
However in the centOS stream 9 zram-generator-0.3.2 [1] ships a default config file, resulting in a swap device being created by default.
This ends up breaking kubelet, until kubernetes 1.30 is released

[1] https://gitlab.com/redhat/centos-stream/rpms/rust-zram-generator/-/blob/c9s/zram-generator.conf?ref_type=heads