### PR TITLE
Revert "overrides: fast-track selinux-policy-41.15-1.fc41"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,16 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  selinux-policy:
-    evra: 41.15-1.fc41.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1597066f01
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1786
-      type: fast-track
-  selinux-policy-targeted:
-    evra: 41.15-1.fc41.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1597066f01
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1786
-      type: fast-track
+packages: {}


### PR DESCRIPTION
This reverts commit 47a33bddc6aa91ee73b6fb48f44531dd48a57e4b.
 selinux-policy-41.15-1.fc41 was pushed to stable