### PR TITLE
denylist: rawhide: snooze `ext.config.files.validate-symlinks`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -51,3 +51,9 @@
   streams:
     - rawhide
     - branched
+- pattern: ext.config.files.validate-symlinks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1782
+  warn: true
+  snooze: 2024-09-02
+  streams:
+    - rawhide


### PR DESCRIPTION
`ext.config.files.validate-symlinks` is failing in rawhide, which is now tracking Fedora 42. 
Snooze it for two weeks until the issue is resolved.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1782