### PR TITLE
denylist: extend snooze on `coreos.ignition.ssh.key`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-05-20
+  snooze: 2024-07-01
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
This test is still failing. Let's snooze again while we wait for https://github.com/coreos/afterburn/pull/1074 to land.