### PR TITLE
[rhcos-4.16] tests/kola: use FCOS defined fedora-archive.repo to set up containers

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -22,7 +22,7 @@ ntp_test_setup() {
     cat <<EOF >Dockerfile
 FROM quay.io/fedora/fedora:40
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -21,6 +21,8 @@ ntp_test_setup() {
     pushd "$(mktemp -d)"
     cat <<EOF >Dockerfile
 FROM quay.io/fedora/fedora:40
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -36,6 +36,8 @@ set -euxo pipefail
 cd $(mktemp -d)
 cat <<EOF > Containerfile
 FROM quay.io/fedora/fedora:40
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -37,7 +37,7 @@ cd $(mktemp -d)
 cat <<EOF > Containerfile
 FROM quay.io/fedora/fedora:40
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \


### PR DESCRIPTION
This is a backport of: https://github.com/coreos/fedora-coreos-config/pull/3061
- 48530410c95836ae6a5b1c352d029e6bbbb26d2d (tests/ntp: use the FCOS defined fedora.repo to set up container)
- b9f3487e71c187742900d33622c996c079cea3df (tests/podman/rootless-systemd: use the FCOS defined fedora.repo to set up container)

There are two tests that use the fedora container to set up and run the test environment. Use the fedora.repo file defined in fedora-coreos-config to set up that container. This will force packages to be downloaded from dl.fedoraproject.org, as specified in the FCOS file. The ITUP cluster, being used by the RHCOS pipeline, requires all outbound connections to be specified in a Firewall Egress file, and this will ensure the same connection will always be used.

---
This is also a backport of https://github.com/coreos/fedora-coreos-config/pull/3146

The fedora-archive.repo file now contains both EOL and non-EOL repo locations[1]. This means we can change the two kola tests that use the fedora container to use fedora-archive.repo as the only repo configuration file. This reduces the maintenance burden because now we don't have to change this curl statement when fedora versions reach EOL.