### PR TITLE
tests/kola: make podman pasta test clean up

### DIFF
--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -20,7 +20,7 @@ set -xeuo pipefail
 runascoreuserscript='#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --net=pasta:--mtu,1500 quay.io/fedora/fedora:40 bash <<"EOF"
+podman run -i --rm --net=pasta:--mtu,1500 quay.io/fedora/fedora:40 bash <<"EOF"
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500


### PR DESCRIPTION
Since this is a non-exclusive test let's clean up a little bit and at least not leave the container hanging around. This caused a conflict with the selinux.file-context-policy-match test because there were some directories in container storage that restorecon was warning about.