### PR TITLE
35coreos-multipath: explicitly depend on multipath module

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -2,6 +2,10 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+depends() {
+    echo multipath
+}
+
 install_unit() {
     local unit=$1; shift
     local target=${1:-initrd}


### PR DESCRIPTION
The multipath module has been included by default so we didn't need to do this, but a bug has recently made it stop being included:

https://github.com/coreos/fedora-coreos-tracker/issues/1803#issuecomment-2384671129

We should have been declaring that dependency here anyway.