### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+packages:
+  amd-ucode-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -123,6 +123,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  podman:
+    evr: 5:5.0.1-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-c7e5c62b91
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   realtek-firmware:
     evra: 20240410-1.fc40.noarch
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  amd-gpu-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  atheros-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  brcmfmac-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   expat:
     evr: 2.6.2-1.fc40
     metadata:
@@ -33,6 +51,24 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-d736bf394f
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  intel-gpu-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libbsd:
+    evr: 0.12.2-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-86fbbe4bc7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  libnfsidmap:
+    evr: 1:2.6.4-0.rc6.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-c74f78d6f8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   librepo:
     evr: 1.17.1-1.fc40
     metadata:
@@ -51,22 +87,82 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1e8a70c30e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  linux-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  linux-firmware-whence:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  mt7xxx-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  nfs-utils-coreos:
+    evr: 1:2.6.4-0.rc6.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-c74f78d6f8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  nvidia-gpu-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  nxpwireless-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  realtek-firmware:
+    evra: 20240410-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree:
+    evr: 2024.4-5.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-589189d414
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2024.4-5.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-589189d414
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   socat:
     evr: 1.8.0.0-2.fc40
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e3c9a5a3c8
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
-  vim-data:
-    evra: 2:9.1.181-1.fc40.noarch
+  tiwilink-firmware:
+    evra: 20240410-1.fc40.noarch
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-918ccf84c1
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  vim-data:
+    evra: 2:9.1.309-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-453669c155
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
   vim-minimal:
-    evr: 2:9.1.181-1.fc40
+    evr: 2:9.1.309-1.fc40
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-918ccf84c1
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-453669c155
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
   zstd:


### PR DESCRIPTION
F40 is in final freeze. We are fast-tracking the downgraded packages.

```
Downgraded:
  amd-gpu-firmware 20240410-1.fc39 -> 20240312-1.fc40
  amd-ucode-firmware 20240410-1.fc39 -> 20240312-1.fc40
  atheros-firmware 20240410-1.fc39 -> 20240312-1.fc40
  brcmfmac-firmware 20240410-1.fc39 -> 20240312-1.fc40
  intel-gpu-firmware 20240410-1.fc39 -> 20240312-1.fc40
  libbsd 0.12.2-1.fc39 -> 0.11.7-7.fc40
  libnfsidmap 1:2.6.4-0.rc6.fc39 -> 1:2.6.4-0.rc5.fc40
  libxmlb 0.3.18-1.fc39 -> 0.3.17-1.fc40
  linux-firmware 20240410-1.fc39 -> 20240312-1.fc40
  linux-firmware-whence 20240410-1.fc39 -> 20240312-1.fc40
  mt7xxx-firmware 20240410-1.fc39 -> 20240312-1.fc40
  nfs-utils-coreos 1:2.6.4-0.rc6.fc39 -> 1:2.6.4-0.rc5.fc40
  nvidia-gpu-firmware 20240410-1.fc39 -> 20240312-1.fc40
  nxpwireless-firmware 20240410-1.fc39 -> 20240312-1.fc40
  realtek-firmware 20240410-1.fc39 -> 20240312-1.fc40
  rpm-ostree 2024.4-6.fc39 -> 2024.4-5.fc40
  rpm-ostree-libs 2024.4-6.fc39 -> 2024.4-5.fc40
  tiwilink-firmware 20240410-1.fc39 -> 20240312-1.fc40
  vim-data 2:9.1.264-1.fc39 -> 2:9.1.181-1.fc40
  vim-minimal 2:9.1.264-1.fc39 -> 2:9.1.181-1.fc40
```

_Note:_ 
Fast-tracking `podman-5.0.1-1.fc40` as the Fedora test day reports show that some issues were fixed with the new version.
F40 Test day: https://testdays.fedoraproject.org/events/179



_Ref:_ https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582