### PR TITLE
denylist: add kdump.crash.nfs for >=f41

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,3 +10,9 @@
   warn: true
   arches:
     - ppc64le
+- pattern: kdump.crash.nfs
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1820
+  streams:
+     - rawhide
+     - next-devel
+     - next


### PR DESCRIPTION
We were not testing this until recently [1] so it slipped through.

Upstream issue : https://github.com/rhkdump/kdump-utils/issues/52
[1] https://github.com/coreos/coreos-assembler/pull/3911