### PR TITLE
manifests/fedora-coreos-base: re-add qed-firmware

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -2124,6 +2124,12 @@
         "sourcerpm": "publicsuffix-list"
       }
     },
+    "qed-firmware": {
+      "evra": "20240610-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "linux-firmware"
+      }
+    },
     "qemu-user-static-x86": {
       "evra": "2:8.2.2-1.fc40.aarch64",
       "metadata": {

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -2112,6 +2112,12 @@
         "sourcerpm": "publicsuffix-list"
       }
     },
+    "qed-firmware": {
+      "evra": "20240610-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "linux-firmware"
+      }
+    },
     "qemu-user-static-x86": {
       "evra": "2:8.2.2-1.fc40.ppc64le",
       "metadata": {

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -2010,6 +2010,12 @@
         "sourcerpm": "publicsuffix-list"
       }
     },
+    "qed-firmware": {
+      "evra": "20240610-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "linux-firmware"
+      }
+    },
     "qemu-user-static-x86": {
       "evra": "2:8.2.2-1.fc40.s390x",
       "metadata": {

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -2148,6 +2148,12 @@
         "sourcerpm": "publicsuffix-list"
       }
     },
+    "qed-firmware": {
+      "evra": "20240610-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "linux-firmware"
+      }
+    },
     "readline": {
       "evra": "8.2-8.fc40.x86_64",
       "metadata": {

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -157,6 +157,8 @@ packages:
   - iptables-legacy
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
+  # NIC firmware we've traditionally shipped but then were split out of linux-firmware in Fedora
+  - qed-firmware # https://github.com/coreos/fedora-coreos-tracker/issues/1746
 
 
 # - irqbalance


### PR DESCRIPTION
We lost this during a recent linux-firmware update which broke it out into a separate subpackage. Re-add it.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1746