### PR TITLE
tests/kola: use fedora-archive.repo when setting up fedora container

### DIFF
--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -22,7 +22,7 @@ ntp_test_setup() {
     cat <<EOF >Dockerfile
 FROM quay.io/fedora/fedora:40
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -37,7 +37,7 @@ cd $(mktemp -d)
 cat <<EOF > Containerfile
 FROM quay.io/fedora/fedora:40
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \


### PR DESCRIPTION
The `fedora-archive.repo` file now contains both EOL and non-EOL repo locations[1]. This means we can change the two kola tests that use the fedora container to use `fedora-archive.repo` as the only repo configuration file. This reduces the maintenance burden because now we don't have to change this curl statement when fedora versions reach EOL.

[1] https://github.com/coreos/fedora-coreos-config/pull/3145