### PR TITLE
[next-devel] overrides: fast-track sssd-2.10.0-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,88 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  libipa_hbac:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  libsss_certmap:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  libsss_idmap:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  libsss_nss_idmap:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  libsss_sudo:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-ad:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-client:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-common:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-common-pac:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-ipa:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-krb5:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-krb5-common:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-ldap:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track
+  sssd-nfs-idmap:
+    evr: 2.10.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
+      type: fast-track


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).