### PR TITLE
[rawhide] re-add manifest-lock.overrides and unpin json-glib

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  json-glib:
+    evr: 1.8.0-1.fc40
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  json-glib:
-    evr: 1.8.0-1.fc40
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2297094
-      type: pin
+packages: {}


### PR DESCRIPTION
The manifest-lock.overrides.yaml file was accidentally deleted in https://github.com/coreos/fedora-coreos-config/pull/3117 (https://github.com/coreos/fedora-coreos-config/pull/3117/commits/4c05d1fb7fb9599aed7bb39df18fff30e7f95c08).

Revert that commit to re-add the file and also unpin json-glib while leaving the file in place.