### PR TITLE
denylist: drop denial for `ignition.ssh.key`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,12 +5,6 @@
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
 - pattern: podman.workflow
   tracker: https://github.com/coreos/coreos-assembler/pull/1478
-- pattern: coreos.ignition.ssh.key
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1553
-  snooze: 2024-10-01
-  warn: true
-  platforms:
-    - azure
 - pattern: coreos.boot-mirror*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1659
   warn: true


### PR DESCRIPTION
After fast tracking to `afterburn-5.7.0-1`, we can remove this entry from the kola-denylist.