### PR TITLE
Avoid fixing labels while deploying new updates

### DIFF
--- a/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
+++ b/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
@@ -11,6 +11,9 @@ ExecStartPre=/bin/touch /var/lib/coreos-fix-selinux-labels.stamp
 ExecStart=/usr/libexec/coreos-fix-selinux-labels
 RemainAfterExit=yes
 MountFlags=slave
+# Run before zincati so we're not creating new files on the filesystem
+# while we are fixing labels on existing files.
+Before=zincati.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In 2e355fd we added a coreos-fix-selinux-labels.service to fix labels on some known files that were unlabeled or mislabeled. We've seen some upgrade tests where the labeling fixes were running at the same time new deployments were getting written into the OSTree repo:

```
Oct 22 11:16:18.923371 kola-runext.service[5408]: Rebasing to fedora-compose:fedora/x86_64/coreos/next
Oct 22 11:16:18.926185 kola-runext.service[5408]: Resolving version '41.20241020.1.0'
Oct 22 11:16:20.877155 rpm-ostreed.service[1053]: Writing objects: 1
Oct 22 11:16:20.914326 rpm-ostreed.service[1053]: libostree pull from 'fedora-compose' for fedora/x86_64/coreos/next complete
                                                  security: GPG: commit
                                                  security: SIGN: disabled http: TLS
                                                  non-delta: meta: 2 content: 0
                                                  transfer: secs: 1 size: 19.0\u00a0kB
Oct 22 11:16:20.968177 kola-runext.service[5408]: 2 metadata, 0 content objects fetched; 18 KiB transferred in 1 seconds; 0 bytes content written
Oct 22 11:16:20.972130 kola-runext.service[5408]: Writing objects: 1...done
Oct 22 11:16:31.630763 coreos-fix-selinux-labels.service[1019]: Relabeled 5582 files to system_u:object_r:root_t:s0
```

Let's try to avoid writing into the OSTree repo and fixing labels at the same time.