### PR TITLE
Move to Fedora Linux 40

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,6 +5,6 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM quay.io/fedora/fedora:39
+FROM quay.io/fedora/fedora:40
 COPY . /src
 RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,2299 +1,2257 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.44.2-1.fc39.aarch64",
+      "evra": "1:1.46.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.44.2-1.fc39.aarch64",
+      "evra": "1:1.46.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.44.2-1.fc39.aarch64",
+      "evra": "1:1.46.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.44.2-1.fc39.aarch64",
+      "evra": "1:1.46.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.44.2-1.fc39.aarch64",
+      "evra": "1:1.46.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.1.1-1.fc39.noarch",
+      "evra": "2.10.0.8-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "1.10.0-1.fc39.aarch64",
+      "evra": "1.10.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.1-9.fc39.aarch64",
+      "evra": "2.3.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-3.fc39.aarch64",
+      "evra": "0.9.2-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.5.1-1.fc39.aarch64",
+      "evra": "5.5.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.5.1-1.fc39.aarch64",
+      "evra": "5.5.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.26-1.fc39.aarch64",
+      "evra": "1.26-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "amd-ucode-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "atheros-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.1-8.fc39.aarch64",
+      "evra": "2.5.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "3.1.2-8.fc39.aarch64",
+      "evra": "4.0.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "3.1.2-8.fc39.aarch64",
+      "evra": "4.0.1-1.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "audit"
+      }
+    },
+    "audit-rules": {
+      "evra": "4.0.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.4.3-1.fc39.aarch64",
+      "evra": "1.5.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc39.aarch64",
+      "evra": "1.5.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-24.fc39.aarch64",
+      "evra": "0.8-26.fc40.aarch64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-18.fc39.noarch",
+      "evra": "11-20.fc40.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-1.fc39.aarch64",
+      "evra": "5.2.26-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4-1.fc39.noarch",
+      "evra": "0.4.1-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-12.fc39.noarch",
+      "evra": "1:2.11-14.fc40.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.24-1.fc39.aarch64",
+      "evra": "32:9.18.24-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-license": {
-      "evra": "32:9.18.24-1.fc39.noarch",
+      "evra": "32:9.18.24-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.24-1.fc39.aarch64",
+      "evra": "32:9.18.24-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.18-2.fc39.aarch64",
+      "evra": "0.2.18-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "brcmfmac-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "bsdtar": {
-      "evra": "3.7.1-1.fc39.aarch64",
+      "evra": "3.7.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.8-1.fc39.aarch64",
+      "evra": "6.8-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.8.0-1.fc39.aarch64",
+      "evra": "0.8.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-16.fc39.aarch64",
+      "evra": "1.0.8-18.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-16.fc39.aarch64",
+      "evra": "1.0.8-18.fc40.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc39.aarch64",
+      "evra": "1.28.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-2.fc39.noarch",
+      "evra": "2023.2.62_v7.0.401-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-18.fc39.aarch64",
+      "evra": "0.1.7-22.fc40.aarch64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.5-1.fc39.aarch64",
+      "evra": "4.5-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-2.fc39.aarch64",
+      "evra": "7.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
-    "cirrus-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "clevis": {
-      "evra": "20-1.fc39.aarch64",
+      "evra": "20-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-1.fc39.aarch64",
+      "evra": "20-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-1.fc39.aarch64",
+      "evra": "20-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
+    "clevis-pin-tpm2": {
+      "evra": "0.5.3-5.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "clevis-pin-tpm2"
+      }
+    },
     "clevis-systemd": {
-      "evra": "20-1.fc39.aarch64",
+      "evra": "20-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc39.noarch",
+      "evra": "0.33-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc39.aarch64",
+      "evra": "1.0.3-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc39.aarch64",
+      "evra": "1.0.3-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.10-1.fc39.aarch64",
+      "evra": "2:2.1.10-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.230.0-1.fc39.noarch",
+      "evra": "2:2.230.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-2.fc39.aarch64",
+      "evra": "1.6.23-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
-    "containernetworking-plugins": {
-      "evra": "1.3.0-3.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "containernetworking-plugins"
-      }
-    },
     "containers-common": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.21.0-1.fc39.aarch64",
+      "evra": "0.21.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.21.0-1.fc39.aarch64",
+      "evra": "0.21.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.3-5.fc39.aarch64",
+      "evra": "9.4-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.3-5.fc39.aarch64",
+      "evra": "9.4-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.14-4.fc39.aarch64",
+      "evra": "2.15-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-2.fc39.aarch64",
+      "evra": "2.9.11-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "3.19-2.fc39.aarch64",
+      "evra": "3.19-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "3.19-2.fc39.aarch64",
+      "evra": "3.19-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.14.4-1.fc39.aarch64",
+      "evra": "1.14.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.14.4-1.fc39.aarch64",
+      "evra": "1.14.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20231204-1.git1e3a2e4.fc39.noarch",
+      "evra": "20240201-2.git9f501f3.fc40.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.6.1-3.fc39.aarch64",
+      "evra": "2.7.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-3.fc39.aarch64",
+      "evra": "2.7.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.2.1-4.fc39.aarch64",
+      "evra": "8.6.0-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-11.fc39.aarch64",
+      "evra": "2.1.28-19.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-11.fc39.aarch64",
+      "evra": "2.1.28-19.fc40.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc39.aarch64",
+      "evra": "1:1.14.10-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "35-2.fc39.aarch64",
+      "evra": "36-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc39.noarch",
+      "evra": "1:1.14.10-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc39.aarch64",
+      "evra": "1:1.14.10-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.197-1.fc39.aarch64",
+      "evra": "1.02.197-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.197-1.fc39.aarch64",
+      "evra": "1.02.197-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.197-1.fc39.aarch64",
+      "evra": "1.02.197-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.197-1.fc39.aarch64",
+      "evra": "1.02.197-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.5-2.fc39.aarch64",
+      "evra": "0.9.7-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.5-2.fc39.aarch64",
+      "evra": "0.9.7-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc39.aarch64",
+      "evra": "1.0.12-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-3.fc39.aarch64",
+      "evra": "3.10-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-1.fc39.aarch64",
+      "evra": "2.90-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "dosfstools": {
-      "evra": "4.2-7.fc39.aarch64",
+      "evra": "4.2-11.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "059-16.fc39.aarch64",
+      "evra": "060-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "059-16.fc39.aarch64",
+      "evra": "060-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "059-16.fc39.aarch64",
+      "evra": "060-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-5.fc39.aarch64",
+      "evra": "2.7.0-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-2.fc39.aarch64",
+      "evra": "1.47.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-2.fc39.aarch64",
+      "evra": "1.47.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "5-9.fc39.noarch",
+      "evra": "5-11.fc40.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-4.fc39.aarch64",
+      "evra": "18-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-1.fc39.aarch64",
+      "evra": "39-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-2.fc39.noarch",
+      "evra": "0.191-4.fc40.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-2.fc39.aarch64",
+      "evra": "0.191-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-2.fc39.aarch64",
+      "evra": "0.191-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.7-1.fc39.aarch64",
+      "evra": "2:6.7-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.2-1.fc39.aarch64",
+      "evra": "2.6.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.44-5.fc39.aarch64",
+      "evra": "5.45-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.44-5.fc39.aarch64",
+      "evra": "5.45-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-6.fc39.aarch64",
+      "evra": "3.18-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-5.fc39.aarch64",
+      "evra": "1:4.9.0-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.6-1.fc39.aarch64",
+      "evra": "1.15.8-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "10.0.0-3.fc39.aarch64",
+      "evra": "10.2.1-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-8.fc39.aarch64",
+      "evra": "0.6.1-10.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse": {
-      "evra": "2.9.9-17.fc39.aarch64",
+      "evra": "2.9.9-21.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-common": {
-      "evra": "3.16.1-1.fc39.aarch64",
+      "evra": "3.16.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse-libs": {
-      "evra": "2.9.9-17.fc39.aarch64",
+      "evra": "2.9.9-21.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc39.aarch64",
+      "evra": "1.13-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc39.aarch64",
+      "evra": "3.7.3-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.1-1.fc39.aarch64",
+      "evra": "3.16.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.1-1.fc39.aarch64",
+      "evra": "3.16.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.16-1.fc39.aarch64",
+      "evra": "1.9.16-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.2.2-2.fc39.aarch64",
+      "evra": "5.3.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
+    "gdbm": {
+      "evra": "1:1.23-6.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "gdbm"
+      }
+    },
     "gdbm-libs": {
-      "evra": "1:1.23-4.fc39.aarch64",
+      "evra": "1:1.23-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc39.aarch64",
+      "evra": "1.0.10-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22-2.fc39.aarch64",
+      "evra": "0.22.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22-2.fc39.aarch64",
+      "evra": "0.22.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22-2.fc39.aarch64",
+      "evra": "0.22.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.44.0-1.fc39.aarch64",
+      "evra": "2.44.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.78.3-1.fc39.aarch64",
+      "evra": "2.80.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.38-18.fc39.aarch64",
+      "evra": "2.39-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.38-18.fc39.aarch64",
+      "evra": "2.39-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.38-18.fc39.aarch64",
+      "evra": "2.39-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.38-18.fc39.aarch64",
+      "evra": "2.39-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-5.fc39.aarch64",
+      "evra": "1:6.2.1-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc39.aarch64",
+      "evra": "2.4.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.5-1.fc39.aarch64",
+      "evra": "3.8.5-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20230929.00-1.fc39.noarch",
+      "evra": "20240307.00-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.20.0-5.fc39.aarch64",
+      "evra": "1.23.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-3.fc39.aarch64",
+      "evra": "3.11-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-118.fc39.noarch",
+      "evra": "1:2.06-119.fc40.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-118.fc39.aarch64",
+      "evra": "1:2.06-119.fc40.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-118.fc39.aarch64",
+      "evra": "1:2.06-119.fc40.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-118.fc39.aarch64",
+      "evra": "1:2.06-119.fc40.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.3-1.fc39.aarch64",
+      "evra": "6:0.7.3-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gvisor-tap-vsock"
       }
     },
     "gzip": {
-      "evra": "1.12-6.fc39.aarch64",
+      "evra": "1.13-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-9.fc39.aarch64",
+      "evra": "3.23-12.fc40.aarch64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "ignition": {
-      "evra": "2.18.0-1.fc39.aarch64",
+      "evra": "2.18.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc39.aarch64",
+      "evra": "58-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
-    "intel-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "intel-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-2.fc39.aarch64",
+      "evra": "1.0.3-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.4.0-2.fc39.aarch64",
+      "evra": "6.7.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.4.0-2.fc39.aarch64",
+      "evra": "6.7.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.9-5.fc39.aarch64",
+      "evra": "1.8.10-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-5.fc39.aarch64",
+      "evra": "1.8.10-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.9-5.fc39.aarch64",
+      "evra": "1.8.10-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.9-5.fc39.aarch64",
+      "evra": "1.8.10-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.9-5.fc39.noarch",
+      "evra": "1.8.10-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.9-5.fc39.aarch64",
+      "evra": "1.8.10-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20221126-4.fc39.aarch64",
+      "evra": "20240117-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.2-2.fc39.aarch64",
+      "evra": "2:1.9.2-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.aarch64",
+      "evra": "6.2.1.9-20.gita65a472.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.aarch64",
+      "evra": "6.2.1.9-20.gita65a472.fc40.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-7.fc39.aarch64",
+      "evra": "0.101-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-7.fc39.aarch64",
+      "evra": "2.13.1-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-4.fc39.aarch64",
+      "evra": "5.3.0-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "13-1.fc39.aarch64",
+      "evra": "13-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.6-17.fc39.aarch64",
+      "evra": "1.7.1-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-1.fc39.aarch64",
+      "evra": "0.17-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-1.fc39.aarch64",
+      "evra": "1.8.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.3-1.fc39.aarch64",
+      "evra": "2.6.4-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kernel": {
-      "evra": "6.8.6-200.fc39.aarch64",
+      "evra": "6.8.7-300.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.8.6-200.fc39.aarch64",
+      "evra": "6.8.7-300.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.8.6-200.fc39.aarch64",
+      "evra": "6.8.7-300.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.8.6-200.fc39.aarch64",
+      "evra": "6.8.7-300.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.27-4.fc39.aarch64",
+      "evra": "2.0.28-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-1.fc39.aarch64",
+      "evra": "1.6.3-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-1.fc39.aarch64",
+      "evra": "1.6.3-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "30-6.fc39.aarch64",
+      "evra": "31-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "30-6.fc39.aarch64",
+      "evra": "31-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.5-2.fc39.aarch64",
+      "evra": "0.9.7-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.2-3.fc39.aarch64",
+      "evra": "1.21.2-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "633-2.fc39.aarch64",
+      "evra": "643-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.1-9.fc39.aarch64",
+      "evra": "2.3.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-16.fc39.aarch64",
+      "evra": "0.3.111-19.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.1-1.fc39.aarch64",
+      "evra": "3.7.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
-    "libargon2": {
-      "evra": "20190702-3.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "argon2"
-      }
-    },
     "libassuan": {
-      "evra": "2.5.6-2.fc39.aarch64",
+      "evra": "2.5.7-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.1-8.fc39.aarch64",
+      "evra": "2.5.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-54.fc39.aarch64",
+      "evra": "0.1.1-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.1.0-4.fc39.aarch64",
+      "evra": "2:1.2.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-1.fc39.aarch64",
+      "evra": "0.12.2-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.48-9.fc39.aarch64",
+      "evra": "2.69-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc39.aarch64",
+      "evra": "0.8.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.10.2-2.fc39.aarch64",
+      "evra": "0.11.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-54.fc39.aarch64",
+      "evra": "0.7.0-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-2.fc39.aarch64",
+      "evra": "1.47.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.2.1-4.fc39.aarch64",
+      "evra": "8.6.0-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-26.fc39.aarch64",
+      "evra": "0.14-29.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
-    "libdb": {
-      "evra": "5.3.28-56.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "libdb"
-      }
-    },
     "libdhash": {
-      "evra": "0.5.0-54.fc39.aarch64",
+      "evra": "0.5.0-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libeconf": {
-      "evra": "0.5.2-2.fc39.aarch64",
+      "evra": "0.6.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-48.20230828cvs.fc39.aarch64",
+      "evra": "3.1-50.20230828cvs.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-9.fc39.aarch64",
+      "evra": "2.1.12-12.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-4.fc39.aarch64",
+      "evra": "3.4.4-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.13.0-3.fc39.aarch64",
+      "evra": "1.14.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "13.2.1-7.fc39.aarch64",
+      "evra": "14.0.1-0.15.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.2-2.fc39.aarch64",
+      "evra": "1.10.3-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.47-2.fc39.aarch64",
+      "evra": "1.48-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-2.fc39.aarch64",
+      "evra": "238-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.8-1.fc39.aarch64",
+      "evra": "0.4.8-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "46.0-4.fc39.aarch64",
+      "evra": "48.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "73.2-2.fc39.aarch64",
+      "evra": "74.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc39.aarch64",
+      "evra": "2.3.7-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-54.fc39.aarch64",
+      "evra": "1.3.1-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.1-1.fc39.aarch64",
+      "evra": "0.2.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "13-1.fc39.aarch64",
+      "evra": "13-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.4.0-7.fc39.aarch64",
+      "evra": "1.4.0-10.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-7.fc39.aarch64",
+      "evra": "1.4.0-10.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.4-2.fc39.aarch64",
+      "evra": "1.6.6-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.8.0-1.fc39.aarch64",
+      "evra": "2.9.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libldb"
       }
     },
     "libluksmeta": {
-      "evra": "9-16.fc39.aarch64",
+      "evra": "9-22.fc40.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.9.1-1.fc39.aarch64",
+      "evra": "1.9.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-2.fc39.aarch64",
+      "evra": "1.1.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-3.fc39.aarch64",
+      "evra": "1.0.5-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-5.fc39.aarch64",
+      "evra": "2.15.0-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-6.fc39.aarch64",
+      "evra": "1.8-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-1.fc39.aarch64",
+      "evra": "1.3-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-2.fc39.aarch64",
+      "evra": "1.0.9-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-24.fc39.aarch64",
+      "evra": "1.0.1-27.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.6.4-0.rc6.fc39.aarch64",
+      "evra": "1:2.6.4-0.rc6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-2.fc39.aarch64",
+      "evra": "1.2.6-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.55.1-5.fc39.aarch64",
+      "evra": "1.59.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.9.0-1.fc39.aarch64",
+      "evra": "3.9.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.9.0-1.fc39.aarch64",
+      "evra": "3.9.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.0-6.fc39.aarch64",
+      "evra": "2.0.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.6-2.fc39.aarch64",
+      "evra": "1.8-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-54.fc39.aarch64",
+      "evra": "0.2.1-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.4-2.fc39.aarch64",
+      "evra": "14:1.10.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "1.9.5-2.fc39.aarch64",
+      "evra": "2.1.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.2-4.fc39.aarch64",
+      "evra": "0.21.5-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-6.fc39.aarch64",
+      "evra": "1.4.5-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-54.fc39.aarch64",
+      "evra": "0.1.5-56.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.17.1-1.fc39.aarch64",
+      "evra": "1.17.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-3.fc39.noarch",
+      "evra": "2.17.15-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.3-6.fc39.aarch64",
+      "evra": "2.5.3-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.5-5.fc39.aarch64",
+      "evra": "3.6-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.5-5.fc39.aarch64",
+      "evra": "3.6-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.5-4.fc39.aarch64",
+      "evra": "3.6-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.5-2.fc39.aarch64",
+      "evra": "3.6-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
-    "libsigsegv": {
-      "evra": "2.14-5.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "libsigsegv"
-      }
-    },
     "libslirp": {
-      "evra": "4.7.0-4.fc39.aarch64",
+      "evra": "4.7.0-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.19.6-1.fc39.aarch64",
+      "evra": "2:4.20.0-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.28-1.fc39.aarch64",
+      "evra": "0.7.28-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-2.fc39.aarch64",
+      "evra": "1.47.0-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "13.2.1-7.fc39.aarch64",
+      "evra": "14.0.1-0.15.fc40.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.1-1.fc39.aarch64",
+      "evra": "2.4.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-3.fc39.aarch64",
+      "evra": "4.19.0-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.9-1.fc39.aarch64",
+      "evra": "1.4.10-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-1.fc39.aarch64",
+      "evra": "1.32-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.15.0-1.fc39.aarch64",
+      "evra": "0.16.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.4-1.rc3.fc39.aarch64",
+      "evra": "1.3.4-1.rc3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-7.fc39.aarch64",
+      "evra": "2.4.7-10.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-5.fc39.aarch64",
+      "evra": "1.1-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-1.fc39.aarch64",
+      "evra": "1.0.27-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
-    "libuser": {
-      "evra": "0.64-4.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "libuser"
-      }
-    },
     "libutempter": {
-      "evra": "1.2.1-10.fc39.aarch64",
+      "evra": "1.2.1-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.48.0-1.fc39.aarch64",
+      "evra": "1:1.48.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-6.fc39.aarch64",
+      "evra": "0.3.2-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.19.6-1.fc39.aarch64",
+      "evra": "2:4.20.0-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-2.fc39.aarch64",
+      "evra": "4.4.36-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.10.4-3.fc39.aarch64",
+      "evra": "2.12.6-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.18-1.fc39.aarch64",
+      "evra": "0.3.18-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-12.fc39.aarch64",
+      "evra": "0.2.5-14.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc39.aarch64",
+      "evra": "1.5.6-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
-    "linux-atm-libs": {
-      "evra": "2.5.1-36.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "linux-atm"
-      }
-    },
     "linux-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.32-1.fc39.aarch64",
+      "evra": "0.9.32-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-4.fc39.aarch64",
+      "evra": "3.21.0-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.96.3-4.fc39.aarch64",
+      "evra": "4.98.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-3.fc39.aarch64",
+      "evra": "5.4.6-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-16.fc39.aarch64",
+      "evra": "9-22.fc40.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.23-1.fc39.aarch64",
+      "evra": "2.03.23-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.23-1.fc39.aarch64",
+      "evra": "2.03.23-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-4.fc39.aarch64",
+      "evra": "1.9.4-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-9.fc39.aarch64",
+      "evra": "2.10-12.fc40.aarch64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "mdadm": {
-      "evra": "4.2-6.fc39.aarch64",
+      "evra": "4.2-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-1.fc39.aarch64",
+      "evra": "24.0.5-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.6.0-7.fc39.aarch64",
+      "evra": "2:0.7.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.0-3.fc39.aarch64",
+      "evra": "4.2.1-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "mt7xxx-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nano": {
-      "evra": "7.2-4.fc39.aarch64",
+      "evra": "7.2-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-4.fc39.noarch",
+      "evra": "7.2-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-7.20230520.fc39.1.aarch64",
+      "evra": "6.4-12.20240127.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-7.20230520.fc39.1.noarch",
+      "evra": "6.4-12.20240127.fc40.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-7.20230520.fc39.1.aarch64",
+      "evra": "6.4-12.20240127.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.67.20160912git.fc39.aarch64",
+      "evra": "2.0-0.69.20160912git.fc40.aarch64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "1.10.3-1.fc39.aarch64",
+      "evra": "1.10.3-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-2.fc39.aarch64",
+      "evra": "3.9.1-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.23-4.fc39.aarch64",
+      "evra": "0.52.24-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.4-0.rc6.fc39.aarch64",
+      "evra": "1:2.6.4-0.rc6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.7-3.fc39.aarch64",
+      "evra": "1:1.0.9-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.26-2.fc39.aarch64",
+      "evra": "2.2.26-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.6-14.fc39.aarch64",
+      "evra": "1.7-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-1.fc39.aarch64",
+      "evra": "2.23.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-3.fc39.aarch64",
+      "evra": "2.0.16-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.6-1.fc39.aarch64",
+      "evra": "2.8-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "nxpwireless-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc39.aarch64",
+      "evra": "6.9.9-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.6-1.fc39.aarch64",
+      "evra": "2.6.7-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.3p1-10.fc39.aarch64",
+      "evra": "9.6p1-1.fc40.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.3p1-10.fc39.aarch64",
+      "evra": "9.6p1-1.fc40.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.3p1-10.fc39.aarch64",
+      "evra": "9.6p1-1.fc40.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.1.1-4.fc39.aarch64",
+      "evra": "1:3.2.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.1.1-4.fc39.aarch64",
+      "evra": "1:3.2.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-4.fc39.aarch64",
+      "evra": "1.81-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.5-1.fc39.aarch64",
+      "evra": "2024.5-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.5-1.fc39.aarch64",
+      "evra": "2024.5-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.3-1.fc39.aarch64",
+      "evra": "0.25.3-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.3-1.fc39.aarch64",
+      "evra": "0.25.3-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.5.3-3.fc39.aarch64",
+      "evra": "1.6.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.5.3-3.fc39.aarch64",
+      "evra": "1.6.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
+    "passim-libs": {
+      "evra": "0.1.5-3.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "passim"
+      }
+    },
     "passt": {
-      "evra": "0^20240326.g4988e2b-1.fc39.aarch64",
+      "evra": "0^20240326.g4988e2b-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240326.g4988e2b-1.fc39.noarch",
+      "evra": "0^20240326.g4988e2b-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
-    "passwd": {
-      "evra": "0.80-15.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "passwd"
-      }
-    },
     "pcre2": {
-      "evra": "10.42-1.fc39.2.aarch64",
+      "evra": "10.42-2.fc40.2.aarch64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc39.2.noarch",
+      "evra": "10.42-2.fc40.2.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-2.fc39.aarch64",
+      "evra": "2.8-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "1.9.5-2.fc39.aarch64",
+      "evra": "2.1.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "1.9.5-2.fc39.noarch",
+      "evra": "2.1.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "1.9.5-2.fc39.aarch64",
+      "evra": "2.1.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:4.9.4-1.fc39.aarch64",
-      "metadata": {
-        "sourcerpm": "podman"
-      }
-    },
-    "podman-plugins": {
-      "evra": "5:4.9.4-1.fc39.aarch64",
+      "evra": "5:5.0.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.5-8.fc39.aarch64",
+      "evra": "3.6-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "123-1.fc39.1.aarch64",
+      "evra": "124-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "123-1.fc39.1.aarch64",
+      "evra": "124-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-26.fc39.aarch64",
+      "evra": "0.1-28.fc40.aarch64",
       "metadata": {
         "sourcerpm": "polkit-pkla-compat"
       }
     },
     "popt": {
-      "evra": "1.19-3.fc39.aarch64",
+      "evra": "1.19-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.3-5.fc39.aarch64",
+      "evra": "4.0.4-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.4.1-5.fc39.aarch64",
+      "evra": "1.5.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-4.fc39.aarch64",
+      "evra": "23.6-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-1.fc39.noarch",
+      "evra": "20240107-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.1.3-5.fc39.aarch64",
+      "evra": "2:8.2.2-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-6.fc39.aarch64",
+      "evra": "8.2-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "realtek-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc3.fc39.aarch64",
+      "evra": "1.2.6-4.rc3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc39.aarch64",
+      "evra": "4.19.1.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc39.aarch64",
+      "evra": "4.19.1.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.4-6.fc39.aarch64",
+      "evra": "2024.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.4-6.fc39.aarch64",
+      "evra": "2024.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc39.aarch64",
+      "evra": "4.19.1.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.6.0-1.fc39.aarch64",
+      "evra": "1.6.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc39.aarch64",
+      "evra": "3.3.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-1.fc39.aarch64",
+      "evra": "2:1.1.12-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.19.6-1.fc39.aarch64",
+      "evra": "2:4.20.0-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.19.6-1.fc39.noarch",
+      "evra": "2:4.20.0-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.19.6-1.fc39.aarch64",
+      "evra": "2:4.20.0-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sed": {
-      "evra": "4.8-14.fc39.aarch64",
+      "evra": "4.9-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.4-1.fc39.noarch",
+      "evra": "2.14.5-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.46-6.fc39.aarch64",
+      "evra": "1.48-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.46-6.fc39.aarch64",
+      "evra": "1.48-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.14.0-2.fc39.aarch64",
+      "evra": "2:4.15.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.14.0-2.fc39.aarch64",
+      "evra": "2:4.15.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.2-4.fc39.aarch64",
+      "evra": "2.3-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2305,313 +2263,313 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.15.0-1.fc39.aarch64",
+      "evra": "1:1.15.0-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-4.fc39.aarch64",
+      "evra": "2.3.3-5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc39.aarch64",
+      "evra": "1.2.2-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-2.fc39.aarch64",
+      "evra": "1.1.10-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc39.aarch64",
+      "evra": "1.8.0.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.12.0-2.fc39.aarch64",
+      "evra": "1.12.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.42.0-7.fc39.aarch64",
+      "evra": "3.45.1-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-2.fc39.aarch64",
+      "evra": "4.6.1-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-4.fc39.aarch64",
+      "evra": "0.1.4-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.4-1.fc39.aarch64",
+      "evra": "2.9.4-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.1-1.fc39.aarch64",
+      "evra": "1.19.1-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-1.p5.fc39.aarch64",
+      "evra": "1.9.15-2.p5.fc40.aarch64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "254.10-1.fc39.aarch64",
+      "evra": "255.4-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-2.fc39.aarch64",
+      "evra": "2:1.35-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-1.fc39.aarch64",
+      "evra": "1.32-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tiwilink-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.5-4.fc39.aarch64",
+      "evra": "0.0.99.5-8.fc40.aarch64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.5-4.fc39.aarch64",
+      "evra": "5.6-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.0.1-6.fc39.aarch64",
+      "evra": "4.0.1-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.0.1-6.fc39.aarch64",
+      "evra": "4.0.1-7.fc40.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-2.fc39.noarch",
+      "evra": "2024a-5.fc40.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-3.fc39.aarch64",
+      "evra": "0.14.0-4.fc40.aarch64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.39.4-1.fc39.aarch64",
+      "evra": "2.40-13.fc40.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.309-1.fc39.noarch",
+      "evra": "2:9.1.309-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.309-1.fc39.aarch64",
+      "evra": "2:9.1.309-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.13.5-1.fc39.aarch64",
+      "evra": "0.13.5-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.21-40.fc39.aarch64",
+      "evra": "2.21-41.fc40.aarch64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-5.fc39.aarch64",
+      "evra": "1.0.20210914-6.fc40.aarch64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.4.0-1.fc39.aarch64",
+      "evra": "6.5.0-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc39.aarch64",
+      "evra": "0.8.2-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "5.4.4-1.fc39.aarch64",
+      "evra": "1:5.4.6-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "5.4.4-1.fc39.aarch64",
+      "evra": "1:5.4.6-3.fc40.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-22.fc39.aarch64",
+      "evra": "2.1.0-23.fc40.aarch64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.4.0-1.fc39.aarch64",
+      "evra": "1.4.0-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-1.fc39.aarch64",
+      "evra": "0.0.27-2.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
-    "zlib": {
-      "evra": "1.2.13-4.fc39.aarch64",
+    "zlib-ng-compat": {
+      "evra": "2.1.6-2.fc40.aarch64",
       "metadata": {
-        "sourcerpm": "zlib"
+        "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-8.fc39.aarch64",
+      "evra": "1.1.2-9.fc40.aarch64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc39.aarch64",
+      "evra": "1.5.6-1.fc40.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
@@ -2620,14 +2578,17 @@
   "metadata": {
     "generated": "2024-04-21T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-11-01T00:12:29Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-04-14T18:51:04Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-04-21T15:19:43Z"
+        "generated": "2024-04-21T12:48:11Z"
       },
-      "fedora-updates": {
-        "generated": "2024-04-21T01:11:35Z"
+      "fedora-next": {
+        "generated": "2024-04-19T08:53:27Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-04-21T01:00:16Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  libbsd:
+    evr: 0.12.2-3.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-86fbbe4bc7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree:
+    evr: 2024.5-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b59ee8264e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2024.5-2.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b59ee8264e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1674#issuecomment-2010200582
+      type: fast-track

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,2605 +1,2563 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.44.2-1.fc39.ppc64le",
+      "evra": "1:1.46.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.44.2-1.fc39.ppc64le",
+      "evra": "1:1.46.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.44.2-1.fc39.ppc64le",
+      "evra": "1:1.46.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.44.2-1.fc39.ppc64le",
+      "evra": "1:1.46.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.44.2-1.fc39.ppc64le",
+      "evra": "1:1.46.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.1.1-1.fc39.noarch",
+      "evra": "2.10.0.8-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "1.10.0-1.fc39.ppc64le",
+      "evra": "1.10.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.1-9.fc39.ppc64le",
+      "evra": "2.3.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-3.fc39.ppc64le",
+      "evra": "0.9.2-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.5.1-1.fc39.ppc64le",
+      "evra": "5.5.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.5.1-1.fc39.ppc64le",
+      "evra": "5.5.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.26-1.fc39.ppc64le",
+      "evra": "1.26-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "amd-ucode-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "atheros-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.1-8.fc39.ppc64le",
+      "evra": "2.5.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "3.1.2-8.fc39.ppc64le",
+      "evra": "4.0.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "3.1.2-8.fc39.ppc64le",
+      "evra": "4.0.1-1.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "audit"
+      }
+    },
+    "audit-rules": {
+      "evra": "4.0.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.4.3-1.fc39.ppc64le",
+      "evra": "1.5.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc39.ppc64le",
+      "evra": "1.5.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-24.fc39.ppc64le",
+      "evra": "0.8-26.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-18.fc39.noarch",
+      "evra": "11-20.fc40.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-1.fc39.ppc64le",
+      "evra": "5.2.26-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4-1.fc39.noarch",
+      "evra": "0.4.1-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-12.fc39.noarch",
+      "evra": "1:2.11-14.fc40.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bc": {
-      "evra": "1.07.1-19.fc39.ppc64le",
+      "evra": "1.07.1-21.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bc"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.24-1.fc39.ppc64le",
+      "evra": "32:9.18.24-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-license": {
-      "evra": "32:9.18.24-1.fc39.noarch",
+      "evra": "32:9.18.24-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.24-1.fc39.ppc64le",
+      "evra": "32:9.18.24-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.18-2.fc39.ppc64le",
+      "evra": "0.2.18-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "brcmfmac-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "bsdtar": {
-      "evra": "3.7.1-1.fc39.ppc64le",
+      "evra": "3.7.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.8-1.fc39.ppc64le",
+      "evra": "6.8-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.8.0-1.fc39.ppc64le",
+      "evra": "0.8.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-16.fc39.ppc64le",
+      "evra": "1.0.8-18.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-16.fc39.ppc64le",
+      "evra": "1.0.8-18.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc39.ppc64le",
+      "evra": "1.28.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-2.fc39.noarch",
+      "evra": "2023.2.62_v7.0.401-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-18.fc39.ppc64le",
+      "evra": "0.1.7-22.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.5-1.fc39.ppc64le",
+      "evra": "4.5-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-2.fc39.ppc64le",
+      "evra": "7.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
-    "cirrus-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "clevis": {
-      "evra": "20-1.fc39.ppc64le",
+      "evra": "20-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-1.fc39.ppc64le",
+      "evra": "20-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-1.fc39.ppc64le",
+      "evra": "20-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
+    "clevis-pin-tpm2": {
+      "evra": "0.5.3-5.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "clevis-pin-tpm2"
+      }
+    },
     "clevis-systemd": {
-      "evra": "20-1.fc39.ppc64le",
+      "evra": "20-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc39.noarch",
+      "evra": "0.33-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc39.ppc64le",
+      "evra": "1.0.3-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc39.ppc64le",
+      "evra": "1.0.3-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.10-1.fc39.ppc64le",
+      "evra": "2:2.1.10-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.230.0-1.fc39.noarch",
+      "evra": "2:2.230.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-2.fc39.ppc64le",
+      "evra": "1.6.23-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
-    "containernetworking-plugins": {
-      "evra": "1.3.0-3.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "containernetworking-plugins"
-      }
-    },
     "containers-common": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.21.0-1.fc39.ppc64le",
+      "evra": "0.21.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.21.0-1.fc39.ppc64le",
+      "evra": "0.21.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.3-5.fc39.ppc64le",
+      "evra": "9.4-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.3-5.fc39.ppc64le",
+      "evra": "9.4-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.14-4.fc39.ppc64le",
+      "evra": "2.15-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-2.fc39.ppc64le",
+      "evra": "2.9.11-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "3.19-2.fc39.ppc64le",
+      "evra": "3.19-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "3.19-2.fc39.ppc64le",
+      "evra": "3.19-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.14.4-1.fc39.ppc64le",
+      "evra": "1.14.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20231204-1.git1e3a2e4.fc39.noarch",
+      "evra": "20240201-2.git9f501f3.fc40.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.6.1-3.fc39.ppc64le",
+      "evra": "2.7.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-3.fc39.ppc64le",
+      "evra": "2.7.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.2.1-4.fc39.ppc64le",
+      "evra": "8.6.0-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-11.fc39.ppc64le",
+      "evra": "2.1.28-19.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-11.fc39.ppc64le",
+      "evra": "2.1.28-19.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc39.ppc64le",
+      "evra": "1:1.14.10-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "35-2.fc39.ppc64le",
+      "evra": "36-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc39.noarch",
+      "evra": "1:1.14.10-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc39.ppc64le",
+      "evra": "1:1.14.10-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.197-1.fc39.ppc64le",
+      "evra": "1.02.197-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.197-1.fc39.ppc64le",
+      "evra": "1.02.197-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.197-1.fc39.ppc64le",
+      "evra": "1.02.197-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.197-1.fc39.ppc64le",
+      "evra": "1.02.197-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.5-2.fc39.ppc64le",
+      "evra": "0.9.7-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.5-2.fc39.ppc64le",
+      "evra": "0.9.7-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc39.ppc64le",
+      "evra": "1.0.12-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-3.fc39.ppc64le",
+      "evra": "3.10-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-1.fc39.ppc64le",
+      "evra": "2.90-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "dosfstools": {
-      "evra": "4.2-7.fc39.ppc64le",
+      "evra": "4.2-11.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "059-16.fc39.ppc64le",
+      "evra": "060-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "059-16.fc39.ppc64le",
+      "evra": "060-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "059-16.fc39.ppc64le",
+      "evra": "060-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-5.fc39.ppc64le",
+      "evra": "2.7.0-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-2.fc39.ppc64le",
+      "evra": "1.47.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-2.fc39.ppc64le",
+      "evra": "1.47.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-2.fc39.noarch",
+      "evra": "0.191-4.fc40.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-2.fc39.ppc64le",
+      "evra": "0.191-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-2.fc39.ppc64le",
+      "evra": "0.191-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.7-1.fc39.ppc64le",
+      "evra": "2:6.7-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.2-1.fc39.ppc64le",
+      "evra": "2.6.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.44-5.fc39.ppc64le",
+      "evra": "5.45-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.44-5.fc39.ppc64le",
+      "evra": "5.45-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-6.fc39.ppc64le",
+      "evra": "3.18-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-5.fc39.ppc64le",
+      "evra": "1:4.9.0-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.6-1.fc39.ppc64le",
+      "evra": "1.15.8-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-8.fc39.ppc64le",
+      "evra": "0.6.1-10.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse": {
-      "evra": "2.9.9-17.fc39.ppc64le",
+      "evra": "2.9.9-21.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-common": {
-      "evra": "3.16.1-1.fc39.ppc64le",
+      "evra": "3.16.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse-libs": {
-      "evra": "2.9.9-17.fc39.ppc64le",
+      "evra": "2.9.9-21.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc39.ppc64le",
+      "evra": "1.13-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc39.ppc64le",
+      "evra": "3.7.3-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.1-1.fc39.ppc64le",
+      "evra": "3.16.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.1-1.fc39.ppc64le",
+      "evra": "3.16.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.16-1.fc39.ppc64le",
+      "evra": "1.9.16-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.2.2-2.fc39.ppc64le",
+      "evra": "5.3.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
+    "gdbm": {
+      "evra": "1:1.23-6.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "gdbm"
+      }
+    },
     "gdbm-libs": {
-      "evra": "1:1.23-4.fc39.ppc64le",
+      "evra": "1:1.23-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc39.ppc64le",
+      "evra": "1.0.10-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22-2.fc39.ppc64le",
+      "evra": "0.22.5-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22-2.fc39.ppc64le",
+      "evra": "0.22.5-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22-2.fc39.ppc64le",
+      "evra": "0.22.5-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.44.0-1.fc39.ppc64le",
+      "evra": "2.44.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.78.3-1.fc39.ppc64le",
+      "evra": "2.80.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.38-18.fc39.ppc64le",
+      "evra": "2.39-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.38-18.fc39.ppc64le",
+      "evra": "2.39-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.38-18.fc39.ppc64le",
+      "evra": "2.39-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.38-18.fc39.ppc64le",
+      "evra": "2.39-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-5.fc39.ppc64le",
+      "evra": "1:6.2.1-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc39.ppc64le",
+      "evra": "2.4.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.5-1.fc39.ppc64le",
+      "evra": "3.8.5-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.20.0-5.fc39.ppc64le",
+      "evra": "1.23.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-3.fc39.ppc64le",
+      "evra": "3.11-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-118.fc39.noarch",
+      "evra": "1:2.06-119.fc40.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le": {
-      "evra": "1:2.06-118.fc39.ppc64le",
+      "evra": "1:2.06-119.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.06-118.fc39.noarch",
+      "evra": "1:2.06-119.fc40.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-118.fc39.ppc64le",
+      "evra": "1:2.06-119.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-118.fc39.ppc64le",
+      "evra": "1:2.06-119.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.3-1.fc39.ppc64le",
+      "evra": "6:0.7.3-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gvisor-tap-vsock"
       }
     },
     "gzip": {
-      "evra": "1.12-6.fc39.ppc64le",
+      "evra": "1.13-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-9.fc39.ppc64le",
+      "evra": "3.23-12.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "ignition": {
-      "evra": "2.18.0-1.fc39.ppc64le",
+      "evra": "2.18.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc39.ppc64le",
+      "evra": "58-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
-    "intel-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "intel-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-2.fc39.ppc64le",
+      "evra": "1.0.3-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.4.0-2.fc39.ppc64le",
+      "evra": "6.7.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.4.0-2.fc39.ppc64le",
+      "evra": "6.7.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.9-5.fc39.ppc64le",
+      "evra": "1.8.10-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-5.fc39.ppc64le",
+      "evra": "1.8.10-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.9-5.fc39.ppc64le",
+      "evra": "1.8.10-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.9-5.fc39.ppc64le",
+      "evra": "1.8.10-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.9-5.fc39.noarch",
+      "evra": "1.8.10-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.9-5.fc39.ppc64le",
+      "evra": "1.8.10-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20221126-4.fc39.ppc64le",
+      "evra": "20240117-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.2-2.fc39.ppc64le",
+      "evra": "2:1.9.2-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.ppc64le",
+      "evra": "6.2.1.9-20.gita65a472.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.ppc64le",
+      "evra": "6.2.1.9-20.gita65a472.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-7.fc39.ppc64le",
+      "evra": "0.101-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-7.fc39.ppc64le",
+      "evra": "2.13.1-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-4.fc39.ppc64le",
+      "evra": "5.3.0-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "13-1.fc39.ppc64le",
+      "evra": "13-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.6-17.fc39.ppc64le",
+      "evra": "1.7.1-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-1.fc39.ppc64le",
+      "evra": "0.17-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-1.fc39.ppc64le",
+      "evra": "1.8.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.3-1.fc39.ppc64le",
+      "evra": "2.6.4-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kernel": {
-      "evra": "6.8.6-200.fc39.ppc64le",
+      "evra": "6.8.7-300.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.8.6-200.fc39.ppc64le",
+      "evra": "6.8.7-300.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.8.6-200.fc39.ppc64le",
+      "evra": "6.8.7-300.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.8.6-200.fc39.ppc64le",
+      "evra": "6.8.7-300.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.27-4.fc39.ppc64le",
+      "evra": "2.0.28-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-1.fc39.ppc64le",
+      "evra": "1.6.3-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-1.fc39.ppc64le",
+      "evra": "1.6.3-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "30-6.fc39.ppc64le",
+      "evra": "31-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "30-6.fc39.ppc64le",
+      "evra": "31-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.5-2.fc39.ppc64le",
+      "evra": "0.9.7-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.2-3.fc39.ppc64le",
+      "evra": "1.21.2-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "633-2.fc39.ppc64le",
+      "evra": "643-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.1-9.fc39.ppc64le",
+      "evra": "2.3.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-16.fc39.ppc64le",
+      "evra": "0.3.111-19.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.1-1.fc39.ppc64le",
+      "evra": "3.7.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
-    "libargon2": {
-      "evra": "20190702-3.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "argon2"
-      }
-    },
     "libassuan": {
-      "evra": "2.5.6-2.fc39.ppc64le",
+      "evra": "2.5.7-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.1-8.fc39.ppc64le",
+      "evra": "2.5.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-54.fc39.ppc64le",
+      "evra": "0.1.1-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.1.0-4.fc39.ppc64le",
+      "evra": "2:1.2.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-1.fc39.ppc64le",
+      "evra": "0.12.2-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.48-9.fc39.ppc64le",
+      "evra": "2.69-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc39.ppc64le",
+      "evra": "0.8.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.10.2-2.fc39.ppc64le",
+      "evra": "0.11.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-54.fc39.ppc64le",
+      "evra": "0.7.0-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-2.fc39.ppc64le",
+      "evra": "1.47.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.2.1-4.fc39.ppc64le",
+      "evra": "8.6.0-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-26.fc39.ppc64le",
+      "evra": "0.14-29.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
-    "libdb": {
-      "evra": "5.3.28-56.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "libdb"
-      }
-    },
     "libdhash": {
-      "evra": "0.5.0-54.fc39.ppc64le",
+      "evra": "0.5.0-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libeconf": {
-      "evra": "0.5.2-2.fc39.ppc64le",
+      "evra": "0.6.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-48.20230828cvs.fc39.ppc64le",
+      "evra": "3.1-50.20230828cvs.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-9.fc39.ppc64le",
+      "evra": "2.1.12-12.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-4.fc39.ppc64le",
+      "evra": "3.4.4-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.13.0-3.fc39.ppc64le",
+      "evra": "1.14.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "13.2.1-7.fc39.ppc64le",
+      "evra": "14.0.1-0.15.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.2-2.fc39.ppc64le",
+      "evra": "1.10.3-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.47-2.fc39.ppc64le",
+      "evra": "1.48-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-2.fc39.ppc64le",
+      "evra": "238-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.8-1.fc39.ppc64le",
+      "evra": "0.4.8-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "46.0-4.fc39.ppc64le",
+      "evra": "48.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "73.2-2.fc39.ppc64le",
+      "evra": "74.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc39.ppc64le",
+      "evra": "2.3.7-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-54.fc39.ppc64le",
+      "evra": "1.3.1-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.1-1.fc39.ppc64le",
+      "evra": "0.2.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "13-1.fc39.ppc64le",
+      "evra": "13-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.4.0-7.fc39.ppc64le",
+      "evra": "1.4.0-10.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-7.fc39.ppc64le",
+      "evra": "1.4.0-10.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.4-2.fc39.ppc64le",
+      "evra": "1.6.6-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.8.0-1.fc39.ppc64le",
+      "evra": "2.9.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libldb"
       }
     },
     "libluksmeta": {
-      "evra": "9-16.fc39.ppc64le",
+      "evra": "9-22.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.9.1-1.fc39.ppc64le",
+      "evra": "1.9.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-2.fc39.ppc64le",
+      "evra": "1.1.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-3.fc39.ppc64le",
+      "evra": "1.0.5-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-5.fc39.ppc64le",
+      "evra": "2.15.0-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-6.fc39.ppc64le",
+      "evra": "1.8-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-1.fc39.ppc64le",
+      "evra": "1.3-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-2.fc39.ppc64le",
+      "evra": "1.0.9-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-24.fc39.ppc64le",
+      "evra": "1.0.1-27.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.6.4-0.rc6.fc39.ppc64le",
+      "evra": "1:2.6.4-0.rc6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-2.fc39.ppc64le",
+      "evra": "1.2.6-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.55.1-5.fc39.ppc64le",
+      "evra": "1.59.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.9.0-1.fc39.ppc64le",
+      "evra": "3.9.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.9.0-1.fc39.ppc64le",
+      "evra": "3.9.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.0-6.fc39.ppc64le",
+      "evra": "2.0.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.6-2.fc39.ppc64le",
+      "evra": "1.8-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-54.fc39.ppc64le",
+      "evra": "0.2.1-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.4-2.fc39.ppc64le",
+      "evra": "14:1.10.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "1.9.5-2.fc39.ppc64le",
+      "evra": "2.1.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.2-4.fc39.ppc64le",
+      "evra": "0.21.5-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-6.fc39.ppc64le",
+      "evra": "1.4.5-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-54.fc39.ppc64le",
+      "evra": "0.1.5-56.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.17.1-1.fc39.ppc64le",
+      "evra": "1.17.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-3.fc39.noarch",
+      "evra": "2.17.15-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "librtas": {
-      "evra": "2.0.4-3.fc39.ppc64le",
+      "evra": "2.0.5-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "librtas"
       }
     },
     "libseccomp": {
-      "evra": "2.5.3-6.fc39.ppc64le",
+      "evra": "2.5.3-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.5-5.fc39.ppc64le",
+      "evra": "3.6-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.5-5.fc39.ppc64le",
+      "evra": "3.6-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.5-4.fc39.ppc64le",
+      "evra": "3.6-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.5-2.fc39.ppc64le",
+      "evra": "3.6-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libservicelog": {
-      "evra": "1.1.19-8.fc39.ppc64le",
+      "evra": "1.1.19-10.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libservicelog"
       }
     },
-    "libsigsegv": {
-      "evra": "2.14-5.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "libsigsegv"
-      }
-    },
     "libslirp": {
-      "evra": "4.7.0-4.fc39.ppc64le",
+      "evra": "4.7.0-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.19.6-1.fc39.ppc64le",
+      "evra": "2:4.20.0-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.28-1.fc39.ppc64le",
+      "evra": "0.7.28-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-2.fc39.ppc64le",
+      "evra": "1.47.0-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "13.2.1-7.fc39.ppc64le",
+      "evra": "14.0.1-0.15.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.1-1.fc39.ppc64le",
+      "evra": "2.4.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-3.fc39.ppc64le",
+      "evra": "4.19.0-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.9-1.fc39.ppc64le",
+      "evra": "1.4.10-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-1.fc39.ppc64le",
+      "evra": "1.32-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.15.0-1.fc39.ppc64le",
+      "evra": "0.16.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.4-1.rc3.fc39.ppc64le",
+      "evra": "1.3.4-1.rc3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-7.fc39.ppc64le",
+      "evra": "2.4.7-10.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-5.fc39.ppc64le",
+      "evra": "1.1-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-1.fc39.ppc64le",
+      "evra": "1.0.27-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
-    "libuser": {
-      "evra": "0.64-4.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "libuser"
-      }
-    },
     "libutempter": {
-      "evra": "1.2.1-10.fc39.ppc64le",
+      "evra": "1.2.1-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.48.0-1.fc39.ppc64le",
+      "evra": "1:1.48.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-6.fc39.ppc64le",
+      "evra": "0.3.2-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.19.6-1.fc39.ppc64le",
+      "evra": "2:4.20.0-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-2.fc39.ppc64le",
+      "evra": "4.4.36-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.10.4-3.fc39.ppc64le",
+      "evra": "2.12.6-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.18-1.fc39.ppc64le",
+      "evra": "0.3.18-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-12.fc39.ppc64le",
+      "evra": "0.2.5-14.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc39.ppc64le",
+      "evra": "1.5.6-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
-    "linux-atm-libs": {
-      "evra": "2.5.1-36.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "linux-atm"
-      }
-    },
     "linux-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.32-1.fc39.ppc64le",
+      "evra": "0.9.32-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-4.fc39.ppc64le",
+      "evra": "3.21.0-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.96.3-4.fc39.ppc64le",
+      "evra": "4.98.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-3.fc39.ppc64le",
+      "evra": "5.4.6-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-16.fc39.ppc64le",
+      "evra": "9-22.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.23-1.fc39.ppc64le",
+      "evra": "2.03.23-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.23-1.fc39.ppc64le",
+      "evra": "2.03.23-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-4.fc39.ppc64le",
+      "evra": "1.9.4-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-9.fc39.ppc64le",
+      "evra": "2.10-12.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "mdadm": {
-      "evra": "4.2-6.fc39.ppc64le",
+      "evra": "4.2-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-1.fc39.ppc64le",
+      "evra": "24.0.5-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.0-3.fc39.ppc64le",
+      "evra": "4.2.1-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "mt7xxx-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nano": {
-      "evra": "7.2-4.fc39.ppc64le",
+      "evra": "7.2-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-4.fc39.noarch",
+      "evra": "7.2-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-7.20230520.fc39.1.ppc64le",
+      "evra": "6.4-12.20240127.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-7.20230520.fc39.1.noarch",
+      "evra": "6.4-12.20240127.fc40.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-7.20230520.fc39.1.ppc64le",
+      "evra": "6.4-12.20240127.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.67.20160912git.fc39.ppc64le",
+      "evra": "2.0-0.69.20160912git.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "1.10.3-1.fc39.ppc64le",
+      "evra": "1.10.3-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-2.fc39.ppc64le",
+      "evra": "3.9.1-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.23-4.fc39.ppc64le",
+      "evra": "0.52.24-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.4-0.rc6.fc39.ppc64le",
+      "evra": "1:2.6.4-0.rc6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.7-3.fc39.ppc64le",
+      "evra": "1:1.0.9-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.26-2.fc39.ppc64le",
+      "evra": "2.2.26-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.6-14.fc39.ppc64le",
+      "evra": "1.7-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-1.fc39.ppc64le",
+      "evra": "2.23.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-3.fc39.ppc64le",
+      "evra": "2.0.16-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.6-1.fc39.ppc64le",
+      "evra": "2.8-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "nxpwireless-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc39.ppc64le",
+      "evra": "6.9.9-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.6-1.fc39.ppc64le",
+      "evra": "2.6.7-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.3p1-10.fc39.ppc64le",
+      "evra": "9.6p1-1.fc40.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.3p1-10.fc39.ppc64le",
+      "evra": "9.6p1-1.fc40.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.3p1-10.fc39.ppc64le",
+      "evra": "9.6p1-1.fc40.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.1.1-4.fc39.ppc64le",
+      "evra": "1:3.2.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.1.1-4.fc39.ppc64le",
+      "evra": "1:3.2.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-4.fc39.ppc64le",
+      "evra": "1.81-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.5-1.fc39.ppc64le",
+      "evra": "2024.5-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-grub2": {
-      "evra": "2024.5-1.fc39.ppc64le",
+      "evra": "2024.5-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.5-1.fc39.ppc64le",
+      "evra": "2024.5-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.3-1.fc39.ppc64le",
+      "evra": "0.25.3-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.3-1.fc39.ppc64le",
+      "evra": "0.25.3-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.5.3-3.fc39.ppc64le",
+      "evra": "1.6.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.5.3-3.fc39.ppc64le",
+      "evra": "1.6.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
+    "passim-libs": {
+      "evra": "0.1.5-3.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "passim"
+      }
+    },
     "passt": {
-      "evra": "0^20240326.g4988e2b-1.fc39.ppc64le",
+      "evra": "0^20240326.g4988e2b-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240326.g4988e2b-1.fc39.noarch",
+      "evra": "0^20240326.g4988e2b-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
-    "passwd": {
-      "evra": "0.80-15.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "passwd"
-      }
-    },
     "pcre2": {
-      "evra": "10.42-1.fc39.2.ppc64le",
+      "evra": "10.42-2.fc40.2.ppc64le",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc39.2.noarch",
+      "evra": "10.42-2.fc40.2.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-2.fc39.ppc64le",
+      "evra": "2.8-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "1.9.5-2.fc39.ppc64le",
+      "evra": "2.1.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "1.9.5-2.fc39.noarch",
+      "evra": "2.1.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "1.9.5-2.fc39.ppc64le",
+      "evra": "2.1.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:4.9.4-1.fc39.ppc64le",
-      "metadata": {
-        "sourcerpm": "podman"
-      }
-    },
-    "podman-plugins": {
-      "evra": "5:4.9.4-1.fc39.ppc64le",
+      "evra": "5:5.0.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.5-8.fc39.ppc64le",
+      "evra": "3.6-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "123-1.fc39.1.ppc64le",
+      "evra": "124-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "123-1.fc39.1.ppc64le",
+      "evra": "124-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-26.fc39.ppc64le",
+      "evra": "0.1-28.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "polkit-pkla-compat"
       }
     },
     "popt": {
-      "evra": "1.19-3.fc39.ppc64le",
+      "evra": "1.19-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "powerpc-utils-core": {
-      "evra": "1.3.11-4.fc39.ppc64le",
+      "evra": "1.3.11-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "powerpc-utils"
       }
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.9-4.fc39.ppc64le",
+      "evra": "2.7.9-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "ppc64-diag"
       }
     },
     "procps-ng": {
-      "evra": "4.0.3-5.fc39.ppc64le",
+      "evra": "4.0.4-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.4.1-5.fc39.ppc64le",
+      "evra": "1.5.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-4.fc39.ppc64le",
+      "evra": "23.6-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-1.fc39.noarch",
+      "evra": "20240107-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.1.3-5.fc39.ppc64le",
+      "evra": "2:8.2.2-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-6.fc39.ppc64le",
+      "evra": "8.2-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "realtek-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc3.fc39.ppc64le",
+      "evra": "1.2.6-4.rc3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc39.ppc64le",
+      "evra": "4.19.1.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc39.ppc64le",
+      "evra": "4.19.1.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.4-6.fc39.ppc64le",
+      "evra": "2024.5-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.4-6.fc39.ppc64le",
+      "evra": "2024.5-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc39.ppc64le",
+      "evra": "4.19.1.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.6.0-1.fc39.ppc64le",
+      "evra": "1.6.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc39.ppc64le",
+      "evra": "3.3.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-1.fc39.ppc64le",
+      "evra": "2:1.1.12-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.19.6-1.fc39.ppc64le",
+      "evra": "2:4.20.0-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.19.6-1.fc39.noarch",
+      "evra": "2:4.20.0-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.19.6-1.fc39.ppc64le",
+      "evra": "2:4.20.0-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sed": {
-      "evra": "4.8-14.fc39.ppc64le",
+      "evra": "4.9-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "servicelog": {
-      "evra": "1.1.16-5.fc39.ppc64le",
+      "evra": "1.1.16-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "servicelog"
       }
     },
     "setup": {
-      "evra": "2.14.4-1.fc39.noarch",
+      "evra": "2.14.5-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.46-6.fc39.ppc64le",
+      "evra": "1.48-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.46-6.fc39.ppc64le",
+      "evra": "1.48-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.14.0-2.fc39.ppc64le",
+      "evra": "2:4.15.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.14.0-2.fc39.ppc64le",
+      "evra": "2:4.15.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.2-4.fc39.ppc64le",
+      "evra": "2.3-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.15.0-1.fc39.ppc64le",
+      "evra": "1:1.15.0-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-4.fc39.ppc64le",
+      "evra": "2.3.3-5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc39.ppc64le",
+      "evra": "1.2.2-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-2.fc39.ppc64le",
+      "evra": "1.1.10-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc39.ppc64le",
+      "evra": "1.8.0.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.42.0-7.fc39.ppc64le",
+      "evra": "3.45.1-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-2.fc39.ppc64le",
+      "evra": "4.6.1-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-4.fc39.ppc64le",
+      "evra": "0.1.4-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.4-1.fc39.ppc64le",
+      "evra": "2.9.4-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.1-1.fc39.ppc64le",
+      "evra": "1.19.1-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-1.p5.fc39.ppc64le",
+      "evra": "1.9.15-2.p5.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "254.10-1.fc39.ppc64le",
+      "evra": "255.4-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-2.fc39.ppc64le",
+      "evra": "2:1.35-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-1.fc39.ppc64le",
+      "evra": "1.32-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tiwilink-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.5-4.fc39.ppc64le",
+      "evra": "0.0.99.5-8.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.5-4.fc39.ppc64le",
+      "evra": "5.6-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.0.1-6.fc39.ppc64le",
+      "evra": "4.0.1-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.0.1-6.fc39.ppc64le",
+      "evra": "4.0.1-7.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-2.fc39.noarch",
+      "evra": "2024a-5.fc40.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-3.fc39.ppc64le",
+      "evra": "0.14.0-4.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.39.4-1.fc39.ppc64le",
+      "evra": "2.40-13.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.309-1.fc39.noarch",
+      "evra": "2:9.1.309-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.309-1.fc39.ppc64le",
+      "evra": "2:9.1.309-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.21-40.fc39.ppc64le",
+      "evra": "2.21-41.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-5.fc39.ppc64le",
+      "evra": "1.0.20210914-6.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.4.0-1.fc39.ppc64le",
+      "evra": "6.5.0-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc39.ppc64le",
+      "evra": "0.8.2-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "5.4.4-1.fc39.ppc64le",
+      "evra": "1:5.4.6-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "5.4.4-1.fc39.ppc64le",
+      "evra": "1:5.4.6-3.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-22.fc39.ppc64le",
+      "evra": "2.1.0-23.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.4.0-1.fc39.ppc64le",
+      "evra": "1.4.0-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-1.fc39.ppc64le",
+      "evra": "0.0.27-2.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
-    "zlib": {
-      "evra": "1.2.13-4.fc39.ppc64le",
+    "zlib-ng-compat": {
+      "evra": "2.1.6-2.fc40.ppc64le",
       "metadata": {
-        "sourcerpm": "zlib"
+        "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-8.fc39.ppc64le",
+      "evra": "1.1.2-9.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc39.ppc64le",
+      "evra": "1.5.6-1.fc40.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
@@ -2608,14 +2566,17 @@
   "metadata": {
     "generated": "2024-04-21T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-11-01T00:12:28Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-04-14T18:51:03Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-04-21T15:17:53Z"
+        "generated": "2024-04-21T12:46:11Z"
       },
-      "fedora-updates": {
-        "generated": "2024-04-21T01:11:44Z"
+      "fedora-next": {
+        "generated": "2024-04-19T08:53:27Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-04-21T01:00:17Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,2509 +1,2467 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.44.2-1.fc39.s390x",
+      "evra": "1:1.46.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.44.2-1.fc39.s390x",
+      "evra": "1:1.46.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.44.2-1.fc39.s390x",
+      "evra": "1:1.46.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.44.2-1.fc39.s390x",
+      "evra": "1:1.46.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.44.2-1.fc39.s390x",
+      "evra": "1:1.46.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.1.1-1.fc39.noarch",
+      "evra": "2.10.0.8-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "1.10.0-1.fc39.s390x",
+      "evra": "1.10.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.1-9.fc39.s390x",
+      "evra": "2.3.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-3.fc39.s390x",
+      "evra": "0.9.2-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.5.1-1.fc39.s390x",
+      "evra": "5.5.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.5.1-1.fc39.s390x",
+      "evra": "5.5.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.26-1.fc39.s390x",
+      "evra": "1.26-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "amd-ucode-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "atheros-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.1-8.fc39.s390x",
+      "evra": "2.5.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "3.1.2-8.fc39.s390x",
+      "evra": "4.0.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "3.1.2-8.fc39.s390x",
+      "evra": "4.0.1-1.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "audit"
+      }
+    },
+    "audit-rules": {
+      "evra": "4.0.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.4.3-1.fc39.s390x",
+      "evra": "1.5.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc39.s390x",
+      "evra": "1.5.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-24.fc39.s390x",
+      "evra": "0.8-26.fc40.s390x",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-18.fc39.noarch",
+      "evra": "11-20.fc40.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-1.fc39.s390x",
+      "evra": "5.2.26-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4-1.fc39.noarch",
+      "evra": "0.4.1-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-12.fc39.noarch",
+      "evra": "1:2.11-14.fc40.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.24-1.fc39.s390x",
+      "evra": "32:9.18.24-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-license": {
-      "evra": "32:9.18.24-1.fc39.noarch",
+      "evra": "32:9.18.24-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.24-1.fc39.s390x",
+      "evra": "32:9.18.24-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.18-2.fc39.s390x",
+      "evra": "0.2.18-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "brcmfmac-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "bsdtar": {
-      "evra": "3.7.1-1.fc39.s390x",
+      "evra": "3.7.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.8-1.fc39.s390x",
+      "evra": "6.8-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.8.0-1.fc39.s390x",
+      "evra": "0.8.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-16.fc39.s390x",
+      "evra": "1.0.8-18.fc40.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-16.fc39.s390x",
+      "evra": "1.0.8-18.fc40.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc39.s390x",
+      "evra": "1.28.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-2.fc39.noarch",
+      "evra": "2023.2.62_v7.0.401-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-18.fc39.s390x",
+      "evra": "0.1.7-22.fc40.s390x",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.5-1.fc39.s390x",
+      "evra": "4.5-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-2.fc39.s390x",
+      "evra": "7.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
-    "cirrus-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "clevis": {
-      "evra": "20-1.fc39.s390x",
+      "evra": "20-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-1.fc39.s390x",
+      "evra": "20-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-1.fc39.s390x",
+      "evra": "20-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
+    "clevis-pin-tpm2": {
+      "evra": "0.5.3-5.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "clevis-pin-tpm2"
+      }
+    },
     "clevis-systemd": {
-      "evra": "20-1.fc39.s390x",
+      "evra": "20-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc39.noarch",
+      "evra": "0.33-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc39.s390x",
+      "evra": "1.0.3-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc39.s390x",
+      "evra": "1.0.3-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.10-1.fc39.s390x",
+      "evra": "2:2.1.10-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.230.0-1.fc39.noarch",
+      "evra": "2:2.230.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-2.fc39.s390x",
+      "evra": "1.6.23-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
-    "containernetworking-plugins": {
-      "evra": "1.3.0-3.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "containernetworking-plugins"
-      }
-    },
     "containers-common": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.21.0-1.fc39.s390x",
+      "evra": "0.21.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.21.0-1.fc39.s390x",
+      "evra": "0.21.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.3-5.fc39.s390x",
+      "evra": "9.4-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.3-5.fc39.s390x",
+      "evra": "9.4-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.14-4.fc39.s390x",
+      "evra": "2.15-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-2.fc39.s390x",
+      "evra": "2.9.11-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "3.19-2.fc39.s390x",
+      "evra": "3.19-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "3.19-2.fc39.s390x",
+      "evra": "3.19-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.14.4-1.fc39.s390x",
+      "evra": "1.14.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20231204-1.git1e3a2e4.fc39.noarch",
+      "evra": "20240201-2.git9f501f3.fc40.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.6.1-3.fc39.s390x",
+      "evra": "2.7.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-3.fc39.s390x",
+      "evra": "2.7.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.2.1-4.fc39.s390x",
+      "evra": "8.6.0-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-11.fc39.s390x",
+      "evra": "2.1.28-19.fc40.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-11.fc39.s390x",
+      "evra": "2.1.28-19.fc40.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc39.s390x",
+      "evra": "1:1.14.10-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "35-2.fc39.s390x",
+      "evra": "36-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc39.noarch",
+      "evra": "1:1.14.10-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc39.s390x",
+      "evra": "1:1.14.10-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.197-1.fc39.s390x",
+      "evra": "1.02.197-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.197-1.fc39.s390x",
+      "evra": "1.02.197-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.197-1.fc39.s390x",
+      "evra": "1.02.197-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.197-1.fc39.s390x",
+      "evra": "1.02.197-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.5-2.fc39.s390x",
+      "evra": "0.9.7-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.5-2.fc39.s390x",
+      "evra": "0.9.7-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc39.s390x",
+      "evra": "1.0.12-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-3.fc39.s390x",
+      "evra": "3.10-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-1.fc39.s390x",
+      "evra": "2.90-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "dosfstools": {
-      "evra": "4.2-7.fc39.s390x",
+      "evra": "4.2-11.fc40.s390x",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "059-16.fc39.s390x",
+      "evra": "060-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "059-16.fc39.s390x",
+      "evra": "060-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "059-16.fc39.s390x",
+      "evra": "060-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-5.fc39.s390x",
+      "evra": "2.7.0-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-2.fc39.s390x",
+      "evra": "1.47.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-2.fc39.s390x",
+      "evra": "1.47.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-2.fc39.noarch",
+      "evra": "0.191-4.fc40.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-2.fc39.s390x",
+      "evra": "0.191-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-2.fc39.s390x",
+      "evra": "0.191-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.7-1.fc39.s390x",
+      "evra": "2:6.7-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.2-1.fc39.s390x",
+      "evra": "2.6.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.44-5.fc39.s390x",
+      "evra": "5.45-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.44-5.fc39.s390x",
+      "evra": "5.45-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-6.fc39.s390x",
+      "evra": "3.18-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-5.fc39.s390x",
+      "evra": "1:4.9.0-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.6-1.fc39.s390x",
+      "evra": "1.15.8-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-8.fc39.s390x",
+      "evra": "0.6.1-10.fc40.s390x",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse": {
-      "evra": "2.9.9-17.fc39.s390x",
+      "evra": "2.9.9-21.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-common": {
-      "evra": "3.16.1-1.fc39.s390x",
+      "evra": "3.16.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse-libs": {
-      "evra": "2.9.9-17.fc39.s390x",
+      "evra": "2.9.9-21.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc39.s390x",
+      "evra": "1.13-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc39.s390x",
+      "evra": "3.7.3-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.1-1.fc39.s390x",
+      "evra": "3.16.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.1-1.fc39.s390x",
+      "evra": "3.16.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.16-1.fc39.s390x",
+      "evra": "1.9.16-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.2.2-2.fc39.s390x",
+      "evra": "5.3.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
+    "gdbm": {
+      "evra": "1:1.23-6.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "gdbm"
+      }
+    },
     "gdbm-libs": {
-      "evra": "1:1.23-4.fc39.s390x",
+      "evra": "1:1.23-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc39.s390x",
+      "evra": "1.0.10-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "git-core": {
-      "evra": "2.44.0-1.fc39.s390x",
+      "evra": "2.44.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.78.3-1.fc39.s390x",
+      "evra": "2.80.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.38-18.fc39.s390x",
+      "evra": "2.39-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.38-18.fc39.s390x",
+      "evra": "2.39-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.38-18.fc39.s390x",
+      "evra": "2.39-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.38-18.fc39.s390x",
+      "evra": "2.39-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-5.fc39.s390x",
+      "evra": "1:6.2.1-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc39.s390x",
+      "evra": "2.4.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.5-1.fc39.s390x",
+      "evra": "3.8.5-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.20.0-5.fc39.s390x",
+      "evra": "1.23.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-3.fc39.s390x",
+      "evra": "3.11-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.3-1.fc39.s390x",
+      "evra": "6:0.7.3-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "gvisor-tap-vsock"
       }
     },
     "gzip": {
-      "evra": "1.12-6.fc39.s390x",
+      "evra": "1.13-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-9.fc39.s390x",
+      "evra": "3.23-12.fc40.s390x",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "ignition": {
-      "evra": "2.18.0-1.fc39.s390x",
+      "evra": "2.18.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc39.s390x",
+      "evra": "58-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
-    "intel-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "intel-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-2.fc39.s390x",
+      "evra": "1.0.3-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.4.0-2.fc39.s390x",
+      "evra": "6.7.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.4.0-2.fc39.s390x",
+      "evra": "6.7.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.9-5.fc39.s390x",
+      "evra": "1.8.10-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-5.fc39.s390x",
+      "evra": "1.8.10-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.9-5.fc39.s390x",
+      "evra": "1.8.10-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.9-5.fc39.s390x",
+      "evra": "1.8.10-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.9-5.fc39.noarch",
+      "evra": "1.8.10-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.9-5.fc39.s390x",
+      "evra": "1.8.10-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20221126-4.fc39.s390x",
+      "evra": "20240117-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.s390x",
+      "evra": "6.2.1.9-20.gita65a472.fc40.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.s390x",
+      "evra": "6.2.1.9-20.gita65a472.fc40.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-7.fc39.s390x",
+      "evra": "0.101-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-7.fc39.s390x",
+      "evra": "2.13.1-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-4.fc39.s390x",
+      "evra": "5.3.0-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "13-1.fc39.s390x",
+      "evra": "13-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.6-17.fc39.s390x",
+      "evra": "1.7.1-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-1.fc39.s390x",
+      "evra": "0.17-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-1.fc39.s390x",
+      "evra": "1.8.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.3-1.fc39.s390x",
+      "evra": "2.6.4-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kernel": {
-      "evra": "6.8.6-200.fc39.s390x",
+      "evra": "6.8.7-300.fc40.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.8.6-200.fc39.s390x",
+      "evra": "6.8.7-300.fc40.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.8.6-200.fc39.s390x",
+      "evra": "6.8.7-300.fc40.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.8.6-200.fc39.s390x",
+      "evra": "6.8.7-300.fc40.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.27-4.fc39.s390x",
+      "evra": "2.0.28-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-1.fc39.s390x",
+      "evra": "1.6.3-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-1.fc39.s390x",
+      "evra": "1.6.3-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "30-6.fc39.s390x",
+      "evra": "31-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "30-6.fc39.s390x",
+      "evra": "31-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.5-2.fc39.s390x",
+      "evra": "0.9.7-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.2-3.fc39.s390x",
+      "evra": "1.21.2-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "633-2.fc39.s390x",
+      "evra": "643-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.1-9.fc39.s390x",
+      "evra": "2.3.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-16.fc39.s390x",
+      "evra": "0.3.111-19.fc40.s390x",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.1-1.fc39.s390x",
+      "evra": "3.7.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
-    "libargon2": {
-      "evra": "20190702-3.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "argon2"
-      }
-    },
     "libassuan": {
-      "evra": "2.5.6-2.fc39.s390x",
+      "evra": "2.5.7-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.1-8.fc39.s390x",
+      "evra": "2.5.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-54.fc39.s390x",
+      "evra": "0.1.1-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.1.0-4.fc39.s390x",
+      "evra": "2:1.2.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-1.fc39.s390x",
+      "evra": "0.12.2-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.48-9.fc39.s390x",
+      "evra": "2.69-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc39.s390x",
+      "evra": "0.8.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.10.2-2.fc39.s390x",
+      "evra": "0.11.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-54.fc39.s390x",
+      "evra": "0.7.0-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-2.fc39.s390x",
+      "evra": "1.47.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.2.1-4.fc39.s390x",
+      "evra": "8.6.0-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-26.fc39.s390x",
+      "evra": "0.14-29.fc40.s390x",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
-    "libdb": {
-      "evra": "5.3.28-56.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "libdb"
-      }
-    },
     "libdhash": {
-      "evra": "0.5.0-54.fc39.s390x",
+      "evra": "0.5.0-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libeconf": {
-      "evra": "0.5.2-2.fc39.s390x",
+      "evra": "0.6.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-48.20230828cvs.fc39.s390x",
+      "evra": "3.1-50.20230828cvs.fc40.s390x",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-9.fc39.s390x",
+      "evra": "2.1.12-12.fc40.s390x",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-4.fc39.s390x",
+      "evra": "3.4.4-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.13.0-3.fc39.s390x",
+      "evra": "1.14.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "13.2.1-7.fc39.s390x",
+      "evra": "14.0.1-0.15.fc40.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.2-2.fc39.s390x",
+      "evra": "1.10.3-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.47-2.fc39.s390x",
+      "evra": "1.48-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-2.fc39.s390x",
+      "evra": "238-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.8-1.fc39.s390x",
+      "evra": "0.4.8-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "46.0-4.fc39.s390x",
+      "evra": "48.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "73.2-2.fc39.s390x",
+      "evra": "74.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc39.s390x",
+      "evra": "2.3.7-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-54.fc39.s390x",
+      "evra": "1.3.1-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.1-1.fc39.s390x",
+      "evra": "0.2.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "13-1.fc39.s390x",
+      "evra": "13-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.4.0-7.fc39.s390x",
+      "evra": "1.4.0-10.fc40.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-7.fc39.s390x",
+      "evra": "1.4.0-10.fc40.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.4-2.fc39.s390x",
+      "evra": "1.6.6-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.8.0-1.fc39.s390x",
+      "evra": "2.9.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libldb"
       }
     },
     "libluksmeta": {
-      "evra": "9-16.fc39.s390x",
+      "evra": "9-22.fc40.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.9.1-1.fc39.s390x",
+      "evra": "1.9.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-2.fc39.s390x",
+      "evra": "1.1.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-3.fc39.s390x",
+      "evra": "1.0.5-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-5.fc39.s390x",
+      "evra": "2.15.0-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-6.fc39.s390x",
+      "evra": "1.8-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-1.fc39.s390x",
+      "evra": "1.3-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-2.fc39.s390x",
+      "evra": "1.0.9-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-24.fc39.s390x",
+      "evra": "1.0.1-27.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.6.4-0.rc6.fc39.s390x",
+      "evra": "1:2.6.4-0.rc6.fc40.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-2.fc39.s390x",
+      "evra": "1.2.6-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.55.1-5.fc39.s390x",
+      "evra": "1.59.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.9.0-1.fc39.s390x",
+      "evra": "3.9.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.9.0-1.fc39.s390x",
+      "evra": "3.9.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.0-6.fc39.s390x",
+      "evra": "2.0.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.6-2.fc39.s390x",
+      "evra": "1.8-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-54.fc39.s390x",
+      "evra": "0.2.1-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.4-2.fc39.s390x",
+      "evra": "14:1.10.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "1.9.5-2.fc39.s390x",
+      "evra": "2.1.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.2-4.fc39.s390x",
+      "evra": "0.21.5-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-6.fc39.s390x",
+      "evra": "1.4.5-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-54.fc39.s390x",
+      "evra": "0.1.5-56.fc40.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.17.1-1.fc39.s390x",
+      "evra": "1.17.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-3.fc39.noarch",
+      "evra": "2.17.15-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.3-6.fc39.s390x",
+      "evra": "2.5.3-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.5-5.fc39.s390x",
+      "evra": "3.6-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.5-5.fc39.s390x",
+      "evra": "3.6-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.5-4.fc39.s390x",
+      "evra": "3.6-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.5-2.fc39.s390x",
+      "evra": "3.6-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
-    "libsigsegv": {
-      "evra": "2.14-5.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "libsigsegv"
-      }
-    },
     "libslirp": {
-      "evra": "4.7.0-4.fc39.s390x",
+      "evra": "4.7.0-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.19.6-1.fc39.s390x",
+      "evra": "2:4.20.0-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.28-1.fc39.s390x",
+      "evra": "0.7.28-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-2.fc39.s390x",
+      "evra": "1.47.0-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "13.2.1-7.fc39.s390x",
+      "evra": "14.0.1-0.15.fc40.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.1-1.fc39.s390x",
+      "evra": "2.4.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-3.fc39.s390x",
+      "evra": "4.19.0-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.9-1.fc39.s390x",
+      "evra": "1.4.10-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-1.fc39.s390x",
+      "evra": "1.32-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.15.0-1.fc39.s390x",
+      "evra": "0.16.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.4-1.rc3.fc39.s390x",
+      "evra": "1.3.4-1.rc3.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-7.fc39.s390x",
+      "evra": "2.4.7-10.fc40.s390x",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-5.fc39.s390x",
+      "evra": "1.1-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-1.fc39.s390x",
+      "evra": "1.0.27-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
-    "libuser": {
-      "evra": "0.64-4.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "libuser"
-      }
-    },
     "libutempter": {
-      "evra": "1.2.1-10.fc39.s390x",
+      "evra": "1.2.1-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.48.0-1.fc39.s390x",
+      "evra": "1:1.48.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-6.fc39.s390x",
+      "evra": "0.3.2-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.19.6-1.fc39.s390x",
+      "evra": "2:4.20.0-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-2.fc39.s390x",
+      "evra": "4.4.36-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.10.4-3.fc39.s390x",
+      "evra": "2.12.6-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.18-1.fc39.s390x",
+      "evra": "0.3.18-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-12.fc39.s390x",
+      "evra": "0.2.5-14.fc40.s390x",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc39.s390x",
+      "evra": "1.5.6-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
-    "linux-atm-libs": {
-      "evra": "2.5.1-36.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "linux-atm"
-      }
-    },
     "linux-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.32-1.fc39.s390x",
+      "evra": "0.9.32-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-4.fc39.s390x",
+      "evra": "3.21.0-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.96.3-4.fc39.s390x",
+      "evra": "4.98.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-3.fc39.s390x",
+      "evra": "5.4.6-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-16.fc39.s390x",
+      "evra": "9-22.fc40.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.23-1.fc39.s390x",
+      "evra": "2.03.23-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.23-1.fc39.s390x",
+      "evra": "2.03.23-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-4.fc39.s390x",
+      "evra": "1.9.4-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-9.fc39.s390x",
+      "evra": "2.10-12.fc40.s390x",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "mdadm": {
-      "evra": "4.2-6.fc39.s390x",
+      "evra": "4.2-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-1.fc39.s390x",
+      "evra": "24.0.5-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.0-3.fc39.s390x",
+      "evra": "4.2.1-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "mt7xxx-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nano": {
-      "evra": "7.2-4.fc39.s390x",
+      "evra": "7.2-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-4.fc39.noarch",
+      "evra": "7.2-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-7.20230520.fc39.1.s390x",
+      "evra": "6.4-12.20240127.fc40.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-7.20230520.fc39.1.noarch",
+      "evra": "6.4-12.20240127.fc40.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-7.20230520.fc39.1.s390x",
+      "evra": "6.4-12.20240127.fc40.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.67.20160912git.fc39.s390x",
+      "evra": "2.0-0.69.20160912git.fc40.s390x",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "1.10.3-1.fc39.s390x",
+      "evra": "1.10.3-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-2.fc39.s390x",
+      "evra": "3.9.1-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.23-4.fc39.s390x",
+      "evra": "0.52.24-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.4-0.rc6.fc39.s390x",
+      "evra": "1:2.6.4-0.rc6.fc40.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.7-3.fc39.s390x",
+      "evra": "1:1.0.9-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.26-2.fc39.s390x",
+      "evra": "2.2.26-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.6-14.fc39.s390x",
+      "evra": "1.7-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-1.fc39.s390x",
+      "evra": "2.23.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.6-1.fc39.s390x",
+      "evra": "2.8-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "nxpwireless-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc39.s390x",
+      "evra": "6.9.9-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.6-1.fc39.s390x",
+      "evra": "2.6.7-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.3p1-10.fc39.s390x",
+      "evra": "9.6p1-1.fc40.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.3p1-10.fc39.s390x",
+      "evra": "9.6p1-1.fc40.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.3p1-10.fc39.s390x",
+      "evra": "9.6p1-1.fc40.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.1.1-4.fc39.s390x",
+      "evra": "1:3.2.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.1.1-4.fc39.s390x",
+      "evra": "1:3.2.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "ostree": {
-      "evra": "2024.5-1.fc39.s390x",
+      "evra": "2024.5-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.5-1.fc39.s390x",
+      "evra": "2024.5-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.3-1.fc39.s390x",
+      "evra": "0.25.3-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.3-1.fc39.s390x",
+      "evra": "0.25.3-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.5.3-3.fc39.s390x",
+      "evra": "1.6.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.5.3-3.fc39.s390x",
+      "evra": "1.6.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
+    "passim-libs": {
+      "evra": "0.1.5-3.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "passim"
+      }
+    },
     "passt": {
-      "evra": "0^20240326.g4988e2b-1.fc39.s390x",
+      "evra": "0^20240326.g4988e2b-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240326.g4988e2b-1.fc39.noarch",
+      "evra": "0^20240326.g4988e2b-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
-    "passwd": {
-      "evra": "0.80-15.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "passwd"
-      }
-    },
     "pcre2": {
-      "evra": "10.42-1.fc39.2.s390x",
+      "evra": "10.42-2.fc40.2.s390x",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc39.2.noarch",
+      "evra": "10.42-2.fc40.2.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-2.fc39.s390x",
+      "evra": "2.8-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "1.9.5-2.fc39.s390x",
+      "evra": "2.1.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "1.9.5-2.fc39.noarch",
+      "evra": "2.1.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "1.9.5-2.fc39.s390x",
+      "evra": "2.1.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:4.9.4-1.fc39.s390x",
-      "metadata": {
-        "sourcerpm": "podman"
-      }
-    },
-    "podman-plugins": {
-      "evra": "5:4.9.4-1.fc39.s390x",
+      "evra": "5:5.0.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.5-8.fc39.s390x",
+      "evra": "3.6-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "123-1.fc39.1.s390x",
+      "evra": "124-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "123-1.fc39.1.s390x",
+      "evra": "124-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-26.fc39.s390x",
+      "evra": "0.1-28.fc40.s390x",
       "metadata": {
         "sourcerpm": "polkit-pkla-compat"
       }
     },
     "popt": {
-      "evra": "1.19-3.fc39.s390x",
+      "evra": "1.19-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.3-5.fc39.s390x",
+      "evra": "4.0.4-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.4.1-5.fc39.s390x",
+      "evra": "1.5.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-4.fc39.s390x",
+      "evra": "23.6-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-1.fc39.noarch",
+      "evra": "20240107-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.1.3-5.fc39.s390x",
+      "evra": "2:8.2.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-6.fc39.s390x",
+      "evra": "8.2-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "realtek-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc3.fc39.s390x",
+      "evra": "1.2.6-4.rc3.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc39.s390x",
+      "evra": "4.19.1.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc39.s390x",
+      "evra": "4.19.1.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.4-6.fc39.s390x",
+      "evra": "2024.5-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.4-6.fc39.s390x",
+      "evra": "2024.5-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc39.s390x",
+      "evra": "4.19.1.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.6.0-1.fc39.s390x",
+      "evra": "1.6.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc39.s390x",
+      "evra": "3.3.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-1.fc39.s390x",
+      "evra": "2:1.1.12-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "s390utils-core": {
-      "evra": "2:2.29.0-4.fc39.s390x",
+      "evra": "2:2.31.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "s390utils"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.19.6-1.fc39.s390x",
+      "evra": "2:4.20.0-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.19.6-1.fc39.noarch",
+      "evra": "2:4.20.0-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.19.6-1.fc39.s390x",
+      "evra": "2:4.20.0-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sed": {
-      "evra": "4.8-14.fc39.s390x",
+      "evra": "4.9-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.4-1.fc39.noarch",
+      "evra": "2.14.5-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.46-6.fc39.s390x",
+      "evra": "1.48-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.46-6.fc39.s390x",
+      "evra": "1.48-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.14.0-2.fc39.s390x",
+      "evra": "2:4.15.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.14.0-2.fc39.s390x",
+      "evra": "2:4.15.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.2-4.fc39.s390x",
+      "evra": "2.3-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.15.0-1.fc39.s390x",
+      "evra": "1:1.15.0-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-4.fc39.s390x",
+      "evra": "2.3.3-5.fc40.s390x",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc39.s390x",
+      "evra": "1.2.2-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-2.fc39.s390x",
+      "evra": "1.1.10-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc39.s390x",
+      "evra": "1.8.0.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.42.0-7.fc39.s390x",
+      "evra": "3.45.1-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-2.fc39.s390x",
+      "evra": "4.6.1-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-4.fc39.s390x",
+      "evra": "0.1.4-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.4-1.fc39.s390x",
+      "evra": "2.9.4-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.1-1.fc39.s390x",
+      "evra": "1.19.1-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-1.p5.fc39.s390x",
+      "evra": "1.9.15-2.p5.fc40.s390x",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "254.10-1.fc39.s390x",
+      "evra": "255.4-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-2.fc39.s390x",
+      "evra": "2:1.35-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-1.fc39.s390x",
+      "evra": "1.32-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tiwilink-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.5-4.fc39.s390x",
+      "evra": "0.0.99.5-8.fc40.s390x",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.5-4.fc39.s390x",
+      "evra": "5.6-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.0.1-6.fc39.s390x",
+      "evra": "4.0.1-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.0.1-6.fc39.s390x",
+      "evra": "4.0.1-7.fc40.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-2.fc39.noarch",
+      "evra": "2024a-5.fc40.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-3.fc39.s390x",
+      "evra": "0.14.0-4.fc40.s390x",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.39.4-1.fc39.s390x",
+      "evra": "2.40-13.fc40.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "veritysetup": {
-      "evra": "2.6.1-3.fc39.s390x",
+      "evra": "2.7.2-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.309-1.fc39.noarch",
+      "evra": "2:9.1.309-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.309-1.fc39.s390x",
+      "evra": "2:9.1.309-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.21-40.fc39.s390x",
+      "evra": "2.21-41.fc40.s390x",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-5.fc39.s390x",
+      "evra": "1.0.20210914-6.fc40.s390x",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.4.0-1.fc39.s390x",
+      "evra": "6.5.0-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc39.s390x",
+      "evra": "0.8.2-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "5.4.4-1.fc39.s390x",
+      "evra": "1:5.4.6-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "5.4.4-1.fc39.s390x",
+      "evra": "1:5.4.6-3.fc40.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-22.fc39.s390x",
+      "evra": "2.1.0-23.fc40.s390x",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.4.0-1.fc39.s390x",
+      "evra": "1.4.0-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-1.fc39.s390x",
+      "evra": "0.0.27-2.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
-    "zlib": {
-      "evra": "1.2.13-4.fc39.s390x",
+    "zlib-ng-compat": {
+      "evra": "2.1.6-2.fc40.s390x",
       "metadata": {
-        "sourcerpm": "zlib"
+        "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-8.fc39.s390x",
+      "evra": "1.1.2-9.fc40.s390x",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc39.s390x",
+      "evra": "1.5.6-1.fc40.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
@@ -2512,14 +2470,17 @@
   "metadata": {
     "generated": "2024-04-21T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-11-01T00:12:19Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-04-14T18:51:01Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-04-21T15:17:00Z"
+        "generated": "2024-04-21T12:46:08Z"
       },
-      "fedora-updates": {
-        "generated": "2024-04-21T01:11:53Z"
+      "fedora-next": {
+        "generated": "2024-04-19T08:53:24Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-04-21T01:00:19Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,2311 +1,2275 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.44.2-1.fc39.x86_64",
+      "evra": "1:1.46.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.44.2-1.fc39.x86_64",
+      "evra": "1:1.46.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.44.2-1.fc39.x86_64",
+      "evra": "1:1.46.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.44.2-1.fc39.x86_64",
+      "evra": "1:1.46.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.44.2-1.fc39.x86_64",
+      "evra": "1:1.46.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.9.1.1-1.fc39.noarch",
+      "evra": "2.10.0.8-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "1.10.0-1.fc39.x86_64",
+      "evra": "1.10.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.1-9.fc39.x86_64",
+      "evra": "2.3.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-3.fc39.x86_64",
+      "evra": "0.9.2-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.5.1-1.fc39.x86_64",
+      "evra": "5.5.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.5.1-1.fc39.x86_64",
+      "evra": "5.5.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.26-1.fc39.x86_64",
+      "evra": "1.26-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "amd-ucode-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "atheros-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.1-8.fc39.x86_64",
+      "evra": "2.5.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "3.1.2-8.fc39.x86_64",
+      "evra": "4.0.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "3.1.2-8.fc39.x86_64",
+      "evra": "4.0.1-1.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "audit"
+      }
+    },
+    "audit-rules": {
+      "evra": "4.0.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.4.3-1.fc39.x86_64",
+      "evra": "1.5.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.4.3-1.fc39.x86_64",
+      "evra": "1.5.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-24.fc39.x86_64",
+      "evra": "0.8-26.fc40.x86_64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-18.fc39.noarch",
+      "evra": "11-20.fc40.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-1.fc39.x86_64",
+      "evra": "5.2.26-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4-1.fc39.noarch",
+      "evra": "0.4.1-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-12.fc39.noarch",
+      "evra": "1:2.11-14.fc40.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.24-1.fc39.x86_64",
+      "evra": "32:9.18.24-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-license": {
-      "evra": "32:9.18.24-1.fc39.noarch",
+      "evra": "32:9.18.24-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.24-1.fc39.x86_64",
+      "evra": "32:9.18.24-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.18-2.fc39.x86_64",
+      "evra": "0.2.18-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "brcmfmac-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "bsdtar": {
-      "evra": "3.7.1-1.fc39.x86_64",
+      "evra": "3.7.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.8-1.fc39.x86_64",
+      "evra": "6.8-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.8.0-1.fc39.x86_64",
+      "evra": "0.8.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-16.fc39.x86_64",
+      "evra": "1.0.8-18.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-16.fc39.x86_64",
+      "evra": "1.0.8-18.fc40.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc39.x86_64",
+      "evra": "1.28.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2023.2.60_v7.0.306-2.fc39.noarch",
+      "evra": "2023.2.62_v7.0.401-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-18.fc39.x86_64",
+      "evra": "0.1.7-22.fc40.x86_64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.5-1.fc39.x86_64",
+      "evra": "4.5-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-2.fc39.x86_64",
+      "evra": "7.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
-    "cirrus-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "clevis": {
-      "evra": "20-1.fc39.x86_64",
+      "evra": "20-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-1.fc39.x86_64",
+      "evra": "20-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-1.fc39.x86_64",
+      "evra": "20-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
+    "clevis-pin-tpm2": {
+      "evra": "0.5.3-5.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "clevis-pin-tpm2"
+      }
+    },
     "clevis-systemd": {
-      "evra": "20-1.fc39.x86_64",
+      "evra": "20-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-3.fc39.noarch",
+      "evra": "0.33-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc39.x86_64",
+      "evra": "1.0.3-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc39.x86_64",
+      "evra": "1.0.3-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.10-1.fc39.x86_64",
+      "evra": "2:2.1.10-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-6.fc39.noarch",
+      "evra": "0.21.3-8.fc40.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.230.0-1.fc39.noarch",
+      "evra": "2:2.230.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-2.fc39.x86_64",
+      "evra": "1.6.23-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
-    "containernetworking-plugins": {
-      "evra": "1.3.0-3.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "containernetworking-plugins"
-      }
-    },
     "containers-common": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "4:1-99.fc39.noarch",
+      "evra": "5:0.58.0-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.21.0-1.fc39.x86_64",
+      "evra": "0.21.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.21.0-1.fc39.x86_64",
+      "evra": "0.21.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.3-5.fc39.x86_64",
+      "evra": "9.4-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.3-5.fc39.x86_64",
+      "evra": "9.4-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.14-4.fc39.x86_64",
+      "evra": "2.15-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-2.fc39.x86_64",
+      "evra": "2.9.11-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "3.19-2.fc39.x86_64",
+      "evra": "3.19-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "3.19-2.fc39.x86_64",
+      "evra": "3.19-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.14.4-1.fc39.x86_64",
+      "evra": "1.14.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.14.4-1.fc39.x86_64",
+      "evra": "1.14.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20231204-1.git1e3a2e4.fc39.noarch",
+      "evra": "20240201-2.git9f501f3.fc40.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.6.1-3.fc39.x86_64",
+      "evra": "2.7.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.6.1-3.fc39.x86_64",
+      "evra": "2.7.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.2.1-4.fc39.x86_64",
+      "evra": "8.6.0-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-11.fc39.x86_64",
+      "evra": "2.1.28-19.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-11.fc39.x86_64",
+      "evra": "2.1.28-19.fc40.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-1.fc39.x86_64",
+      "evra": "1:1.14.10-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "35-2.fc39.x86_64",
+      "evra": "36-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-1.fc39.noarch",
+      "evra": "1:1.14.10-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-1.fc39.x86_64",
+      "evra": "1:1.14.10-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.197-1.fc39.x86_64",
+      "evra": "1.02.197-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.197-1.fc39.x86_64",
+      "evra": "1.02.197-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.197-1.fc39.x86_64",
+      "evra": "1.02.197-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.197-1.fc39.x86_64",
+      "evra": "1.02.197-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.5-2.fc39.x86_64",
+      "evra": "0.9.7-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.5-2.fc39.x86_64",
+      "evra": "0.9.7-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc39.x86_64",
+      "evra": "1.0.12-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-3.fc39.x86_64",
+      "evra": "3.10-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-1.fc39.x86_64",
+      "evra": "2.90-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "dosfstools": {
-      "evra": "4.2-7.fc39.x86_64",
+      "evra": "4.2-11.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "059-16.fc39.x86_64",
+      "evra": "060-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "059-16.fc39.x86_64",
+      "evra": "060-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "059-16.fc39.x86_64",
+      "evra": "060-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-5.fc39.x86_64",
+      "evra": "2.7.0-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-2.fc39.x86_64",
+      "evra": "1.47.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-2.fc39.x86_64",
+      "evra": "1.47.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "5-9.fc39.noarch",
+      "evra": "5-11.fc40.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-4.fc39.x86_64",
+      "evra": "18-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-1.fc39.x86_64",
+      "evra": "39-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-2.fc39.noarch",
+      "evra": "0.191-4.fc40.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-2.fc39.x86_64",
+      "evra": "0.191-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-2.fc39.x86_64",
+      "evra": "0.191-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.7-1.fc39.x86_64",
+      "evra": "2:6.7-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.2-1.fc39.x86_64",
+      "evra": "2.6.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "39-36.noarch",
+      "evra": "40-39.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "39-1.noarch",
+      "evra": "40-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.44-5.fc39.x86_64",
+      "evra": "5.45-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.44-5.fc39.x86_64",
+      "evra": "5.45-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-6.fc39.x86_64",
+      "evra": "3.18-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-5.fc39.x86_64",
+      "evra": "1:4.9.0-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.6-1.fc39.x86_64",
+      "evra": "1.15.8-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "10.0.0-3.fc39.x86_64",
+      "evra": "10.2.1-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-8.fc39.x86_64",
+      "evra": "0.6.1-10.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse": {
-      "evra": "2.9.9-17.fc39.x86_64",
+      "evra": "2.9.9-21.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-common": {
-      "evra": "3.16.1-1.fc39.x86_64",
+      "evra": "3.16.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse-libs": {
-      "evra": "2.9.9-17.fc39.x86_64",
+      "evra": "2.9.9-21.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse"
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc39.x86_64",
+      "evra": "1.13-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc39.x86_64",
+      "evra": "3.7.3-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.1-1.fc39.x86_64",
+      "evra": "3.16.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.1-1.fc39.x86_64",
+      "evra": "3.16.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.16-1.fc39.x86_64",
+      "evra": "1.9.16-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.2.2-2.fc39.x86_64",
+      "evra": "5.3.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
+    "gdbm": {
+      "evra": "1:1.23-6.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "gdbm"
+      }
+    },
     "gdbm-libs": {
-      "evra": "1:1.23-4.fc39.x86_64",
+      "evra": "1:1.23-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc39.x86_64",
+      "evra": "1.0.10-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22-2.fc39.x86_64",
+      "evra": "0.22.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22-2.fc39.x86_64",
+      "evra": "0.22.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22-2.fc39.x86_64",
+      "evra": "0.22.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.44.0-1.fc39.x86_64",
+      "evra": "2.44.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.78.3-1.fc39.x86_64",
+      "evra": "2.80.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.38-18.fc39.x86_64",
+      "evra": "2.39-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.38-18.fc39.x86_64",
+      "evra": "2.39-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.38-18.fc39.x86_64",
+      "evra": "2.39-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.38-18.fc39.x86_64",
+      "evra": "2.39-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-5.fc39.x86_64",
+      "evra": "1:6.2.1-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc39.x86_64",
+      "evra": "2.4.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.5-1.fc39.x86_64",
+      "evra": "3.8.5-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20230929.00-1.fc39.noarch",
+      "evra": "20240307.00-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.20.0-5.fc39.x86_64",
+      "evra": "1.23.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-3.fc39.x86_64",
+      "evra": "3.11-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-118.fc39.noarch",
+      "evra": "1:2.06-119.fc40.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-118.fc39.x86_64",
+      "evra": "1:2.06-119.fc40.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc": {
-      "evra": "1:2.06-118.fc39.x86_64",
+      "evra": "1:2.06-119.fc40.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-118.fc39.noarch",
+      "evra": "1:2.06-119.fc40.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-118.fc39.x86_64",
+      "evra": "1:2.06-119.fc40.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-118.fc39.x86_64",
+      "evra": "1:2.06-119.fc40.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.3-1.fc39.x86_64",
+      "evra": "6:0.7.3-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gvisor-tap-vsock"
       }
     },
     "gzip": {
-      "evra": "1.12-6.fc39.x86_64",
+      "evra": "1.13-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-9.fc39.x86_64",
+      "evra": "3.23-12.fc40.x86_64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "ignition": {
-      "evra": "2.18.0-1.fc39.x86_64",
+      "evra": "2.18.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc39.x86_64",
+      "evra": "58-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
-    "intel-audio-firmware": {
-      "evra": "20240410-1.fc39.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "intel-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-2.fc39.x86_64",
+      "evra": "1.0.3-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.4.0-2.fc39.x86_64",
+      "evra": "6.7.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.4.0-2.fc39.x86_64",
+      "evra": "6.7.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.9-5.fc39.x86_64",
+      "evra": "1.8.10-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.9-5.fc39.x86_64",
+      "evra": "1.8.10-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.9-5.fc39.x86_64",
+      "evra": "1.8.10-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.9-5.fc39.x86_64",
+      "evra": "1.8.10-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.9-5.fc39.noarch",
+      "evra": "1.8.10-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.9-5.fc39.x86_64",
+      "evra": "1.8.10-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20221126-4.fc39.x86_64",
+      "evra": "20240117-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.2-2.fc39.x86_64",
+      "evra": "2:1.9.2-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.x86_64",
+      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-17.gitc26218d.fc39.x86_64",
+      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-7.fc39.x86_64",
+      "evra": "0.101-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-7.fc39.x86_64",
+      "evra": "2.13.1-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-4.fc39.x86_64",
+      "evra": "5.3.0-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "13-1.fc39.x86_64",
+      "evra": "13-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.6-17.fc39.x86_64",
+      "evra": "1.7.1-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-1.fc39.x86_64",
+      "evra": "0.17-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-1.fc39.x86_64",
+      "evra": "1.8.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.3-1.fc39.x86_64",
+      "evra": "2.6.4-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.3-1.fc39.noarch",
+      "evra": "2.6.4-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kernel": {
-      "evra": "6.8.6-200.fc39.x86_64",
+      "evra": "6.8.7-300.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.8.6-200.fc39.x86_64",
+      "evra": "6.8.7-300.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.8.6-200.fc39.x86_64",
+      "evra": "6.8.7-300.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.8.6-200.fc39.x86_64",
+      "evra": "6.8.7-300.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.27-4.fc39.x86_64",
+      "evra": "2.0.28-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-1.fc39.x86_64",
+      "evra": "1.6.3-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-1.fc39.x86_64",
+      "evra": "1.6.3-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "30-6.fc39.x86_64",
+      "evra": "31-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "30-6.fc39.x86_64",
+      "evra": "31-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.5-2.fc39.x86_64",
+      "evra": "0.9.7-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.2-3.fc39.x86_64",
+      "evra": "1.21.2-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "633-2.fc39.x86_64",
+      "evra": "643-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.1-9.fc39.x86_64",
+      "evra": "2.3.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-16.fc39.x86_64",
+      "evra": "0.3.111-19.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.1-1.fc39.x86_64",
+      "evra": "3.7.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
-    "libargon2": {
-      "evra": "20190702-3.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "argon2"
-      }
-    },
     "libassuan": {
-      "evra": "2.5.6-2.fc39.x86_64",
+      "evra": "2.5.7-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.1-8.fc39.x86_64",
+      "evra": "2.5.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-54.fc39.x86_64",
+      "evra": "0.1.1-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.1.0-4.fc39.x86_64",
+      "evra": "2:1.2.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-1.fc39.x86_64",
+      "evra": "0.12.2-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.48-9.fc39.x86_64",
+      "evra": "2.69-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.3-8.fc39.x86_64",
+      "evra": "0.8.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.10.2-2.fc39.x86_64",
+      "evra": "0.11.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-54.fc39.x86_64",
+      "evra": "0.7.0-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-2.fc39.x86_64",
+      "evra": "1.47.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.2.1-4.fc39.x86_64",
+      "evra": "8.6.0-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-26.fc39.x86_64",
+      "evra": "0.14-29.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
-    "libdb": {
-      "evra": "5.3.28-56.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "libdb"
-      }
-    },
     "libdhash": {
-      "evra": "0.5.0-54.fc39.x86_64",
+      "evra": "0.5.0-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libeconf": {
-      "evra": "0.5.2-2.fc39.x86_64",
+      "evra": "0.6.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-48.20230828cvs.fc39.x86_64",
+      "evra": "3.1-50.20230828cvs.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-9.fc39.x86_64",
+      "evra": "2.1.12-12.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-4.fc39.x86_64",
+      "evra": "3.4.4-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.13.0-3.fc39.x86_64",
+      "evra": "1.14.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "13.2.1-7.fc39.x86_64",
+      "evra": "14.0.1-0.15.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.2-2.fc39.x86_64",
+      "evra": "1.10.3-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.47-2.fc39.x86_64",
+      "evra": "1.48-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-2.fc39.x86_64",
+      "evra": "238-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.8-1.fc39.x86_64",
+      "evra": "0.4.8-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "46.0-4.fc39.x86_64",
+      "evra": "48.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "73.2-2.fc39.x86_64",
+      "evra": "74.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc39.x86_64",
+      "evra": "2.3.7-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-54.fc39.x86_64",
+      "evra": "1.3.1-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.1-1.fc39.x86_64",
+      "evra": "0.2.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "13-1.fc39.x86_64",
+      "evra": "13-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.4.0-7.fc39.x86_64",
+      "evra": "1.4.0-10.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-7.fc39.x86_64",
+      "evra": "1.4.0-10.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.4-2.fc39.x86_64",
+      "evra": "1.6.6-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.8.0-1.fc39.x86_64",
+      "evra": "2.9.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libldb"
       }
     },
     "libluksmeta": {
-      "evra": "9-16.fc39.x86_64",
+      "evra": "9-22.fc40.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.9.1-1.fc39.x86_64",
+      "evra": "1.9.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-2.fc39.x86_64",
+      "evra": "1.1.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-3.fc39.x86_64",
+      "evra": "1.0.5-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-5.fc39.x86_64",
+      "evra": "2.15.0-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-6.fc39.x86_64",
+      "evra": "1.8-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-1.fc39.x86_64",
+      "evra": "1.3-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-2.fc39.x86_64",
+      "evra": "1.0.9-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-24.fc39.x86_64",
+      "evra": "1.0.1-27.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.6.4-0.rc6.fc39.x86_64",
+      "evra": "1:2.6.4-0.rc6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-2.fc39.x86_64",
+      "evra": "1.2.6-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.55.1-5.fc39.x86_64",
+      "evra": "1.59.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.9.0-1.fc39.x86_64",
+      "evra": "3.9.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.9.0-1.fc39.x86_64",
+      "evra": "3.9.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.0-6.fc39.x86_64",
+      "evra": "2.0.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.6-2.fc39.x86_64",
+      "evra": "1.8-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-54.fc39.x86_64",
+      "evra": "0.2.1-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.4-2.fc39.x86_64",
+      "evra": "14:1.10.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "1.9.5-2.fc39.x86_64",
+      "evra": "2.1.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.2-4.fc39.x86_64",
+      "evra": "0.21.5-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-6.fc39.x86_64",
+      "evra": "1.4.5-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-54.fc39.x86_64",
+      "evra": "0.1.5-56.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.17.1-1.fc39.x86_64",
+      "evra": "1.17.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.11-3.fc39.noarch",
+      "evra": "2.17.15-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.3-6.fc39.x86_64",
+      "evra": "2.5.3-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.5-5.fc39.x86_64",
+      "evra": "3.6-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.5-5.fc39.x86_64",
+      "evra": "3.6-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.5-4.fc39.x86_64",
+      "evra": "3.6-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.5-2.fc39.x86_64",
+      "evra": "3.6-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
-    "libsigsegv": {
-      "evra": "2.14-5.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "libsigsegv"
-      }
-    },
     "libslirp": {
-      "evra": "4.7.0-4.fc39.x86_64",
+      "evra": "4.7.0-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.19.6-1.fc39.x86_64",
+      "evra": "2:4.20.0-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.28-1.fc39.x86_64",
+      "evra": "0.7.28-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-2.fc39.x86_64",
+      "evra": "1.47.0-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "13.2.1-7.fc39.x86_64",
+      "evra": "14.0.1-0.15.fc40.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.1-1.fc39.x86_64",
+      "evra": "2.4.2-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-3.fc39.x86_64",
+      "evra": "4.19.0-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.9-1.fc39.x86_64",
+      "evra": "1.4.10-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-1.fc39.x86_64",
+      "evra": "1.32-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.15.0-1.fc39.x86_64",
+      "evra": "0.16.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.4-1.rc3.fc39.x86_64",
+      "evra": "1.3.4-1.rc3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-7.fc39.x86_64",
+      "evra": "2.4.7-10.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-5.fc39.x86_64",
+      "evra": "1.1-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-1.fc39.x86_64",
+      "evra": "1.0.27-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
-    "libuser": {
-      "evra": "0.64-4.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "libuser"
-      }
-    },
     "libutempter": {
-      "evra": "1.2.1-10.fc39.x86_64",
+      "evra": "1.2.1-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.48.0-1.fc39.x86_64",
+      "evra": "1:1.48.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-6.fc39.x86_64",
+      "evra": "0.3.2-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.19.6-1.fc39.x86_64",
+      "evra": "2:4.20.0-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-2.fc39.x86_64",
+      "evra": "4.4.36-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.10.4-3.fc39.x86_64",
+      "evra": "2.12.6-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.18-1.fc39.x86_64",
+      "evra": "0.3.18-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-12.fc39.x86_64",
+      "evra": "0.2.5-14.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc39.x86_64",
+      "evra": "1.5.6-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
-    "linux-atm-libs": {
-      "evra": "2.5.1-36.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "linux-atm"
-      }
-    },
     "linux-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.32-1.fc39.x86_64",
+      "evra": "0.9.32-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-4.fc39.x86_64",
+      "evra": "3.21.0-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.96.3-4.fc39.x86_64",
+      "evra": "4.98.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-3.fc39.x86_64",
+      "evra": "5.4.6-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-16.fc39.x86_64",
+      "evra": "9-22.fc40.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.23-1.fc39.x86_64",
+      "evra": "2.03.23-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.23-1.fc39.x86_64",
+      "evra": "2.03.23-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-4.fc39.x86_64",
+      "evra": "1.9.4-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-9.fc39.x86_64",
+      "evra": "2.10-12.fc40.x86_64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "mdadm": {
-      "evra": "4.2-6.fc39.x86_64",
+      "evra": "4.2-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "microcode_ctl": {
-      "evra": "2:2.1-58.fc39.x86_64",
+      "evra": "2:2.1-61.fc40.x86_64",
       "metadata": {
         "sourcerpm": "microcode_ctl"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-1.fc39.x86_64",
+      "evra": "24.0.5-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.6.0-7.fc39.x86_64",
+      "evra": "2:0.7.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.0-3.fc39.x86_64",
+      "evra": "4.2.1-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "mt7xxx-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nano": {
-      "evra": "7.2-4.fc39.x86_64",
+      "evra": "7.2-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-4.fc39.noarch",
+      "evra": "7.2-6.fc40.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-7.20230520.fc39.1.x86_64",
+      "evra": "6.4-12.20240127.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-7.20230520.fc39.1.noarch",
+      "evra": "6.4-12.20240127.fc40.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-7.20230520.fc39.1.x86_64",
+      "evra": "6.4-12.20240127.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.67.20160912git.fc39.x86_64",
+      "evra": "2.0-0.69.20160912git.fc40.x86_64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "1.10.3-1.fc39.x86_64",
+      "evra": "1.10.3-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-2.fc39.x86_64",
+      "evra": "3.9.1-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.23-4.fc39.x86_64",
+      "evra": "0.52.24-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.4-0.rc6.fc39.x86_64",
+      "evra": "1:2.6.4-0.rc6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.7-3.fc39.x86_64",
+      "evra": "1:1.0.9-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.26-2.fc39.x86_64",
+      "evra": "2.2.26-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.6-14.fc39.x86_64",
+      "evra": "1.7-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-1.fc39.x86_64",
+      "evra": "2.23.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-3.fc39.x86_64",
+      "evra": "2.0.16-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.6-1.fc39.x86_64",
+      "evra": "2.8-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "nxpwireless-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "oniguruma": {
-      "evra": "6.9.9-1.fc39.x86_64",
+      "evra": "6.9.9-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.6-1.fc39.x86_64",
+      "evra": "2.6.7-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.3p1-10.fc39.x86_64",
+      "evra": "9.6p1-1.fc40.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.3p1-10.fc39.x86_64",
+      "evra": "9.6p1-1.fc40.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.3p1-10.fc39.x86_64",
+      "evra": "9.6p1-1.fc40.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.1.1-4.fc39.x86_64",
+      "evra": "1:3.2.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.1.1-4.fc39.x86_64",
+      "evra": "1:3.2.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-4.fc39.x86_64",
+      "evra": "1.81-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.5-1.fc39.x86_64",
+      "evra": "2024.5-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.5-1.fc39.x86_64",
+      "evra": "2024.5-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.3-1.fc39.x86_64",
+      "evra": "0.25.3-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.3-1.fc39.x86_64",
+      "evra": "0.25.3-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.5.3-3.fc39.x86_64",
+      "evra": "1.6.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.5.3-3.fc39.x86_64",
+      "evra": "1.6.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
+    "passim-libs": {
+      "evra": "0.1.5-3.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "passim"
+      }
+    },
     "passt": {
-      "evra": "0^20240326.g4988e2b-1.fc39.x86_64",
+      "evra": "0^20240326.g4988e2b-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240326.g4988e2b-1.fc39.noarch",
+      "evra": "0^20240326.g4988e2b-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
-    "passwd": {
-      "evra": "0.80-15.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "passwd"
-      }
-    },
     "pcre2": {
-      "evra": "10.42-1.fc39.2.x86_64",
+      "evra": "10.42-2.fc40.2.x86_64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.42-1.fc39.2.noarch",
+      "evra": "10.42-2.fc40.2.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-2.fc39.x86_64",
+      "evra": "2.8-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "1.9.5-2.fc39.x86_64",
+      "evra": "2.1.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "1.9.5-2.fc39.noarch",
+      "evra": "2.1.0-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "1.9.5-2.fc39.x86_64",
+      "evra": "2.1.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:4.9.4-1.fc39.x86_64",
-      "metadata": {
-        "sourcerpm": "podman"
-      }
-    },
-    "podman-plugins": {
-      "evra": "5:4.9.4-1.fc39.x86_64",
+      "evra": "5:5.0.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.5-8.fc39.x86_64",
+      "evra": "3.6-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "123-1.fc39.1.x86_64",
+      "evra": "124-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "123-1.fc39.1.x86_64",
+      "evra": "124-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-pkla-compat": {
-      "evra": "0.1-26.fc39.x86_64",
+      "evra": "0.1-28.fc40.x86_64",
       "metadata": {
         "sourcerpm": "polkit-pkla-compat"
       }
     },
     "popt": {
-      "evra": "1.19-3.fc39.x86_64",
+      "evra": "1.19-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.3-5.fc39.x86_64",
+      "evra": "4.0.4-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.4.1-5.fc39.x86_64",
+      "evra": "1.5.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-4.fc39.x86_64",
+      "evra": "23.6-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-1.fc39.noarch",
+      "evra": "20240107-3.fc40.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "readline": {
-      "evra": "8.2-6.fc39.x86_64",
+      "evra": "8.2-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "realtek-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "rpcbind": {
-      "evra": "1.2.6-4.rc3.fc39.x86_64",
+      "evra": "1.2.6-4.rc3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc39.x86_64",
+      "evra": "4.19.1.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc39.x86_64",
+      "evra": "4.19.1.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.4-6.fc39.x86_64",
+      "evra": "2024.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.4-6.fc39.x86_64",
+      "evra": "2024.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc39.x86_64",
+      "evra": "4.19.1.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.6.0-1.fc39.x86_64",
+      "evra": "1.6.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc39.x86_64",
+      "evra": "3.3.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-1.fc39.x86_64",
+      "evra": "2:1.1.12-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.19.6-1.fc39.x86_64",
+      "evra": "2:4.20.0-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.19.6-1.fc39.noarch",
+      "evra": "2:4.20.0-7.fc40.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.19.6-1.fc39.x86_64",
+      "evra": "2:4.20.0-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sed": {
-      "evra": "4.8-14.fc39.x86_64",
+      "evra": "4.9-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "39.5-1.fc39.noarch",
+      "evra": "40.16-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.4-1.fc39.noarch",
+      "evra": "2.14.5-2.fc40.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.46-6.fc39.x86_64",
+      "evra": "1.48-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.46-6.fc39.x86_64",
+      "evra": "1.48-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.14.0-2.fc39.x86_64",
+      "evra": "2:4.15.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.14.0-2.fc39.x86_64",
+      "evra": "2:4.15.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.2-4.fc39.x86_64",
+      "evra": "2.3-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2317,313 +2281,313 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.15.0-1.fc39.x86_64",
+      "evra": "1:1.15.0-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-4.fc39.x86_64",
+      "evra": "2.3.3-5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-1.fc39.x86_64",
+      "evra": "1.2.2-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-2.fc39.x86_64",
+      "evra": "1.1.10-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc39.x86_64",
+      "evra": "1.8.0.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.12.0-2.fc39.x86_64",
+      "evra": "1.12.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.42.0-7.fc39.x86_64",
+      "evra": "3.45.1-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-2.fc39.x86_64",
+      "evra": "4.6.1-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-4.fc39.x86_64",
+      "evra": "0.1.4-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.4-1.fc39.x86_64",
+      "evra": "2.9.4-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.1-1.fc39.x86_64",
+      "evra": "1.19.1-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-1.p5.fc39.x86_64",
+      "evra": "1.9.15-2.p5.fc40.x86_64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "254.10-1.fc39.x86_64",
+      "evra": "255.4-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-2.fc39.x86_64",
+      "evra": "2:1.35-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-1.fc39.x86_64",
+      "evra": "1.32-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tiwilink-firmware": {
-      "evra": "20240410-1.fc39.noarch",
+      "evra": "20240410-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.5-4.fc39.x86_64",
+      "evra": "0.0.99.5-8.fc40.x86_64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.5-4.fc39.x86_64",
+      "evra": "5.6-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.0.1-6.fc39.x86_64",
+      "evra": "4.0.1-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.0.1-6.fc39.x86_64",
+      "evra": "4.0.1-7.fc40.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-2.fc39.noarch",
+      "evra": "2024a-5.fc40.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-3.fc39.x86_64",
+      "evra": "0.14.0-4.fc40.x86_64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.39.4-1.fc39.x86_64",
+      "evra": "2.40-13.fc40.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.309-1.fc39.noarch",
+      "evra": "2:9.1.309-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.309-1.fc39.x86_64",
+      "evra": "2:9.1.309-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.13.5-1.fc39.x86_64",
+      "evra": "0.13.5-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.21-40.fc39.x86_64",
+      "evra": "2.21-41.fc40.x86_64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-5.fc39.x86_64",
+      "evra": "1.0.20210914-6.fc40.x86_64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.4.0-1.fc39.x86_64",
+      "evra": "6.5.0-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-1.fc39.x86_64",
+      "evra": "0.8.2-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "5.4.4-1.fc39.x86_64",
+      "evra": "1:5.4.6-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "5.4.4-1.fc39.x86_64",
+      "evra": "1:5.4.6-3.fc40.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-22.fc39.x86_64",
+      "evra": "2.1.0-23.fc40.x86_64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.4.0-1.fc39.x86_64",
+      "evra": "1.4.0-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-1.fc39.x86_64",
+      "evra": "0.0.27-2.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
-    "zlib": {
-      "evra": "1.2.13-4.fc39.x86_64",
+    "zlib-ng-compat": {
+      "evra": "2.1.6-2.fc40.x86_64",
       "metadata": {
-        "sourcerpm": "zlib"
+        "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-8.fc39.x86_64",
+      "evra": "1.1.2-9.fc40.x86_64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc39.x86_64",
+      "evra": "1.5.6-1.fc40.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
@@ -2632,14 +2596,17 @@
   "metadata": {
     "generated": "2024-04-21T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2023-11-01T00:12:39Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-04-14T18:51:11Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-04-21T15:19:06Z"
+        "generated": "2024-04-21T12:47:21Z"
       },
-      "fedora-updates": {
-        "generated": "2024-04-21T01:12:02Z"
+      "fedora-next": {
+        "generated": "2024-04-19T08:53:31Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-04-21T01:00:20Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: testing-devel
   prod: false
 
-releasever: 39
+releasever: 40
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -20,7 +20,7 @@ set -xeuo pipefail
 
 case "$(arch)" in
     aarch64|ppc64le|s390x)
-        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:39 arch)
+        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:40 arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"
         fi

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -13,6 +13,6 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-docker run --rm quay.io/fedora/fedora:39 true
+docker run --rm quay.io/fedora/fedora:40 true
 
 ok "basic docker run successfully"

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,7 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:39
+FROM quay.io/fedora/fedora:40
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -23,7 +23,7 @@ runascoreuserscript='
 set -euxo pipefail
 
 podman network create testnetwork
-podman run --rm -t --network=testnetwork quay.io/fedora/fedora:39 getent hosts google.com
+podman run --rm -t --network=testnetwork quay.io/fedora/fedora:40 getent hosts google.com
 podman network rm testnetwork
 '
 

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -20,7 +20,7 @@ set -xeuo pipefail
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:39 bash <<"EOF"
+podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:40 bash <<"EOF"
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,7 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:39
+FROM quay.io/fedora/fedora:40
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora:40 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora-toolbox:40 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora:39 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora:40 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
The Fedora 40 GA is to be released on Tuesday April 23rd.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1674