### PR TITLE
ci & tests: Use registry.fedoraproject.org for Fedora container images

### DIFF
--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,6 +5,6 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM quay.io/fedora/fedora:40
+FROM registry.fedoraproject.org/fedora:40
 COPY . /src
 RUN ./src/install-buildroot.sh && yum clean all && rm /src -rf

--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -20,7 +20,7 @@ set -xeuo pipefail
 
 case "$(arch)" in
     aarch64|ppc64le|s390x)
-        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:40 arch)
+        containerArch=$(podman run --arch=amd64 --rm registry.fedoraproject.org/fedora:40 arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"
         fi

--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=quay.io/fedora/fedora-minimal:39
+          Image=registry.fedoraproject.org/fedora-minimal:39
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=registry.fedoraproject.org/fedora-minimal:39
+          Image=registry.fedoraproject.org/fedora-minimal:40
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -32,7 +32,7 @@ if ! is_service_active test.service; then
   fatal "test-network.service failed to start"
 fi
 container_info=$(podman container inspect systemd-test)
-if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:39" ]]; then
+if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "registry.fedoraproject.org/fedora-minimal:39" ]]; then
     fatal "Container not using the correct image"
 fi
 if [[ "$(jq -r '.[0].NetworkSettings.Networks[].NetworkID' <<< "$container_info")" != "systemd-test" ]]; then

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -32,7 +32,7 @@ if ! is_service_active test.service; then
   fatal "test-network.service failed to start"
 fi
 container_info=$(podman container inspect systemd-test)
-if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "registry.fedoraproject.org/fedora-minimal:39" ]]; then
+if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "registry.fedoraproject.org/fedora-minimal:40" ]]; then
     fatal "Container not using the correct image"
 fi
 if [[ "$(jq -r '.[0].NetworkSettings.Networks[].NetworkID' <<< "$container_info")" != "systemd-test" ]]; then

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -13,6 +13,6 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-docker run --rm quay.io/fedora/fedora:40 true
+docker run --rm registry.fedoraproject.org/fedora:40 true
 
 ok "basic docker run successfully"

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,7 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:40
+FROM registry.fedoraproject.org/fedora:40
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -23,7 +23,7 @@ runascoreuserscript='
 set -euxo pipefail
 
 podman network create testnetwork
-podman run --rm -t --network=testnetwork quay.io/fedora/fedora:40 getent hosts google.com
+podman run --rm -t --network=testnetwork registry.fedoraproject.org/fedora:40 getent hosts google.com
 podman network rm testnetwork
 '
 

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -20,7 +20,7 @@ set -xeuo pipefail
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:40 bash <<"EOF"
+podman run -i --net=pasta:--mtu,1500 registry.fedoraproject.org/fedora:40 bash <<"EOF"
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,7 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:40
+FROM registry.fedoraproject.org/fedora:40
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora-toolbox:40 \
+context=$(podman run --rm --privileged registry.fedoraproject.org/fedora-toolbox:40 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
The plan is to keep using the registry.fedoraproject.org name but redirect it to quay.io.

Reverts: https://github.com/coreos/fedora-coreos-config/pull/2623

See: https://pagure.io/fedora-infrastructure/issue/11543