### PR TITLE
overrides: pin selinux-policy-40.20-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  selinux-policy:
+    evra: 40.20-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1758
+      type: pin
+  selinux-policy-targeted:
+    evra: 40.20-1.fc40.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1758
+      type: pin


### PR DESCRIPTION
Requested by @jlebon via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).