### PR TITLE
Denylist: re-enable ext/var-mount/scsi-id

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,15 +11,6 @@
   warn: true
   platforms:
     - azure
-- pattern: ext.config.var-mount.scsi-id
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1670
-  snooze: 2024-04-15
-  warn: true
-  streams:
-    - rawhide
-    - branched
-    - next
-    - next-devel
 - pattern: coreos.boot-mirror*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1659
   warn: true


### PR DESCRIPTION
An update in rawhide broke /dev/disk-by symlinks that the scsi-id relied on. [1] fixed the test but i forgot to re-enable it

[1] https://github.com/coreos/fedora-coreos-config/pull/2943