### PR TITLE
[rawhide] overrides: pin selinux-policy-41.20-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  selinux-policy:
+    evra: 41.20-1.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1817
+      type: pin
+  selinux-policy-targeted:
+    evra: 41.20-1.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1817
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).