### PR TITLE
[rawhide] overrides: remove selinux-policy pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,16 +14,6 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
       type: pin
-  selinux-policy:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
-  selinux-policy-targeted:
-    evra: 41.2-1.fc41.noarch
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2292472
-      type: pin
   device-mapper:
     evr: 1.02.197-1.fc40
     metadata:


### PR DESCRIPTION
The issue related to this pin seems to have been resolved and keeping the pin is causing build failures in rawhide.

Wait for https://github.com/coreos/fedora-coreos-config/pull/3101 to merge so CI can run smoothly past the build stage.
