### PR TITLE
buildroot: update URL to rpm-ostree spec

### DIFF
--- a/ci/buildroot/buildroot-specs.txt
+++ b/ci/buildroot/buildroot-specs.txt
@@ -1,3 +1,3 @@
 # for projects which have their canonical spec files upstream, use those instead
 # since they're more up to date
-https://raw.githubusercontent.com/coreos/rpm-ostree/main/packaging/rpm-ostree.spec.in
+https://raw.githubusercontent.com/coreos/rpm-ostree/main/packaging/rpm-ostree.spec


### PR DESCRIPTION
This was changed in https://github.com/coreos/rpm-ostree/pull/4964.