### PR TITLE
[Rawhide]  overrides: pin `podman`, `shawdow-utils` and `skopeo`

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  podman:
+    evr: 5:5.2.2-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
+      type: pin
+  shadow-utils:
+    evr: 2:4.15.1-9.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
+      type: pin
+  shadow-utils-subid:
+    evr: 2:4.15.1-9.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
+      type: pin
+  skopeo:
+    evr: 1:1.16.1-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
+      type: pin


### PR DESCRIPTION
Regressions in these packages fails the toolbox creation. Pinning the packages till then.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1793