### PR TITLE
manifests: add pciutils

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -876,6 +876,12 @@
         "sourcerpm": "hostname"
       }
     },
+    "hwdata": {
+      "evra": "0.386-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "hwdata"
+      }
+    },
     "ignition": {
       "evra": "2.19.0-1.fc40.aarch64",
       "metadata": {
@@ -2026,6 +2032,18 @@
       "evra": "0^20240821.g1d6142f-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
+      }
+    },
+    "pciutils": {
+      "evra": "3.13.0-1.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
+    "pciutils-libs": {
+      "evra": "3.13.0-1.fc40.aarch64",
+      "metadata": {
+        "sourcerpm": "pciutils"
       }
     },
     "pcre2": {

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -852,6 +852,12 @@
         "sourcerpm": "hostname"
       }
     },
+    "hwdata": {
+      "evra": "0.386-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "hwdata"
+      }
+    },
     "ignition": {
       "evra": "2.19.0-1.fc40.ppc64le",
       "metadata": {
@@ -2002,6 +2008,18 @@
       "evra": "0^20240821.g1d6142f-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
+      }
+    },
+    "pciutils": {
+      "evra": "3.13.0-1.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
+    "pciutils-libs": {
+      "evra": "3.13.0-1.fc40.ppc64le",
+      "metadata": {
+        "sourcerpm": "pciutils"
       }
     },
     "pcre2": {

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -798,6 +798,12 @@
         "sourcerpm": "hostname"
       }
     },
+    "hwdata": {
+      "evra": "0.386-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "hwdata"
+      }
+    },
     "ignition": {
       "evra": "2.19.0-1.fc40.s390x",
       "metadata": {
@@ -1906,6 +1912,18 @@
       "evra": "0^20240821.g1d6142f-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
+      }
+    },
+    "pciutils": {
+      "evra": "3.13.0-1.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
+    "pciutils-libs": {
+      "evra": "3.13.0-1.fc40.s390x",
+      "metadata": {
+        "sourcerpm": "pciutils"
       }
     },
     "pcre2": {

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -894,6 +894,12 @@
         "sourcerpm": "hostname"
       }
     },
+    "hwdata": {
+      "evra": "0.386-1.fc40.noarch",
+      "metadata": {
+        "sourcerpm": "hwdata"
+      }
+    },
     "ignition": {
       "evra": "2.19.0-1.fc40.x86_64",
       "metadata": {
@@ -2050,6 +2056,18 @@
       "evra": "0^20240821.g1d6142f-1.fc40.noarch",
       "metadata": {
         "sourcerpm": "passt"
+      }
+    },
+    "pciutils": {
+      "evra": "3.13.0-1.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
+    "pciutils-libs": {
+      "evra": "3.13.0-1.fc40.x86_64",
+      "metadata": {
+        "sourcerpm": "pciutils"
       }
     },
     "pcre2": {

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -52,3 +52,5 @@ packages:
   - lsof
   # Locates executable files' paths in `PATH`
   - which
+  # provides utilities for inspecting/setting devices connected to the PCI bus
+  - pciutils


### PR DESCRIPTION
pciutils provides a set of utilities for inspecting and setting devices connected to the PCI bus.
The utilities works from a privileged container but as they are tiny (~350 ko once uncompressed), the decision was made to include them in base system.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1778