### PR TITLE
rawhide: overrides: pin toolbox in rawhide

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,3 +29,8 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
       type: pin
+  toolbox:
+    evr: 0.0.99.5-17.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1793
+      type: pin


### PR DESCRIPTION
Regressions in toolbox package fails the creation of toolbox Pinning the package till then.
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1793