### PR TITLE
[stable] denylist: snooze ext.config.extensions.package for aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,8 @@
   # warn: true (disabled on promotion)
   arches:
     - ppc64le
+- pattern: ext.config.extensions.package
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1776
+  snooze: 2024-09-02
+  arches:
+    - aarch64


### PR DESCRIPTION
See: https://github.com/coreos/fedora-coreos-tracker/issues/1776