### PR TITLE
[rawhide] manifest: remove bootc from top level manifest

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,8 +8,3 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
-
-# Ship this in rawhide because we want to enable it in the future, also
-# to shake out any integration issues.
-packages:
-  - bootc


### PR DESCRIPTION
It was added to base on https://github.com/coreos/fedora-coreos-config/pull/3246