### PR TITLE
tests/files/validate-symlinks: add bootc/storage symlink to allowlist

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -22,6 +22,7 @@ list_broken_symlinks_skip=(
     '/etc/swid/swidtags.d/fedoraproject.org'
     '/etc/xdg/systemd/user'
     '/usr/lib/.build-id/'
+    '/usr/lib/bootc/storage'
     '/usr/lib/firmware'
     '/usr/lib/modules/'
     '/usr/share/rhel/secrets/etc-pki-entitlement'


### PR DESCRIPTION
This symlink isn't broken on a system deployed via bootc, but it it is broken otherwise. Add the symlink to the allowlist for the test so it will pass in rawhide.

fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1782