### PR TITLE
denylist: extend snooze for `kdump.crash`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,7 +12,7 @@
     - ppc64le
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1791
-  snooze: 2024-09-26
+  snooze: 2024-10-14
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
This test is still failing. Extend the snooze while we wait for a fix upstream for the issue.
see: https://github.com/coreos/fedora-coreos-tracker/issues/1791

Extending the snooze to expire on 2024-10-14 to coincide with the pipeline health sync meeting.