### PR TITLE
overrides: fast-track kexec-tools-2.0.28-12.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,12 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  kexec-tools:
+    evr: 2.0.28-12.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-e9e4994b36
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1762
+      type: fast-track
   selinux-policy:
     evra: 40.20-1.fc40.noarch
     metadata:


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).