### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  containers-common:
-    evra: 5:0.59.1-2.fc40.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ebe5c816a1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1748
-      type: fast-track
-  containers-common-extra:
-    evra: 5:0.59.1-2.fc40.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ebe5c816a1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1748
-      type: fast-track
   ignition:
     evr: 2.19.0-1.fc40
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).