### PR TITLE
denylist: add ext.kdump.crash for aarch64 and remove for ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,9 +16,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1750
-  warn: true
-  snooze: 2024-07-15
-  arches:
-    - ppc64le

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,9 @@
   warn: true
   arches:
     - ppc64le
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/rhkdump/kdump-utils/issues/22
+  warn: true
+  snooze: 2024-07-15
+  arches:
+    - aarch64


### PR DESCRIPTION
See https://github.com/rhkdump/kdump-utils/issues/22