### PR TITLE
tests: Update container images to Fedora 40

### DIFF
--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=quay.io/fedora/fedora-minimal:39
+          Image=quay.io/fedora/fedora-minimal:40
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -32,7 +32,7 @@ if ! is_service_active test.service; then
   fatal "test-network.service failed to start"
 fi
 container_info=$(podman container inspect systemd-test)
-if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:39" ]]; then
+if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:40" ]]; then
     fatal "Container not using the correct image"
 fi
 if [[ "$(jq -r '.[0].NetworkSettings.Networks[].NetworkID' <<< "$container_info")" != "systemd-test" ]]; then


### PR DESCRIPTION
Those were missed in https://github.com/coreos/fedora-coreos-config/pull/2981.

Fixes: https://github.com/coreos/fedora-coreos-config/pull/2981