### PR TITLE
[rawhide] overrides: pin kernel-6.12.0-0.rc7.59.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,3 +29,23 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
       type: pin
+  kernel:
+    evr: 6.12.0-0.rc7.59.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+      type: pin
+  kernel-core:
+    evr: 6.12.0-0.rc7.59.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+      type: pin
+  kernel-modules:
+    evr: 6.12.0-0.rc7.59.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+      type: pin
+  kernel-modules-core:
+    evr: 6.12.0-0.rc7.59.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).