### PR TITLE
[rawhide] manifest: Rawhide is now F42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,16 +14,6 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
       type: pin
-  selinux-policy:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
-  selinux-policy-targeted:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
   device-mapper:
     evr: 1.02.197-1.fc40
     metadata:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: rawhide
   prod: false
 
-releasever: 41
+releasever: 42
 
 repos:
   - fedora-rawhide


### PR DESCRIPTION
Fedora 41 branched from rawhide, so rawhide is now F42