### PR TITLE
[branched] overrides: fast-track selinux-policy-41.15-1.fc41

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,8 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-extra-kargs:
-    # Disable systemd-ssh-generator until selinux-policy get fixed
-    # see https://github.com/coreos/fedora-coreos-tracker/issues/1786
-    - systemd.ssh_auto=no

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  selinux-policy:
+    evra: 41.15-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1597066f01
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1786
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 41.15-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1597066f01
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1786
+      type: fast-track


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).