### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -51,12 +51,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-1448111d6c
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
       type: fast-track
-  flatpak-session-helper:
-    evr: 1.15.10-1.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-0c6db96fc3
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1695#issuecomment-2350064109
-      type: fast-track
   hwdata:
     evra: 0.387-1.fc41.noarch
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).