### PR TITLE
tests/update-ca-trust: validate new `ca-bundle.crt` location

### DIFF
--- a/tests/kola/security/coreos-update-ca-trust/test.sh
+++ b/tests/kola/security/coreos-update-ca-trust/test.sh
@@ -12,7 +12,7 @@ set -xeuo pipefail
 if ! systemctl show coreos-update-ca-trust.service -p ActiveState | grep ActiveState=active; then
     fatal "coreos-update-ca-trust.service not active"
 fi
-if ! grep '^# coreos.com$' /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt; then
+if ! grep '^# coreos.com$' /etc/pki/tls/certs/ca-bundle.crt; then
     fatal "expected coreos.com in ca-bundle"
 fi
 ok "coreos-update-ca-trust.service"


### PR DESCRIPTION
A recent update to the ca-certificates package in Fedora removed the `openssl_format_trust_bundle` ca-bundle to improve the startup speed of OpenSSL. Certificates passed into `/etc/pki/ca-trust/source/anchors` are picked up and added to `/etc/pki/tls/certs/ca-bundle.crt` after running `update-ca-trust extract`, so let's change the location here to the new cert bundle.
see: https://github.com/coreos/fedora-coreos-tracker/issues/1804