### PR TITLE
manifests/user-experience: Add `which` package

### DIFF
--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -50,3 +50,5 @@ packages:
   - nvme-cli
   # Used by admins interactively
   - lsof
+  # Locates executable files' paths in `PATH`
+  - which


### PR DESCRIPTION
The `which` package is required to locate the path of executable files in the system's PATH environment. Let's add it to manifests for FCOS and RHCOS.
Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1783