### PR TITLE
denylist: add multipath.partition

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,3 +6,7 @@
   warn: true
   arches:
     - ppc64le
+- pattern: multipath.partition
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+  streams:
+     - rawhide


### PR DESCRIPTION
multipath.partition fails after the recent kernel upgrade.

For more details ...

See: https://github.com/coreos/fedora-coreos-tracker/issues/1840