### PR TITLE
[testing] tree: promote changes from next at 0be8682846fb270aa4ae7615a1aee5a4725d9e41

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,10 +10,9 @@
   # warn: true (disabled on promotion)
   arches:
     - ppc64le
-- pattern: kdump.crash.ssh
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1813
+- pattern: kdump.crash.nfs
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1820
   streams:
-    - rawhide
-    - branched
-    - next-devel
-    - next
+     - rawhide
+     - next-devel
+     - next

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,2299 +1,2299 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.46.2-1.fc40.aarch64",
+      "evra": "1:1.50.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.46.2-1.fc40.aarch64",
+      "evra": "1:1.50.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.46.2-1.fc40.aarch64",
+      "evra": "1:1.50.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.46.2-1.fc40.aarch64",
+      "evra": "1:1.50.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.46.2-1.fc40.aarch64",
+      "evra": "1:1.50.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.10.0.8-2.fc40.noarch",
+      "evra": "2.11.1.4-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.12.2-2.fc40.aarch64",
+      "evra": "2:1.12.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-1.fc40.aarch64",
+      "evra": "2.3.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-6.fc40.aarch64",
+      "evra": "0.9.2-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.7.0-1.fc40.aarch64",
+      "evra": "5.7.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.7.0-1.fc40.aarch64",
+      "evra": "5.7.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.27-1.fc40.aarch64",
+      "evra": "1.30-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "atheros-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-3.fc40.aarch64",
+      "evra": "2.5.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.0.2-1.fc40.aarch64",
+      "evra": "4.0.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.0.2-1.fc40.aarch64",
+      "evra": "4.0.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.0.2-1.fc40.aarch64",
+      "evra": "4.0.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.0-5.fc40.aarch64",
+      "evra": "1.5.0-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.0-5.fc40.aarch64",
+      "evra": "1.5.0-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-26.fc40.aarch64",
+      "evra": "0.8-29.fc41.aarch64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-20.fc40.noarch",
+      "evra": "11-21.fc41.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-3.fc40.aarch64",
+      "evra": "5.2.32-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4.2-1.fc40.noarch",
+      "evra": "0.5-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-14.fc40.noarch",
+      "evra": "1:2.13-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.28-2.fc40.aarch64",
+      "evra": "32:9.18.30-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.28-2.fc40.aarch64",
+      "evra": "32:9.18.30-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.19-1.fc40.aarch64",
+      "evra": "0.2.24-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
-    "brcmfmac-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "bsdtar": {
-      "evra": "3.7.2-7.fc40.aarch64",
+      "evra": "3.7.4-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.11-1.fc40.aarch64",
+      "evra": "6.11-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc40.aarch64",
+      "evra": "0.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-18.fc40.aarch64",
+      "evra": "1.0.8-19.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-18.fc40.aarch64",
+      "evra": "1.0.8-19.fc41.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc40.aarch64",
+      "evra": "1.33.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2024.2.69_v8.0.401-1.0.fc40.noarch",
+      "evra": "2024.2.69_v8.0.401-1.0.fc41.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-22.fc40.aarch64",
+      "evra": "0.1.7-23.fc41.aarch64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.6.1-1.fc40.aarch64",
+      "evra": "4.6.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-5.fc40.aarch64",
+      "evra": "7.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "20-2.fc40.aarch64",
+      "evra": "21-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-2.fc40.aarch64",
+      "evra": "21-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-2.fc40.aarch64",
+      "evra": "21-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-5.fc40.aarch64",
+      "evra": "0.5.3-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "20-2.fc40.aarch64",
+      "evra": "21-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-7.fc40.noarch",
+      "evra": "0.33-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc40.aarch64",
+      "evra": "1.0.6-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc40.aarch64",
+      "evra": "1.0.6-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.12-2.fc40.aarch64",
+      "evra": "2:2.1.12-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.233.0-1.fc40.noarch",
+      "evra": "2:2.233.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-5.fc40.aarch64",
+      "evra": "1.7.22-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.22.1-3.fc40.aarch64",
+      "evra": "0.22.1-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.22.1-3.fc40.aarch64",
+      "evra": "0.22.1-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.4-8.fc40.aarch64",
+      "evra": "9.5-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.4-8.fc40.aarch64",
+      "evra": "9.5-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-1.fc40.aarch64",
+      "evra": "2.15-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-5.fc40.aarch64",
+      "evra": "2.9.11-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.0-1.fc40.aarch64",
+      "evra": "4.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.0-1.fc40.aarch64",
+      "evra": "4.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.17-1.fc40.aarch64",
+      "evra": "1.18-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.17-1.fc40.aarch64",
+      "evra": "1.18-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20240725-1.git28d3e2d.fc40.noarch",
+      "evra": "20241010-1.git8baf557.fc41.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.7.5-1.fc40.aarch64",
+      "evra": "2.7.5-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.7.5-1.fc40.aarch64",
+      "evra": "2.7.5-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.6.0-10.fc40.aarch64",
+      "evra": "8.9.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-19.fc40.aarch64",
+      "evra": "2.1.28-27.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-19.fc40.aarch64",
+      "evra": "2.1.28-27.fc41.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-3.fc40.aarch64",
+      "evra": "1:1.14.10-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-2.fc40.aarch64",
+      "evra": "36-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-3.fc40.noarch",
+      "evra": "1:1.14.10-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-3.fc40.aarch64",
+      "evra": "1:1.14.10-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.199-1.fc40.aarch64",
+      "evra": "1.02.199-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.199-1.fc40.aarch64",
+      "evra": "1.02.199-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.199-1.fc40.aarch64",
+      "evra": "1.02.199-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.199-1.fc40.aarch64",
+      "evra": "1.02.199-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.7-7.fc40.aarch64",
+      "evra": "0.9.9-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.7-7.fc40.aarch64",
+      "evra": "0.9.9-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc40.aarch64",
+      "evra": "1.0.12-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-5.fc40.aarch64",
+      "evra": "3.10-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
+    "dnf5": {
+      "evra": "5.2.6.2-1.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "dnsmasq": {
-      "evra": "2.90-1.fc40.aarch64",
+      "evra": "2.90-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
+    "docker-cli": {
+      "evra": "27.3.1-2.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
     "dosfstools": {
-      "evra": "4.2-11.fc40.aarch64",
+      "evra": "4.2-13.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "102-2.fc40.aarch64",
+      "evra": "102-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "102-2.fc40.aarch64",
+      "evra": "102-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "102-2.fc40.aarch64",
+      "evra": "102-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-7.fc40.aarch64",
+      "evra": "2.7.0-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-5.fc40.aarch64",
+      "evra": "1.47.1-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-5.fc40.aarch64",
+      "evra": "1.47.1-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "5-11.fc40.noarch",
+      "evra": "5-12.fc41.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-6.fc40.aarch64",
+      "evra": "18-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-2.fc40.aarch64",
+      "evra": "39-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-4.fc40.noarch",
+      "evra": "0.192-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-4.fc40.aarch64",
+      "evra": "0.192-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-4.fc40.aarch64",
+      "evra": "0.192-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.11-1.fc40.aarch64",
+      "evra": "2:6.11-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.3-1.fc40.aarch64",
+      "evra": "2.6.3-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.45-4.fc40.aarch64",
+      "evra": "5.45-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.45-4.fc40.aarch64",
+      "evra": "5.45-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-8.fc40.aarch64",
+      "evra": "3.18-23.fc41.aarch64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-9.fc40.aarch64",
+      "evra": "1:4.10.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.10-1.fc40.aarch64",
+      "evra": "1.15.10-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "10.2.1-5.fc40.aarch64",
+      "evra": "11.0.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-10.fc40.aarch64",
+      "evra": "0.6.1-11.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse-common": {
-      "evra": "3.16.2-3.fc40.aarch64",
+      "evra": "3.16.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
-    "fuse-libs": {
-      "evra": "2.9.9-21.fc40.aarch64",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc40.aarch64",
+      "evra": "1.13-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc40.aarch64",
+      "evra": "3.7.3-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.2-3.fc40.aarch64",
+      "evra": "3.16.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.2-3.fc40.aarch64",
+      "evra": "3.16.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.26-1.fc40.aarch64",
+      "evra": "1.9.26-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.0-3.fc40.aarch64",
+      "evra": "5.3.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-6.fc40.aarch64",
+      "evra": "1:1.23-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-6.fc40.aarch64",
+      "evra": "1:1.23-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc40.aarch64",
+      "evra": "1.0.10-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22.5-4.fc40.aarch64",
+      "evra": "0.22.5-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22.5-4.fc40.aarch64",
+      "evra": "0.22.5-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22.5-4.fc40.aarch64",
+      "evra": "0.22.5-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.47.0-1.fc40.aarch64",
+      "evra": "2.47.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.80.3-1.fc40.aarch64",
+      "evra": "2.82.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.39-22.fc40.aarch64",
+      "evra": "2.40-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.39-22.fc40.aarch64",
+      "evra": "2.40-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.39-22.fc40.aarch64",
+      "evra": "2.40-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.39-22.fc40.aarch64",
+      "evra": "2.40-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-8.fc40.aarch64",
+      "evra": "1:6.3.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc40.aarch64",
+      "evra": "2.4.5-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.6-1.fc40.aarch64",
+      "evra": "3.8.6-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20240830.00-1.fc40.noarch",
+      "evra": "20240905.00-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.23.2-3.fc40.aarch64",
+      "evra": "1.23.2-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-7.fc40.aarch64",
+      "evra": "3.11-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-123.fc40.noarch",
+      "evra": "1:2.12-10.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.06-123.fc40.aarch64",
+      "evra": "1:2.12-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-123.fc40.aarch64",
+      "evra": "1:2.12-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-123.fc40.aarch64",
+      "evra": "1:2.12-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-1.fc40.aarch64",
+      "evra": "1.13-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-12.fc40.aarch64",
+      "evra": "3.23-13.fc41.aarch64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.388-1.fc40.noarch",
+      "evra": "0.388-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.19.0-1.fc40.aarch64",
+      "evra": "2.20.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc40.aarch64",
+      "evra": "58-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-9.fc40.aarch64",
+      "evra": "1.0.3-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.7.0-2.fc40.aarch64",
+      "evra": "6.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.7.0-2.fc40.aarch64",
+      "evra": "6.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.10-7.fc40.aarch64",
+      "evra": "1.8.10-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.10-7.fc40.aarch64",
+      "evra": "1.8.10-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.10-7.fc40.aarch64",
+      "evra": "1.8.10-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.10-7.fc40.aarch64",
+      "evra": "1.8.10-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.10-7.fc40.noarch",
+      "evra": "1.8.10-15.fc41.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.10-7.fc40.aarch64",
+      "evra": "1.8.10-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20240117-4.fc40.aarch64",
+      "evra": "20240905-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-3.fc40.aarch64",
+      "evra": "2:1.9.4-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.aarch64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.aarch64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-9.fc40.aarch64",
+      "evra": "0.101-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-9.fc40.aarch64",
+      "evra": "2.13.1-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-6.fc40.aarch64",
+      "evra": "5.3.0-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "14-1.fc40.aarch64",
+      "evra": "14-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-7.fc40.aarch64",
+      "evra": "1.7.1-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-3.fc40.aarch64",
+      "evra": "0.17-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-3.fc40.aarch64",
+      "evra": "1.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.4-3.fc40.aarch64",
+      "evra": "2.6.4-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.44-1.fc40.aarch64",
+      "evra": "1.0.48-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.11.3-200.fc40.aarch64",
+      "evra": "6.11.5-300.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.11.3-200.fc40.aarch64",
+      "evra": "6.11.5-300.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.11.3-200.fc40.aarch64",
+      "evra": "6.11.5-300.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.11.3-200.fc40.aarch64",
+      "evra": "6.11.5-300.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.29-1.fc40.aarch64",
+      "evra": "2.0.29-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-3.fc40.aarch64",
+      "evra": "1.6.3-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-3.fc40.aarch64",
+      "evra": "1.6.3-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "31-5.fc40.aarch64",
+      "evra": "33-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "31-5.fc40.aarch64",
+      "evra": "33-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.7-7.fc40.aarch64",
+      "evra": "0.9.9-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-1.fc40.aarch64",
+      "evra": "1.21.3-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "643-6.fc40.aarch64",
+      "evra": "661-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-1.fc40.aarch64",
+      "evra": "2.3.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-19.fc40.aarch64",
+      "evra": "0.3.111-20.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.2-7.fc40.aarch64",
+      "evra": "3.7.4-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-1.fc40.aarch64",
+      "evra": "2.5.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
+    "libatomic": {
+      "evra": "14.2.1-3.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "gcc"
+      }
+    },
     "libattr": {
-      "evra": "2.5.2-3.fc40.aarch64",
+      "evra": "2.5.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-56.fc40.aarch64",
+      "evra": "0.1.1-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.2.3-1.fc40.aarch64",
+      "evra": "2:1.4.6-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-3.fc40.aarch64",
+      "evra": "0.12.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.69-8.fc40.aarch64",
+      "evra": "2.70-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.4-4.fc40.aarch64",
+      "evra": "0.8.5-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-1.fc40.aarch64",
+      "evra": "0.11.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-56.fc40.aarch64",
+      "evra": "0.7.0-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-5.fc40.aarch64",
+      "evra": "1.47.1-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.6.0-10.fc40.aarch64",
+      "evra": "8.9.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-29.fc40.aarch64",
+      "evra": "0.14-30.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-56.fc40.aarch64",
+      "evra": "0.5.0-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
+    "libdnf5": {
+      "evra": "5.2.6.2-1.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
+    "libdnf5-cli": {
+      "evra": "5.2.6.2-1.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "libeconf": {
-      "evra": "0.6.2-2.fc40.aarch64",
+      "evra": "0.6.2-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-53.20240808cvs.fc40.aarch64",
+      "evra": "3.1-53.20240808cvs.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-12.fc40.aarch64",
+      "evra": "2.1.12-14.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-7.fc40.aarch64",
+      "evra": "3.4.6-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.14.0-4.fc40.aarch64",
+      "evra": "1.15.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "14.2.1-3.fc40.aarch64",
+      "evra": "14.2.1-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.3-3.fc40.aarch64",
+      "evra": "1.11.0-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.49-1.fc40.aarch64",
+      "evra": "1.50-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-5.fc40.aarch64",
+      "evra": "238-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.9-1.fc40.aarch64",
+      "evra": "0.4.9-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "48.0-4.fc40.aarch64",
+      "evra": "51.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "74.2-1.fc40.aarch64",
+      "evra": "74.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc40.aarch64",
+      "evra": "2.3.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-56.fc40.aarch64",
+      "evra": "1.3.1-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.2-1.fc40.aarch64",
+      "evra": "0.2.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-1.fc40.aarch64",
+      "evra": "14-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-4.fc40.aarch64",
+      "evra": "1.5.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-4.fc40.aarch64",
+      "evra": "1.5.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-4.fc40.aarch64",
+      "evra": "1.5.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.6-1.fc40.aarch64",
+      "evra": "1.6.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.9.1-4.fc40.aarch64",
+      "evra": "2:4.21.1-7.fc41.aarch64",
       "metadata": {
-        "sourcerpm": "libldb"
+        "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-22.fc40.aarch64",
+      "evra": "9-23.fc41.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.11.0-1.fc40.aarch64",
+      "evra": "1.11.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-4.fc40.aarch64",
+      "evra": "1.1.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-5.fc40.aarch64",
+      "evra": "1.0.5-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-12.fc40.aarch64",
+      "evra": "2.15.0-14.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-9.fc40.aarch64",
+      "evra": "1.9-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-3.fc40.aarch64",
+      "evra": "1.3-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-5.fc40.aarch64",
+      "evra": "1.0.9-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-27.fc40.aarch64",
+      "evra": "1.0.1-28.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.7.1-0.fc40.aarch64",
+      "evra": "1:2.8.1-0.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-5.fc40.aarch64",
+      "evra": "1.2.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.59.0-3.fc40.aarch64",
+      "evra": "1.62.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.10.0-1.fc40.aarch64",
+      "evra": "3.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.10.0-1.fc40.aarch64",
+      "evra": "3.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-1.fc40.aarch64",
+      "evra": "2.0.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.8-1.fc40.aarch64",
+      "evra": "1.10-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-56.fc40.aarch64",
+      "evra": "0.2.1-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-1.fc40.aarch64",
+      "evra": "14:1.10.5-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "2.1.1-2.fc40.aarch64",
+      "evra": "2.3.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-3.fc40.aarch64",
+      "evra": "0.21.5-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-9.fc40.aarch64",
+      "evra": "1.4.5-11.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-56.fc40.aarch64",
+      "evra": "0.1.5-57.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc40.aarch64",
+      "evra": "1.18.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-1.fc40.noarch",
+      "evra": "2.17.15-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-1.fc40.aarch64",
+      "evra": "2.5.5-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.7-5.fc40.aarch64",
+      "evra": "3.7-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.7-5.fc40.aarch64",
+      "evra": "3.7-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.7-2.fc40.aarch64",
+      "evra": "3.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.7-2.fc40.aarch64",
+      "evra": "3.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.7.0-6.fc40.aarch64",
+      "evra": "4.8.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.20.5-1.fc40.aarch64",
+      "evra": "2:4.21.1-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.30-1.fc40.aarch64",
+      "evra": "0.7.30-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-5.fc40.aarch64",
+      "evra": "1.47.1-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "14.2.1-3.fc40.aarch64",
+      "evra": "14.2.1-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.2-1.fc40.aarch64",
+      "evra": "2.4.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-6.fc40.aarch64",
+      "evra": "4.19.0-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.10-1.fc40.aarch64",
+      "evra": "1.4.12-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-7.fc40.aarch64",
+      "evra": "1.32-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.1-1.fc40.aarch64",
+      "evra": "0.16.1-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.22.5-4.fc40.aarch64",
+      "evra": "0.22.5-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.5-0.fc40.aarch64",
+      "evra": "1.3.6-0.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-10.fc40.aarch64",
+      "evra": "2.4.7-12.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-7.fc40.aarch64",
+      "evra": "1.1-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-2.fc40.aarch64",
+      "evra": "1.0.27-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libutempter": {
-      "evra": "1.2.1-13.fc40.aarch64",
+      "evra": "1.2.1-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.49.1-1.fc40.aarch64",
+      "evra": "1:1.49.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-8.fc40.aarch64",
+      "evra": "0.3.2-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.20.5-1.fc40.aarch64",
+      "evra": "2:4.21.1-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-5.fc40.aarch64",
+      "evra": "4.4.36-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.8-1.fc40.aarch64",
+      "evra": "2.12.8-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.21-1.fc40.aarch64",
+      "evra": "0.3.21-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-14.fc40.aarch64",
+      "evra": "0.2.5-15.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc40.aarch64",
+      "evra": "1.5.6-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
-    "lld-libs": {
-      "evra": "18.1.8-1.fc40.aarch64",
+    "lld18-libs": {
+      "evra": "18.1.8-6.fc41.aarch64",
       "metadata": {
-        "sourcerpm": "lld"
+        "sourcerpm": "lld18"
       }
     },
-    "llvm-libs": {
-      "evra": "18.1.8-2.fc40.aarch64",
+    "llvm18-libs": {
+      "evra": "18.1.8-4.fc41.aarch64",
       "metadata": {
-        "sourcerpm": "llvm"
+        "sourcerpm": "llvm18"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-1.fc40.aarch64",
+      "evra": "0.9.33-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-6.fc40.aarch64",
+      "evra": "3.22.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-4.fc40.aarch64",
+      "evra": "4.98.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-5.fc40.aarch64",
+      "evra": "5.4.6-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-22.fc40.aarch64",
+      "evra": "9-23.fc41.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.25-1.fc40.aarch64",
+      "evra": "2.03.25-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.25-1.fc40.aarch64",
+      "evra": "2.03.25-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-6.fc40.aarch64",
+      "evra": "1.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-12.fc40.aarch64",
+      "evra": "2.10-13.fc41.aarch64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.5-13.fc40.aarch64",
+      "evra": "1.7.5-13.fc41.aarch64",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.2-8.fc40.aarch64",
+      "evra": "4.3-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-4.fc40.aarch64",
+      "evra": "27.3.1-2.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
+    "moby-filesystem": {
+      "evra": "27.3.1-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.7.1-1.fc40.aarch64",
+      "evra": "2:0.7.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.1-4.fc40.aarch64",
+      "evra": "4.2.1-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
-    "mt7xxx-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "nano": {
-      "evra": "7.2-7.fc40.aarch64",
+      "evra": "8.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-7.fc40.noarch",
+      "evra": "8.1-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-12.20240127.fc40.aarch64",
+      "evra": "6.5-2.20240629.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-12.20240127.fc40.noarch",
+      "evra": "6.5-2.20240629.fc41.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-12.20240127.fc40.aarch64",
+      "evra": "6.5-2.20240629.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.69.20160912git.fc40.aarch64",
+      "evra": "2.0-0.71.20160912git.fc41.aarch64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.12.2-1.fc40.aarch64",
+      "evra": "2:1.12.2-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-6.fc40.aarch64",
+      "evra": "3.10-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.24-3.fc40.aarch64",
+      "evra": "0.52.24-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.7.1-0.fc40.aarch64",
+      "evra": "1:2.8.1-0.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.9-3.fc40.aarch64",
+      "evra": "1:1.0.9-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.34-1.fc40.aarch64",
+      "evra": "2.2.34-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.7-1.fc40.aarch64",
+      "evra": "1.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-4.fc40.aarch64",
+      "evra": "2.23.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-5.fc40.aarch64",
+      "evra": "2.0.18-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.8-1.fc40.aarch64",
+      "evra": "2.10.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
-    "nxpwireless-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "oniguruma": {
-      "evra": "6.9.9-3.fc40.aarch64",
+      "evra": "6.9.9-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.7-1.fc40.aarch64",
+      "evra": "2.6.8-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.6p1-1.fc40.4.aarch64",
+      "evra": "9.8p1-3.fc41.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.6p1-1.fc40.4.aarch64",
+      "evra": "9.8p1-3.fc41.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.6p1-1.fc40.4.aarch64",
+      "evra": "9.8p1-3.fc41.2.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.2-3.fc40.aarch64",
+      "evra": "1:3.2.2-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.2-3.fc40.aarch64",
+      "evra": "1:3.2.2-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-6.fc40.aarch64",
+      "evra": "1.81-8.fc41.aarch64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.8-1.fc40.aarch64",
+      "evra": "2024.8-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.8-1.fc40.aarch64",
+      "evra": "2024.8-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.5-1.fc40.aarch64",
+      "evra": "0.25.5-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.5-1.fc40.aarch64",
+      "evra": "0.25.5-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.6.1-3.fc40.aarch64",
+      "evra": "1.6.1-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.6.1-3.fc40.aarch64",
+      "evra": "1.6.1-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.7-1.fc40.aarch64",
+      "evra": "0.1.8-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20240906.g6b38f07-1.fc40.aarch64",
+      "evra": "0^20240906.g6b38f07-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240906.g6b38f07-1.fc40.noarch",
+      "evra": "0^20240906.g6b38f07-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.13.0-1.fc40.aarch64",
+      "evra": "3.13.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.13.0-1.fc40.aarch64",
+      "evra": "3.13.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.44-1.fc40.aarch64",
+      "evra": "10.44-1.fc41.1.aarch64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.44-1.fc40.noarch",
+      "evra": "10.44-1.fc41.1.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-4.fc40.aarch64",
+      "evra": "2.8-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.1.1-2.fc40.aarch64",
+      "evra": "2.3.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.1.1-2.fc40.noarch",
+      "evra": "2.3.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.1.1-2.fc40.aarch64",
+      "evra": "2.3.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.2.4-1.fc40.aarch64",
+      "evra": "5:5.2.5-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.7-3.fc40.aarch64",
+      "evra": "3.7-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "124-2.fc40.aarch64",
+      "evra": "125-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "124-2.fc40.aarch64",
+      "evra": "125-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
-    "polkit-pkla-compat": {
-      "evra": "0.1-28.fc40.aarch64",
-      "metadata": {
-        "sourcerpm": "polkit-pkla-compat"
-      }
-    },
     "popt": {
-      "evra": "1.19-6.fc40.aarch64",
+      "evra": "1.19-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-3.fc40.aarch64",
+      "evra": "4.0.4-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.0-3.fc40.aarch64",
+      "evra": "1.5.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-6.fc40.aarch64",
+      "evra": "23.7-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-3.fc40.noarch",
+      "evra": "20240107-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.2.7-1.fc40.aarch64",
+      "evra": "2:9.1.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-8.fc40.aarch64",
+      "evra": "8.2-10.fc41.aarch64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
-    "realtek-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "rpcbind": {
-      "evra": "1.2.7-1.rc1.fc40.aarch64",
+      "evra": "1.2.7-1.rc1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc40.aarch64",
+      "evra": "4.20.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc40.aarch64",
+      "evra": "4.20.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.8-1.fc40.aarch64",
+      "evra": "2024.8-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.8-1.fc40.aarch64",
+      "evra": "2024.8-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc40.aarch64",
+      "evra": "4.20.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-1.fc40.aarch64",
+      "evra": "1.7.0-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc40.aarch64",
+      "evra": "3.3.0-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-3.fc40.aarch64",
+      "evra": "2:1.1.12-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.20.5-1.fc40.aarch64",
+      "evra": "2:4.21.1-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.20.5-1.fc40.noarch",
+      "evra": "2:4.21.1-7.fc41.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.20.5-1.fc40.aarch64",
+      "evra": "2:4.21.1-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
+    "sdbus-cpp": {
+      "evra": "1.5.0-3.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "sdbus-cpp"
+      }
+    },
     "sed": {
-      "evra": "4.9-1.fc40.aarch64",
+      "evra": "4.9-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.5-2.fc40.noarch",
+      "evra": "2.15.0-5.fc41.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-1.fc40.aarch64",
+      "evra": "1.48-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-1.fc40.aarch64",
+      "evra": "1.48-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.15.1-4.fc40.aarch64",
+      "evra": "2:4.15.1-12.fc41.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.15.1-4.fc40.aarch64",
+      "evra": "2:4.15.1-12.fc41.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-5.fc40.aarch64",
+      "evra": "2.3-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2305,329 +2305,332 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.16.1-1.fc40.aarch64",
+      "evra": "1:1.16.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-5.fc40.aarch64",
+      "evra": "2.3.3-6.fc41.aarch64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-2.fc40.aarch64",
+      "evra": "1.2.2-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-4.fc40.aarch64",
+      "evra": "1.2.1-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc40.aarch64",
+      "evra": "1.8.0.0-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.12.0-4.fc40.aarch64",
+      "evra": "1.14.1-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.45.1-2.fc40.aarch64",
+      "evra": "3.46.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-4.fc40.aarch64",
+      "evra": "4.6.1-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-8.fc40.aarch64",
+      "evra": "0.1.4-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.5-1.fc40.aarch64",
+      "evra": "2.10.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.6-1.fc40.aarch64",
+      "evra": "1.19.6-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-2.p5.fc40.aarch64",
+      "evra": "1.9.15-5.p5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "255.13-1.fc40.aarch64",
+      "evra": "256.7-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-3.fc40.aarch64",
+      "evra": "2:1.35-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-7.fc40.aarch64",
+      "evra": "1.32-9.fc41.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
-    "tiwilink-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+    "tini-static": {
+      "evra": "0.19.0-9.fc41.aarch64",
       "metadata": {
-        "sourcerpm": "linux-firmware"
+        "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.6-1.fc40.aarch64",
+      "evra": "0.1.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-1.fc40.aarch64",
+      "evra": "5.7-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-1.fc40.aarch64",
+      "evra": "4.1.3-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-1.fc40.aarch64",
+      "evra": "4.1.3-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-5.fc40.noarch",
+      "evra": "2024a-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-4.fc40.aarch64",
+      "evra": "0.14.0-5.fc41.aarch64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.2-1.fc40.aarch64",
+      "evra": "2.40.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.785-1.fc40.noarch",
+      "evra": "2:9.1.785-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.785-1.fc40.aarch64",
+      "evra": "2:9.1.785-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.14.0-1.fc40.aarch64",
+      "evra": "0.14.0-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.21-41.fc40.aarch64",
+      "evra": "2.21-42.fc41.aarch64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-6.fc40.aarch64",
+      "evra": "1.0.20210914-7.fc41.aarch64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.5.0-3.fc40.aarch64",
+      "evra": "6.9.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-4.fc40.aarch64",
+      "evra": "0.8.2-4.fc41.aarch64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.4.6-3.fc40.aarch64",
+      "evra": "1:5.6.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.4.6-3.fc40.aarch64",
+      "evra": "1:5.6.2-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-23.fc40.aarch64",
+      "evra": "2.1.0-24.fc41.aarch64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-1.fc40.aarch64",
+      "evra": "1.5.1-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-2.fc40.aarch64",
+      "evra": "0.0.27-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.1.7-2.fc40.aarch64",
+      "evra": "2.1.7-3.fc41.aarch64",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-11.fc40.aarch64",
+      "evra": "1.1.2-12.fc41.aarch64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc40.aarch64",
+      "evra": "1.5.6-2.fc41.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2024-10-19T00:00:00Z",
+    "generated": "2024-10-27T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2024-04-14T18:51:04Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-10-24T13:55:58Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-10-18T02:01:33Z"
+        "generated": "2024-10-27T02:50:50Z"
       },
-      "fedora-updates": {
-        "generated": "2024-10-19T01:43:57Z"
+      "fedora-next": {
+        "generated": "2024-10-25T08:41:17Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-10-27T20:24:41Z"
       }
     }
   }

--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,35 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).  
+
+packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-efi-aa64:
+    evra: 1:2.12-10.fc41.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-ppc64le:
+    evra: 1:2.12-10.fc41.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-ppc64le-modules:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,47 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-efi-x64:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-pc-modules:
+    evra: 1:2.12-10.fc41.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track
+  grub2-pc:
+    evra: 1:2.12-10.fc41.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-7d58433dd5
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1802
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,9 +9,8 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  podman:
-    evr: 5:5.2.4-1.fc40
+  ignition:
+    evr: 2.20.0-1.fc41
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f0fd63c638
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1809
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-5298e9e9d4
       type: fast-track

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,2609 +1,2618 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.46.2-1.fc40.ppc64le",
+      "evra": "1:1.50.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.46.2-1.fc40.ppc64le",
+      "evra": "1:1.50.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.46.2-1.fc40.ppc64le",
+      "evra": "1:1.50.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.46.2-1.fc40.ppc64le",
+      "evra": "1:1.50.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.46.2-1.fc40.ppc64le",
+      "evra": "1:1.50.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.10.0.8-2.fc40.noarch",
+      "evra": "2.11.1.4-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.12.2-2.fc40.ppc64le",
+      "evra": "2:1.12.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-1.fc40.ppc64le",
+      "evra": "2.3.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-6.fc40.ppc64le",
+      "evra": "0.9.2-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.7.0-1.fc40.ppc64le",
+      "evra": "5.7.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.7.0-1.fc40.ppc64le",
+      "evra": "5.7.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.27-1.fc40.ppc64le",
+      "evra": "1.30-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "atheros-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-3.fc40.ppc64le",
+      "evra": "2.5.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.0.2-1.fc40.ppc64le",
+      "evra": "4.0.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.0.2-1.fc40.ppc64le",
+      "evra": "4.0.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.0.2-1.fc40.ppc64le",
+      "evra": "4.0.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.0-5.fc40.ppc64le",
+      "evra": "1.5.0-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.0-5.fc40.ppc64le",
+      "evra": "1.5.0-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-26.fc40.ppc64le",
+      "evra": "0.8-29.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-20.fc40.noarch",
+      "evra": "11-21.fc41.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-3.fc40.ppc64le",
+      "evra": "5.2.32-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4.2-1.fc40.noarch",
+      "evra": "0.5-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-14.fc40.noarch",
+      "evra": "1:2.13-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bc": {
-      "evra": "1.07.1-21.fc40.ppc64le",
+      "evra": "1.07.1-22.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bc"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.28-2.fc40.ppc64le",
+      "evra": "32:9.18.30-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.28-2.fc40.ppc64le",
+      "evra": "32:9.18.30-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.19-1.fc40.ppc64le",
+      "evra": "0.2.24-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
-    "brcmfmac-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "bsdtar": {
-      "evra": "3.7.2-7.fc40.ppc64le",
+      "evra": "3.7.4-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.11-1.fc40.ppc64le",
+      "evra": "6.11-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc40.ppc64le",
+      "evra": "0.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-18.fc40.ppc64le",
+      "evra": "1.0.8-19.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-18.fc40.ppc64le",
+      "evra": "1.0.8-19.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc40.ppc64le",
+      "evra": "1.33.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2024.2.69_v8.0.401-1.0.fc40.noarch",
+      "evra": "2024.2.69_v8.0.401-1.0.fc41.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-22.fc40.ppc64le",
+      "evra": "0.1.7-23.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.6.1-1.fc40.ppc64le",
+      "evra": "4.6.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-5.fc40.ppc64le",
+      "evra": "7.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "20-2.fc40.ppc64le",
+      "evra": "21-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-2.fc40.ppc64le",
+      "evra": "21-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-2.fc40.ppc64le",
+      "evra": "21-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-5.fc40.ppc64le",
+      "evra": "0.5.3-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "20-2.fc40.ppc64le",
+      "evra": "21-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-7.fc40.noarch",
+      "evra": "0.33-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc40.ppc64le",
+      "evra": "1.0.6-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc40.ppc64le",
+      "evra": "1.0.6-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.12-2.fc40.ppc64le",
+      "evra": "2:2.1.12-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.233.0-1.fc40.noarch",
+      "evra": "2:2.233.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-5.fc40.ppc64le",
+      "evra": "1.7.22-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.22.1-3.fc40.ppc64le",
+      "evra": "0.22.1-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.22.1-3.fc40.ppc64le",
+      "evra": "0.22.1-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.4-8.fc40.ppc64le",
+      "evra": "9.5-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.4-8.fc40.ppc64le",
+      "evra": "9.5-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-1.fc40.ppc64le",
+      "evra": "2.15-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-5.fc40.ppc64le",
+      "evra": "2.9.11-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.0-1.fc40.ppc64le",
+      "evra": "4.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.0-1.fc40.ppc64le",
+      "evra": "4.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.17-1.fc40.ppc64le",
+      "evra": "1.18-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20240725-1.git28d3e2d.fc40.noarch",
+      "evra": "20241010-1.git8baf557.fc41.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.7.5-1.fc40.ppc64le",
+      "evra": "2.7.5-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.7.5-1.fc40.ppc64le",
+      "evra": "2.7.5-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.6.0-10.fc40.ppc64le",
+      "evra": "8.9.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-19.fc40.ppc64le",
+      "evra": "2.1.28-27.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-19.fc40.ppc64le",
+      "evra": "2.1.28-27.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-3.fc40.ppc64le",
+      "evra": "1:1.14.10-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-2.fc40.ppc64le",
+      "evra": "36-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-3.fc40.noarch",
+      "evra": "1:1.14.10-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-3.fc40.ppc64le",
+      "evra": "1:1.14.10-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.199-1.fc40.ppc64le",
+      "evra": "1.02.199-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.199-1.fc40.ppc64le",
+      "evra": "1.02.199-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.199-1.fc40.ppc64le",
+      "evra": "1.02.199-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.199-1.fc40.ppc64le",
+      "evra": "1.02.199-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.7-7.fc40.ppc64le",
+      "evra": "0.9.9-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.7-7.fc40.ppc64le",
+      "evra": "0.9.9-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc40.ppc64le",
+      "evra": "1.0.12-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-5.fc40.ppc64le",
+      "evra": "3.10-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
+    "dnf5": {
+      "evra": "5.2.6.2-1.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "dnsmasq": {
-      "evra": "2.90-1.fc40.ppc64le",
+      "evra": "2.90-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
+    "docker-cli": {
+      "evra": "27.3.1-2.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
     "dosfstools": {
-      "evra": "4.2-11.fc40.ppc64le",
+      "evra": "4.2-13.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "102-2.fc40.ppc64le",
+      "evra": "102-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "102-2.fc40.ppc64le",
+      "evra": "102-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "102-2.fc40.ppc64le",
+      "evra": "102-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-7.fc40.ppc64le",
+      "evra": "2.7.0-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-5.fc40.ppc64le",
+      "evra": "1.47.1-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-5.fc40.ppc64le",
+      "evra": "1.47.1-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-4.fc40.noarch",
+      "evra": "0.192-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-4.fc40.ppc64le",
+      "evra": "0.192-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-4.fc40.ppc64le",
+      "evra": "0.192-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.11-1.fc40.ppc64le",
+      "evra": "2:6.11-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.3-1.fc40.ppc64le",
+      "evra": "2.6.3-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.45-4.fc40.ppc64le",
+      "evra": "5.45-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.45-4.fc40.ppc64le",
+      "evra": "5.45-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-8.fc40.ppc64le",
+      "evra": "3.18-23.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-9.fc40.ppc64le",
+      "evra": "1:4.10.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.10-1.fc40.ppc64le",
+      "evra": "1.15.10-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
+    "fmt": {
+      "evra": "11.0.2-2.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "fmt"
+      }
+    },
     "fstrm": {
-      "evra": "0.6.1-10.fc40.ppc64le",
+      "evra": "0.6.1-11.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse-common": {
-      "evra": "3.16.2-3.fc40.ppc64le",
+      "evra": "3.16.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
-    "fuse-libs": {
-      "evra": "2.9.9-21.fc40.ppc64le",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc40.ppc64le",
+      "evra": "1.13-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc40.ppc64le",
+      "evra": "3.7.3-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.2-3.fc40.ppc64le",
+      "evra": "3.16.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.2-3.fc40.ppc64le",
+      "evra": "3.16.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.26-1.fc40.ppc64le",
+      "evra": "1.9.26-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.0-3.fc40.ppc64le",
+      "evra": "5.3.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-6.fc40.ppc64le",
+      "evra": "1:1.23-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-6.fc40.ppc64le",
+      "evra": "1:1.23-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc40.ppc64le",
+      "evra": "1.0.10-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22.5-4.fc40.ppc64le",
+      "evra": "0.22.5-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22.5-4.fc40.ppc64le",
+      "evra": "0.22.5-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22.5-4.fc40.ppc64le",
+      "evra": "0.22.5-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.47.0-1.fc40.ppc64le",
+      "evra": "2.47.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.80.3-1.fc40.ppc64le",
+      "evra": "2.82.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.39-22.fc40.ppc64le",
+      "evra": "2.40-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.39-22.fc40.ppc64le",
+      "evra": "2.40-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.39-22.fc40.ppc64le",
+      "evra": "2.40-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.39-22.fc40.ppc64le",
+      "evra": "2.40-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-8.fc40.ppc64le",
+      "evra": "1:6.3.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc40.ppc64le",
+      "evra": "2.4.5-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.6-1.fc40.ppc64le",
+      "evra": "3.8.6-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.23.2-3.fc40.ppc64le",
+      "evra": "1.23.2-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-7.fc40.ppc64le",
+      "evra": "3.11-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-123.fc40.noarch",
+      "evra": "1:2.12-10.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le": {
-      "evra": "1:2.06-123.fc40.ppc64le",
+      "evra": "1:2.12-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.06-123.fc40.noarch",
+      "evra": "1:2.12-10.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-123.fc40.ppc64le",
+      "evra": "1:2.12-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-123.fc40.ppc64le",
+      "evra": "1:2.12-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-1.fc40.ppc64le",
+      "evra": "1.13-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-12.fc40.ppc64le",
+      "evra": "3.23-13.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.388-1.fc40.noarch",
+      "evra": "0.388-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.19.0-1.fc40.ppc64le",
+      "evra": "2.20.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc40.ppc64le",
+      "evra": "58-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-9.fc40.ppc64le",
+      "evra": "1.0.3-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.7.0-2.fc40.ppc64le",
+      "evra": "6.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.7.0-2.fc40.ppc64le",
+      "evra": "6.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.10-7.fc40.ppc64le",
+      "evra": "1.8.10-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.10-7.fc40.ppc64le",
+      "evra": "1.8.10-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.10-7.fc40.ppc64le",
+      "evra": "1.8.10-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.10-7.fc40.ppc64le",
+      "evra": "1.8.10-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.10-7.fc40.noarch",
+      "evra": "1.8.10-15.fc41.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.10-7.fc40.ppc64le",
+      "evra": "1.8.10-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20240117-4.fc40.ppc64le",
+      "evra": "20240905-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-3.fc40.ppc64le",
+      "evra": "2:1.9.4-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.ppc64le",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.ppc64le",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-9.fc40.ppc64le",
+      "evra": "0.101-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-9.fc40.ppc64le",
+      "evra": "2.13.1-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-6.fc40.ppc64le",
+      "evra": "5.3.0-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "14-1.fc40.ppc64le",
+      "evra": "14-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-7.fc40.ppc64le",
+      "evra": "1.7.1-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-3.fc40.ppc64le",
+      "evra": "0.17-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-3.fc40.ppc64le",
+      "evra": "1.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.4-3.fc40.ppc64le",
+      "evra": "2.6.4-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.44-1.fc40.ppc64le",
+      "evra": "1.0.48-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.11.3-200.fc40.ppc64le",
+      "evra": "6.11.5-300.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.11.3-200.fc40.ppc64le",
+      "evra": "6.11.5-300.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.11.3-200.fc40.ppc64le",
+      "evra": "6.11.5-300.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.11.3-200.fc40.ppc64le",
+      "evra": "6.11.5-300.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.29-1.fc40.ppc64le",
+      "evra": "2.0.29-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-3.fc40.ppc64le",
+      "evra": "1.6.3-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-3.fc40.ppc64le",
+      "evra": "1.6.3-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "31-5.fc40.ppc64le",
+      "evra": "33-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "31-5.fc40.ppc64le",
+      "evra": "33-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.7-7.fc40.ppc64le",
+      "evra": "0.9.9-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-1.fc40.ppc64le",
+      "evra": "1.21.3-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "643-6.fc40.ppc64le",
+      "evra": "661-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-1.fc40.ppc64le",
+      "evra": "2.3.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-19.fc40.ppc64le",
+      "evra": "0.3.111-20.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.2-7.fc40.ppc64le",
+      "evra": "3.7.4-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-1.fc40.ppc64le",
+      "evra": "2.5.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
+    "libatomic": {
+      "evra": "14.2.1-3.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "gcc"
+      }
+    },
     "libattr": {
-      "evra": "2.5.2-3.fc40.ppc64le",
+      "evra": "2.5.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-56.fc40.ppc64le",
+      "evra": "0.1.1-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.2.3-1.fc40.ppc64le",
+      "evra": "2:1.4.6-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-3.fc40.ppc64le",
+      "evra": "0.12.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.69-8.fc40.ppc64le",
+      "evra": "2.70-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.4-4.fc40.ppc64le",
+      "evra": "0.8.5-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-1.fc40.ppc64le",
+      "evra": "0.11.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-56.fc40.ppc64le",
+      "evra": "0.7.0-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-5.fc40.ppc64le",
+      "evra": "1.47.1-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.6.0-10.fc40.ppc64le",
+      "evra": "8.9.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-29.fc40.ppc64le",
+      "evra": "0.14-30.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-56.fc40.ppc64le",
+      "evra": "0.5.0-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
+    "libdnf5": {
+      "evra": "5.2.6.2-1.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
+    "libdnf5-cli": {
+      "evra": "5.2.6.2-1.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "libeconf": {
-      "evra": "0.6.2-2.fc40.ppc64le",
+      "evra": "0.6.2-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-53.20240808cvs.fc40.ppc64le",
+      "evra": "3.1-53.20240808cvs.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-12.fc40.ppc64le",
+      "evra": "2.1.12-14.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-7.fc40.ppc64le",
+      "evra": "3.4.6-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.14.0-4.fc40.ppc64le",
+      "evra": "1.15.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "14.2.1-3.fc40.ppc64le",
+      "evra": "14.2.1-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.3-3.fc40.ppc64le",
+      "evra": "1.11.0-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.49-1.fc40.ppc64le",
+      "evra": "1.50-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-5.fc40.ppc64le",
+      "evra": "238-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.9-1.fc40.ppc64le",
+      "evra": "0.4.9-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "48.0-4.fc40.ppc64le",
+      "evra": "51.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "74.2-1.fc40.ppc64le",
+      "evra": "74.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc40.ppc64le",
+      "evra": "2.3.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-56.fc40.ppc64le",
+      "evra": "1.3.1-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.2-1.fc40.ppc64le",
+      "evra": "0.2.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-1.fc40.ppc64le",
+      "evra": "14-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-4.fc40.ppc64le",
+      "evra": "1.5.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-4.fc40.ppc64le",
+      "evra": "1.5.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-4.fc40.ppc64le",
+      "evra": "1.5.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.6-1.fc40.ppc64le",
+      "evra": "1.6.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.9.1-4.fc40.ppc64le",
+      "evra": "2:4.21.1-7.fc41.ppc64le",
       "metadata": {
-        "sourcerpm": "libldb"
+        "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-22.fc40.ppc64le",
+      "evra": "9-23.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.11.0-1.fc40.ppc64le",
+      "evra": "1.11.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-4.fc40.ppc64le",
+      "evra": "1.1.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-5.fc40.ppc64le",
+      "evra": "1.0.5-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-12.fc40.ppc64le",
+      "evra": "2.15.0-14.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-9.fc40.ppc64le",
+      "evra": "1.9-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-3.fc40.ppc64le",
+      "evra": "1.3-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-5.fc40.ppc64le",
+      "evra": "1.0.9-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-27.fc40.ppc64le",
+      "evra": "1.0.1-28.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.7.1-0.fc40.ppc64le",
+      "evra": "1:2.8.1-0.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-5.fc40.ppc64le",
+      "evra": "1.2.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.59.0-3.fc40.ppc64le",
+      "evra": "1.62.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.10.0-1.fc40.ppc64le",
+      "evra": "3.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.10.0-1.fc40.ppc64le",
+      "evra": "3.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-1.fc40.ppc64le",
+      "evra": "2.0.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.8-1.fc40.ppc64le",
+      "evra": "1.10-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-56.fc40.ppc64le",
+      "evra": "0.2.1-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-1.fc40.ppc64le",
+      "evra": "14:1.10.5-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "2.1.1-2.fc40.ppc64le",
+      "evra": "2.3.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-3.fc40.ppc64le",
+      "evra": "0.21.5-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-9.fc40.ppc64le",
+      "evra": "1.4.5-11.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-56.fc40.ppc64le",
+      "evra": "0.1.5-57.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc40.ppc64le",
+      "evra": "1.18.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-1.fc40.noarch",
+      "evra": "2.17.15-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "librtas": {
-      "evra": "2.0.5-1.fc40.ppc64le",
+      "evra": "2.0.6-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "librtas"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-1.fc40.ppc64le",
+      "evra": "2.5.5-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.7-5.fc40.ppc64le",
+      "evra": "3.7-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.7-5.fc40.ppc64le",
+      "evra": "3.7-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.7-2.fc40.ppc64le",
+      "evra": "3.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.7-2.fc40.ppc64le",
+      "evra": "3.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libservicelog": {
-      "evra": "1.1.19-10.fc40.ppc64le",
+      "evra": "1.1.19-11.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libservicelog"
       }
     },
     "libslirp": {
-      "evra": "4.7.0-6.fc40.ppc64le",
+      "evra": "4.8.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.20.5-1.fc40.ppc64le",
+      "evra": "2:4.21.1-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.30-1.fc40.ppc64le",
+      "evra": "0.7.30-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-5.fc40.ppc64le",
+      "evra": "1.47.1-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "14.2.1-3.fc40.ppc64le",
+      "evra": "14.2.1-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.2-1.fc40.ppc64le",
+      "evra": "2.4.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-6.fc40.ppc64le",
+      "evra": "4.19.0-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.10-1.fc40.ppc64le",
+      "evra": "1.4.12-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-7.fc40.ppc64le",
+      "evra": "1.32-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.1-1.fc40.ppc64le",
+      "evra": "0.16.1-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.22.5-4.fc40.ppc64le",
+      "evra": "0.22.5-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.5-0.fc40.ppc64le",
+      "evra": "1.3.6-0.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-10.fc40.ppc64le",
+      "evra": "2.4.7-12.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-7.fc40.ppc64le",
+      "evra": "1.1-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-2.fc40.ppc64le",
+      "evra": "1.0.27-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libutempter": {
-      "evra": "1.2.1-13.fc40.ppc64le",
+      "evra": "1.2.1-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.49.1-1.fc40.ppc64le",
+      "evra": "1:1.49.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-8.fc40.ppc64le",
+      "evra": "0.3.2-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.20.5-1.fc40.ppc64le",
+      "evra": "2:4.21.1-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-5.fc40.ppc64le",
+      "evra": "4.4.36-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.8-1.fc40.ppc64le",
+      "evra": "2.12.8-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.21-1.fc40.ppc64le",
+      "evra": "0.3.21-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-14.fc40.ppc64le",
+      "evra": "0.2.5-15.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc40.ppc64le",
+      "evra": "1.5.6-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-1.fc40.ppc64le",
+      "evra": "0.9.33-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-6.fc40.ppc64le",
+      "evra": "3.22.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-4.fc40.ppc64le",
+      "evra": "4.98.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-5.fc40.ppc64le",
+      "evra": "5.4.6-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-22.fc40.ppc64le",
+      "evra": "9-23.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.25-1.fc40.ppc64le",
+      "evra": "2.03.25-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.25-1.fc40.ppc64le",
+      "evra": "2.03.25-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-6.fc40.ppc64le",
+      "evra": "1.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-12.fc40.ppc64le",
+      "evra": "2.10-13.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.5-13.fc40.ppc64le",
+      "evra": "1.7.5-13.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.2-8.fc40.ppc64le",
+      "evra": "4.3-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-4.fc40.ppc64le",
+      "evra": "27.3.1-2.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
+    "moby-filesystem": {
+      "evra": "27.3.1-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.1-4.fc40.ppc64le",
+      "evra": "4.2.1-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
-    "mt7xxx-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "nano": {
-      "evra": "7.2-7.fc40.ppc64le",
+      "evra": "8.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-7.fc40.noarch",
+      "evra": "8.1-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-12.20240127.fc40.ppc64le",
+      "evra": "6.5-2.20240629.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-12.20240127.fc40.noarch",
+      "evra": "6.5-2.20240629.fc41.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-12.20240127.fc40.ppc64le",
+      "evra": "6.5-2.20240629.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.69.20160912git.fc40.ppc64le",
+      "evra": "2.0-0.71.20160912git.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.12.2-1.fc40.ppc64le",
+      "evra": "2:1.12.2-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-6.fc40.ppc64le",
+      "evra": "3.10-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.24-3.fc40.ppc64le",
+      "evra": "0.52.24-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.7.1-0.fc40.ppc64le",
+      "evra": "1:2.8.1-0.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.9-3.fc40.ppc64le",
+      "evra": "1:1.0.9-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.34-1.fc40.ppc64le",
+      "evra": "2.2.34-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.7-1.fc40.ppc64le",
+      "evra": "1.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-4.fc40.ppc64le",
+      "evra": "2.23.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-5.fc40.ppc64le",
+      "evra": "2.0.18-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.8-1.fc40.ppc64le",
+      "evra": "2.10.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
-    "nxpwireless-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "oniguruma": {
-      "evra": "6.9.9-3.fc40.ppc64le",
+      "evra": "6.9.9-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.7-1.fc40.ppc64le",
+      "evra": "2.6.8-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.6p1-1.fc40.4.ppc64le",
+      "evra": "9.8p1-3.fc41.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.6p1-1.fc40.4.ppc64le",
+      "evra": "9.8p1-3.fc41.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.6p1-1.fc40.4.ppc64le",
+      "evra": "9.8p1-3.fc41.2.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.2-3.fc40.ppc64le",
+      "evra": "1:3.2.2-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.2-3.fc40.ppc64le",
+      "evra": "1:3.2.2-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-6.fc40.ppc64le",
+      "evra": "1.81-8.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.8-1.fc40.ppc64le",
+      "evra": "2024.8-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-grub2": {
-      "evra": "2024.8-1.fc40.ppc64le",
+      "evra": "2024.8-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.8-1.fc40.ppc64le",
+      "evra": "2024.8-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.5-1.fc40.ppc64le",
+      "evra": "0.25.5-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.5-1.fc40.ppc64le",
+      "evra": "0.25.5-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.6.1-3.fc40.ppc64le",
+      "evra": "1.6.1-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.6.1-3.fc40.ppc64le",
+      "evra": "1.6.1-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.7-1.fc40.ppc64le",
+      "evra": "0.1.8-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20240906.g6b38f07-1.fc40.ppc64le",
+      "evra": "0^20240906.g6b38f07-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240906.g6b38f07-1.fc40.noarch",
+      "evra": "0^20240906.g6b38f07-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.13.0-1.fc40.ppc64le",
+      "evra": "3.13.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.13.0-1.fc40.ppc64le",
+      "evra": "3.13.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.44-1.fc40.ppc64le",
+      "evra": "10.44-1.fc41.1.ppc64le",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.44-1.fc40.noarch",
+      "evra": "10.44-1.fc41.1.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-4.fc40.ppc64le",
+      "evra": "2.8-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.1.1-2.fc40.ppc64le",
+      "evra": "2.3.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.1.1-2.fc40.noarch",
+      "evra": "2.3.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.1.1-2.fc40.ppc64le",
+      "evra": "2.3.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.2.4-1.fc40.ppc64le",
+      "evra": "5:5.2.5-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.7-3.fc40.ppc64le",
+      "evra": "3.7-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "124-2.fc40.ppc64le",
+      "evra": "125-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "124-2.fc40.ppc64le",
+      "evra": "125-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
-    "polkit-pkla-compat": {
-      "evra": "0.1-28.fc40.ppc64le",
-      "metadata": {
-        "sourcerpm": "polkit-pkla-compat"
-      }
-    },
     "popt": {
-      "evra": "1.19-6.fc40.ppc64le",
+      "evra": "1.19-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "powerpc-utils-core": {
-      "evra": "1.3.11-6.fc40.ppc64le",
+      "evra": "1.3.12-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "powerpc-utils"
       }
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.9-6.fc40.ppc64le",
+      "evra": "2.7.9-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "ppc64-diag"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-3.fc40.ppc64le",
+      "evra": "4.0.4-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.0-3.fc40.ppc64le",
+      "evra": "1.5.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-6.fc40.ppc64le",
+      "evra": "23.7-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-3.fc40.noarch",
+      "evra": "20240107-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.2.7-1.fc40.ppc64le",
+      "evra": "2:9.1.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-8.fc40.ppc64le",
+      "evra": "8.2-10.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
-    "realtek-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "rpcbind": {
-      "evra": "1.2.7-1.rc1.fc40.ppc64le",
+      "evra": "1.2.7-1.rc1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc40.ppc64le",
+      "evra": "4.20.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc40.ppc64le",
+      "evra": "4.20.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.8-1.fc40.ppc64le",
+      "evra": "2024.8-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.8-1.fc40.ppc64le",
+      "evra": "2024.8-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc40.ppc64le",
+      "evra": "4.20.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-1.fc40.ppc64le",
+      "evra": "1.7.0-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc40.ppc64le",
+      "evra": "3.3.0-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-3.fc40.ppc64le",
+      "evra": "2:1.1.12-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.20.5-1.fc40.ppc64le",
+      "evra": "2:4.21.1-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.20.5-1.fc40.noarch",
+      "evra": "2:4.21.1-7.fc41.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.20.5-1.fc40.ppc64le",
+      "evra": "2:4.21.1-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
+    "sdbus-cpp": {
+      "evra": "1.5.0-3.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "sdbus-cpp"
+      }
+    },
     "sed": {
-      "evra": "4.9-1.fc40.ppc64le",
+      "evra": "4.9-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "servicelog": {
-      "evra": "1.1.16-6.fc40.ppc64le",
+      "evra": "1.1.16-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "servicelog"
       }
     },
     "setup": {
-      "evra": "2.14.5-2.fc40.noarch",
+      "evra": "2.15.0-5.fc41.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-1.fc40.ppc64le",
+      "evra": "1.48-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-1.fc40.ppc64le",
+      "evra": "1.48-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.15.1-4.fc40.ppc64le",
+      "evra": "2:4.15.1-12.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.15.1-4.fc40.ppc64le",
+      "evra": "2:4.15.1-12.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-5.fc40.ppc64le",
+      "evra": "2.3-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.16.1-1.fc40.ppc64le",
+      "evra": "1:1.16.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-5.fc40.ppc64le",
+      "evra": "2.3.3-6.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-2.fc40.ppc64le",
+      "evra": "1.2.2-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-4.fc40.ppc64le",
+      "evra": "1.2.1-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc40.ppc64le",
+      "evra": "1.8.0.0-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.45.1-2.fc40.ppc64le",
+      "evra": "3.46.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-4.fc40.ppc64le",
+      "evra": "4.6.1-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-8.fc40.ppc64le",
+      "evra": "0.1.4-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.5-1.fc40.ppc64le",
+      "evra": "2.10.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.6-1.fc40.ppc64le",
+      "evra": "1.19.6-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-2.p5.fc40.ppc64le",
+      "evra": "1.9.15-5.p5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "255.13-1.fc40.ppc64le",
+      "evra": "256.7-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-3.fc40.ppc64le",
+      "evra": "2:1.35-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-7.fc40.ppc64le",
+      "evra": "1.32-9.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
-    "tiwilink-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+    "tini-static": {
+      "evra": "0.19.0-9.fc41.ppc64le",
       "metadata": {
-        "sourcerpm": "linux-firmware"
+        "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.6-1.fc40.ppc64le",
+      "evra": "0.1.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-1.fc40.ppc64le",
+      "evra": "5.7-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-1.fc40.ppc64le",
+      "evra": "4.1.3-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-1.fc40.ppc64le",
+      "evra": "4.1.3-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-5.fc40.noarch",
+      "evra": "2024a-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-4.fc40.ppc64le",
+      "evra": "0.14.0-5.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.2-1.fc40.ppc64le",
+      "evra": "2.40.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.785-1.fc40.noarch",
+      "evra": "2:9.1.785-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.785-1.fc40.ppc64le",
+      "evra": "2:9.1.785-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.21-41.fc40.ppc64le",
+      "evra": "2.21-42.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-6.fc40.ppc64le",
+      "evra": "1.0.20210914-7.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.5.0-3.fc40.ppc64le",
+      "evra": "6.9.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-4.fc40.ppc64le",
+      "evra": "0.8.2-4.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.4.6-3.fc40.ppc64le",
+      "evra": "1:5.6.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.4.6-3.fc40.ppc64le",
+      "evra": "1:5.6.2-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-23.fc40.ppc64le",
+      "evra": "2.1.0-24.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-1.fc40.ppc64le",
+      "evra": "1.5.1-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-2.fc40.ppc64le",
+      "evra": "0.0.27-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.1.7-2.fc40.ppc64le",
+      "evra": "2.1.7-3.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-11.fc40.ppc64le",
+      "evra": "1.1.2-12.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc40.ppc64le",
+      "evra": "1.5.6-2.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2024-10-19T00:00:00Z",
+    "generated": "2024-10-27T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2024-04-14T18:51:03Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-10-24T13:55:58Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-10-18T01:59:31Z"
+        "generated": "2024-10-27T02:47:53Z"
       },
-      "fedora-updates": {
-        "generated": "2024-10-19T01:44:08Z"
+      "fedora-next": {
+        "generated": "2024-10-25T08:41:17Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-10-27T20:24:42Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,2507 +1,2510 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.46.2-1.fc40.s390x",
+      "evra": "1:1.50.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.46.2-1.fc40.s390x",
+      "evra": "1:1.50.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.46.2-1.fc40.s390x",
+      "evra": "1:1.50.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.46.2-1.fc40.s390x",
+      "evra": "1:1.50.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.46.2-1.fc40.s390x",
+      "evra": "1:1.50.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.10.0.8-2.fc40.noarch",
+      "evra": "2.11.1.4-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.12.2-2.fc40.s390x",
+      "evra": "2:1.12.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-1.fc40.s390x",
+      "evra": "2.3.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-6.fc40.s390x",
+      "evra": "0.9.2-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.7.0-1.fc40.s390x",
+      "evra": "5.7.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.7.0-1.fc40.s390x",
+      "evra": "5.7.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.27-1.fc40.s390x",
+      "evra": "1.30-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "atheros-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-3.fc40.s390x",
+      "evra": "2.5.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.0.2-1.fc40.s390x",
+      "evra": "4.0.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.0.2-1.fc40.s390x",
+      "evra": "4.0.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.0.2-1.fc40.s390x",
+      "evra": "4.0.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.0-5.fc40.s390x",
+      "evra": "1.5.0-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.0-5.fc40.s390x",
+      "evra": "1.5.0-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-26.fc40.s390x",
+      "evra": "0.8-29.fc41.s390x",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-20.fc40.noarch",
+      "evra": "11-21.fc41.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-3.fc40.s390x",
+      "evra": "5.2.32-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4.2-1.fc40.noarch",
+      "evra": "0.5-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-14.fc40.noarch",
+      "evra": "1:2.13-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.28-2.fc40.s390x",
+      "evra": "32:9.18.30-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.28-2.fc40.s390x",
+      "evra": "32:9.18.30-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.19-1.fc40.s390x",
+      "evra": "0.2.24-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
-    "brcmfmac-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "bsdtar": {
-      "evra": "3.7.2-7.fc40.s390x",
+      "evra": "3.7.4-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.11-1.fc40.s390x",
+      "evra": "6.11-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc40.s390x",
+      "evra": "0.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-18.fc40.s390x",
+      "evra": "1.0.8-19.fc41.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-18.fc40.s390x",
+      "evra": "1.0.8-19.fc41.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc40.s390x",
+      "evra": "1.33.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2024.2.69_v8.0.401-1.0.fc40.noarch",
+      "evra": "2024.2.69_v8.0.401-1.0.fc41.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-22.fc40.s390x",
+      "evra": "0.1.7-23.fc41.s390x",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.6.1-1.fc40.s390x",
+      "evra": "4.6.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-5.fc40.s390x",
+      "evra": "7.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "20-2.fc40.s390x",
+      "evra": "21-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-2.fc40.s390x",
+      "evra": "21-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-2.fc40.s390x",
+      "evra": "21-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-5.fc40.s390x",
+      "evra": "0.5.3-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "20-2.fc40.s390x",
+      "evra": "21-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-7.fc40.noarch",
+      "evra": "0.33-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc40.s390x",
+      "evra": "1.0.6-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc40.s390x",
+      "evra": "1.0.6-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.12-2.fc40.s390x",
+      "evra": "2:2.1.12-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.233.0-1.fc40.noarch",
+      "evra": "2:2.233.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-5.fc40.s390x",
+      "evra": "1.7.22-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.22.1-3.fc40.s390x",
+      "evra": "0.22.1-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.22.1-3.fc40.s390x",
+      "evra": "0.22.1-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.4-8.fc40.s390x",
+      "evra": "9.5-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.4-8.fc40.s390x",
+      "evra": "9.5-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-1.fc40.s390x",
+      "evra": "2.15-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-5.fc40.s390x",
+      "evra": "2.9.11-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.0-1.fc40.s390x",
+      "evra": "4.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.0-1.fc40.s390x",
+      "evra": "4.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.17-1.fc40.s390x",
+      "evra": "1.18-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20240725-1.git28d3e2d.fc40.noarch",
+      "evra": "20241010-1.git8baf557.fc41.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.7.5-1.fc40.s390x",
+      "evra": "2.7.5-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.7.5-1.fc40.s390x",
+      "evra": "2.7.5-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.6.0-10.fc40.s390x",
+      "evra": "8.9.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-19.fc40.s390x",
+      "evra": "2.1.28-27.fc41.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-19.fc40.s390x",
+      "evra": "2.1.28-27.fc41.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-3.fc40.s390x",
+      "evra": "1:1.14.10-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-2.fc40.s390x",
+      "evra": "36-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-3.fc40.noarch",
+      "evra": "1:1.14.10-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-3.fc40.s390x",
+      "evra": "1:1.14.10-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.199-1.fc40.s390x",
+      "evra": "1.02.199-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.199-1.fc40.s390x",
+      "evra": "1.02.199-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.199-1.fc40.s390x",
+      "evra": "1.02.199-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.199-1.fc40.s390x",
+      "evra": "1.02.199-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.7-7.fc40.s390x",
+      "evra": "0.9.9-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.7-7.fc40.s390x",
+      "evra": "0.9.9-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc40.s390x",
+      "evra": "1.0.12-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-5.fc40.s390x",
+      "evra": "3.10-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
+    "dnf5": {
+      "evra": "5.2.6.2-1.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "dnsmasq": {
-      "evra": "2.90-1.fc40.s390x",
+      "evra": "2.90-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
+    "docker-cli": {
+      "evra": "27.3.1-2.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
     "dosfstools": {
-      "evra": "4.2-11.fc40.s390x",
+      "evra": "4.2-13.fc41.s390x",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "102-2.fc40.s390x",
+      "evra": "102-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "102-2.fc40.s390x",
+      "evra": "102-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "102-2.fc40.s390x",
+      "evra": "102-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-7.fc40.s390x",
+      "evra": "2.7.0-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-5.fc40.s390x",
+      "evra": "1.47.1-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-5.fc40.s390x",
+      "evra": "1.47.1-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-4.fc40.noarch",
+      "evra": "0.192-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-4.fc40.s390x",
+      "evra": "0.192-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-4.fc40.s390x",
+      "evra": "0.192-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.11-1.fc40.s390x",
+      "evra": "2:6.11-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.3-1.fc40.s390x",
+      "evra": "2.6.3-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.45-4.fc40.s390x",
+      "evra": "5.45-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.45-4.fc40.s390x",
+      "evra": "5.45-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-8.fc40.s390x",
+      "evra": "3.18-23.fc41.s390x",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-9.fc40.s390x",
+      "evra": "1:4.10.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.10-1.fc40.s390x",
+      "evra": "1.15.10-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
+    "fmt": {
+      "evra": "11.0.2-2.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "fmt"
+      }
+    },
     "fstrm": {
-      "evra": "0.6.1-10.fc40.s390x",
+      "evra": "0.6.1-11.fc41.s390x",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse-common": {
-      "evra": "3.16.2-3.fc40.s390x",
+      "evra": "3.16.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
-    "fuse-libs": {
-      "evra": "2.9.9-21.fc40.s390x",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc40.s390x",
+      "evra": "1.13-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc40.s390x",
+      "evra": "3.7.3-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.2-3.fc40.s390x",
+      "evra": "3.16.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.2-3.fc40.s390x",
+      "evra": "3.16.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.26-1.fc40.s390x",
+      "evra": "1.9.26-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.0-3.fc40.s390x",
+      "evra": "5.3.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-6.fc40.s390x",
+      "evra": "1:1.23-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-6.fc40.s390x",
+      "evra": "1:1.23-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc40.s390x",
+      "evra": "1.0.10-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "git-core": {
-      "evra": "2.47.0-1.fc40.s390x",
+      "evra": "2.47.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.80.3-1.fc40.s390x",
+      "evra": "2.82.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.39-22.fc40.s390x",
+      "evra": "2.40-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.39-22.fc40.s390x",
+      "evra": "2.40-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.39-22.fc40.s390x",
+      "evra": "2.40-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.39-22.fc40.s390x",
+      "evra": "2.40-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-8.fc40.s390x",
+      "evra": "1:6.3.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc40.s390x",
+      "evra": "2.4.5-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.6-1.fc40.s390x",
+      "evra": "3.8.6-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.23.2-3.fc40.s390x",
+      "evra": "1.23.2-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-7.fc40.s390x",
+      "evra": "3.11-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "gzip": {
-      "evra": "1.13-1.fc40.s390x",
+      "evra": "1.13-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-12.fc40.s390x",
+      "evra": "3.23-13.fc41.s390x",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.388-1.fc40.noarch",
+      "evra": "0.388-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.19.0-1.fc40.s390x",
+      "evra": "2.20.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc40.s390x",
+      "evra": "58-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-9.fc40.s390x",
+      "evra": "1.0.3-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.7.0-2.fc40.s390x",
+      "evra": "6.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.7.0-2.fc40.s390x",
+      "evra": "6.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.10-7.fc40.s390x",
+      "evra": "1.8.10-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.10-7.fc40.s390x",
+      "evra": "1.8.10-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.10-7.fc40.s390x",
+      "evra": "1.8.10-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.10-7.fc40.s390x",
+      "evra": "1.8.10-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.10-7.fc40.noarch",
+      "evra": "1.8.10-15.fc41.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.10-7.fc40.s390x",
+      "evra": "1.8.10-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20240117-4.fc40.s390x",
+      "evra": "20240905-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.s390x",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.s390x",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-9.fc40.s390x",
+      "evra": "0.101-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-9.fc40.s390x",
+      "evra": "2.13.1-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-6.fc40.s390x",
+      "evra": "5.3.0-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "14-1.fc40.s390x",
+      "evra": "14-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-7.fc40.s390x",
+      "evra": "1.7.1-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-3.fc40.s390x",
+      "evra": "0.17-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-3.fc40.s390x",
+      "evra": "1.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.4-3.fc40.s390x",
+      "evra": "2.6.4-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.44-1.fc40.s390x",
+      "evra": "1.0.48-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.11.3-200.fc40.s390x",
+      "evra": "6.11.5-300.fc41.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.11.3-200.fc40.s390x",
+      "evra": "6.11.5-300.fc41.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.11.3-200.fc40.s390x",
+      "evra": "6.11.5-300.fc41.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.11.3-200.fc40.s390x",
+      "evra": "6.11.5-300.fc41.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.29-1.fc40.s390x",
+      "evra": "2.0.29-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-3.fc40.s390x",
+      "evra": "1.6.3-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-3.fc40.s390x",
+      "evra": "1.6.3-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "31-5.fc40.s390x",
+      "evra": "33-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "31-5.fc40.s390x",
+      "evra": "33-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.7-7.fc40.s390x",
+      "evra": "0.9.9-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-1.fc40.s390x",
+      "evra": "1.21.3-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "643-6.fc40.s390x",
+      "evra": "661-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-1.fc40.s390x",
+      "evra": "2.3.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-19.fc40.s390x",
+      "evra": "0.3.111-20.fc41.s390x",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.2-7.fc40.s390x",
+      "evra": "3.7.4-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-1.fc40.s390x",
+      "evra": "2.5.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.2-3.fc40.s390x",
+      "evra": "2.5.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-56.fc40.s390x",
+      "evra": "0.1.1-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.2.3-1.fc40.s390x",
+      "evra": "2:1.4.6-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-3.fc40.s390x",
+      "evra": "0.12.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.69-8.fc40.s390x",
+      "evra": "2.70-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.4-4.fc40.s390x",
+      "evra": "0.8.5-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-1.fc40.s390x",
+      "evra": "0.11.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-56.fc40.s390x",
+      "evra": "0.7.0-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-5.fc40.s390x",
+      "evra": "1.47.1-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.6.0-10.fc40.s390x",
+      "evra": "8.9.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-29.fc40.s390x",
+      "evra": "0.14-30.fc41.s390x",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-56.fc40.s390x",
+      "evra": "0.5.0-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
+    "libdnf5": {
+      "evra": "5.2.6.2-1.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
+    "libdnf5-cli": {
+      "evra": "5.2.6.2-1.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "libeconf": {
-      "evra": "0.6.2-2.fc40.s390x",
+      "evra": "0.6.2-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-53.20240808cvs.fc40.s390x",
+      "evra": "3.1-53.20240808cvs.fc41.s390x",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-12.fc40.s390x",
+      "evra": "2.1.12-14.fc41.s390x",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-7.fc40.s390x",
+      "evra": "3.4.6-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.14.0-4.fc40.s390x",
+      "evra": "1.15.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "14.2.1-3.fc40.s390x",
+      "evra": "14.2.1-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.3-3.fc40.s390x",
+      "evra": "1.11.0-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.49-1.fc40.s390x",
+      "evra": "1.50-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-5.fc40.s390x",
+      "evra": "238-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.9-1.fc40.s390x",
+      "evra": "0.4.9-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "48.0-4.fc40.s390x",
+      "evra": "51.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "74.2-1.fc40.s390x",
+      "evra": "74.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc40.s390x",
+      "evra": "2.3.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-56.fc40.s390x",
+      "evra": "1.3.1-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.2-1.fc40.s390x",
+      "evra": "0.2.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-1.fc40.s390x",
+      "evra": "14-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-4.fc40.s390x",
+      "evra": "1.5.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-4.fc40.s390x",
+      "evra": "1.5.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-4.fc40.s390x",
+      "evra": "1.5.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.6-1.fc40.s390x",
+      "evra": "1.6.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.9.1-4.fc40.s390x",
+      "evra": "2:4.21.1-7.fc41.s390x",
       "metadata": {
-        "sourcerpm": "libldb"
+        "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-22.fc40.s390x",
+      "evra": "9-23.fc41.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.11.0-1.fc40.s390x",
+      "evra": "1.11.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-4.fc40.s390x",
+      "evra": "1.1.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-5.fc40.s390x",
+      "evra": "1.0.5-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-12.fc40.s390x",
+      "evra": "2.15.0-14.fc41.s390x",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-9.fc40.s390x",
+      "evra": "1.9-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-3.fc40.s390x",
+      "evra": "1.3-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-5.fc40.s390x",
+      "evra": "1.0.9-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-27.fc40.s390x",
+      "evra": "1.0.1-28.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.7.1-0.fc40.s390x",
+      "evra": "1:2.8.1-0.fc41.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-5.fc40.s390x",
+      "evra": "1.2.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.59.0-3.fc40.s390x",
+      "evra": "1.62.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.10.0-1.fc40.s390x",
+      "evra": "3.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.10.0-1.fc40.s390x",
+      "evra": "3.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-1.fc40.s390x",
+      "evra": "2.0.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.8-1.fc40.s390x",
+      "evra": "1.10-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-56.fc40.s390x",
+      "evra": "0.2.1-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-1.fc40.s390x",
+      "evra": "14:1.10.5-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "2.1.1-2.fc40.s390x",
+      "evra": "2.3.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-3.fc40.s390x",
+      "evra": "0.21.5-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-9.fc40.s390x",
+      "evra": "1.4.5-11.fc41.s390x",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-56.fc40.s390x",
+      "evra": "0.1.5-57.fc41.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc40.s390x",
+      "evra": "1.18.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-1.fc40.noarch",
+      "evra": "2.17.15-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-1.fc40.s390x",
+      "evra": "2.5.5-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.7-5.fc40.s390x",
+      "evra": "3.7-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.7-5.fc40.s390x",
+      "evra": "3.7-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.7-2.fc40.s390x",
+      "evra": "3.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.7-2.fc40.s390x",
+      "evra": "3.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.7.0-6.fc40.s390x",
+      "evra": "4.8.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.20.5-1.fc40.s390x",
+      "evra": "2:4.21.1-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.30-1.fc40.s390x",
+      "evra": "0.7.30-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-5.fc40.s390x",
+      "evra": "1.47.1-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "14.2.1-3.fc40.s390x",
+      "evra": "14.2.1-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.2-1.fc40.s390x",
+      "evra": "2.4.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-6.fc40.s390x",
+      "evra": "4.19.0-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.10-1.fc40.s390x",
+      "evra": "1.4.12-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-7.fc40.s390x",
+      "evra": "1.32-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.1-1.fc40.s390x",
+      "evra": "0.16.1-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.5-0.fc40.s390x",
+      "evra": "1.3.6-0.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-10.fc40.s390x",
+      "evra": "2.4.7-12.fc41.s390x",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-7.fc40.s390x",
+      "evra": "1.1-8.fc41.s390x",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-2.fc40.s390x",
+      "evra": "1.0.27-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libutempter": {
-      "evra": "1.2.1-13.fc40.s390x",
+      "evra": "1.2.1-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.49.1-1.fc40.s390x",
+      "evra": "1:1.49.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-8.fc40.s390x",
+      "evra": "0.3.2-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.20.5-1.fc40.s390x",
+      "evra": "2:4.21.1-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-5.fc40.s390x",
+      "evra": "4.4.36-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.8-1.fc40.s390x",
+      "evra": "2.12.8-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.21-1.fc40.s390x",
+      "evra": "0.3.21-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-14.fc40.s390x",
+      "evra": "0.2.5-15.fc41.s390x",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc40.s390x",
+      "evra": "1.5.6-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-1.fc40.s390x",
+      "evra": "0.9.33-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-6.fc40.s390x",
+      "evra": "3.22.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-4.fc40.s390x",
+      "evra": "4.98.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-5.fc40.s390x",
+      "evra": "5.4.6-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-22.fc40.s390x",
+      "evra": "9-23.fc41.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.25-1.fc40.s390x",
+      "evra": "2.03.25-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.25-1.fc40.s390x",
+      "evra": "2.03.25-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-6.fc40.s390x",
+      "evra": "1.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-12.fc40.s390x",
+      "evra": "2.10-13.fc41.s390x",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.5-13.fc40.s390x",
+      "evra": "1.7.5-13.fc41.s390x",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.2-8.fc40.s390x",
+      "evra": "4.3-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-4.fc40.s390x",
+      "evra": "27.3.1-2.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
+    "moby-filesystem": {
+      "evra": "27.3.1-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.1-4.fc40.s390x",
+      "evra": "4.2.1-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
-    "mt7xxx-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "nano": {
-      "evra": "7.2-7.fc40.s390x",
+      "evra": "8.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-7.fc40.noarch",
+      "evra": "8.1-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-12.20240127.fc40.s390x",
+      "evra": "6.5-2.20240629.fc41.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-12.20240127.fc40.noarch",
+      "evra": "6.5-2.20240629.fc41.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-12.20240127.fc40.s390x",
+      "evra": "6.5-2.20240629.fc41.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.69.20160912git.fc40.s390x",
+      "evra": "2.0-0.71.20160912git.fc41.s390x",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.12.2-1.fc40.s390x",
+      "evra": "2:1.12.2-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-6.fc40.s390x",
+      "evra": "3.10-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.24-3.fc40.s390x",
+      "evra": "0.52.24-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.7.1-0.fc40.s390x",
+      "evra": "1:2.8.1-0.fc41.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.9-3.fc40.s390x",
+      "evra": "1:1.0.9-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.34-1.fc40.s390x",
+      "evra": "2.2.34-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.7-1.fc40.s390x",
+      "evra": "1.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-4.fc40.s390x",
+      "evra": "2.23.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.8-1.fc40.s390x",
+      "evra": "2.10.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
-    "nxpwireless-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "oniguruma": {
-      "evra": "6.9.9-3.fc40.s390x",
+      "evra": "6.9.9-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.7-1.fc40.s390x",
+      "evra": "2.6.8-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.6p1-1.fc40.4.s390x",
+      "evra": "9.8p1-3.fc41.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.6p1-1.fc40.4.s390x",
+      "evra": "9.8p1-3.fc41.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.6p1-1.fc40.4.s390x",
+      "evra": "9.8p1-3.fc41.2.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.2-3.fc40.s390x",
+      "evra": "1:3.2.2-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.2-3.fc40.s390x",
+      "evra": "1:3.2.2-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "ostree": {
-      "evra": "2024.8-1.fc40.s390x",
+      "evra": "2024.8-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.8-1.fc40.s390x",
+      "evra": "2024.8-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.5-1.fc40.s390x",
+      "evra": "0.25.5-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.5-1.fc40.s390x",
+      "evra": "0.25.5-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.6.1-3.fc40.s390x",
+      "evra": "1.6.1-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.6.1-3.fc40.s390x",
+      "evra": "1.6.1-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.7-1.fc40.s390x",
+      "evra": "0.1.8-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20240906.g6b38f07-1.fc40.s390x",
+      "evra": "0^20240906.g6b38f07-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240906.g6b38f07-1.fc40.noarch",
+      "evra": "0^20240906.g6b38f07-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.13.0-1.fc40.s390x",
+      "evra": "3.13.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.13.0-1.fc40.s390x",
+      "evra": "3.13.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.44-1.fc40.s390x",
+      "evra": "10.44-1.fc41.1.s390x",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.44-1.fc40.noarch",
+      "evra": "10.44-1.fc41.1.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-4.fc40.s390x",
+      "evra": "2.8-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.1.1-2.fc40.s390x",
+      "evra": "2.3.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.1.1-2.fc40.noarch",
+      "evra": "2.3.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.1.1-2.fc40.s390x",
+      "evra": "2.3.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.2.4-1.fc40.s390x",
+      "evra": "5:5.2.5-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.7-3.fc40.s390x",
+      "evra": "3.7-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "124-2.fc40.s390x",
+      "evra": "125-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "124-2.fc40.s390x",
+      "evra": "125-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
-    "polkit-pkla-compat": {
-      "evra": "0.1-28.fc40.s390x",
-      "metadata": {
-        "sourcerpm": "polkit-pkla-compat"
-      }
-    },
     "popt": {
-      "evra": "1.19-6.fc40.s390x",
+      "evra": "1.19-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-3.fc40.s390x",
+      "evra": "4.0.4-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.0-3.fc40.s390x",
+      "evra": "1.5.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-6.fc40.s390x",
+      "evra": "23.7-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-3.fc40.noarch",
+      "evra": "20240107-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:8.2.7-1.fc40.s390x",
+      "evra": "2:9.1.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-8.fc40.s390x",
+      "evra": "8.2-10.fc41.s390x",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
-    "realtek-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "rpcbind": {
-      "evra": "1.2.7-1.rc1.fc40.s390x",
+      "evra": "1.2.7-1.rc1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc40.s390x",
+      "evra": "4.20.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc40.s390x",
+      "evra": "4.20.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.8-1.fc40.s390x",
+      "evra": "2024.8-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.8-1.fc40.s390x",
+      "evra": "2024.8-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc40.s390x",
+      "evra": "4.20.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-1.fc40.s390x",
+      "evra": "1.7.0-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc40.s390x",
+      "evra": "3.3.0-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-3.fc40.s390x",
+      "evra": "2:1.1.12-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "s390utils-core": {
-      "evra": "2:2.33.1-3.fc40.s390x",
+      "evra": "2:2.35.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "s390utils"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.20.5-1.fc40.s390x",
+      "evra": "2:4.21.1-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.20.5-1.fc40.noarch",
+      "evra": "2:4.21.1-7.fc41.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.20.5-1.fc40.s390x",
+      "evra": "2:4.21.1-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
+    "sdbus-cpp": {
+      "evra": "1.5.0-3.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "sdbus-cpp"
+      }
+    },
     "sed": {
-      "evra": "4.9-1.fc40.s390x",
+      "evra": "4.9-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.5-2.fc40.noarch",
+      "evra": "2.15.0-5.fc41.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-1.fc40.s390x",
+      "evra": "1.48-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-1.fc40.s390x",
+      "evra": "1.48-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.15.1-4.fc40.s390x",
+      "evra": "2:4.15.1-12.fc41.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.15.1-4.fc40.s390x",
+      "evra": "2:4.15.1-12.fc41.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-5.fc40.s390x",
+      "evra": "2.3-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.16.1-1.fc40.s390x",
+      "evra": "1:1.16.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-5.fc40.s390x",
+      "evra": "2.3.3-6.fc41.s390x",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-2.fc40.s390x",
+      "evra": "1.2.2-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-4.fc40.s390x",
+      "evra": "1.2.1-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc40.s390x",
+      "evra": "1.8.0.0-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.45.1-2.fc40.s390x",
+      "evra": "3.46.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-4.fc40.s390x",
+      "evra": "4.6.1-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-8.fc40.s390x",
+      "evra": "0.1.4-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.5-1.fc40.s390x",
+      "evra": "2.10.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.6-1.fc40.s390x",
+      "evra": "1.19.6-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-2.p5.fc40.s390x",
+      "evra": "1.9.15-5.p5.fc41.s390x",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "255.13-1.fc40.s390x",
+      "evra": "256.7-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-3.fc40.s390x",
+      "evra": "2:1.35-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-7.fc40.s390x",
+      "evra": "1.32-9.fc41.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
-    "tiwilink-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+    "tini-static": {
+      "evra": "0.19.0-9.fc41.s390x",
       "metadata": {
-        "sourcerpm": "linux-firmware"
+        "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.6-1.fc40.s390x",
+      "evra": "0.1.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-1.fc40.s390x",
+      "evra": "5.7-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-1.fc40.s390x",
+      "evra": "4.1.3-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-1.fc40.s390x",
+      "evra": "4.1.3-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-5.fc40.noarch",
+      "evra": "2024a-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-4.fc40.s390x",
+      "evra": "0.14.0-5.fc41.s390x",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.2-1.fc40.s390x",
+      "evra": "2.40.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "veritysetup": {
-      "evra": "2.7.5-1.fc40.s390x",
+      "evra": "2.7.5-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.785-1.fc40.noarch",
+      "evra": "2:9.1.785-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.785-1.fc40.s390x",
+      "evra": "2:9.1.785-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.21-41.fc40.s390x",
+      "evra": "2.21-42.fc41.s390x",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-6.fc40.s390x",
+      "evra": "1.0.20210914-7.fc41.s390x",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.5.0-3.fc40.s390x",
+      "evra": "6.9.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-4.fc40.s390x",
+      "evra": "0.8.2-4.fc41.s390x",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.4.6-3.fc40.s390x",
+      "evra": "1:5.6.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.4.6-3.fc40.s390x",
+      "evra": "1:5.6.2-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-23.fc40.s390x",
+      "evra": "2.1.0-24.fc41.s390x",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-1.fc40.s390x",
+      "evra": "1.5.1-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-2.fc40.s390x",
+      "evra": "0.0.27-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.1.7-2.fc40.s390x",
+      "evra": "2.1.7-3.fc41.s390x",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-11.fc40.s390x",
+      "evra": "1.1.2-12.fc41.s390x",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc40.s390x",
+      "evra": "1.5.6-2.fc41.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2024-10-19T00:00:00Z",
+    "generated": "2024-10-27T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2024-04-14T18:51:01Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-10-24T13:55:55Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-10-18T01:58:39Z"
+        "generated": "2024-10-27T02:46:42Z"
       },
-      "fedora-updates": {
-        "generated": "2024-10-19T01:44:20Z"
+      "fedora-next": {
+        "generated": "2024-10-25T08:41:17Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-10-27T20:24:43Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,2317 +1,2311 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.46.2-1.fc40.x86_64",
+      "evra": "1:1.50.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.46.2-1.fc40.x86_64",
+      "evra": "1:1.50.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.46.2-1.fc40.x86_64",
+      "evra": "1:1.50.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.46.2-1.fc40.x86_64",
+      "evra": "1:1.50.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.46.2-1.fc40.x86_64",
+      "evra": "1:1.50.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.10.0.8-2.fc40.noarch",
+      "evra": "2.11.1.4-8.fc41.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.12.2-2.fc40.x86_64",
+      "evra": "2:1.12.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-1.fc40.x86_64",
+      "evra": "2.3.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-6.fc40.x86_64",
+      "evra": "0.9.2-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.7.0-1.fc40.x86_64",
+      "evra": "5.7.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.7.0-1.fc40.x86_64",
+      "evra": "5.7.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.27-1.fc40.x86_64",
+      "evra": "1.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "amd-ucode-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
-    "atheros-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-3.fc40.x86_64",
+      "evra": "2.5.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.0.2-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.0.2-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.0.2-1.fc40.x86_64",
+      "evra": "4.0.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.0-5.fc40.x86_64",
+      "evra": "1.5.0-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.0-5.fc40.x86_64",
+      "evra": "1.5.0-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.8-26.fc40.x86_64",
+      "evra": "0.8-29.fc41.x86_64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "basesystem": {
-      "evra": "11-20.fc40.noarch",
+      "evra": "11-21.fc41.noarch",
       "metadata": {
         "sourcerpm": "basesystem"
       }
     },
     "bash": {
-      "evra": "5.2.26-3.fc40.x86_64",
+      "evra": "5.2.32-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.4.2-1.fc40.noarch",
+      "evra": "0.5-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.11-14.fc40.noarch",
+      "evra": "1:2.13-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.28-2.fc40.x86_64",
+      "evra": "32:9.18.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.28-2.fc40.x86_64",
+      "evra": "32:9.18.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootupd": {
-      "evra": "0.2.19-1.fc40.x86_64",
+      "evra": "0.2.24-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
-    "brcmfmac-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "bsdtar": {
-      "evra": "3.7.2-7.fc40.x86_64",
+      "evra": "3.7.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.11-1.fc40.x86_64",
+      "evra": "6.11-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc40.x86_64",
+      "evra": "0.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-18.fc40.x86_64",
+      "evra": "1.0.8-19.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-18.fc40.x86_64",
+      "evra": "1.0.8-19.fc41.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.28.1-1.fc40.x86_64",
+      "evra": "1.33.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2024.2.69_v8.0.401-1.0.fc40.noarch",
+      "evra": "2024.2.69_v8.0.401-1.0.fc41.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.1.7-22.fc40.x86_64",
+      "evra": "0.1.7-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.6.1-1.fc40.x86_64",
+      "evra": "4.6.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.0-5.fc40.x86_64",
+      "evra": "7.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "21-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "21-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "21-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-5.fc40.x86_64",
+      "evra": "0.5.3-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "20-2.fc40.x86_64",
+      "evra": "21-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-7.fc40.noarch",
+      "evra": "0.33-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.3-1.fc40.x86_64",
+      "evra": "1.0.6-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.3-1.fc40.x86_64",
+      "evra": "1.0.6-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.12-2.fc40.x86_64",
+      "evra": "2:2.1.12-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-8.fc40.noarch",
+      "evra": "0.21.3-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "2:2.233.0-1.fc40.noarch",
+      "evra": "2:2.233.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "1.6.23-5.fc40.x86_64",
+      "evra": "1.7.22-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.60.4-2.fc40.noarch",
+      "evra": "5:0.60.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.22.1-3.fc40.x86_64",
+      "evra": "0.22.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.22.1-3.fc40.x86_64",
+      "evra": "0.22.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.4-8.fc40.x86_64",
+      "evra": "9.5-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.4-8.fc40.x86_64",
+      "evra": "9.5-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-1.fc40.x86_64",
+      "evra": "2.15-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-5.fc40.x86_64",
+      "evra": "2.9.11-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.0-1.fc40.x86_64",
+      "evra": "4.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.0-1.fc40.x86_64",
+      "evra": "4.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.17-1.fc40.x86_64",
+      "evra": "1.18-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.17-1.fc40.x86_64",
+      "evra": "1.18-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20240725-1.git28d3e2d.fc40.noarch",
+      "evra": "20241010-1.git8baf557.fc41.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.7.5-1.fc40.x86_64",
+      "evra": "2.7.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.7.5-1.fc40.x86_64",
+      "evra": "2.7.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.6.0-10.fc40.x86_64",
+      "evra": "8.9.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-19.fc40.x86_64",
+      "evra": "2.1.28-27.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-19.fc40.x86_64",
+      "evra": "2.1.28-27.fc41.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.14.10-3.fc40.x86_64",
+      "evra": "1:1.14.10-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-2.fc40.x86_64",
+      "evra": "36-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.14.10-3.fc40.noarch",
+      "evra": "1:1.14.10-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.14.10-3.fc40.x86_64",
+      "evra": "1:1.14.10-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.199-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.199-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.199-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.199-1.fc40.x86_64",
+      "evra": "1.02.199-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.0.12-1.fc40.x86_64",
+      "evra": "1.0.12-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.10-5.fc40.x86_64",
+      "evra": "3.10-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
+    "dnf5": {
+      "evra": "5.2.6.2-1.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "dnsmasq": {
-      "evra": "2.90-1.fc40.x86_64",
+      "evra": "2.90-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
+    "docker-cli": {
+      "evra": "27.3.1-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
     "dosfstools": {
-      "evra": "4.2-11.fc40.x86_64",
+      "evra": "4.2-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "102-2.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "102-2.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "102-2.fc40.x86_64",
+      "evra": "102-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-7.fc40.x86_64",
+      "evra": "2.7.0-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "5-11.fc40.noarch",
+      "evra": "5-12.fc41.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-6.fc40.x86_64",
+      "evra": "18-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-2.fc40.x86_64",
+      "evra": "39-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.191-4.fc40.noarch",
+      "evra": "0.192-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.191-4.fc40.x86_64",
+      "evra": "0.192-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.191-4.fc40.x86_64",
+      "evra": "0.192-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.11-1.fc40.x86_64",
+      "evra": "2:6.11-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.6.3-1.fc40.x86_64",
+      "evra": "2.6.3-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "40-39.noarch",
+      "evra": "41-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "40-2.noarch",
+      "evra": "41-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.45-4.fc40.x86_64",
+      "evra": "5.45-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.45-4.fc40.x86_64",
+      "evra": "5.45-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-8.fc40.x86_64",
+      "evra": "3.18-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.9.0-9.fc40.x86_64",
+      "evra": "1:4.10.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.15.10-1.fc40.x86_64",
+      "evra": "1.15.10-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "10.2.1-5.fc40.x86_64",
+      "evra": "11.0.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-10.fc40.x86_64",
+      "evra": "0.6.1-11.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
     },
     "fuse-common": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
-    "fuse-libs": {
-      "evra": "2.9.9-21.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "fuse"
-      }
-    },
     "fuse-overlayfs": {
-      "evra": "1.13-1.fc40.x86_64",
+      "evra": "1.13-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-9.fc40.x86_64",
+      "evra": "3.7.3-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
     },
     "fuse3": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fuse3-libs": {
-      "evra": "3.16.2-3.fc40.x86_64",
+      "evra": "3.16.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fuse3"
       }
     },
     "fwupd": {
-      "evra": "1.9.26-1.fc40.x86_64",
+      "evra": "1.9.26-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.0-3.fc40.x86_64",
+      "evra": "5.3.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-6.fc40.x86_64",
+      "evra": "1:1.23-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-6.fc40.x86_64",
+      "evra": "1:1.23-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-1.fc40.x86_64",
+      "evra": "1.0.10-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.22.5-4.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.22.5-4.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.22.5-4.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.47.0-1.fc40.x86_64",
+      "evra": "2.47.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.80.3-1.fc40.x86_64",
+      "evra": "2.82.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.39-22.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.39-22.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.39-22.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.39-22.fc40.x86_64",
+      "evra": "2.40-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.2.1-8.fc40.x86_64",
+      "evra": "1:6.3.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnupg2": {
-      "evra": "2.4.4-1.fc40.x86_64",
+      "evra": "2.4.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.6-1.fc40.x86_64",
+      "evra": "3.8.6-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20240830.00-1.fc40.noarch",
+      "evra": "20240905.00-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.23.2-3.fc40.x86_64",
+      "evra": "1.23.2-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-7.fc40.x86_64",
+      "evra": "3.11-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.06-123.fc40.noarch",
+      "evra": "1:2.12-10.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-x64": {
-      "evra": "1:2.06-123.fc40.x86_64",
+      "evra": "1:2.12-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc": {
-      "evra": "1:2.06-123.fc40.x86_64",
+      "evra": "1:2.12-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc-modules": {
-      "evra": "1:2.06-123.fc40.noarch",
+      "evra": "1:2.12-10.fc41.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.06-123.fc40.x86_64",
+      "evra": "1:2.12-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.06-123.fc40.x86_64",
+      "evra": "1:2.12-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-1.fc40.x86_64",
+      "evra": "1.13-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.23-12.fc40.x86_64",
+      "evra": "3.23-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.388-1.fc40.noarch",
+      "evra": "0.388-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.19.0-1.fc40.x86_64",
+      "evra": "2.20.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "58-1.fc40.x86_64",
+      "evra": "58-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-9.fc40.x86_64",
+      "evra": "1.0.3-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.7.0-2.fc40.x86_64",
+      "evra": "6.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.7.0-2.fc40.x86_64",
+      "evra": "6.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iptables-legacy": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-legacy-libs": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-libs": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.10-7.fc40.noarch",
+      "evra": "1.8.10-15.fc41.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.10-7.fc40.x86_64",
+      "evra": "1.8.10-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20240117-4.fc40.x86_64",
+      "evra": "20240905-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-3.fc40.x86_64",
+      "evra": "2:1.9.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.9-20.gita65a472.fc40.x86_64",
+      "evra": "6.2.1.10-0.gitd0f04ae.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.101-9.fc40.x86_64",
+      "evra": "0.101-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.13.1-9.fc40.x86_64",
+      "evra": "2.13.1-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jemalloc": {
-      "evra": "5.3.0-6.fc40.x86_64",
+      "evra": "5.3.0-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jemalloc"
       }
     },
     "jose": {
-      "evra": "14-1.fc40.x86_64",
+      "evra": "14-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-7.fc40.x86_64",
+      "evra": "1.7.1-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.17-3.fc40.x86_64",
+      "evra": "0.17-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.8.0-3.fc40.x86_64",
+      "evra": "1.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.6.4-3.fc40.x86_64",
+      "evra": "2.6.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.6.4-3.fc40.noarch",
+      "evra": "2.6.4-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.44-1.fc40.x86_64",
+      "evra": "1.0.48-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.11.3-200.fc40.x86_64",
+      "evra": "6.11.5-300.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.11.3-200.fc40.x86_64",
+      "evra": "6.11.5-300.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.11.3-200.fc40.x86_64",
+      "evra": "6.11.5-300.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.11.3-200.fc40.x86_64",
+      "evra": "6.11.5-300.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.29-1.fc40.x86_64",
+      "evra": "2.0.29-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-3.fc40.x86_64",
+      "evra": "1.6.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-3.fc40.x86_64",
+      "evra": "1.6.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "31-5.fc40.x86_64",
+      "evra": "33-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "31-5.fc40.x86_64",
+      "evra": "33-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.9.7-7.fc40.x86_64",
+      "evra": "0.9.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-1.fc40.x86_64",
+      "evra": "1.21.3-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "643-6.fc40.x86_64",
+      "evra": "661-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-1.fc40.x86_64",
+      "evra": "2.3.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-19.fc40.x86_64",
+      "evra": "0.3.111-20.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.7.2-7.fc40.x86_64",
+      "evra": "3.7.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-1.fc40.x86_64",
+      "evra": "2.5.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.2-3.fc40.x86_64",
+      "evra": "2.5.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-56.fc40.x86_64",
+      "evra": "0.1.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.2.3-1.fc40.x86_64",
+      "evra": "2:1.4.6-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-3.fc40.x86_64",
+      "evra": "0.12.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.69-8.fc40.x86_64",
+      "evra": "2.70-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.4-4.fc40.x86_64",
+      "evra": "0.8.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-1.fc40.x86_64",
+      "evra": "0.11.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-56.fc40.x86_64",
+      "evra": "0.7.0-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.6.0-10.fc40.x86_64",
+      "evra": "8.9.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-29.fc40.x86_64",
+      "evra": "0.14-30.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-56.fc40.x86_64",
+      "evra": "0.5.0-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
+    "libdnf5": {
+      "evra": "5.2.6.2-1.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
+    "libdnf5-cli": {
+      "evra": "5.2.6.2-1.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "dnf5"
+      }
+    },
     "libeconf": {
-      "evra": "0.6.2-2.fc40.x86_64",
+      "evra": "0.6.2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-53.20240808cvs.fc40.x86_64",
+      "evra": "3.1-53.20240808cvs.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-12.fc40.x86_64",
+      "evra": "2.1.12-14.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.4-7.fc40.x86_64",
+      "evra": "3.4.6-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.14.0-4.fc40.x86_64",
+      "evra": "1.15.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "14.2.1-3.fc40.x86_64",
+      "evra": "14.2.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.10.3-3.fc40.x86_64",
+      "evra": "1.11.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.49-1.fc40.x86_64",
+      "evra": "1.50-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libgudev": {
-      "evra": "238-5.fc40.x86_64",
+      "evra": "238-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgudev"
       }
     },
     "libgusb": {
-      "evra": "0.4.9-1.fc40.x86_64",
+      "evra": "0.4.9-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libgusb"
       }
     },
     "libibverbs": {
-      "evra": "48.0-4.fc40.x86_64",
+      "evra": "51.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "74.2-1.fc40.x86_64",
+      "evra": "74.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.7-1.fc40.x86_64",
+      "evra": "2.3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-56.fc40.x86_64",
+      "evra": "1.3.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.2-1.fc40.x86_64",
+      "evra": "0.2.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-1.fc40.x86_64",
+      "evra": "14-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-4.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-4.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-4.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.6-1.fc40.x86_64",
+      "evra": "1.6.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
     "libldb": {
-      "evra": "2.9.1-4.fc40.x86_64",
+      "evra": "2:4.21.1-7.fc41.x86_64",
       "metadata": {
-        "sourcerpm": "libldb"
+        "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-22.fc40.x86_64",
+      "evra": "9-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.11.0-1.fc40.x86_64",
+      "evra": "1.11.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-4.fc40.x86_64",
+      "evra": "1.1.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-5.fc40.x86_64",
+      "evra": "1.0.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.0-12.fc40.x86_64",
+      "evra": "2.15.0-14.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.8-9.fc40.x86_64",
+      "evra": "1.9-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-3.fc40.x86_64",
+      "evra": "1.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-5.fc40.x86_64",
+      "evra": "1.0.9-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-27.fc40.x86_64",
+      "evra": "1.0.1-28.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.7.1-0.fc40.x86_64",
+      "evra": "1:2.8.1-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.6-5.fc40.x86_64",
+      "evra": "1.2.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.59.0-3.fc40.x86_64",
+      "evra": "1.62.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.10.0-1.fc40.x86_64",
+      "evra": "3.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.10.0-1.fc40.x86_64",
+      "evra": "3.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-1.fc40.x86_64",
+      "evra": "2.0.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.8-1.fc40.x86_64",
+      "evra": "1.10-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-56.fc40.x86_64",
+      "evra": "0.2.1-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-1.fc40.x86_64",
+      "evra": "14:1.10.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpkgconf": {
-      "evra": "2.1.1-2.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-3.fc40.x86_64",
+      "evra": "0.21.5-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-9.fc40.x86_64",
+      "evra": "1.4.5-11.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-56.fc40.x86_64",
+      "evra": "0.1.5-57.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc40.x86_64",
+      "evra": "1.18.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-1.fc40.noarch",
+      "evra": "2.17.15-3.fc41.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-1.fc40.x86_64",
+      "evra": "2.5.5-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.7-5.fc40.x86_64",
+      "evra": "3.7-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.7-5.fc40.x86_64",
+      "evra": "3.7-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.7-2.fc40.x86_64",
+      "evra": "3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.7-2.fc40.x86_64",
+      "evra": "3.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.7.0-6.fc40.x86_64",
+      "evra": "4.8.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.20.5-1.fc40.x86_64",
+      "evra": "2:4.21.1-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.30-1.fc40.x86_64",
+      "evra": "0.7.30-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.0-5.fc40.x86_64",
+      "evra": "1.47.1-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "14.2.1-3.fc40.x86_64",
+      "evra": "14.2.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.2-1.fc40.x86_64",
+      "evra": "2.4.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.19.0-6.fc40.x86_64",
+      "evra": "4.19.0-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.10-1.fc40.x86_64",
+      "evra": "1.4.12-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-7.fc40.x86_64",
+      "evra": "1.32-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.1-1.fc40.x86_64",
+      "evra": "0.16.1-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.22.5-4.fc40.x86_64",
+      "evra": "0.22.5-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.5-0.fc40.x86_64",
+      "evra": "1.3.6-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.4.7-10.fc40.x86_64",
+      "evra": "2.4.7-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-7.fc40.x86_64",
+      "evra": "1.1-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.27-2.fc40.x86_64",
+      "evra": "1.0.27-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libutempter": {
-      "evra": "1.2.1-13.fc40.x86_64",
+      "evra": "1.2.1-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libutempter"
       }
     },
     "libuuid": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.49.1-1.fc40.x86_64",
+      "evra": "1:1.49.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-8.fc40.x86_64",
+      "evra": "0.3.2-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.20.5-1.fc40.x86_64",
+      "evra": "2:4.21.1-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.36-5.fc40.x86_64",
+      "evra": "4.4.36-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.8-1.fc40.x86_64",
+      "evra": "2.12.8-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.21-1.fc40.x86_64",
+      "evra": "0.3.21-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-14.fc40.x86_64",
+      "evra": "0.2.5-15.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.6-1.fc40.x86_64",
+      "evra": "1.5.6-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
-    "lld-libs": {
-      "evra": "18.1.8-1.fc40.x86_64",
+    "lld18-libs": {
+      "evra": "18.1.8-6.fc41.x86_64",
       "metadata": {
-        "sourcerpm": "lld"
+        "sourcerpm": "lld18"
       }
     },
-    "llvm-libs": {
-      "evra": "18.1.8-2.fc40.x86_64",
+    "llvm18-libs": {
+      "evra": "18.1.8-4.fc41.x86_64",
       "metadata": {
-        "sourcerpm": "llvm"
+        "sourcerpm": "llvm18"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-1.fc40.x86_64",
+      "evra": "0.9.33-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.21.0-6.fc40.x86_64",
+      "evra": "3.22.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-4.fc40.x86_64",
+      "evra": "4.98.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.6-5.fc40.x86_64",
+      "evra": "5.4.6-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-22.fc40.x86_64",
+      "evra": "9-23.fc41.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.25-1.fc40.x86_64",
+      "evra": "2.03.25-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.25-1.fc40.x86_64",
+      "evra": "2.03.25-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.9.4-6.fc40.x86_64",
+      "evra": "1.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-12.fc40.x86_64",
+      "evra": "2.10-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.5-13.fc40.x86_64",
+      "evra": "1.7.5-13.fc41.x86_64",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.2-8.fc40.x86_64",
+      "evra": "4.3-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "microcode_ctl": {
-      "evra": "2:2.1-61.3.fc40.x86_64",
+      "evra": "2:2.1-65.fc41.x86_64",
       "metadata": {
         "sourcerpm": "microcode_ctl"
       }
     },
     "moby-engine": {
-      "evra": "24.0.5-4.fc40.x86_64",
+      "evra": "27.3.1-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "moby-engine"
+      }
+    },
+    "moby-filesystem": {
+      "evra": "27.3.1-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.7.1-1.fc40.x86_64",
+      "evra": "2:0.7.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.1-4.fc40.x86_64",
+      "evra": "4.2.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
-    "mt7xxx-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "nano": {
-      "evra": "7.2-7.fc40.x86_64",
+      "evra": "8.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "7.2-7.fc40.noarch",
+      "evra": "8.1-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.4-12.20240127.fc40.x86_64",
+      "evra": "6.5-2.20240629.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.4-12.20240127.fc40.noarch",
+      "evra": "6.5-2.20240629.fc41.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.4-12.20240127.fc40.x86_64",
+      "evra": "6.5-2.20240629.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.69.20160912git.fc40.x86_64",
+      "evra": "2.0-0.71.20160912git.fc41.x86_64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.12.2-1.fc40.x86_64",
+      "evra": "2:1.12.2-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.9.1-6.fc40.x86_64",
+      "evra": "3.10-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.24-3.fc40.x86_64",
+      "evra": "0.52.24-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.7.1-0.fc40.x86_64",
+      "evra": "1:2.8.1-0.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.0.9-3.fc40.x86_64",
+      "evra": "1:1.0.9-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
     "nmstate": {
-      "evra": "2.2.34-1.fc40.x86_64",
+      "evra": "2.2.34-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.7-1.fc40.x86_64",
+      "evra": "1.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-4.fc40.x86_64",
+      "evra": "2.23.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.16-5.fc40.x86_64",
+      "evra": "2.0.18-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.8-1.fc40.x86_64",
+      "evra": "2.10.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
-    "nxpwireless-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "oniguruma": {
-      "evra": "6.9.9-3.fc40.x86_64",
+      "evra": "6.9.9-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.7-1.fc40.x86_64",
+      "evra": "2.6.8-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.6p1-1.fc40.4.x86_64",
+      "evra": "9.8p1-3.fc41.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.6p1-1.fc40.4.x86_64",
+      "evra": "9.8p1-3.fc41.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.6p1-1.fc40.4.x86_64",
+      "evra": "9.8p1-3.fc41.2.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.2-3.fc40.x86_64",
+      "evra": "1:3.2.2-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.2-3.fc40.x86_64",
+      "evra": "1:3.2.2-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-6.fc40.x86_64",
+      "evra": "1.81-8.fc41.x86_64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2024.8-1.fc40.x86_64",
+      "evra": "2024.8-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2024.8-1.fc40.x86_64",
+      "evra": "2024.8-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.5-1.fc40.x86_64",
+      "evra": "0.25.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.5-1.fc40.x86_64",
+      "evra": "0.25.5-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.6.1-3.fc40.x86_64",
+      "evra": "1.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.6.1-3.fc40.x86_64",
+      "evra": "1.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.7-1.fc40.x86_64",
+      "evra": "0.1.8-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20240906.g6b38f07-1.fc40.x86_64",
+      "evra": "0^20240906.g6b38f07-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20240906.g6b38f07-1.fc40.noarch",
+      "evra": "0^20240906.g6b38f07-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.13.0-1.fc40.x86_64",
+      "evra": "3.13.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.13.0-1.fc40.x86_64",
+      "evra": "3.13.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.44-1.fc40.x86_64",
+      "evra": "10.44-1.fc41.1.x86_64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.44-1.fc40.noarch",
+      "evra": "10.44-1.fc41.1.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-4.fc40.x86_64",
+      "evra": "2.8-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.1.1-2.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.1.1-2.fc40.noarch",
+      "evra": "2.3.0-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.1.1-2.fc40.x86_64",
+      "evra": "2.3.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.2.4-1.fc40.x86_64",
+      "evra": "5:5.2.5-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.7-3.fc40.x86_64",
+      "evra": "3.7-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "124-2.fc40.x86_64",
+      "evra": "125-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "124-2.fc40.x86_64",
+      "evra": "125-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
-    "polkit-pkla-compat": {
-      "evra": "0.1-28.fc40.x86_64",
-      "metadata": {
-        "sourcerpm": "polkit-pkla-compat"
-      }
-    },
     "popt": {
-      "evra": "1.19-6.fc40.x86_64",
+      "evra": "1.19-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-3.fc40.x86_64",
+      "evra": "4.0.4-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.0-3.fc40.x86_64",
+      "evra": "1.5.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.6-6.fc40.x86_64",
+      "evra": "23.7-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20240107-3.fc40.noarch",
+      "evra": "20240107-4.fc41.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+      "evra": "20241017-2.fc41.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "readline": {
-      "evra": "8.2-8.fc40.x86_64",
+      "evra": "8.2-10.fc41.x86_64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
-    "realtek-firmware": {
-      "evra": "20241017-1.fc40.noarch",
-      "metadata": {
-        "sourcerpm": "linux-firmware"
-      }
-    },
     "rpcbind": {
-      "evra": "1.2.7-1.rc1.fc40.x86_64",
+      "evra": "1.2.7-1.rc1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.20.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.20.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2024.8-1.fc40.x86_64",
+      "evra": "2024.8-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2024.8-1.fc40.x86_64",
+      "evra": "2024.8-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.19.1.1-1.fc40.x86_64",
+      "evra": "4.20.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-1.fc40.x86_64",
+      "evra": "1.7.0-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.3.0-1.fc40.x86_64",
+      "evra": "3.3.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.1.12-3.fc40.x86_64",
+      "evra": "2:1.1.12-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.20.5-1.fc40.x86_64",
+      "evra": "2:4.21.1-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.20.5-1.fc40.noarch",
+      "evra": "2:4.21.1-7.fc41.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.20.5-1.fc40.x86_64",
+      "evra": "2:4.21.1-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
+    "sdbus-cpp": {
+      "evra": "1.5.0-3.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "sdbus-cpp"
+      }
+    },
     "sed": {
-      "evra": "4.9-1.fc40.x86_64",
+      "evra": "4.9-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "40.28-1.fc40.noarch",
+      "evra": "41.23-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.14.5-2.fc40.noarch",
+      "evra": "2.15.0-5.fc41.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-1.fc40.x86_64",
+      "evra": "1.48-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-1.fc40.x86_64",
+      "evra": "1.48-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.15.1-4.fc40.x86_64",
+      "evra": "2:4.15.1-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.15.1-4.fc40.x86_64",
+      "evra": "2:4.15.1-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-5.fc40.x86_64",
+      "evra": "2.3-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2323,329 +2317,332 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.16.1-1.fc40.x86_64",
+      "evra": "1:1.16.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-5.fc40.x86_64",
+      "evra": "2.3.3-6.fc41.x86_64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.2.2-2.fc40.x86_64",
+      "evra": "1.2.2-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.1.10-4.fc40.x86_64",
+      "evra": "1.2.1-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.0-2.fc40.x86_64",
+      "evra": "1.8.0.0-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.12.0-4.fc40.x86_64",
+      "evra": "1.14.1-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.45.1-2.fc40.x86_64",
+      "evra": "3.46.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-4.fc40.x86_64",
+      "evra": "4.6.1-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.4-8.fc40.x86_64",
+      "evra": "0.1.4-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.9.5-1.fc40.x86_64",
+      "evra": "2.10.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.19.6-1.fc40.x86_64",
+      "evra": "1.19.6-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.15-2.p5.fc40.x86_64",
+      "evra": "1.9.15-5.p5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "255.13-1.fc40.x86_64",
+      "evra": "256.7-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-3.fc40.x86_64",
+      "evra": "2:1.35-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-7.fc40.x86_64",
+      "evra": "1.32-9.fc41.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
-    "tiwilink-firmware": {
-      "evra": "20241017-1.fc40.noarch",
+    "tini-static": {
+      "evra": "0.19.0-9.fc41.x86_64",
       "metadata": {
-        "sourcerpm": "linux-firmware"
+        "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.0.99.6-1.fc40.x86_64",
+      "evra": "0.1.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-1.fc40.x86_64",
+      "evra": "5.7-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-1.fc40.x86_64",
+      "evra": "4.1.3-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-1.fc40.x86_64",
+      "evra": "4.1.3-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2024a-5.fc40.noarch",
+      "evra": "2024a-9.fc41.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.14.0-4.fc40.x86_64",
+      "evra": "0.14.0-5.fc41.x86_64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.2-1.fc40.x86_64",
+      "evra": "2.40.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.785-1.fc40.noarch",
+      "evra": "2:9.1.785-1.fc41.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.785-1.fc40.x86_64",
+      "evra": "2:9.1.785-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.14.0-1.fc40.x86_64",
+      "evra": "0.14.0-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.21-41.fc40.x86_64",
+      "evra": "2.21-42.fc41.x86_64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-6.fc40.x86_64",
+      "evra": "1.0.20210914-7.fc41.x86_64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.5.0-3.fc40.x86_64",
+      "evra": "6.9.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.2-4.fc40.x86_64",
+      "evra": "0.8.2-4.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.4.6-3.fc40.x86_64",
+      "evra": "1:5.6.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.4.6-3.fc40.x86_64",
+      "evra": "1:5.6.2-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-23.fc40.x86_64",
+      "evra": "2.1.0-24.fc41.x86_64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-1.fc40.x86_64",
+      "evra": "1.5.1-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.27-2.fc40.x86_64",
+      "evra": "0.0.27-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.1.7-2.fc40.x86_64",
+      "evra": "2.1.7-3.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.1.2-11.fc40.x86_64",
+      "evra": "1.1.2-12.fc41.x86_64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.6-1.fc40.x86_64",
+      "evra": "1.5.6-2.fc41.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2024-10-19T00:00:00Z",
+    "generated": "2024-10-27T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2024-04-14T18:51:11Z"
+      "fedora-candidate-compose": {
+        "generated": "2024-10-24T13:55:59Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2024-10-18T02:01:26Z"
+        "generated": "2024-10-27T02:49:49Z"
       },
-      "fedora-updates": {
-        "generated": "2024-10-19T01:44:32Z"
+      "fedora-next": {
+        "generated": "2024-10-25T08:41:19Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2024-10-27T20:24:43Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,6 +2,6 @@ variables:
   stream: testing
   prod: true
 
-releasever: 40
+releasever: 41
 
 include: manifests/fedora-coreos.yaml

--- a/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
+++ b/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
@@ -11,6 +11,9 @@ ExecStartPre=/bin/touch /var/lib/coreos-fix-selinux-labels.stamp
 ExecStart=/usr/libexec/coreos-fix-selinux-labels
 RemainAfterExit=yes
 MountFlags=slave
+# Run before zincati so we're not creating new files on the filesystem
+# while we are fixing labels on existing files.
+Before=zincati.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Moving to Fedora Linux 41, in preparation for Fedora 41 GA.