### PR TITLE
overrides: fast-track rust-coreos-installer-0.23.0-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  coreos-installer:
+    evr: 0.23.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.23.0-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
+      type: fast-track
   ignition:
     evr: 2.20.0-1.fc41
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).