### PR TITLE
s390x: Move copying of 01-secex.ign config from systemd generator to service

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -150,7 +150,6 @@ fi
 if [[ "${secure_execution}" = "1" ]]; then
     mkdir -p /run/coreos/
     touch /run/coreos/secure-execution
-    cp /usr/lib/coreos/01-secex.ign /usr/lib/ignition/base.d/01-secex.ign
     # Add dropins to disable Ignition logging for all stages
     stages=("fetch-offline" "fetch" "kargs" "disks" "mount" "files")
     for s in "${stages[@]}"; do
@@ -167,5 +166,5 @@ EOF
     # This one is done dynamically because it hard Requires a device to appear
     # and if it's always part of the transaction, systemd will want the device
     # to appear regardless of ConditionPathExists.
-    add_requires coreos-secex-ignition-decrypt.service ignition-diskful.target
+    add_requires coreos-secex-ignition-prepare.service ignition-diskful.target
 fi

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.service
@@ -1,7 +1,7 @@
 # This service is enabled by coreos-diskful-generator
 
 [Unit]
-Description=CoreOS Secex Ignition Config Decryptor
+Description=CoreOS Secex Ignition Config Preparation
 ConditionPathExists=/etc/initrd-release
 ConditionPathExists=/run/coreos/secure-execution
 DefaultDependencies=false
@@ -17,4 +17,4 @@ Before=ignition-fetch-offline.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/sbin/coreos-secex-ignition-decrypt
+ExecStart=/usr/sbin/coreos-secex-ignition-prepare

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.sh
@@ -15,6 +15,10 @@ cleanup() {
 
 trap cleanup EXIT
 
+# copy base Secure Execution config (enables LUKS+dm-verity for boot and root partitions)
+cp /usr/lib/coreos/01-secex.ign /usr/lib/ignition/base.d/01-secex.ign
+
+# decrypt user's config
 tmpd=$(mktemp -d)
 
 if [ ! -e "${disk}" ]; then

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -83,10 +83,10 @@ install() {
 
     # IBM Secure Execution. Ignition config for reencryption of / and /boot
     inst_simple "$moddir/01-secex.ign" /usr/lib/coreos/01-secex.ign
-    inst_simple "$moddir/coreos-secex-ignition-decrypt.service" \
-        "$systemdsystemunitdir/coreos-secex-ignition-decrypt.service"
-    inst_script "$moddir/coreos-secex-ignition-decrypt.sh" \
-        "/usr/sbin/coreos-secex-ignition-decrypt"
+    inst_simple "$moddir/coreos-secex-ignition-prepare.service" \
+        "$systemdsystemunitdir/coreos-secex-ignition-prepare.service"
+    inst_script "$moddir/coreos-secex-ignition-prepare.sh" \
+        "/usr/sbin/coreos-secex-ignition-prepare"
 
     inst_multiple jq blkid
     inst_script "$moddir/coreos-rootflags.sh" \


### PR DESCRIPTION
Fedora 40 during early startup (initramfs) mounts rootfs as read-only, so systemd-generators fail to modify it:
```
Welcome to Fedora CoreOS 40.20240524.dev.0 dracut-101-1.fc40 (Initramfs)!
[    1.857142] systemd[1]: No hostname configured, using default hostname.
[    1.857175] systemd[1]: Hostname set to <localhost>.
[    1.857230] systemd[1]: Initializing machine ID from random generator.
[    2.010194] systemd[1]: bpf-lsm: LSM BPF program attached
[    2.014388] ln:
[    2.014407] failed to create symbolic link '/var/log'
[    2.014414] : Read-only file system
[    2.014415]
[    2.038544] cp:
[    2.038553] cannot create regular file '/usr/lib/ignition/base.d/01-secex.ign'
```

This moves all config related logic to one place.