### PR TITLE
[branched] Disable systemd-ssh-generator for s390x

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,8 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+extra-kargs:
+    # Disable systemd-ssh-generator until selinux-policy get fixed
+    # see https://github.com/coreos/fedora-coreos-tracker/issues/1786
+    - systemd.ssh_auto=no


### PR DESCRIPTION
selinux-policy denies access to /proc/sysinfo which is required by the ssh-generator for s390x architecture.
Desabling this generator until selinux-policy get an update as all the tests fails due to this: kola check for badness in the console output.

See https://github.com/coreos/fedora-coreos-tracker/issues/1786