### PR TITLE
[rawhide] Revert "Disable systemd-ssh-generator for s390x"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -9,8 +9,3 @@ include: image-base.yaml
 # and enable it by default for rawhide!
 deploy-via-container: true
 container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:rawhide"
-
-extra-kargs:
-    # Disable systemd-ssh-generator until selinux-policy get fixed
-    # see https://github.com/coreos/fedora-coreos-tracker/issues/1786
-    - systemd.ssh_auto=no


### PR DESCRIPTION
This reverts commit da05de367255a1af44dd6628d8017e8b7d95f485. Upstream selinux-policy was fixed in https://github.com/fedora-selinux/selinux-policy/pull/2326 and release in selinux-policy-41.15-1.fc41

https://bodhi.fedoraproject.org/updates/FEDORA-2024-1597066f01