### PR TITLE
coreos-boot-edit: relabel rdcore files

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-boot-edit.sh
@@ -16,8 +16,7 @@ karg() {
 
 # Mount /boot. Note that we mount /boot but we don't unmount it because we
 # are run in a systemd unit with MountFlags=slave so it is unmounted for us.
-bootmnt=/mnt/boot_partition
-mkdir -p ${bootmnt}
+bootmnt=/sysroot/boot
 bootdev=/dev/disk/by-label/boot
 mount -o rw ${bootdev} ${bootmnt}
 
@@ -44,3 +43,9 @@ fi
 # 4. it adds GRUB bootuuid.cfg dropins so that GRUB selects the boot filesystem
 #    by UUID
 rdcore bind-boot /sysroot ${bootmnt}
+
+# relabel files rdcore created; ideally in the future rdcore does this itself
+coreos-relabel /boot/.root_uuid
+if [ -e /sysroot/boot/grub2/bootuuid.cfg ]; then
+    coreos-relabel /boot/grub2/bootuuid.cfg
+fi


### PR DESCRIPTION
The `rdcore bind-boot` command write files to the bootfs but currently doesn't relabel them. Let's just relabel it from this side for now. In the future we could look at having `rdcore` call `setfiles` like Ignition does, or better, make `coreos-relabel` a more public API.

This fixes https://github.com/coreos/fedora-coreos-tracker/issues/1770 for new installs.

Refrained from adding tests for this. I think instead what we need is once all these relabeling issues are fixed, a test that verifies that *everything* is labeled.