### PR TITLE
overrides: fast-track selinux-policy-40.27-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,3 +19,13 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eeaf090672
       type: fast-track
+  selinux-policy:
+    evra: 40.27-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-995d585c91
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 40.27-1.fc40.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-995d585c91
+      type: fast-track


### PR DESCRIPTION
With the latest build of selinux-policy (selinux-policy-40.27-1.fc40), the issue with `no serial console login` is fixed.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1758