### PR TITLE
denylist: branched: add kola-iso tests failing due to SELinux denials

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,33 @@
   warn: true
   arches:
     - ppc64le
+- pattern: iso-install.bios
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
+  warn: true
+  snooze: 2024-08-31
+  streams:
+    - branched
+- pattern: iso-offline-*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
+  warn: true
+  snooze: 2024-08-31
+  streams:
+    - branched
+- pattern: miniso-install*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
+  warn: true
+  snooze: 2024-08-31
+  streams:
+    - branched
+- pattern: pxe-online-*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
+  warn: true
+  snooze: 2024-08-31
+  streams:
+    - branched
+- pattern: pxe-offline-*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
+  warn: true
+  snooze: 2024-08-31
+  streams:
+    - branched


### PR DESCRIPTION
These tests are all experiencing SELinux AVC denials causing CoreOS Installer to fail in these installation configurations.
These failures are preventing us from getting out a `branched` build tracking Fedora 41.

```
iso-install.bios
iso-offline-install.bios
iso-offline-install.mpath.bios
iso-offline-install-fromram.4k.uefi
miniso-install.bios
miniso-install.nm.bios
miniso-install.4k.nm.uefi
pxe-offline-install.bios
pxe-offline-install.4k.uefi
pxe-online-install.bios
pxe-online-install.4k.uefi
```

Denylist them on the `branched` stream for now until we can get the issue resolved.

### Tracker Issue
https://github.com/coreos/fedora-coreos-tracker/issues/1779

### BugZilla Issue
https://bugzilla.redhat.com/show_bug.cgi?id=2305385