### PR TITLE
[rhcos-4.16] Updates for the RHCOS Pipeline migration to an ITUP Cluster

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,9 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:latest
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,9 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:latest
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \


### PR DESCRIPTION
backport https://github.com/coreos/fedora-coreos-config/pull/3061 to `rhcos-4.16`.

EDIT:
Note: the commits were amended to use the `fedora:latest` container so we never use EOL releases in these tests.

```
commit c27a14fbfea8ae6e96d51a5c87ade75d444072d0
Author: Michael Armijo <marmijo@redhat.com>
Date:   Thu Jul 11 13:28:36 2024 -0600

    tests/podman/rootless-systemd: use the FCOS defined fedora.repo to set up container
    
    Use the fedora.repo file defined in fedora-coreos-config to set up the
    container. This will force packages to be downloaded from
    dl.fedoraproject.org, as specified in the FCOS file. The ITUP cluster,
    being used by the RHCOS pipeline, requires all outbound connections
    to be specified in a Firewall Egress file, and this will ensure the
    same connection will always be used.
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>

commit 0988f93b273b2b77b57e13e97af5e250a95856e2
Author: Michael Armijo <marmijo@redhat.com>
Date:   Thu Jul 11 13:27:14 2024 -0600

    tests/ntp: use the FCOS defined fedora.repo to set up container
    
    Use the fedora.repo file defined in fedora-coreos-config to set up the
    container. This will force packages to be downloaded from
    dl.fedoraproject.org, as specified in the FCOS file. The ITUP cluster,
    being used by the RHCOS pipeline, requires all outbound connections
    to be specified in a Firewall Egress file, and this will ensure the
    same connection will always be used.
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>

```