### PR TITLE
[rhcos-4.18] 07fix-selinux-labels: fix service ordering

### DIFF
--- a/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
+++ b/overlay.d/07fix-selinux-labels/usr/lib/systemd/system/coreos-fix-selinux-labels.service
@@ -3,6 +3,9 @@ Description=Fix mislabeled or unlabeled SELinux contexts on files
 Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/1771
 Documentation=https://github.com/coreos/fedora-coreos-tracker/issues/1772
 ConditionPathExists=!/var/lib/coreos-fix-selinux-labels.stamp
+# Run before zincati so we're not creating new files on the filesystem
+# while we are fixing labels on existing files.
+Before=zincati.service
 
 [Service]
 Type=oneshot
@@ -11,9 +14,6 @@ ExecStartPre=/bin/touch /var/lib/coreos-fix-selinux-labels.stamp
 ExecStart=/usr/libexec/coreos-fix-selinux-labels
 RemainAfterExit=yes
 MountFlags=slave
-# Run before zincati so we're not creating new files on the filesystem
-# while we are fixing labels on existing files.
-Before=zincati.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes a mistake in b182027. Before/After directives need to go in the [Unit] section, not [Service].

(cherry picked from commit e2c37dbec85c3853424cc31d79f9bfd18ba8a1eb)

Backporting this to the rhcos-4.18 branch per https://github.com/openshift/os/pull/1644#issuecomment-2485860058

https://github.com/coreos/fedora-coreos-config/pull/3273 was inadvertently targeting the incorrect branch.