### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -135,6 +135,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cb8093bdf
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  rpm-ostree:
+    evr: 2024.5-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b59ee8264e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2024.5-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b59ee8264e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
   socat:
     evr: 1.8.0.0-2.fc40
     metadata:

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -45,6 +45,30 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-a960990153
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
       type: fast-track
+  glibc:
+    evr: 2.39-8.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eafbf519ec
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1711
+      type: fast-track
+  glibc-common:
+    evr: 2.39-8.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eafbf519ec
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1711
+      type: fast-track
+  glibc-gconv-extra:
+    evr: 2.39-8.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eafbf519ec
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1711
+      type: fast-track
+  glibc-minimal-langpack:
+    evr: 2.39-8.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eafbf519ec
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1711
+      type: fast-track
   gnutls:
     evr: 3.8.4-1.fc40
     metadata:


### PR DESCRIPTION
F40 is in final freeze. We are fast-tracking the downgraded packages.

- https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582 

Fast-tracking `glibc-2.39-8.fc40` as it carries an important security issue fix.
- https://github.com/coreos/fedora-coreos-tracker/issues/1711