### PR TITLE
tests/upgrade: fix permission error; add logging

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -217,6 +217,10 @@ fi
 set -o pipefail
 
 
-# OK update has been initiated, prepare for reboot and sleep
+# OK update has been initiated, prepare for reboot and loop to show
+# status of zincati and rpm-ostreed
 /tmp/autopkgtest-reboot-prepare reboot
-sleep infinity
+while true; do
+    sleep 20
+    systemctl status rpm-ostreed zincati --lines=0
+done

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -144,10 +144,10 @@ ok "Reached version: $version"
 # If so then we can exit with success!
 if vereq $version $target_version; then
     ok "Fully upgraded to $target_version"
-    # log bootupctl information for inspection where available
-    # and check the status output
-    [ -f /usr/bin/bootupctl ] && /usr/bin/bootupctl status | tee bootupctl.txt
-    if ! grep "CoreOS aleph version" bootupctl.txt; then
+    # log bootupctl information for inspection and check the status output
+    state=$(/usr/bin/bootupctl status 2>&1)
+    echo "$state"
+    if ! echo "$state" | grep -q "CoreOS aleph version"; then
         fatal "check bootupctl status output"
     fi
     exit 0


### PR DESCRIPTION
With e726f1f we get a permission denied when this test runs in the
kola-upgrade job in the pipeline:

```
kola-runext-test.sh[1840]: + /usr/bin/bootupctl status
kola-runext-test.sh[1841]: + tee bootupctl.txt
kola-runext-test.sh[1841]: tee: bootupctl.txt: Operation not permitted
```

Let's rework it to not need to `tee` to write to a file and also
remove the "where available" part since we should have bootupd
in all of our newly built CoreOS versions.
