### PR TITLE
[rawhide] overrides: pin json-glib and selinux-policy

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,21 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  json-glib:
+    evr: 1.8.0-1.fc40
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
+      type: pin
+  selinux-policy:
+    evra: 41.2-1.fc41.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
+      type: pin
+  selinux-policy-targeted:
+    evra: 41.2-1.fc41.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
+      type: pin
   device-mapper:
     evr: 1.02.197-1.fc40
     metadata:


### PR DESCRIPTION
A lot of things are pinned right now because of a bunch of SELinux issues.

As a result, we haven't had a new rawhide build in almost a month, and this is starting to affect the reliability of Bodhi testing. Let's pin the problematic packages for now to get a build out.