### PR TITLE
overlay/coreos-check-ssh-keys: Remove invalid service key

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -16,7 +16,6 @@ ConditionKernelCommandLine=ignition.firstboot
 Before=systemd-user-sessions.service
 
 [Service]
-Before=systemd-user-sessions.service
 Type=oneshot
 ProtectHome=read-only
 ExecStart=/usr/libexec/coreos-check-ssh-keys


### PR DESCRIPTION
The `Before` key is undefined for the `Service` Section. This was silentely ignored by systemd until systemd-v256-rc1 where it started emmitting a log message :
`Unknown key name 'Before' in section 'Service', ignoring.`

This causes the pipeline to fail as kola consider this an error.