### PR TITLE
tests/kdump: bump timeout for kdump.service

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -80,8 +80,9 @@ cmdline_arg() {
 
 # wait for ~60s when in activating status
 is_service_active() {
-    local service="$1"
-    for _x in {0..60}; do
+    local service="$1"; shift
+    local timeout="${1:-60}"; shift
+    for _x in $(seq "${timeout}"); do
         [ "$(systemctl is-active "${service}")" != "activating" ] && break
         sleep 1
     done

--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -19,7 +19,9 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-      if ! is_service_active kdump.service; then
+      # use 120s for this since kdump can take a while to build its initramfs,
+      # especially if the system is loaded
+      if ! is_service_active kdump.service 120; then
           fatal "kdump.service failed to start"
       fi
       # Verify that the crashkernel reserved memory is large enough


### PR DESCRIPTION
Saw a CI run timeout because `kdump.service` took 65s to build its initramfs but we only wait 60s. Let's just bump this to have a larger margin of error.