### PR TITLE
[rawhide] overrides: fast-track kdump-utils-1.0.47-1.fc42

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1791
-  snooze: 2024-10-14
-  warn: true
-  streams:
-    - rawhide
-    - branched
-    - next-devel
-    - next

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -44,3 +44,9 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1803
       type: pin
+  kdump-utils:
+    evr: 1.0.47-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-edff699e08
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1791
+      type: fast-track


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).