### PR TITLE
[rawhide] overrides: remove clevis pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,26 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  clevis:
-    evr: 21-6.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
-  clevis-dracut:
-    evr: 21-6.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
-  clevis-luks:
-    evr: 21-6.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
-  clevis-systemd:
-    evr: 21-6.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
   qemu-user-static-x86:
     evr: 2:9.1.1-2.fc42
     metadata:


### PR DESCRIPTION
The kola test ext.config.var-mount.luks seems to PASS when tested with the latest clevis pkg update `clevis-21-8.fc42.x86_64`. By unpinning this clevis pkg, the latest clevis pkg could be fetched and tested.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1836