### PR TITLE
tests/setuid: add userhelper to RHCOS allow list

### DIFF
--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -39,6 +39,7 @@ list_setuid_files_rhcos=(
     '/usr/libexec/sssd/ldap_child'
     '/usr/libexec/sssd/proxy_child'
     '/usr/libexec/sssd/selinux_child'
+    '/usr/sbin/userhelper'
 )
 
 is_fcos="false"


### PR DESCRIPTION
I'd like to add subscription-manager in RHCOS, which unfortunately currently pulls in the usermode stack for authentication. That includes the well-known userhelper setuid binary.

Add it to the RHCOS allow list.

See also: https://github.com/openshift/os/pull/1563