### PR TITLE
manifests: add selinux-workaround.yaml for >= F41

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,41 +16,6 @@
   warn: true
   arches:
     - ppc64le
-- pattern: iso-install.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
-  warn: true
-  snooze: 2024-09-16
-  streams:
-    - rawhide
-    - branched
-- pattern: iso-offline-*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
-  warn: true
-  snooze: 2024-09-16
-  streams:
-    - rawhide
-    - branched
-- pattern: miniso-install*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
-  warn: true
-  snooze: 2024-09-16
-  streams:
-    - rawhide
-    - branched
-- pattern: pxe-online-*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
-  warn: true
-  snooze: 2024-09-16
-  streams:
-    - rawhide
-    - branched
-- pattern: pxe-offline-*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779
-  warn: true
-  snooze: 2024-09-16
-  streams:
-    - rawhide
-    - branched
 - pattern: ext.config.kdump.crash
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2284097
   snooze: 2024-09-16

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -32,6 +32,8 @@ conditional-include:
     include: wifi-firmwares.yaml
   - if: releasever >= 41
     include: composefs.yaml
+  - if: releasever >= 41
+    include: selinux-workaround.yaml
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/selinux-workaround.yaml
+++ b/manifests/selinux-workaround.yaml
@@ -1,0 +1,23 @@
+# Recent changes in the SELinux policy have broken a lot of our code.
+# Revert the affected domains back to permissive mode so we can
+# continue to build and test `releasever >= 41` until
+# https://github.com/fedora-selinux/selinux-policy/pull/2257 merges
+# and the domains are reverted upstream or until the issue is resolved
+# altogether
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    cat > /tmp/fcos-workarounds.cil << EOF
+    ; https://bugzilla.redhat.com/show_bug.cgi?id=2300306
+    (typeattributeset cil_gen_require bootupd_t)
+    (typepermissive bootupd_t)
+    ; https://bugzilla.redhat.com/show_bug.cgi?id=2305385
+    (typeattributeset cil_gen_require coreos_installer_t)
+    (typepermissive coreos_installer_t)
+    ; https://bugzilla.redhat.com/show_bug.cgi?id=2306352
+    (typeattributeset cil_gen_require afterburn_t)
+    (typepermissive afterburn_t)
+    EOF
+    /usr/sbin/semodule -i /tmp/fcos-workarounds.cil
+    rm /tmp/fcos-workarounds.cil


### PR DESCRIPTION
Recent changes in the SELinux policy have broken a lot of our code. Add a `selinux-workaround.yaml` file to revert the affected domains back to permissive mode until https://github.com/fedora-selinux/selinux-policy/pull/2257 merges and the domains are reverted back to permissive mode upstream or the issue is resolved altogether. The `selinux-workaround.yaml` file is included only when `releasever >= 41` since we are seeing these issues in `branched` and `rawhide`.

**EDIT**: Remove the kola-iso test entries for `rawhide` and `branched` from the kola-denylist file. These tests now longer fail with the coreos_installer_t domain reverted back to permissive.

**EDIT 2**: Add the workaround for afterburn_t as well.

---

bootupd_t: https://bugzilla.redhat.com/show_bug.cgi?id=2300306

---

coreos_installer_t: 
- RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2305385
- FCOS Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1779

---

afterburn_t
- RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2306352
- FCOS Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1784