### PR TITLE
overrides: unpin selinux-policy-40.20-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,13 +19,3 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eeaf090672
       type: fast-track
-  selinux-policy:
-    evra: 40.20-1.fc40.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1758
-      type: pin
-  selinux-policy-targeted:
-    evra: 40.20-1.fc40.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1758
-      type: pin


### PR DESCRIPTION
With the latest build of selinux-policy (selinux-policy-40.27-1.fc40), the issue with `no serial console login` is fixed.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1758