### PR TITLE
Updating container image to fedora-toolbox:40

### DIFF
--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora:39 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora-toolbox:40 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
PR : https://github.com/coreos/fedora-coreos-config/pull/2981

The CI in PR-2891 fails as the 'mount' command could not be executed. Looks like F40 got rid of 'util-linux-core' package which provides the 'mount' command among other things.

In order to make the CI test PASS in PR-2981, the container image needs to be updated to quay.io/fedora/fedora-toolbox:40.