### PR TITLE
manifests: add kexec-utils subpackage for kexec-tools

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -34,8 +34,8 @@ conditional-include:
     # Checks for breaking changes that came with Podman v5.
     include: podman-v5.yaml
   - if: releasever >= 41
-    # Include makedumpfile subpackage from kexec-tools (new in F41+)
-    include: makedumpfile.yaml
+    # Include makedumpfile and kexec-utils subpackages from kexec-tools (new in F41+)
+    include: kdump.yaml
   # On <41, we want to keep making sure dnf doesn't slip in somehow
   # On 41+, we do want it
   # https://github.com/coreos/fedora-coreos-tracker/issues/1687

--- a/manifests/kdump.yaml
+++ b/manifests/kdump.yaml
@@ -1,0 +1,8 @@
+packages:
+# makedumpfile is needed for kdump and was broken out to a subpackage
+# in F41+. Move this to a main manifest file when we no longer support <F41.
+  - makedumpfile
+# systemd service files and other tools were moved into a subpackage
+# in F41+. Move this to a main manifest file when we no longer support <F41.
+# https://src.fedoraproject.org/rpms/kexec-tools/c/372b4c6c1597c3d9aaddda2d691260474973989e?branch=rawhide
+  - kdump-utils

--- a/manifests/makedumpfile.yaml
+++ b/manifests/makedumpfile.yaml
@@ -1,4 +1,0 @@
-# makedumpfile is needed for kdump and was broken out to a subpackage
-# in F41+. Drop this when we no longer support <F41.
-packages:
-  - makedumpfile


### PR DESCRIPTION
In kexec-tools 2.0.28-8 some of the config files
were broken out in a subpackage.
Kexec-utils is a weak dependency on kexec-tools
so we need to pull it manually.

See: https://src.fedoraproject.org/rpms/kexec-tools/c/372b4c6c1597c3d9aaddda2d691260474973989e?branch=rawhide