### PR TITLE
tests/kola: use latest fedora:latest on tests that require it

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,7 +20,7 @@ ntp_test_setup() {
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:latest
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -35,7 +35,7 @@ set -euxo pipefail
 #       https://github.com/coreos/coreos-assembler/issues/1645
 cd $(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:latest
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y update \


### PR DESCRIPTION
Both `ntp.chrony.dhcp-propagation` and `podman.rootless-systemd` use the Fedora container to set up the environment for the test. Always use the `fedora:latest` container so we never use EOL Fedora releases in kola tests.