### PR TITLE
overrides: fast-track podman-5.2.5-1.fc40

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,7 @@
 
 packages:
   podman:
-    evr: 5:5.2.4-1.fc40
+    evr: 5:5.2.5-1.fc40
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f0fd63c638
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1809


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).