### PR TITLE
[rawhide] overrides: remove kernel pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,23 +29,3 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
       type: pin
-  kernel:
-    evr: 6.12.0-65.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
-      type: pin
-  kernel-core:
-    evr: 6.12.0-65.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
-      type: pin
-  kernel-modules:
-    evr: 6.12.0-65.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
-      type: pin
-  kernel-modules-core:
-    evr: 6.12.0-65.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1840
-      type: pin


### PR DESCRIPTION
The kernel was pinned as the kernel upgrade from
`kernel-6.12.0-0.rc7.59.fc42 →> 6.13.0-0.rc0.20241119git158f238aa69d.2.fc42` was causing the multipath.partition kola test to fail. Now the multipath.partition test is added to the kola-denylist and we are unpinning the kernel to monitor  the working of `kernel-6.13.0-0.rc0.20241119git158f238aa69d.2.fc42`

_Ref:_ 
`Tracker`: https://github.com/coreos/fedora-coreos-tracker/issues/1840
`Denylist`: https://github.com/coreos/fedora-coreos-config/pull/3282