### PR TITLE
denylist: update denial to include next/next-devel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,8 +18,10 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1791
-  snooze: 2024-09-16
+  snooze: 2024-09-26
   warn: true
   streams:
     - rawhide
     - branched
+    - next-devel
+    - next


### PR DESCRIPTION
We're moving next over to F41 so we'll need to apply this denial there too.

https://github.com/coreos/fedora-coreos-tracker/issues/1791