### PR TITLE
Add a fedora-archive repo

### DIFF
--- a/fedora-archive.repo
+++ b/fedora-archive.repo
@@ -1,0 +1,32 @@
+# Certain kola tests on older RHCOS branches rely on EOL Fedora containers
+# to set up and run the test environment. The ITUP cluster, being used by
+# the RHCOS pipeline, requires all outbound connections to be explicitly
+# specified in a Firewall Egress file. By using these archive repos on
+# the older RHCOS branches, we can ensure that those kola tests will
+# always download archived content from `https://dl.fedoraproject.org`.
+
+[fedora-archive]
+name=Fedora $releasever - $basearch
+baseurl=https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/archive/fedora-secondary/releases/$releasever/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False
+
+[fedora-archive-updates]
+name=Fedora $releasever - $basearch
+baseurl=https://dl.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/archive/fedora-secondary/updates/$releasever/Everything/$basearch/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+#metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+skip_if_unavailable=False


### PR DESCRIPTION
Certain kola tests on older RHCOS branches rely on EOL fedora containers to set up and run the test environment. Right now, the older content can be found on the mirrors, but as part of the RHCOS pipeline migration effort to the ITUP cluster, we have to explicitly specify each outbound connection.

Add a `fedora-archive.repo` file to be used in these tests so we can always download the older content from: `https://dl.fedoraproject.org`

see: https://github.com/coreos/fedora-coreos-config/pull/3123#issuecomment-2310780609

EDIT [2025-01-17]: This file was updated to use both the EOL and non-EOL repos to simplify things for the ITUP cluster, see the updated PR: https://github.com/coreos/fedora-coreos-config/pull/3145