### PR TITLE
[next-devel] Start tracking fedora 41

### DIFF
--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,2275 +1,2305 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.46.0-2.fc40.x86_64",
+      "evra": "1:1.49.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.46.0-2.fc40.x86_64",
+      "evra": "1:1.49.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.46.0-2.fc40.x86_64",
+      "evra": "1:1.49.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.46.0-2.fc40.x86_64",
+      "evra": "1:1.49.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.46.0-2.fc40.x86_64",
+      "evra": "1:1.49.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.10.0.8-1.fc40.noarch",
+      "evra": "2.11.1.4-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "1.10.0-1.fc40.x86_64",
+      "evra": "2:1.12.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-1.fc40.x86_64",
+      "evra": "2.3.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-6.fc40.x86_64",
+      "evra": "0.9.2-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.5.1-2.fc40.x86_64",
+      "evra": "5.6.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.5.1-2.fc40.x86_64",
+      "evra": "5.6.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.26-3.fc40.x86_64",
+      "evra": "1.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "amd-ucode-firmware": {
-      "evra": "20240410-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "atheros-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-3.fc40.x86_64",
+      "evra": "2.5.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.0.1-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.0.1-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.0.1-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.0-5.fc40.x86_64",
+      "evra": "1.5.0-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.0-5.fc40.x86_64",
+      "evra": "1.5.0-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-26.fc40.x86_64",
+      "evra": "0.8-29.fc41.x86_64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-20.fc40.noarch",
+      "evra": "11-21.fc41.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-3.fc40.x86_64",
+      "evra": "5.2.32-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4.1-1.fc40.noarch",
+      "evra": "0.5-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-14.fc40.noarch",
+      "evra": "1:2.13-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.24-1.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "bind"
-      }
-    },
-    "bind-license": {
-      "evra": "32:9.18.24-1.fc40.noarch",
+      "evra": "32:9.18.28-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.24-1.fc40.x86_64",
+      "evra": "32:9.18.28-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.18-2.fc40.x86_64",
+      "evra": "0.2.20-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
-    "brcmfmac-firmware": {
-      "evra": "20240410-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "bsdtar": {
-      "evra": "3.7.2-3.fc40.x86_64",
+      "evra": "3.7.4-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.8-1.fc40.x86_64",
+      "evra": "6.10.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.8.0-3.fc40.x86_64",
+      "evra": "0.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-18.fc40.x86_64",
+      "evra": "1.0.8-19.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-18.fc40.x86_64",
+      "evra": "1.0.8-19.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc40.x86_64",
+      "evra": "1.33.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2023.2.62_v7.0.401-6.fc40.noarch",
+      "evra": "2024.2.68_v8.0.302-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-22.fc40.x86_64",
+      "evra": "0.1.7-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.5-3.fc40.x86_64",
+      "evra": "4.6-0.1.pre1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-4.fc40.x86_64",
+      "evra": "7.0-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "20-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "20-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "20-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-5.fc40.x86_64",
+      "evra": "0.5.3-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "20-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-7.fc40.noarch",
+      "evra": "0.33-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc40.x86_64",
+      "evra": "1.0.4-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc40.x86_64",
+      "evra": "1.0.4-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.10-1.fc40.x86_64",
+      "evra": "2:2.1.12-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.230.0-1.fc40.noarch",
+      "evra": "2:2.232.1-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-5.fc40.x86_64",
+      "evra": "1.7.19-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.58.0-2.fc40.noarch",
+      "evra": "5:0.60.2-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.58.0-2.fc40.noarch",
+      "evra": "5:0.60.2-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.21.0-1.fc40.x86_64",
+      "evra": "0.22.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.21.0-1.fc40.x86_64",
+      "evra": "0.22.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.4-6.fc40.x86_64",
+      "evra": "9.5-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.4-6.fc40.x86_64",
+      "evra": "9.5-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-1.fc40.x86_64",
+      "evra": "2.15-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-5.fc40.x86_64",
+      "evra": "2.9.11-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "3.19-4.fc40.x86_64",
+      "evra": "3.19-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "3.19-4.fc40.x86_64",
+      "evra": "3.19-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.14.4-1.fc40.x86_64",
+      "evra": "1.15-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.14.4-1.fc40.x86_64",
+      "evra": "1.15-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20240201-2.git9f501f3.fc40.noarch",
+      "evra": "20240826-1.gite824389.fc41.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.7.2-1.fc40.x86_64",
+      "evra": "2.7.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.7.2-1.fc40.x86_64",
+      "evra": "2.7.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.6.0-8.fc40.x86_64",
+      "evra": "8.9.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-19.fc40.x86_64",
+      "evra": "2.1.28-27.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-19.fc40.x86_64",
+      "evra": "2.1.28-27.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-3.fc40.x86_64",
+      "evra": "1:1.14.10-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-2.fc40.x86_64",
+      "evra": "36-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-3.fc40.noarch",
+      "evra": "1:1.14.10-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-3.fc40.x86_64",
+      "evra": "1:1.14.10-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.197-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.197-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.197-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.197-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc40.x86_64",
+      "evra": "1.0.12-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-5.fc40.x86_64",
+      "evra": "3.10-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
+    "dnf5": {
+      "evra": "5.2.5.0-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "dnsmasq": {
-      "evra": "2.90-1.fc40.x86_64",
+      "evra": "2.90-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
+    "docker-cli": {
+      "evra": "27.1.2-1.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
     "dosfstools": {
-      "evra": "4.2-11.fc40.x86_64",
+      "evra": "4.2-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "060-1.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "060-1.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "060-1.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-7.fc40.x86_64",
+      "evra": "2.7.0-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "5-11.fc40.noarch",
+      "evra": "5-12.fc41.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-6.fc40.x86_64",
+      "evra": "18-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-1.fc40.x86_64",
+      "evra": "39-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-4.fc40.noarch",
+      "evra": "0.191-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-4.fc40.x86_64",
+      "evra": "0.191-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-4.fc40.x86_64",
+      "evra": "0.191-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.7-1.fc40.x86_64",
+      "evra": "2:6.10-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.2-1.fc40.x86_64",
+      "evra": "2.6.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "40-1.noarch",
+      "evra": "41-0.5.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "40-39.noarch",
+      "evra": "41-0.21.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-0.21.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-0.21.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "40-1.noarch",
+      "evra": "41-0.5.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "40-1.noarch",
+      "evra": "41-0.5.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "40-1.noarch",
+      "evra": "41-0.5.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.45-4.fc40.x86_64",
+      "evra": "5.45-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.45-4.fc40.x86_64",
+      "evra": "5.45-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-8.fc40.x86_64",
+      "evra": "3.18-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-8.fc40.x86_64",
+      "evra": "1:4.10.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.8-1.fc40.x86_64",
+      "evra": "1.15.8-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "10.2.1-4.fc40.x86_64",
+      "evra": "11.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-10.fc40.x86_64",
+      "evra": "0.6.1-11.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
-    "fuse": {
-      "evra": "2.9.9-21.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-common": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
-    "fuse-libs": {
-      "evra": "2.9.9-21.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc40.x86_64",
+      "evra": "1.13-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc40.x86_64",
+      "evra": "3.7.3-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.16-1.fc40.x86_64",
+      "evra": "1.9.23-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.0-3.fc40.x86_64",
+      "evra": "5.3.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-6.fc40.x86_64",
+      "evra": "1:1.23-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-6.fc40.x86_64",
+      "evra": "1:1.23-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc40.x86_64",
+      "evra": "1.0.10-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22.5-2.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22.5-2.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22.5-2.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.44.0-1.fc40.x86_64",
+      "evra": "2.46.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.80.0-1.fc40.x86_64",
+      "evra": "2.82.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.39-8.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.39-8.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.39-8.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.39-8.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-8.fc40.x86_64",
+      "evra": "1:6.3.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc40.x86_64",
+      "evra": "2.4.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.5-1.fc40.x86_64",
+      "evra": "3.8.6-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20240307.00-1.fc40.noarch",
+      "evra": "20240725.00-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.23.2-3.fc40.x86_64",
+      "evra": "1.23.2-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-7.fc40.x86_64",
+      "evra": "3.11-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-119.fc40.noarch",
+      "evra": "1:2.12-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-119.fc40.x86_64",
+      "evra": "1:2.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc": {
-      "evra": "1:2.06-119.fc40.x86_64",
+      "evra": "1:2.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-119.fc40.noarch",
+      "evra": "1:2.12-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-119.fc40.x86_64",
+      "evra": "1:2.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-119.fc40.x86_64",
+      "evra": "1:2.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
-    "gvisor-tap-vsock-gvforwarder": {
-      "evra": "6:0.7.3-2.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "gvisor-tap-vsock"
-      }
-    },
     "gzip": {
-      "evra": "1.13-1.fc40.x86_64",
+      "evra": "1.13-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-12.fc40.x86_64",
+      "evra": "3.23-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
+    "hwdata": {
+      "evra": "0.385-1.fc41.noarch",
+      "metadata": {
+        "sourcerpm": "hwdata"
+      }
+    },
     "ignition": {
-      "evra": "2.18.0-1.fc40.x86_64",
+      "evra": "2.19.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc40.x86_64",
+      "evra": "58-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-9.fc40.x86_64",
+      "evra": "1.0.3-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.7.0-1.fc40.x86_64",
+      "evra": "6.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.7.0-1.fc40.x86_64",
+      "evra": "6.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.10-7.fc40.noarch",
+      "evra": "1.8.10-15.fc41.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20240117-4.fc40.x86_64",
+      "evra": "20240117-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.2-4.fc40.x86_64",
+      "evra": "2:1.9.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-9.fc40.x86_64",
+      "evra": "0.101-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-9.fc40.x86_64",
+      "evra": "2.13.1-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-6.fc40.x86_64",
+      "evra": "5.3.0-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "13-1.fc40.x86_64",
+      "evra": "14-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-4.fc40.x86_64",
+      "evra": "1.7.1-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-3.fc40.x86_64",
+      "evra": "0.17-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-3.fc40.x86_64",
+      "evra": "1.9.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.4-3.fc40.x86_64",
+      "evra": "2.6.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
+    "kdump-utils": {
+      "evra": "1.0.44-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "kdump-utils"
+      }
+    },
     "kernel": {
-      "evra": "6.8.7-300.fc40.x86_64",
+      "evra": "6.11.0-0.rc5.43.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.8.7-300.fc40.x86_64",
+      "evra": "6.11.0-0.rc5.43.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.8.7-300.fc40.x86_64",
+      "evra": "6.11.0-0.rc5.43.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.8.7-300.fc40.x86_64",
+      "evra": "6.11.0-0.rc5.43.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.28-4.fc40.x86_64",
+      "evra": "2.0.29-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-3.fc40.x86_64",
+      "evra": "1.6.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-3.fc40.x86_64",
+      "evra": "1.6.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "31-5.fc40.x86_64",
+      "evra": "33-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "31-5.fc40.x86_64",
+      "evra": "33-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.2-5.fc40.x86_64",
+      "evra": "1.21.3-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "643-4.fc40.x86_64",
+      "evra": "661-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-1.fc40.x86_64",
+      "evra": "2.3.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-19.fc40.x86_64",
+      "evra": "0.3.111-20.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.2-3.fc40.x86_64",
+      "evra": "3.7.4-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-1.fc40.x86_64",
+      "evra": "2.5.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.2-3.fc40.x86_64",
+      "evra": "2.5.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-56.fc40.x86_64",
+      "evra": "0.1.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.2.0-3.fc40.x86_64",
+      "evra": "2:1.4.3-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-3.fc40.x86_64",
+      "evra": "0.12.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.69-8.fc40.x86_64",
+      "evra": "2.70-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.4-4.fc40.x86_64",
+      "evra": "0.8.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-1.fc40.x86_64",
+      "evra": "0.11.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-56.fc40.x86_64",
+      "evra": "0.7.0-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.6.0-8.fc40.x86_64",
+      "evra": "8.9.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-29.fc40.x86_64",
+      "evra": "0.14-30.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-56.fc40.x86_64",
+      "evra": "0.5.0-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
+    "libdnf5": {
+      "evra": "5.2.5.0-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
+    "libdnf5-cli": {
+      "evra": "5.2.5.0-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "libeconf": {
-      "evra": "0.6.2-1.fc40.x86_64",
+      "evra": "0.6.2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-50.20230828cvs.fc40.x86_64",
+      "evra": "3.1-53.20240808cvs.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-12.fc40.x86_64",
+      "evra": "2.1.12-14.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-7.fc40.x86_64",
+      "evra": "3.4.6-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.14.0-4.fc40.x86_64",
+      "evra": "1.15.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "14.0.1-0.15.fc40.x86_64",
+      "evra": "14.2.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.3-3.fc40.x86_64",
+      "evra": "1.11.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.48-1.fc40.x86_64",
+      "evra": "1.50-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-5.fc40.x86_64",
+      "evra": "238-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.8-3.fc40.x86_64",
+      "evra": "0.4.9-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "48.0-4.fc40.x86_64",
+      "evra": "51.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "74.2-1.fc40.x86_64",
+      "evra": "74.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc40.x86_64",
+      "evra": "2.3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-56.fc40.x86_64",
+      "evra": "1.3.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.1-2.fc40.x86_64",
+      "evra": "0.2.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "13-1.fc40.x86_64",
+      "evra": "14-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.4.0-10.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "libkcapi"
+      }
+    },
+    "libkcapi-hasher": {
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.4.0-10.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.6-1.fc40.x86_64",
+      "evra": "1.6.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.9.0-1.fc40.x86_64",
+      "evra": "2.9.1-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libldb"
       }
     },
     "libluksmeta": {
-      "evra": "9-22.fc40.x86_64",
+      "evra": "9-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.9.1-2.fc40.x86_64",
+      "evra": "1.11.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-4.fc40.x86_64",
+      "evra": "1.1.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-5.fc40.x86_64",
+      "evra": "1.0.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-9.fc40.x86_64",
+      "evra": "2.15.0-14.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-9.fc40.x86_64",
+      "evra": "1.9-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-3.fc40.x86_64",
+      "evra": "1.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-5.fc40.x86_64",
+      "evra": "1.0.9-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-27.fc40.x86_64",
+      "evra": "1.0.1-28.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.6.4-0.rc6.fc40.x86_64",
+      "evra": "1:2.7.1-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-5.fc40.x86_64",
+      "evra": "1.2.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.59.0-3.fc40.x86_64",
+      "evra": "1.62.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.9.0-3.fc40.x86_64",
+      "evra": "3.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.9.0-3.fc40.x86_64",
+      "evra": "3.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-1.fc40.x86_64",
+      "evra": "2.0.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.8-1.fc40.x86_64",
+      "evra": "1.10-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-56.fc40.x86_64",
+      "evra": "0.2.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.4-4.fc40.x86_64",
+      "evra": "14:1.10.4-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "2.1.0-1.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-3.fc40.x86_64",
+      "evra": "0.21.5-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-9.fc40.x86_64",
+      "evra": "1.4.5-11.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-56.fc40.x86_64",
+      "evra": "0.1.5-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.17.1-1.fc40.x86_64",
+      "evra": "1.18.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-1.fc40.noarch",
+      "evra": "2.17.15-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.3-8.fc40.x86_64",
+      "evra": "2.5.5-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.6-4.fc40.x86_64",
+      "evra": "3.7-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.6-4.fc40.x86_64",
+      "evra": "3.7-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.6-3.fc40.x86_64",
+      "evra": "3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.6-3.fc40.x86_64",
+      "evra": "3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.7.0-6.fc40.x86_64",
+      "evra": "4.8.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.20.0-7.fc40.x86_64",
+      "evra": "2:4.20.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.28-1.fc40.x86_64",
+      "evra": "0.7.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "14.0.1-0.15.fc40.x86_64",
+      "evra": "14.2.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.2-1.fc40.x86_64",
+      "evra": "2.4.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-6.fc40.x86_64",
+      "evra": "4.19.0-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.10-1.fc40.x86_64",
+      "evra": "1.4.10-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-4.fc40.x86_64",
+      "evra": "1.32-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.1-1.fc40.x86_64",
+      "evra": "0.16.1-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
+    "libtextstyle": {
+      "evra": "0.22.5-6.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "gettext"
+      }
+    },
     "libtirpc": {
-      "evra": "1.3.4-1.rc3.fc40.x86_64",
+      "evra": "1.3.5-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-10.fc40.x86_64",
+      "evra": "2.4.7-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-7.fc40.x86_64",
+      "evra": "1.1-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-1.fc40.x86_64",
+      "evra": "1.0.27-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libutempter": {
-      "evra": "1.2.1-13.fc40.x86_64",
+      "evra": "1.2.1-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.48.0-1.fc40.x86_64",
+      "evra": "1:1.48.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-8.fc40.x86_64",
+      "evra": "0.3.2-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.20.0-7.fc40.x86_64",
+      "evra": "2:4.20.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-5.fc40.x86_64",
+      "evra": "4.4.36-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.6-1.fc40.x86_64",
+      "evra": "2.12.8-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.18-1.fc40.x86_64",
+      "evra": "0.3.19-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-14.fc40.x86_64",
+      "evra": "0.2.5-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc40.x86_64",
+      "evra": "1.5.6-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
+    "lld-libs": {
+      "evra": "18.1.8-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "lld"
+      }
+    },
+    "llvm-libs": {
+      "evra": "18.1.8-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "llvm"
+      }
+    },
     "lmdb-libs": {
-      "evra": "0.9.32-1.fc40.x86_64",
+      "evra": "0.9.33-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-6.fc40.x86_64",
+      "evra": "3.22.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-4.fc40.x86_64",
+      "evra": "4.98.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-5.fc40.x86_64",
+      "evra": "5.4.6-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-22.fc40.x86_64",
+      "evra": "9-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.23-1.fc40.x86_64",
+      "evra": "2.03.25-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.23-1.fc40.x86_64",
+      "evra": "2.03.25-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-6.fc40.x86_64",
+      "evra": "1.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-12.fc40.x86_64",
+      "evra": "2.10-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
+    "makedumpfile": {
+      "evra": "1.7.5-13.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "makedumpfile"
+      }
+    },
     "mdadm": {
-      "evra": "4.2-8.fc40.x86_64",
+      "evra": "4.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "microcode_ctl": {
-      "evra": "2:2.1-61.fc40.x86_64",
+      "evra": "2:2.1-63.fc41.x86_64",
       "metadata": {
         "sourcerpm": "microcode_ctl"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-4.fc40.x86_64",
+      "evra": "27.1.2-1.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
+    "moby-filesystem": {
+      "evra": "27.1.2-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.7.1-1.fc40.x86_64",
+      "evra": "2:0.7.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.1-3.fc40.x86_64",
+      "evra": "4.2.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
-    "mt7xxx-firmware": {
-      "evra": "20240410-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "nano": {
-      "evra": "7.2-6.fc40.x86_64",
+      "evra": "8.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-6.fc40.noarch",
+      "evra": "8.1-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-12.20240127.fc40.x86_64",
+      "evra": "6.5-2.20240629.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-12.20240127.fc40.noarch",
+      "evra": "6.5-2.20240629.fc41.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-12.20240127.fc40.x86_64",
+      "evra": "6.5-2.20240629.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.69.20160912git.fc40.x86_64",
+      "evra": "2.0-0.71.20160912git.fc41.x86_64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "1.10.3-3.fc40.x86_64",
+      "evra": "2:1.12.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-6.fc40.x86_64",
+      "evra": "3.10-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.24-3.fc40.x86_64",
+      "evra": "0.52.24-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.6.4-0.rc6.fc40.x86_64",
+      "evra": "1:2.7.1-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.9-3.fc40.x86_64",
+      "evra": "1:1.0.9-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.26-4.fc40.x86_64",
+      "evra": "2.2.34-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.7-1.fc40.x86_64",
+      "evra": "1.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-4.fc40.x86_64",
+      "evra": "2.23.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-5.fc40.x86_64",
+      "evra": "2.0.18-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.8-1.fc40.x86_64",
+      "evra": "2.10.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
-    "nxpwireless-firmware": {
-      "evra": "20240410-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "oniguruma": {
-      "evra": "6.9.9-3.fc40.x86_64",
+      "evra": "6.9.9-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.7-1.fc40.x86_64",
+      "evra": "2.6.8-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.6p1-1.fc40.2.x86_64",
+      "evra": "9.8p1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.6p1-1.fc40.2.x86_64",
+      "evra": "9.8p1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.6p1-1.fc40.2.x86_64",
+      "evra": "9.8p1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.1-2.fc40.x86_64",
+      "evra": "1:3.2.2-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.1-2.fc40.x86_64",
+      "evra": "1:3.2.2-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-6.fc40.x86_64",
+      "evra": "1.81-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.5-1.fc40.x86_64",
+      "evra": "2024.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.5-1.fc40.x86_64",
+      "evra": "2024.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.3-4.fc40.x86_64",
+      "evra": "0.25.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.3-4.fc40.x86_64",
+      "evra": "0.25.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.6.0-2.fc40.x86_64",
+      "evra": "1.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.6.0-2.fc40.x86_64",
+      "evra": "1.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.5-3.fc40.x86_64",
+      "evra": "0.1.8-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20240326.g4988e2b-1.fc40.x86_64",
+      "evra": "0^20240821.g1d6142f-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240326.g4988e2b-1.fc40.noarch",
+      "evra": "0^20240821.g1d6142f-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
+    "pciutils": {
+      "evra": "3.13.0-5.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
+    "pciutils-libs": {
+      "evra": "3.13.0-5.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "pciutils"
+      }
+    },
     "pcre2": {
-      "evra": "10.42-2.fc40.2.x86_64",
+      "evra": "10.44-1.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.42-2.fc40.2.noarch",
+      "evra": "10.44-1.fc41.1.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
-    "pigz": {
-      "evra": "2.8-4.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "pigz"
-      }
-    },
     "pkgconf": {
-      "evra": "2.1.0-1.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.1.0-1.fc40.noarch",
+      "evra": "2.3.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.1.0-1.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.0.1-1.fc40.x86_64",
+      "evra": "5:5.2.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.6-3.fc40.x86_64",
+      "evra": "3.7-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "124-2.fc40.x86_64",
+      "evra": "125-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "124-2.fc40.x86_64",
+      "evra": "125-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
-    "polkit-pkla-compat": {
-      "evra": "0.1-28.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "polkit-pkla-compat"
-      }
-    },
     "popt": {
-      "evra": "1.19-6.fc40.x86_64",
+      "evra": "1.19-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-3.fc40.x86_64",
+      "evra": "4.0.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.0-3.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-6.fc40.x86_64",
+      "evra": "23.7-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-3.fc40.noarch",
+      "evra": "20240107-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
-    "readline": {
-      "evra": "8.2-8.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "readline"
-      }
-    },
-    "realtek-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+    "qed-firmware": {
+      "evra": "20240811-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
+    "readline": {
+      "evra": "8.2-10.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "readline"
+      }
+    },
     "rpcbind": {
-      "evra": "1.2.6-4.rc3.fc40.x86_64",
+      "evra": "1.2.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.19.92-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.19.92-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.5-2.fc40.x86_64",
+      "evra": "2024.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.5-2.fc40.x86_64",
+      "evra": "2024.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.19.92-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.6.0-2.fc40.x86_64",
+      "evra": "1.7.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc40.x86_64",
+      "evra": "3.3.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-3.fc40.x86_64",
+      "evra": "2:1.1.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.20.0-7.fc40.x86_64",
+      "evra": "2:4.20.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.20.0-7.fc40.noarch",
+      "evra": "2:4.20.4-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.20.0-7.fc40.x86_64",
+      "evra": "2:4.20.4-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
+    "sdbus-cpp": {
+      "evra": "1.5.0-3.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "sdbus-cpp"
+      }
+    },
     "sed": {
-      "evra": "4.9-1.fc40.x86_64",
+      "evra": "4.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "40.16-1.fc40.noarch",
+      "evra": "41.16-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "40.16-1.fc40.noarch",
+      "evra": "41.16-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.5-2.fc40.noarch",
+      "evra": "2.15.0-5.fc41.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-1.fc40.x86_64",
+      "evra": "1.48-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-1.fc40.x86_64",
+      "evra": "1.48-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.15.1-2.fc40.x86_64",
+      "evra": "2:4.15.1-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.15.1-2.fc40.x86_64",
+      "evra": "2:4.15.1-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-4.fc40.x86_64",
+      "evra": "2.3-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2281,332 +2311,332 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.15.0-1.fc40.x86_64",
+      "evra": "1:1.16.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-5.fc40.x86_64",
+      "evra": "2.3.3-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-2.fc40.x86_64",
+      "evra": "1.2.2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-4.fc40.x86_64",
+      "evra": "1.2.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc40.x86_64",
+      "evra": "1.8.0.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.12.0-3.fc40.x86_64",
+      "evra": "1.14.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.45.1-2.fc40.x86_64",
+      "evra": "3.46.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-4.fc40.x86_64",
+      "evra": "4.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-6.fc40.x86_64",
+      "evra": "0.1.4-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.4-4.fc40.x86_64",
+      "evra": "2.10.0~beta2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.1-1.fc40.x86_64",
+      "evra": "1.19.6-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-2.p5.fc40.x86_64",
+      "evra": "1.9.15-5.p5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "255.4-1.fc40.x86_64",
+      "evra": "256.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-3.fc40.x86_64",
+      "evra": "2:1.35-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-4.fc40.x86_64",
+      "evra": "1.32-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
-    "tiwilink-firmware": {
-      "evra": "20240410-1.fc40.noarch",
+    "tini-static": {
+      "evra": "0.19.0-9.fc41.x86_64",
       "metadata": {
-        "sourcerpm": "linux-firmware"
+        "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.5-8.fc40.x86_64",
+      "evra": "0.0.99.5-17.fc41.x86_64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.6-2.fc40.x86_64",
+      "evra": "5.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.0.1-7.fc40.x86_64",
+      "evra": "4.1.3-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.0.1-7.fc40.x86_64",
+      "evra": "4.1.3-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-5.fc40.noarch",
+      "evra": "2024a-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-4.fc40.x86_64",
+      "evra": "0.14.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40-13.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.309-1.fc40.noarch",
+      "evra": "2:9.1.660-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.309-1.fc40.x86_64",
+      "evra": "2:9.1.660-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.13.5-2.fc40.x86_64",
+      "evra": "0.14.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.21-41.fc40.x86_64",
+      "evra": "2.21-42.fc41.x86_64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-6.fc40.x86_64",
+      "evra": "1.0.20210914-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.5.0-3.fc40.x86_64",
+      "evra": "6.9.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-2.fc40.x86_64",
+      "evra": "0.8.2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.4.6-3.fc40.x86_64",
+      "evra": "1:5.6.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.4.6-3.fc40.x86_64",
+      "evra": "1:5.6.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-23.fc40.x86_64",
+      "evra": "2.1.0-24.fc41.x86_64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.4.0-2.fc40.x86_64",
+      "evra": "1.5.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-2.fc40.x86_64",
+      "evra": "0.0.27-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.1.6-2.fc40.x86_64",
+      "evra": "2.1.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-9.fc40.x86_64",
+      "evra": "1.1.2-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc40.x86_64",
+      "evra": "1.5.6-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2024-04-21T00:00:00Z",
+    "generated": "2024-09-13T00:00:00Z",
     "rpmmd_repos": {
       "fedora-candidate-compose": {
-        "generated": "2024-04-14T18:51:11Z"
+        "generated": "2024-09-11T21:51:31Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-04-21T12:47:21Z"
+        "generated": "2024-09-12T23:37:45Z"
       },
       "fedora-next": {
-        "generated": "2024-04-19T08:53:31Z"
+        "generated": "2024-09-13T08:35:41Z"
       },
       "fedora-next-updates": {
-        "generated": "2024-04-21T01:00:20Z"
+        "generated": "2018-02-20T19:18:14Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: next-devel
   prod: false
 
-releasever: 40
+releasever: 41
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to
@@ -11,6 +11,6 @@ repos:
   # GitHub Action.
   - fedora-next
   - fedora-next-updates
-#  - fedora-candidate-compose
+  - fedora-candidate-compose
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Fedora 41 beta is go for release on 2024-09-17. Modify `next-devel` to start tracking Fedora 41 and also enable the fedora-candidate-compose repo.