### PR TITLE
overrides: fast-track containers-common-0.59.1-2.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  containers-common:
+    evra: 5:0.59.1-2.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ebe5c816a1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1748
+      type: fast-track
+  containers-common-extra:
+    evra: 5:0.59.1-2.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ebe5c816a1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1748
+      type: fast-track
   ignition:
     evr: 2.19.0-1.fc40
     metadata:


### PR DESCRIPTION
Requested by @travier via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1748