### PR TITLE
Denylist: add kdump.crash for ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,9 @@
   warn: true
   arches:
     - ppc64le
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1750
+  warn: true
+  snooze: 2024-07-15
+  arches:
+    - ppc64le


### PR DESCRIPTION
Looks like kexec-tools is not compatible with kernel 6.9, add the test to denylist and snooze it for a couple of weeks.

Tracking issue: https://github.com/coreos/fedora-coreos-tracker/issues/1750 See https://github.com/rhkdump/kdump-utils/issues/15