### PR TITLE
[rhcos-4.13] tests/kola: use fedora-archive.repo for EOL Fedora containers

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -20,6 +20,8 @@ ntp_test_setup() {
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
 FROM registry.fedoraproject.org/fedora:37
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -33,6 +33,8 @@ set -euxo pipefail
 cd $(mktemp -d)
 cat <<EOF > Containerfile
 FROM registry.fedoraproject.org/fedora:37
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \


### PR DESCRIPTION
Use the fedora-archive.repo file defined in fedora-coreos-config to set up the EOL containers in tests that use it. This will force packages to be downloaded from `https://df.fedoraproject.org`, as specified in the repo file. The ITUP cluster, being used by the RHCOS pipeline, requires all outbound connections to be specified in a Firewall Egress file, and this will ensure the same connection will always be used when downloading the archived fedora content.

See: https://github.com/coreos/fedora-coreos-config/pull/3128
This is a backport of https://github.com/coreos/fedora-coreos-config/pull/3136