### PR TITLE
denylist: rawhide: add kola-iso tests failing due to SELinux denials

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,28 +21,33 @@
   warn: true
   snooze: 2024-08-31
   streams:
+    - rawhide
     - branched
 - pattern: iso-offline-*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
   warn: true
   snooze: 2024-08-31
   streams:
+    - rawhide
     - branched
 - pattern: miniso-install*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
   warn: true
   snooze: 2024-08-31
   streams:
+    - rawhide
     - branched
 - pattern: pxe-online-*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
   warn: true
   snooze: 2024-08-31
   streams:
+    - rawhide
     - branched
 - pattern: pxe-offline-*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
   warn: true
   snooze: 2024-08-31
   streams:
+    - rawhide
     - branched


### PR DESCRIPTION
These tests are all experiencing SELinux AVC denials causing CoreOS Installer to fail in these installation configurations. Denylist them for now until we can get the issue resolved:

``` text
iso-install.bios
iso-offline-install.bios
iso-offline-install.mpath.bios
iso-offline-install-fromram.4k.uefi
miniso-install.bios
miniso-install.nm.bios
miniso-install.4k.nm.uefi
pxe-offline-install.bios
pxe-offline-install.4k.uefi
pxe-online-install.bios
pxe-online-install.4k.uefi
```

see: https://github.com/coreos/fedora-coreos-tracker/issues/1779

This should have been part of https://github.com/coreos/fedora-coreos-config/pull/3100.