### PR TITLE
[next-devel] overrides: fast-track grub packages: 2.12-10.fc41

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,25 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).  
+
+packages:
+  grub2-efi-aa64:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-pc-modules:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+
+

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,23 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-ppc64le:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-ppc64le-modules:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,24 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-efi-x64:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-pc-modules:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,27 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7e02fdb76d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1553
       type: fast-track
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-pc:
+    evr: 1:2.12-10.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evr: 1:2.12-10.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evr: 1:2.12-10.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track


### PR DESCRIPTION
- VMWare OVA Fails To Boot due grub update See: https://github.com/coreos/fedora-coreos-tracker/issues/1802