### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,8 +21,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
       reason: https://bodhi.fedoraproject.org/updates/FEDORA-2024-f74beba038
       type: fast-track
-  ignition:
-    evr: 2.20.0-1.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-5298e9e9d4
-      type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).