### PR TITLE
manifests/fedora-coreos: move from `rojig` to `metadata`

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -3,7 +3,7 @@
 # or are very "opinionated" like disabling SSH passwords by default.
 
 ref: fedora/${basearch}/coreos/${stream}
-rojig:
+metadata:
   license: MIT
   name: fedora-coreos
   summary: Fedora CoreOS ${stream}


### PR DESCRIPTION
Now that cosa supports looking at the `metadata` key, let's finally stop abusing the `rojig` key.