### PR TITLE
Enable composefs for 41+

### DIFF
--- a/manifests/composefs.yaml
+++ b/manifests/composefs.yaml
@@ -1,0 +1,3 @@
+# Enable composefs by default.
+ostree-layers:
+  - overlay/08composefs

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -30,6 +30,8 @@ conditional-include:
   # Wifi firmwares will be dropped in F41
   - if: releasever < 41
     include: wifi-firmwares.yaml
+  - if: stream == "rawhide"
+    include: composefs.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/overlay.d/08composefs/README.md
+++ b/overlay.d/08composefs/README.md
@@ -1,0 +1,2 @@
+Enable composefs by default; more in https://ostreedev.github.io/ostree/composefs/
+For now rawhide only.

--- a/overlay.d/08composefs/etc/systemd/system/kdump.service.d/override.conf
+++ b/overlay.d/08composefs/etc/systemd/system/kdump.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+PrivateTmp=no

--- a/overlay.d/08composefs/usr/lib/ostree/prepare-root.conf
+++ b/overlay.d/08composefs/usr/lib/ostree/prepare-root.conf
@@ -1,0 +1,2 @@
+[composefs]
+enabled = true


### PR DESCRIPTION
We really want to aim to eventually enable this by default, let's
test things out in rawhide.

A thing that this is known to break is the "chattr -i" hack
for new toplevel dirs (xref coreos/rpm-ostree#337 )

Basically if you want that, you either need to make a derived image,
or enable transient root.

Replaces #3009 