### PR TITLE
[rawhide] overrides: unpin google-compute-engine-guest-configs-udev

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  google-compute-engine-guest-configs-udev:
-    evra: 20240119.00-1.fc40.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1702
-      type: pin
+packages: {}


### PR DESCRIPTION
The package has been unretired and is back in the rawhide repos again!

https://github.com/coreos/fedora-coreos-tracker/issues/1702