### PR TITLE
Denylist: add ext.config.shared.ntp.chrony.dhcp-propagation

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -22,3 +22,7 @@
   snooze: 2024-07-15
   arches:
     - aarch64
+- pattern: ext.config.shared.ntp.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1761
+  warn: true
+  snooze: 2024-07-29


### PR DESCRIPTION
The test currently fails to fetch F38 metadata

Tracker issue: https://github.com/coreos/fedora-coreos-tracker/issues/1761
Also see: https://pagure.io/releng/issue/12204