### PR TITLE
[rawhide] overrides: fast-track systemd-256.5-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,78 +14,39 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
       type: pin
-  device-mapper:
-    evr: 1.02.197-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  device-mapper-event:
-    evr: 1.02.197-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  device-mapper-event-libs:
-    evr: 1.02.197-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  device-mapper-libs:
-    evr: 1.02.197-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  device-mapper-multipath:
-    evr: 0.9.7-7.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  device-mapper-multipath-libs:
-    evr: 0.9.7-7.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  kpartx:
-    evr: 0.9.7-7.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  lvm2:
-    evr: 2.03.23-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
-  lvm2-libs:
-    evr: 2.03.23-1.fc40
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
   systemd:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track
   systemd-container:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track
   systemd-libs:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track
   systemd-pam:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track
   systemd-resolved:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track
   systemd-udev:
-    evr: 255.5-1.fc41
+    evr: 256.5-1.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1735
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-ff872f0544
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1775
+      type: fast-track


### PR DESCRIPTION
systemd v256 added a new userdb functionality where SSH authorized
keys can be part of a User Record. To make this transparently
work with sshd authentication, an sshd config dropin that sets an
`AuthorizedKeysCommand` directive was added.

Unfortunately, it was added with a higher priority than intended,
which meant that it overrode the `AuthorizedKeysCommand` directive from
`ssh-key-dir`, which is how our `~/.ssh/authorized_keys.d/` magic works
today with Ignition and Afterburn. So the end result is that this broke
SSH which of course broke kola too.

This is tracked in upstream systemd at:

https://github.com/systemd/systemd/issues/33648

The dropin was recently reverted in Fedora:

https://src.fedoraproject.org/rpms/systemd/c/38291e13c1dec15618b7d09e4217d10076897cdf?branch=rawhide

Fast-track the latest rawhide systemd build with that change.

We'll need to keep an eye on the conversation there to make sure that
the final solution doesn't re-break FCOS, but we would notice it pretty
quickly too.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1775