### PR TITLE
denylist: add kdump.crash.ssh for aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,8 +17,14 @@
   arches:
     - ppc64le
 - pattern: ext.config.kdump.crash
-  tracker: https://github.com/rhkdump/kdump-utils/issues/22
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1762
   warn: true
-  snooze: 2024-07-15
+  snooze: 2024-07-20
+  arches:
+    - aarch64
+- pattern: kdump.crash.ssh
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1762
+  warn: true
+  snooze: 2024-07-20
   arches:
     - aarch64


### PR DESCRIPTION
This test was recently added in https://github.com/coreos/coreos-assembler/pull/3829 but hit the same issue as `ext.kdump.crash`.
This should be fixed in kexec-tools-2.0.28-12.fc40, so extending the snooze for 5 days only as it should hit stable soon.