### PR TITLE
denylist: extend snooze for failing kola tests, remove kdump.crash

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-04-15
+  snooze: 2024-04-29
   warn: true
   platforms:
     - azure
@@ -18,7 +18,7 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1698
-  snooze: 2024-04-07
+  snooze: 2024-04-29
   warn: true
   streams:
     - rawhide

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,9 +16,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1698
-  snooze: 2024-04-29
-  warn: true
-  streams:
-    - rawhide


### PR DESCRIPTION
The `coreos.ignition.ssh.key` is now expired. Extending the snooze to stop our pipeline from failing.

Also removing here the `ext.config.kdump.crash` since it should be fixed by the https://github.com/coreos/fedora-coreos-config/pull/2966