### PR TITLE
[next-devel] overrides: fast-track podman-5.2.4-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,3 +21,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7e02fdb76d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1553
       type: fast-track
+  podman:
+    evr: 5:5.2.4-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-2e8c63e8bf
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1809
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).