### PR TITLE
overrides: pin clevis-21-5.fc41

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -42,10 +42,8 @@ cosaPod(cpus: 4, memory: "9Gi") {
     }
     cosaBuild(skipInit: true, noStrict: no_strict_build, extraFetchArgs: '--with-cosa-overrides', extraArgs: parent_arg)
 
-    parallel metal: {
-        shwrap("cd /srv/coreos && cosa buildextend-metal")
-    }, metal4k: {
-        shwrap("cd /srv/coreos && cosa buildextend-metal4k")
+    stage("Metal/Metal4k") {
+        shwrap("cd /srv/coreos && cosa osbuild metal metal4k")
     }
 
     stage("Test ISO") {

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,26 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  clevis:
+    evr: 21-5.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-dracut:
+    evr: 21-5.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-luks:
+    evr: 21-5.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
+  clevis-systemd:
+    evr: 21-5.fc41
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
+      type: pin
   coreos-installer:
     evr: 0.23.0-1.fc41
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).