### PR TITLE
Revert "denylist: add kdump.crash for rawhide"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,3 +10,10 @@
   warn: true
   arches:
     - ppc64le
+- pattern: kdump.crash.ssh
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1813
+  streams:
+    - rawhide
+    - branched
+    - next-devel
+    - next

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1791
-  snooze: 2024-10-14
-  warn: true
-  streams:
-    - rawhide
-    - branched
-    - next-devel
-    - next


### PR DESCRIPTION
This reverts commit e8625af2e7ecd4423d8f138eff196a76a8e9a5d5.

kdump-utils updates fixed this issue.
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1791