### PR TITLE
denylist: snooze ssh.key until new afterburn release

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,7 +7,7 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: coreos.ignition.ssh.key
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-07-01
+  snooze: 2024-08-01
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
Extend the snooze on the `coreos.ignition.ssh.key` test failure for another month until a new release of Afterburn can be performed that will include the fix for the failure: https://github.com/coreos/afterburn/pull/1074.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1553