### PR TITLE
overlay/15fcos: fix aleph file and update bootloader for Secure Boot nodes

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -6,3 +6,6 @@ enable fwupd-refresh.timer
 # Check if wifi firmwares are missing when NetworkManager-wifi is installed
 # https://github.com/coreos/fedora-coreos-tracker/issues/1575
 enable coreos-check-wireless-firmwares.service
+# Strip extraneous field in aleph files to avoid bootupctl failing
+# https://github.com/coreos/fedora-coreos-tracker/issues/1724
+enable coreos-fix-aleph-file.service

--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -9,3 +9,6 @@ enable coreos-check-wireless-firmwares.service
 # Strip extraneous field in aleph files to avoid bootupctl failing
 # https://github.com/coreos/fedora-coreos-tracker/issues/1724
 enable coreos-fix-aleph-file.service
+# Upgrade bootloader on Secure Boot-enabled nodes to avoid
+# https://github.com/coreos/fedora-coreos-tracker/issues/1752
+enable coreos-bootupctl-update-secureboot.service

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-bootupctl-update-secureboot.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-bootupctl-update-secureboot.service
@@ -1,0 +1,20 @@
+# Remove after the next barrier release
+
+[Unit]
+Description=Update Bootloader for Secure Boot-enabled Systems
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/1752
+ConditionSecurity=uefi-secureboot
+
+# make sure to run after the aleph file is fixed
+# see https://github.com/coreos/fedora-coreos-tracker/issues/1724
+After=coreos-fix-aleph-file.service
+Requires=coreos-fix-aleph-file.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-update-bootloader
+RemainAfterExit=yes
+MountFlags=slave
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-fix-aleph-file.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-fix-aleph-file.service
@@ -1,0 +1,14 @@
+# Remove after the next barrier release
+
+[Unit]
+Description=Fix CoreOS Aleph File
+Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/1724
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-fix-aleph-file
+RemainAfterExit=yes
+MountFlags=slave
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/15fcos/usr/libexec/coreos-fix-aleph-file
+++ b/overlay.d/15fcos/usr/libexec/coreos-fix-aleph-file
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+# This script removes the extra `version` field
+# which was shipped in a couple of builds
+# when switching to the `build` field
+# To be removed after the next barrier release.
+# see https://github.com/coreos/fedora-coreos-tracker/issues/1724 for more details
+
+set -euo pipefail
+
+ALEPH_FILE=/sysroot/.coreos-aleph-version.json
+
+if ! jq -e 'has("build") and has("version")' ${ALEPH_FILE}; then
+    echo "Aleph file does not require fixing"
+    exit
+fi
+
+echo "Aleph file is invalid; fixing"
+
+# remount /sysroot as writable
+mount -o rw,remount /sysroot
+
+# remove field "build"
+fixed_aleph=$(jq 'del(.build)' ${ALEPH_FILE})
+
+echo "$fixed_aleph" > ${ALEPH_FILE}
+
+echo "Aleph file is fixed"

--- a/overlay.d/15fcos/usr/libexec/coreos-update-bootloader
+++ b/overlay.d/15fcos/usr/libexec/coreos-update-bootloader
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script update the bootloader using bootupd
+# and also detect RAID-1 setups as those requires
+# extra steps
+
+if [ -e /dev/disk/by-label/EFI-SYSTEM ]; then
+    echo "Found ESP; calling 'bootupctl update'"
+    bootupctl update
+    exit
+fi
+
+# handle RAID case manually since bootupd doesn't support it
+# https://github.com/coreos/bootupd/issues/132
+i=1
+while true; do
+    if [ ! -e /dev/disk/by-label/esp-$i ]; then
+        break
+    fi
+    echo "Found ESP (replica $i); updating"
+    mount /dev/disk/by-label/esp-$i /boot/efi
+    cp -rp /usr/lib/bootupd/updates/EFI /boot/efi
+    umount /boot/efi
+    i=$((i+1))
+done
+sync


### PR DESCRIPTION
overlay/15fcos: ensure valid aleph file

Due to an ordering mishap, some builds have both a `version` and a
`build` field. This causes bootupctl to fail while parsing the file.

Detect this case, and fix the aleph if necessary by removing the `build`
field.

This should be removed after the next barrier release.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1724

---

overlay/15fcos: upgrade bootloader for Secure Boot-enabled systems

The 6.9 kernel won't boot on systems installed prior to F39, as the shim
is too old.

Add a systemd unit that updates the bootloader on those machines.
Manually handle systems with mirrored ESPs.

See also: https://github.com/coreos/fedora-coreos-tracker/issues/1752
Fixes: https://github.com/fedora-silverblue/issue-tracker/issues/543