### PR TITLE
[rawhide] overrides: Pin kdump-utils-1.0.48-1.fc42 for ppc64le

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,16 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  kdump-utils:
+    evr: 1.0.48-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1830
+      type: pin


### PR DESCRIPTION
Pin `kdump-utils-1.0.48-1.fc42` for arch specific overrides for only ppc64le.
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1830
