### PR TITLE
manifests: Don't include Wi-Fi firmwares starting with Fedora 41

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -157,8 +157,6 @@ packages:
   - iptables-legacy
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
-  # Wifi/BT firmware files https://github.com/coreos/fedora-coreos-tracker/issues/1575
-  - atheros-firmware brcmfmac-firmware mt7xxx-firmware realtek-firmware nxpwireless-firmware tiwilink-firmware
 
 
 # - irqbalance

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -43,6 +43,9 @@ conditional-include:
     include: exclude-dnf.yaml
   - if: releasever >= 41
     include: include-dnf.yaml
+  # Wifi firmwares will be dropped in F41
+  - if: releasever < 41
+    include: wifi-firmwares.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/wifi-firmwares.yaml
+++ b/manifests/wifi-firmwares.yaml
@@ -1,0 +1,9 @@
+# Wifi/BT firmware files kept in FCOS until the F41 rebase
+# See: https://github.com/coreos/fedora-coreos-tracker/issues/1575
+packages:
+  - atheros-firmware
+  - brcmfmac-firmware
+  - mt7xxx-firmware
+  - nxpwireless-firmware
+  - realtek-firmware
+  - tiwilink-firmware


### PR DESCRIPTION
manifests: Don't include Wi-Fi firmwares starting with Fedora 41

Move Wi-Fi firmwares to their own manifest so that we can automatically
drop then when we rebase to Fedora 41.

We can safely do that now that we have included a warning for existing
users.

See: https://github.com/coreos/fedora-coreos-config/pull/2978
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1575