### PR TITLE
manifest: Add bootc

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -156,6 +156,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootc": {
+      "evra": "1.1.0-2.fc41.aarch64",
+      "metadata": {
+        "sourcerpm": "bootc"
+      }
+    },
     "bootupd": {
       "evra": "0.2.24-1.fc41.aarch64",
       "metadata": {
@@ -1507,7 +1513,7 @@
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc41.aarch64",
+      "evra": "1.19.0-1.fc41.aarch64",
       "metadata": {
         "sourcerpm": "librepo"
       }
@@ -2618,7 +2624,7 @@
     }
   },
   "metadata": {
-    "generated": "2024-11-07T00:00:00Z",
+    "generated": "2024-11-08T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2024-10-24T13:55:58Z"
@@ -2627,7 +2633,7 @@
         "generated": "2024-11-07T18:32:31Z"
       },
       "fedora-updates": {
-        "generated": "2024-11-07T02:11:09Z"
+        "generated": "2024-11-08T03:16:14Z"
       }
     }
   }

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -162,6 +162,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootc": {
+      "evra": "1.1.0-2.fc41.ppc64le",
+      "metadata": {
+        "sourcerpm": "bootc"
+      }
+    },
     "bootupd": {
       "evra": "0.2.24-1.fc41.ppc64le",
       "metadata": {
@@ -1489,7 +1495,7 @@
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc41.ppc64le",
+      "evra": "1.19.0-1.fc41.ppc64le",
       "metadata": {
         "sourcerpm": "librepo"
       }
@@ -2600,7 +2606,7 @@
     }
   },
   "metadata": {
-    "generated": "2024-11-07T00:00:00Z",
+    "generated": "2024-11-08T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2024-10-24T13:55:58Z"
@@ -2609,7 +2615,7 @@
         "generated": "2024-11-07T18:29:52Z"
       },
       "fedora-updates": {
-        "generated": "2024-11-07T02:11:10Z"
+        "generated": "2024-11-08T03:16:14Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -156,6 +156,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootc": {
+      "evra": "1.1.0-2.fc41.s390x",
+      "metadata": {
+        "sourcerpm": "bootc"
+      }
+    },
     "bootupd": {
       "evra": "0.2.24-1.fc41.s390x",
       "metadata": {
@@ -1423,7 +1429,7 @@
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc41.s390x",
+      "evra": "1.19.0-1.fc41.s390x",
       "metadata": {
         "sourcerpm": "librepo"
       }
@@ -2492,7 +2498,7 @@
     }
   },
   "metadata": {
-    "generated": "2024-11-07T00:00:00Z",
+    "generated": "2024-11-08T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2024-10-24T13:55:55Z"
@@ -2501,7 +2507,7 @@
         "generated": "2024-11-07T18:29:18Z"
       },
       "fedora-updates": {
-        "generated": "2024-11-07T02:11:12Z"
+        "generated": "2024-11-08T03:16:14Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -162,6 +162,12 @@
         "sourcerpm": "bind"
       }
     },
+    "bootc": {
+      "evra": "1.1.0-2.fc41.x86_64",
+      "metadata": {
+        "sourcerpm": "bootc"
+      }
+    },
     "bootupd": {
       "evra": "0.2.24-1.fc41.x86_64",
       "metadata": {
@@ -1519,7 +1525,7 @@
       }
     },
     "librepo": {
-      "evra": "1.18.1-1.fc41.x86_64",
+      "evra": "1.19.0-1.fc41.x86_64",
       "metadata": {
         "sourcerpm": "librepo"
       }
@@ -2630,7 +2636,7 @@
     }
   },
   "metadata": {
-    "generated": "2024-11-07T00:00:00Z",
+    "generated": "2024-11-08T00:00:00Z",
     "rpmmd_repos": {
       "fedora": {
         "generated": "2024-10-24T13:55:59Z"
@@ -2639,7 +2645,7 @@
         "generated": "2024-11-07T18:32:20Z"
       },
       "fedora-updates": {
-        "generated": "2024-11-07T02:11:13Z"
+        "generated": "2024-11-08T03:16:14Z"
       }
     }
   }

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -159,6 +159,8 @@ packages:
   - iptables-legacy
   # NIC firmware we've traditionally shipped but then were split out of linux-firmware in Fedora
   - qed-firmware # https://github.com/coreos/fedora-coreos-tracker/issues/1746
+  # https://fedoraproject.org/wiki/Changes/DNFAndBootcInImageModeFedora
+  - bootc
 
 
 # - irqbalance


### PR DESCRIPTION
follows https://github.com/coreos/fedora-coreos-config/pull/2758

https://fedoraproject.org/wiki/Changes/DNFAndBootcInImageModeFedora

We should ship this along with dnf5 for 41.