### PR TITLE
overrides: fast-track kdump-utils-1.0.48-1.fc40

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,10 +10,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: kdump.crash.ssh
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1813
-  streams:
-    - rawhide
-    - branched
-    - next-devel
-    - next

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,12 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  kdump-utils:
+    evr: 1.0.48-1.fc40
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b6681fcf56
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1813#issuecomment-2429448152
+      type: fast-track
   podman:
     evr: 5:5.2.5-1.fc40
     metadata:


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).