### PR TITLE
Revert "tests/kola: use toolbox container image for selinux.podman-tmpfs-context"

### DIFF
--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora-toolbox:40 \
+context=$(podman run --rm --privileged quay.io/fedora/fedora:40 \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
This reverts commit 5c9ec57af9191a48b6bc802bbf1993b4206cf73f.

Looks like util-linux-core is back in the the fedora:40 image now.

See also: https://pagure.io/fedora-kiwi-descriptions/pull-request/45
See also: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/VDZA546GESX7JP5ZSS6KEHOYFG22V3R7/