### PR TITLE
Revert "denylist: add kdump.crash.ssh for aarch64"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,9 +16,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/rhkdump/kdump-utils/issues/22
-  warn: true
-  snooze: 2024-07-15
-  arches:
-    - aarch64

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,14 +17,8 @@
   arches:
     - ppc64le
 - pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1762
+  tracker: https://github.com/rhkdump/kdump-utils/issues/22
   warn: true
-  snooze: 2024-07-20
-  arches:
-    - aarch64
-- pattern: kdump.crash.ssh
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1762
-  warn: true
-  snooze: 2024-07-20
+  snooze: 2024-07-15
   arches:
     - aarch64


### PR DESCRIPTION
This reverts commit b907804.
Fixed by fast tracking kexec-tools-2.0.28-12.fc40
in 78a21dc