### PR TITLE
[rawhide] overrides: pin clevis-21-6.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  clevis:
+    evr: 21-6.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-dracut:
+    evr: 21-6.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-luks:
+    evr: 21-6.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-systemd:
+    evr: 21-6.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).