### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+packages:
+  veritysetup:
+    evra: 2.7.5-1.fc41.s390x
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1448111d6c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+packages:
+  amd-ucode-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,112 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  aardvark-dns:
+    evr: 2:1.12.2-2.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-30ed35ba86
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  amd-gpu-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  atheros-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  brcmfmac-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  chrony:
+    evr: 4.6-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-fef2f6c9a7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  cryptsetup:
+    evr: 2.7.5-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1448111d6c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  cryptsetup-libs:
+    evr: 2.7.5-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1448111d6c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  flatpak-session-helper:
+    evr: 1.15.10-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-0c6db96fc3
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  hwdata:
+    evra: 0.387-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-aed4890721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  intel-gpu-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  linux-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  linux-firmware-whence:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  mt7xxx-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  nvidia-gpu-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  nxpwireless-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  realtek-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  rpcbind:
+    evr: 1.2.7-1.rc1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-8963515937
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track
+  tiwilink-firmware:
+    evra: 20240909-1.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
+      type: fast-track


### PR DESCRIPTION
F41 is now in beta freeze. This means that some packages in F40 will sort as newer than packages in F41. We'll prevent downgrades by fast-tracking any packages that would violate this "no downgrade" rule.

Today they are:

- `aardvark-dns`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-30ed35ba86
- `linux-firmware`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-3cd42e9e29
- `chrony`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-fef2f6c9a7
- `cryptsetup`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1448111d6c
- `flatpak`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-0c6db96fc3
- `hwdata`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-aed4890721
- `rpcbind`: https://bodhi.fedoraproject.org/updates/FEDORA-2024-8963515937



see: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109