### PR TITLE
tests/kola: adapt for new pure-RHEL variants

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -49,12 +49,6 @@ get_rhel_maj_ver() {
     echo "${RHEL_VERSION%%.*}"
 }
 
-# rhcos8
-is_rhcos8() {
-    source /etc/os-release
-    [ "${ID}" == "rhcos" ] && [ "${RHEL_VERSION%%.*}" -eq 8 ]
-}
-
 # rhcos9
 is_rhcos9() {
     source /etc/os-release

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -34,6 +34,7 @@ is_fcos() {
 # Note when using this, you probably also want to check `get_rhel_maj_ver`.
 is_rhcos() {
     source /etc/os-release
+    { [ "${ID}" == "rhel" ] && [ "${VARIANT_ID}" == "coreos" ]; } || \
     [ "${ID}" == "rhcos" ]
 }
 
@@ -46,13 +47,20 @@ get_fedora_ver() {
 
 get_rhel_maj_ver() {
     source /etc/os-release
-    echo "${RHEL_VERSION%%.*}"
+    if [ "${ID}" == "rhcos" ]; then
+        echo "${RHEL_VERSION%%.*}"
+    elif [ "${ID}" == "rhel" ]; then
+        echo "${VERSION_ID%%.*}"
+    else
+        fatal "Unknown ID $ID"
+    fi
 }
 
 # rhcos9
 is_rhcos9() {
     source /etc/os-release
-    [ "${ID}" == "rhcos" ] && [ "${RHEL_VERSION%%.*}" -eq 9 ]
+    { [ "${ID}" == "rhcos" ] && [ "${RHEL_VERSION%%.*}" -eq 9 ]; } || \
+    { [ "${ID}" == "rhel" ] && [ "${VERSION_ID%%.*}" -eq 9 ]; }
 }
 
 # scos

--- a/tests/kola/files/initrd/compression
+++ b/tests/kola/files/initrd/compression
@@ -12,11 +12,7 @@ set -xeuo pipefail
 . "$KOLA_EXT_DATA/commonlib.sh"
 
 # Check initrd for zstd magic number
-if is_rhcos8; then
-    ok "Skipping initrd zstd compression test on RHCOS 8"
-else
-    if ! LANG=C grep -aUPq "\x28\xb5\x2f\xfd" /boot/ostree/*/init*; then
-        fatal "Didn't find zstd compression in initrd"
-    fi
-    ok "Found zstd compression in initrd"
+if ! LANG=C grep -aUPq "\x28\xb5\x2f\xfd" /boot/ostree/*/init*; then
+    fatal "Didn't find zstd compression in initrd"
 fi
+ok "Found zstd compression in initrd"

--- a/tests/kola/files/rpmdb-sqlite
+++ b/tests/kola/files/rpmdb-sqlite
@@ -2,8 +2,7 @@
 ## kola:
 ##   # Read only test thus safe to run in parallel
 ##   exclusive: false
-##   description: Verify that we're using the sqlite rpmdb backend
-##     for RHCOS 9+ and FCOS 33+.
+##   description: Verify that we're using the sqlite rpmdb backend.
 
 # See https://github.com/coreos/fedora-coreos-tracker/issues/623
 
@@ -11,11 +10,6 @@ set -xeuo pipefail
 
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
-
-if is_rhcos8; then
-    ok "nothing to check for RHCOS 8"
-    exit 0
-fi
 
 if [ ! -f /usr/share/rpm/rpmdb.sqlite ]; then
     fatal "Didn't find file /usr/share/rpm/rpmdb.sqlite"

--- a/tests/kola/networking/default-network-behavior-change/test.sh
+++ b/tests/kola/networking/default-network-behavior-change/test.sh
@@ -160,7 +160,7 @@ if [ "$ID" == "fedora" ]; then
     else
         fatal "fail: not operating on expected OS version"
     fi
-elif [[ "${ID_LIKE}" =~ "rhel" ]]; then
+elif [[ "${ID}" = "rhel" ]] || [[ "${ID_LIKE}" =~ "rhel" ]]; then
     # For the version comparison use string substitution to remove the
     # '.` from the version so we can use integer comparison
 

--- a/tests/kola/networking/hostname/fallback-hostname/test.sh
+++ b/tests/kola/networking/hostname/fallback-hostname/test.sh
@@ -51,34 +51,25 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-if is_rhcos8; then
-    if [ $(hostnamectl --transient) != 'localhost' ]; then
-        fatal "transient hostname was not expected"
-    fi
-    if [ ! -z $(hostnamectl --static) ]; then
-        fatal "static hostname not expected to be set"
-    fi
-else
-    output=$(hostnamectl --json=pretty)
-    hostname=$(echo "$output" | jq -r '.Hostname')
-    fallback=$(echo "$output" | jq -r '.DefaultHostname')
-    static=$(echo "$output" | jq -r '.StaticHostname')
-    namesource=$(echo "$output" | jq -r '.HostnameSource')
+output=$(hostnamectl --json=pretty)
+hostname=$(echo "$output" | jq -r '.Hostname')
+fallback=$(echo "$output" | jq -r '.DefaultHostname')
+static=$(echo "$output" | jq -r '.StaticHostname')
+namesource=$(echo "$output" | jq -r '.HostnameSource')
 
-    if [ "$hostname" != 'localhost' ]; then
-        fatal "hostname was not expected"
-    fi
-    if [ "$fallback" != 'localhost' ]; then
-        fatal "fallback hostname was not expected"
-    fi
-    if [ "$static" != 'null' ]; then
-        fatal "static hostname not expected to be set"
-    fi
-    if [ "$namesource" != 'default' ]; then
-        # For this test since we disabled NM setting the hostname we
-        # expect the hostname to have been set via the fallback/default
-        fatal "hostname was set from non-default/fallback source"
-    fi
+if [ "$hostname" != 'localhost' ]; then
+    fatal "hostname was not expected"
+fi
+if [ "$fallback" != 'localhost' ]; then
+    fatal "fallback hostname was not expected"
+fi
+if [ "$static" != 'null' ]; then
+    fatal "static hostname not expected to be set"
+fi
+if [ "$namesource" != 'default' ]; then
+    # For this test since we disabled NM setting the hostname we
+    # expect the hostname to have been set via the fallback/default
+    fatal "hostname was set from non-default/fallback source"
 fi
 
 ok "fallback hostname wired up correctly"

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -66,10 +66,6 @@ main() {
     sleep 5
 
     retryflag="--retry-all-errors"
-    # --retry-all-errors flag passed to curl is not available on RHEL8
-    if is_rhcos8; then
-        retryflag="--retry-connrefused"
-    fi
     # Try to grab the web page. Retry as it might not be up fully yet.
     if ! curl --silent --show-error --retry 5 ${retryflag} http://localhost:8080 >/dev/null; then
         runascoreuser podman logs httpd


### PR DESCRIPTION
A big part of the new variants added in
https://github.com/openshift/os/pull/1445 is that we only minimally
modify `/etc/os-release`. This means that e.g. `ID` is still `rhel` and
`VERSION_ID` is e.g. `9.4` for the `rhel-9.4` variant. We do still
inject `VARIANT` and `VARIANT_ID` though.

Adapt these library functions here to handle this.