### PR TITLE
fedora-archive.repo: use both EOL and non-EOL locations

### DIFF
--- a/fedora-archive.repo
+++ b/fedora-archive.repo
@@ -4,10 +4,15 @@
 # specified in a Firewall Egress file. By using these archive repos on
 # the older RHCOS branches, we can ensure that those kola tests will
 # always download archived content from `https://dl.fedoraproject.org`.
+# We include both EOL and non-EOL repository locations in the baseurl list
+# to simplify maintenance, avoiding the need to remove the fedora.repo file
+# as versions reach EOL.
 
 [fedora-archive]
 name=Fedora $releasever - $basearch
-baseurl=https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/fedora-secondary/releases/$releasever/Everything/$basearch/os/
+        https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
         https://dl.fedoraproject.org/pub/archive/fedora-secondary/releases/$releasever/Everything/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1
@@ -20,7 +25,9 @@ skip_if_unavailable=False
 
 [fedora-archive-updates]
 name=Fedora $releasever - $basearch
-baseurl=https://dl.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/Everything/$basearch/
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/fedora-secondary/updates/$releasever/Everything/$basearch/
+        https://dl.fedoraproject.org/pub/archive/fedora/linux/updates/$releasever/Everything/$basearch/
         https://dl.fedoraproject.org/pub/archive/fedora-secondary/updates/$releasever/Everything/$basearch/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1


### PR DESCRIPTION
Include both the EOL and non-EOL repo locations in the baseurl list to simplify maintenance. This update benefits two kola tests and the RHCOS extensions container by simplifying the repo configuration into a single file. As Fedora versions used by those containers reach EOL, we wont have to remove and replace the `fedora.repo` file. Instead, we can just use this file for container setup.