### PR TITLE
[rawhide] overrides: fast-track selinux-policy-41.23-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  selinux-policy:
+    evra: 41.23-1.fc42.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b3e53a2b43
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1817
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 41.23-1.fc42.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-b3e53a2b43
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1817
+      type: fast-track


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).