### PR TITLE
Revert "overrides: pin `dracut-102-2.fc41` and `clevis-20-2.fc41`"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,39 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  clevis:
-    evr: 20-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  clevis-dracut:
-    evr: 20-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  clevis-luks:
-    evr: 20-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  clevis-systemd:
-    evr: 20-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  dracut:
-    evr: 102-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  dracut-network:
-    evr: 102-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
-  dracut-squash:
-    evr: 102-2.fc41
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
-      type: pin
+packages: {}


### PR DESCRIPTION
This reverts commit abe168bf28768ca08ac1a3eb684acb2aa78eadc0.

We think we have addressed the underlying problem now with https://github.com/coreos/fedora-coreos-config/pull/3187

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1803