### PR TITLE
fasttrack openssh-9.6p1-1.fc40.4

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -39,3 +39,21 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1752
       type: pin
+  openssh:
+    evr: 9.6p1-1.fc40.4
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-dc89a2e1bf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1754
+      type: fast-track
+  openssh-clients:
+    evr: 9.6p1-1.fc40.4
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-dc89a2e1bf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1754
+      type: fast-track
+  openssh-server:
+    evr: 9.6p1-1.fc40.4
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-dc89a2e1bf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1754
+      type: fast-track


### PR DESCRIPTION
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1754