### PR TITLE
coreos-ignition-setup-user: remount `/usr` rw if needed

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-setup-user.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-ignition-setup-user.sh
@@ -14,6 +14,13 @@ copy_file_if_exists() {
 destination=/usr/lib/ignition
 mkdir -p $destination
 
+# systemd v256 now runs the initrd with ProtectSystem=yes, which makes /usr
+# read-only. Just remount it rw until we have:
+# https://github.com/coreos/ignition/issues/1891
+if [ ! -w /usr ]; then
+    mount -o rw,remount /usr
+fi
+
 if is-live-image; then
     # Live image. If the user has supplied a config.ign via an appended
     # initrd, put it in the right place.


### PR DESCRIPTION
systemd v256 now runs the initrd with `ProtectSystem=yes`, which makes `/usr` read-only:

https://github.com/systemd/systemd/blob/07748c53df5a72111d8b3eef49d275210d6018cd/NEWS#L168-L175

This breaks coreos-ignition-setup-user which wants to copy the Ignition config to `/usr/lib/ignition`.

I think the right fix for this is to have Ignition learn to also source from `/etc` and `/run`, which is the standard nowadays:

https://github.com/coreos/ignition/issues/1891

But for now at least, we can safely remount `/usr` read-write ourselves without affecting the rest of the system since we're already running with `MountFlags=slave`.