### PR TITLE
tests/setuid: add clevis-luks-udisks2 to allow list

### DIFF
--- a/tests/kola/files/setuid
+++ b/tests/kola/files/setuid
@@ -40,6 +40,7 @@ list_setuid_files_rhcos=(
     '/usr/libexec/sssd/proxy_child'
     '/usr/libexec/sssd/selinux_child'
     '/usr/sbin/userhelper'
+    '/usr/libexec/clevis-luks-udisks2'
 )
 
 is_fcos="false"


### PR DESCRIPTION
`clevis-luks-udisks2` shipped as a subpackage of clevis have the setuid bit set [1].
I am not sure why this is failing only now since it's been enabled for a long time.

[1]: https://gitlab.com/redhat/centos-stream/rpms/clevis/-/commit/ca4761025e6332e6d0e148f59833506b1f6b7470#4b7d5bd4b543f32d3da8004f4e1de346e6a2c2c9_0_184

Also see https://github.com/openshift/os/pull/1631#issuecomment-2402208453