### PR TITLE
[rhcos-4.12] Updates for the RHCOS Pipeline migration to an ITUP Cluster

### DIFF
--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -34,7 +34,9 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:latest
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \


### PR DESCRIPTION
backport https://github.com/coreos/fedora-coreos-config/pull/3061 to rhcos-4.12.

Note: 
- EDIT: the commit was amended to use the `fedora:latest` container so we never use EOL releases in this tests.
- `tests/kola/ntp` does not exist in this branch so https://github.com/coreos/fedora-coreos-config/pull/3061/commits/48530410c95836ae6a5b1c352d029e6bbbb26d2d was omitted from this backport.