### PR TITLE
[rhcos-4.15] tests/var-mount/scsi-id: simplify bootloader entry finding

### DIFF
--- a/tests/kola/var-mount/scsi-id/test.sh
+++ b/tests/kola/var-mount/scsi-id/test.sh
@@ -18,15 +18,7 @@ if [ $fstype != xfs ]; then
     fatal "Error: /var fstype is $fstype, expected is xfs"
 fi
 
-source /etc/os-release
-ostree_conf=""
-if [ "$ID" == "fedora" ]; then
-    ostree_conf="/boot/loader.1/entries/ostree-1-fedora-coreos.conf"
-elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
-    ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"
-else
-    fatal "fail: not operating on expected OS"
-fi
+ostree_conf=$(ls /boot/loader/entries/*.conf)
 
 initramfs=/boot$(grep initrd ${ostree_conf} | sed 's/initrd //g')
 tempfile=$(mktemp)


### PR DESCRIPTION
We don't have to be super strict here in how we find the bootloader entry. There should only be one, so simplify the logic using a glob instead.

Motivated by the fact that this will break otherwise as part of https://github.com/openshift/os/pull/1445 where the `ID` will be `centos`, but the stateroot will still be `scos`.

(cherry picked from commit 476a371ef9093ae6a5d34fe38db51eccdf121071)

---

We're backporting this because a recent rebuild of 4.15 cosa pulled in a new ostree which enables `bootloader-naming-2` by default, which changes the BLS entry name:

https://github.com/ostreedev/ostree/pull/3206