### PR TITLE
[rawhide] overrides: pin selinux-policy-40.20-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -54,6 +54,16 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
       type: pin
+  selinux-policy:
+    evra: 40.20-1.fc41.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  selinux-policy-targeted:
+    evra: 40.20-1.fc41.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
   systemd:
     evr: 255.5-1.fc41
     metadata:


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).