### PR TITLE
workflows/remove-graduated-overrides: clone with submodule

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
+          submodules: true
       # https://github.com/actions/checkout/issues/766
       - name: Mark git checkout as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
The `overrides.py` script needs to call
`rpm-ostree compose tree --print-only`, and rpm-ostree will want to recurse into tier-x treefiles, so we need submodules here.