### PR TITLE
workflows/openshift-os: add rhcos-4.17

### DIFF
--- a/.github/workflows/openshift-os.yml
+++ b/.github/workflows/openshift-os.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - testing-devel
+          - rhcos-4.17
           - rhcos-4.16
           - rhcos-4.15
           - rhcos-4.14


### PR DESCRIPTION
Add `rhcos-4.17` to keep that branch in sync with openshift/os.