### PR TITLE
[rhcos-4.12] kola/dhcp-propagation: use fedora-archive.repo to set up container

### DIFF
--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -49,6 +49,8 @@ test_setup() {
     NTPHOSTIP=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
     cat <<EOF >Dockerfile
 FROM registry.fedoraproject.org/fedora:36
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq


### PR DESCRIPTION
This should have been part of https://github.com/coreos/fedora-coreos-config/pull/3138. I thought the dhcp-propagation test had been introduced in 4.13, but it had just been moved to another directory (https://github.com/coreos/fedora-coreos-config/commit/3d5ec3563db2a6d4a901ad90398a21244c778f3e).

---
Use the fedora-archive.repo file defined in fedora-coreos-config to set up the EOL containers in tests that use it. This will force packages to be downloaded from `https://df.fedoraproject.org`, as specified in the repo file. The ITUP cluster, being used by the RHCOS pipeline, requires all outbound connections to be specified in a Firewall Egress file, and this will ensure the same connection will always be used when downloading the archived fedora content.

see: https://github.com/coreos/fedora-coreos-config/pull/3128