### PR TITLE
manifests: Prepare for CentOS Stream 9 -> 10 transition

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -13,6 +13,7 @@ include:
   # See https://github.com/coreos/bootupd
   - bootupd.yaml
   - shared-el9.yaml
+  - shared-el10.yaml
 ostree-layers:
   - overlay/05core
   - overlay/08nouveau
@@ -156,16 +157,8 @@ packages:
   # In F35+ need `iptables-legacy` package
   # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
   - iptables-legacy
-  # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
-  - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
   # NIC firmware we've traditionally shipped but then were split out of linux-firmware in Fedora
   - qed-firmware # https://github.com/coreos/fedora-coreos-tracker/issues/1746
-  # makedumpfile and kexec were split into subpackages in kexec-tools 0.2.28-7
-  # which is not in RHCOS yet
-  # These should be with kexec-tools in the user-experience manifest, move them
-  # once the split lands in RHCOS.
-  - makedumpfile
-  - kdump-utils
 
 
 # - irqbalance

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -12,6 +12,7 @@ include:
   - shared-workarounds.yaml
   # See https://github.com/coreos/bootupd
   - bootupd.yaml
+  - shared-el9.yaml
 ostree-layers:
   - overlay/05core
   - overlay/08nouveau

--- a/manifests/networking-tools.yaml
+++ b/manifests/networking-tools.yaml
@@ -7,9 +7,6 @@ packages:
   - NetworkManager hostname
   # Interactive Networking configuration during coreos-install
   - NetworkManager-tui
-  # Teaming https://github.com/coreos/fedora-coreos-config/pull/289
-  # and http://bugzilla.redhat.com/1758162
-  - NetworkManager-team teamd
   # Support for cloud quirks and dynamic config in real rootfs:
   # https://github.com/coreos/fedora-coreos-tracker/issues/320
   - NetworkManager-cloud-setup

--- a/manifests/shared-el10.yaml
+++ b/manifests/shared-el10.yaml
@@ -1,0 +1,8 @@
+# Shared with EL 10 (CentOS Stream 10 and RHCOS 10) only
+packages:
+  # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
+  - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
+  # makedumpfile and kexec were split into subpackages in kexec-tools 0.2.28-7
+  # These should be with kexec-tools in the user-experience manifest
+  - makedumpfile
+  - kdump-utils

--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -1,0 +1,5 @@
+# Shared with EL 9 (CentOS Stream 9 and RHCOS 9) only
+packages:
+  # Teaming https://github.com/coreos/fedora-coreos-config/pull/289
+  # and http://bugzilla.redhat.com/1758162
+  - NetworkManager-team teamd

--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -3,3 +3,5 @@ packages:
   # Teaming https://github.com/coreos/fedora-coreos-config/pull/289
   # and http://bugzilla.redhat.com/1758162
   - NetworkManager-team teamd
+  # runc is not in C10S
+  - runc

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -41,7 +41,6 @@ packages:
   ## checkpoint/restore. https://github.com/coreos/fedora-coreos-tracker/issues/1370
   - crun criu criu-libs
   - podman
-  - runc
   - skopeo
   - toolbox
   # passt provides user-mode networking daemons for namespaces


### PR DESCRIPTION
manifests: Move NetworkManager-team/teamd to EL9 shared manifest

libteam support is removed in CentOS Stream 10. Move packages related to
this support to a Enterprise Linux 9 only manifest to prepare for that
removal.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1727

---

manifests: Move runc to EL9 shared manifest

runc is not included in CentOS Stream 10. Move the runc package to an
Enterprise Linux 9 only manifest to prepare for that removal.

---

manifests: Move GPU firmwares & kdump tools to EL10 shared manifest

Move packages to an Enterprise Linux 10 only manifest to prepare
for the package split changes:
- GPU firmwares are split into their own package in CentOS Stream 10
- kdump tools are split between kexec-utils, makedumpfile and
  kdump-utils

---

See also: https://github.com/openshift/os/pull/1498