### PR TITLE
DNM: experiment with unit requirements for multipath over iscsi work

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-trigger.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-trigger.service
@@ -11,7 +11,7 @@ Description=CoreOS Trigger Multipath
 DefaultDependencies=false
 Requires=coreos-multipath-wait.target
 After=coreos-multipath-wait.target
-Before=cryptsetup-pre.target
+#Before=cryptsetup-pre.target
 
 [Service]
 Type=oneshot

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
@@ -1,7 +1,7 @@
 [Unit]
 Description=CoreOS Wait For Multipathed Boot
 DefaultDependencies=false
-Before=dracut-initqueue.service
+#Before=dracut-initqueue.service
 After=dracut-cmdline.service
 Requires=dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device
 After=dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device
@@ -15,6 +15,6 @@ OnFailureJobMode=isolate
 # already have our multipath target.
 Before=coreos-ignition-setup-user.service
 
-# This is already enforced by coreos-multipath-trigger.service, though ideally
-# eventually we can get rid of that one and then we *would* need this.
-Before=cryptsetup-pre.target
+## This is already enforced by coreos-multipath-trigger.service, though ideally
+## eventually we can get rid of that one and then we *would* need this.
+#Before=cryptsetup-pre.target


### PR DESCRIPTION
We are experimenting with iscsi and also multipath+iscsi.

In the multipath+iscsi case we end up with dependency issues in our initramfs because of `coreos-multipath-wait.target`:

- It blocks `cryptsetup-pre.target` and thus `basic.target`:

```
basic.target -> sysinit.target -> cryptsetup.target -> cryptsetup-pre.target -> coreos-multipath-wait.target -> /boot disk
```

- It blocks `dracut-initqueue.service` and that is what sets up the iscsi disks:

```
dracut-initqueue.service -> coreos-multipath-wait.target
```


I was testing this with a disk that was installed using:

```
sudo coreos-installer install /path/to/disk \
    --append-karg rd.multipath=default      \
    --append-karg root=/dev/disk/by-label/dm-mpath-root \
    --append-karg rw --append-karg rd.iscsi.firmware=1  \
    --console ttyS0,115200n8 -i config.ign --insecure   \
    --image-file fedora-coreos-40.20240424.dev.1-metal.x86_64.raw.xz
```

an a PXE config that looked like:

```
[dustymabe@media images]$ cat boot.ipxe 
#!ipxe
# set some random uuid as the initiator iqn, otherwise
# this will fail pointing to https://ipxe.org/1c0d6502
set initiator-iqn iqn.68cc69b9-1b54-4ff1-9d61-eedb570da8fd
sanboot iscsi:192.168.122.137::::iqn.2024-04.com.coreos:0 \
        iscsi:192.168.122.137::::iqn.2024-04.com.coreos:1

```
