### PR TITLE
workflows/add-overrides: install python3-dnf

### DIFF
--- a/.github/workflows/add-override.yml
+++ b/.github/workflows/add-override.yml
@@ -40,7 +40,10 @@ jobs:
     container: quay.io/fedora/fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git jq python3-bodhi-client python3-pyyaml
+        # XXX: Note here we're installing python3-dnf, which pulls in libdnf,
+        # which is the old one. We should migrate to libdnf5 to match dnf5.
+        # https://github.com/coreos/fedora-coreos-config/issues/3254
+        run: dnf install -y git jq python3-bodhi-client python3-pyyaml python3-dnf
       - name: Check out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
F41 moved on to dnf5, which doesn't pull in Python bindings anymore. But anyway, the Python API in libdnf5 is different and we'd need to migrate `overrides.py`.

For now at least to unbreak things, just re-install back python3-dnf.

See also: https://github.com/coreos/fedora-coreos-config/issues/3254