### PR TITLE
[rawhide] overrides: pin systemd-255.5-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,34 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  systemd:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-container:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-libs:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-pam:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-resolved:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-udev:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,51 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  device-mapper:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-event:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-event-libs:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-libs:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-multipath:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-multipath-libs:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  kpartx:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  lvm2:
+    evr: 2.03.23-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  lvm2-libs:
+    evr: 2.03.23-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
   systemd:
     evr: 255.5-1.fc41
     metadata:


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).