### PR TITLE
[branched] Start tracking Fedora 41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,94 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  json-glib:
+    evr: 1.8.0-1.fc40
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
+      type: pin
+  selinux-policy:
+    evra: 41.2-1.fc41.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
+      type: pin
+  selinux-policy-targeted:
+    evra: 41.2-1.fc41.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
+      type: pin
+  device-mapper:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-event:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-event-libs:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-libs:
+    evr: 1.02.197-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-multipath:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  device-mapper-multipath-libs:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  kpartx:
+    evr: 0.9.7-7.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  lvm2:
+    evr: 2.03.23-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  lvm2-libs:
+    evr: 2.03.23-1.fc40
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-container:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-libs:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-pam:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-resolved:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin
+  systemd-udev:
+    evr: 255.5-1.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,16 +14,6 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
       type: pin
-  selinux-policy:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
-  selinux-policy-targeted:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
   device-mapper:
     evr: 1.02.197-1.fc40
     metadata:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 40
+releasever: 41
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 41 has now branched from rawhide.

- manifest: bump to F41
- overrides: copy list of overrides from rawhide
- overrides: drop selinux-policy pin

EDITS:

- PR title change: ~~[branched] manifest: bump to F41~~ [branched] Start tracking Fedora 41