### PR TITLE
[next-devel] overrides: fix grub2 arch specific overrides

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -9,17 +9,27 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).  
 
 packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
   grub2-efi-aa64:
     evra: 1:2.12-10.fc41.aarch64
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
       type: fast-track
-  grub2-pc-modules:
-    evra: 1:2.12-10.fc41.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
-      type: fast-track
-
-

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
   grub2-ppc64le:
     evra: 1:2.12-10.fc41.ppc64le
     metadata:

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
   grub2-efi-x64:
     evra: 1:2.12-10.fc41.x86_64
     metadata:
@@ -21,4 +39,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
       type: fast-track
-
+  grub2-pc:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -93,27 +93,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-73827b9035
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1798
       type: fast-track
-  grub2-common:
-    evra: 1:2.12-10.fc41.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
-      type: fast-track
-  grub2-pc:
-    evr: 1:2.12-10.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
-      type: fast-track
-  grub2-tools:
-    evr: 1:2.12-10.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
-      type: fast-track
-  grub2-tools-minimal:
-    evr: 1:2.12-10.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
-      type: fast-track


### PR DESCRIPTION
We can't have any grub2 overrides in the manifest-lock.overrides.yaml file because there are no grub2 packages on s390x. Let's move those into the arch specific overrides files and also correct a few of them.

Fixes 31802d2