### PR TITLE
overlay.d/05core: assume metadata_csum_seed in ignition-ostree-firstboot-uuid

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-unique-boot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-unique-boot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=CoreOS Ensure Unique Boot Filesystem
+Description=CoreOS Ignition Ensure Unique Boot Filesystem
 ConditionPathExists=/etc/initrd-release
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-unique-boot.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-unique-boot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ensure Unique `boot` Filesystem Label
+Description=CoreOS Ensure Unique Boot Filesystem Label
 ConditionPathExists=/etc/initrd-release
 DefaultDependencies=no
 Before=ignition-diskful.target

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-firstboot-uuid
@@ -27,37 +27,7 @@ esac
 
 if [ "${TYPE}" == "${orig_type}" ] && [ "${UUID}" == "${orig_uuid}" ]; then
   case "${TYPE}" in
-    ext4)
-          # If the filesystem supports metadata_csum_seed then the UUID is stored
-          # in the superblock and there is no need to worry with an fsck. For the
-          # boot filesystem this FS feature wasn't supported by GRUB until recently.
-          # https://lists.gnu.org/archive/html/grub-devel/2021-06/msg00031.html
-          # Once grub is updated in all systems we care about we can standardize
-          # on the metadata_csum_seed and delete the `else` code block.
-          if tune2fs -l ${target} | grep 'metadata_csum_seed'; then
-              tune2fs -U random "${target}"
-          else
-              # Run an fsck since tune2fs -U requires the FS to be clean
-              e2fsck -fy "${target}"
-              # We just ran an fsck, but there is a bug where tune2fs -U will still
-              # complain. It will still error if the last checked timestamp (just
-              # set by the e2fsck above) is older than the last mount timestamp (happens
-              # on systems with out of date or non-functioning hardware clocks).
-              # See https://github.com/coreos/fedora-coreos-tracker/issues/735#issuecomment-859605953
-              # Potentially fixed in future by: https://www.spinics.net/lists/linux-ext4/msg78012.html
-              tune2fsinfo="$(tune2fs -l ${target})"
-              lastmount=$(echo "$tune2fsinfo" | grep '^Last mount time:' | cut -d ':' -f 2,3,4)
-              lastfsck=$(echo "$tune2fsinfo" | grep '^Last checked:' | cut -d ':' -f 2,3,4)
-              lastmountsse=$(date --date="$lastmount" +%s)
-              lastfscksse=$(date --date="$lastfsck" +%s)
-              if (( lastfscksse < lastmountsse )); then
-                  echo "Detected timestamp of last fsck is older than timestamp of last mount."
-                  echo "Setting "${target}" timestamp of last fsck to same time as last mount."
-                  tune2fs -T $(date --date="$lastmount" +%Y%m%d%H%M%S) "${target}"
-              fi
-              # Finally, we can randomize the UUID
-              tune2fs -U random "${target}"
-          fi ;;
+    ext4) tune2fs -U random "${target}"    ;;
     xfs) xfs_admin -U generate "${target}" ;;
     *) echo "unexpected filesystem type ${TYPE}" 1>&2; exit 1 ;;
   esac


### PR DESCRIPTION
We always set the metadata_csum_seed option on the ext4 filesystems
now so let's remove the conditional logic from the code.

Also have a 2nd commit in here to tweak descriptions of some unit files.