### PR TITLE
[rawhide] overrides: drop selinux-policy pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,16 +14,6 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
       type: pin
-  selinux-policy:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
-  selinux-policy-targeted:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
   device-mapper:
     evr: 1.02.197-1.fc40
     metadata:


### PR DESCRIPTION
Let's run CI against dropping the selinux-policy pin. I tested this locally and produced a successful build that passed all kola tests. 