### PR TITLE
tests/kdump.crash: enable more debugging in kdump service

### DIFF
--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -12,3 +12,8 @@ systemd:
   units:
     - name: kdump.service
       enabled: true
+      dropins:
+        - name: debug.conf
+          contents: |
+            [Service]
+            Environment="debug=1"


### PR DESCRIPTION
   
    Recent kdump updates started to fail without any error, so this
    will increase the verbosity of the kdump service.
    This will increase the logs size but logs are discarded on
    successful tests so that's fine.
    
    See https://github.com/rhkdump/kdump-utils/issues/15#issuecomment-2188528819
