### PR TITLE
overlay.d/05core: fix variable usage in coreos-diskful-generator

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -27,8 +27,7 @@ EARLY_DIR="${2:-/tmp}"
 
 IFS=" " read -r -a cmdline <<< "$(</proc/cmdline)"
 cmdline_arg() {
-    local name value
-    name="$1"
+    local name="$1" value=""
     for arg in "${cmdline[@]}"; do
         if [[ "${arg%%=*}" == "${name}" ]]; then
             value="${arg#*=}"


### PR DESCRIPTION
Saw this scroll by in a log:

```
[    1.792490] /usr/lib/systemd/system-generators/coreos-diskful-generator: line 37: value: unbound variable
```

We need to set a value for value in order to prevent the unbound variable error.