### PR TITLE
coreos-secex-ignition-prepare: remount /usr rw if needed

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.service
@@ -16,5 +16,7 @@ Before=ignition-fetch-offline.service
 
 [Service]
 Type=oneshot
+# Set to slave so rw remounting of /usr won't be for other units
+MountFlags=slave
 RemainAfterExit=yes
 ExecStart=/usr/sbin/coreos-secex-ignition-prepare

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-secex-ignition-prepare.sh
@@ -15,6 +15,12 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Fedora 41 comes with systemd-256, where /usr is read-only during initramfs time.
+# https://github.com/coreos/ignition/issues/1891
+if [ ! -w /usr ]; then
+    mount -o rw,remount /usr
+fi
+
 # copy base Secure Execution config (enables LUKS+dm-verity for boot and root partitions)
 cp /usr/lib/coreos/01-secex.ign /usr/lib/ignition/base.d/01-secex.ign
 


### PR DESCRIPTION
Fedora 41 comes with systemd-256, where /usr is read-only during initramfs time.

See similar issue description in https://github.com/coreos/ignition/issues/1891