### PR TITLE
image-base.yaml: compress applehv with gzip, hyperv with zip

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -24,3 +24,9 @@ vmware-os-type: fedora64Guest
 vmware-hw-version: 17
 
 compressor: xz
+
+platform-compressor:
+    # On Windows, it's the only compression tool we can rely on.
+    hyperv: zip
+    # On macOS, it's the only compression tool we can rely on.
+    applehv: gzip


### PR DESCRIPTION
These platforms are already compressed using those compressors today, but we're moving that policy out of cosa and into here since it's not a requirement from the platform itself and more an opinion (which others may want to differ from).

This uses a new `platform-compressor` key which `cosa compress` will learn to read.