### PR TITLE
manifests: dnf5 is now default in rawhide; stop symlinking dnf

### DIFF
--- a/manifests/include-dnf.yaml
+++ b/manifests/include-dnf.yaml
@@ -1,13 +1,2 @@
 packages:
   - dnf5
-
-# until dnf5 becomes the default, manually symlink dnf to it
-postprocess:
-  - |
-    #!/usr/bin/bash
-    set -euo pipefail
-    if command -v dnf; then
-      echo 'dnf5 is now the default, remove this postprocess script!' >&2
-      exit 1
-    fi
-    ln -s dnf5 /usr/bin/dnf


### PR DESCRIPTION
The postprocess bomb here went off this morning, which means we can simplify this by a lot!