### PR TITLE
tests: add/use common definition for container repo/tag to use

### DIFF
--- a/tests/kola/binfmt/qemu
+++ b/tests/kola/binfmt/qemu
@@ -18,9 +18,10 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
+container=$(get_fedora_container_ref)
 case "$(arch)" in
     aarch64|ppc64le|s390x)
-        containerArch=$(podman run --arch=amd64 --rm quay.io/fedora/fedora:40 arch)
+        containerArch=$(podman run --arch=amd64 --rm "${container}" arch)
         if [ "$containerArch" != "x86_64" ]; then
             fatal "Test failed: x86_64 qemu emulator failed to run"
         fi

--- a/tests/kola/containers/quadlet/config.bu
+++ b/tests/kola/containers/quadlet/config.bu
@@ -9,7 +9,7 @@ storage:
           Description=A minimal container
 
           [Container]
-          Image=quay.io/fedora/fedora-minimal:40
+          Image=quay.io/fedora/fedora-minimal:latest
           Exec=sleep 60
           Volume=test.volume:/data
           Network=test.network

--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -32,7 +32,7 @@ if ! is_service_active test.service; then
   fatal "test-network.service failed to start"
 fi
 container_info=$(podman container inspect systemd-test)
-if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:40" ]]; then
+if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:latest" ]]; then
     fatal "Container not using the correct image"
 fi
 if [[ "$(jq -r '.[0].NetworkSettings.Networks[].NetworkID' <<< "$container_info")" != "systemd-test" ]]; then

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -22,6 +22,18 @@ get_ipv4_for_nic() {
     echo "$ip"
 }
 
+get_fedora_container_ref() {
+    local repo='quay.io/fedora/fedora'
+    local tag='41'
+    echo "${repo}:${tag}"
+}
+
+get_fedora_minimal_container_ref() {
+    local repo='quay.io/fedora/fedora-minimal'
+    local tag='41'
+    echo "${repo}:${tag}"
+}
+
 get_fcos_stream() {
     rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]'
 }

--- a/tests/kola/docker/basic
+++ b/tests/kola/docker/basic
@@ -13,6 +13,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-docker run --rm quay.io/fedora/fedora:40 true
+container=$(get_fedora_minimal_container_ref)
+docker run --rm "${container}" true
 
 ok "basic docker run successfully"

--- a/tests/kola/ntp/data/ntplib.sh
+++ b/tests/kola/ntp/data/ntplib.sh
@@ -19,8 +19,9 @@ ntp_test_setup() {
 
     # run podman commands to set up dnsmasq server
     pushd "$(mktemp -d)"
+    container=$(get_fedora_container_ref)
     cat <<EOF >Dockerfile
-FROM quay.io/fedora/fedora:40
+FROM $container
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y install systemd dnsmasq iproute iputils \

--- a/tests/kola/podman/dns/test.sh
+++ b/tests/kola/podman/dns/test.sh
@@ -18,14 +18,15 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-runascoreuserscript='
+container=$(get_fedora_minimal_container_ref)
+runascoreuserscript="
 #!/bin/bash
 set -euxo pipefail
 
 podman network create testnetwork
-podman run --rm -t --network=testnetwork quay.io/fedora/fedora:40 getent hosts google.com
+podman run --rm -t --network=testnetwork $container getent hosts google.com
 podman network rm testnetwork
-'
+"
 
 runascoreuser() {
     # NOTE: If we don't use `| cat` the output won't get copied

--- a/tests/kola/podman/rootless-pasta-networking
+++ b/tests/kola/podman/rootless-pasta-networking
@@ -17,19 +17,20 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-runascoreuserscript='#!/bin/bash
+container=$(get_fedora_minimal_container_ref)
+runascoreuserscript="#!/bin/bash
 set -euxo pipefail
 # Just a basic test that uses pasta network and sets the gateway
-podman run -i --rm --net=pasta:--mtu,1500 quay.io/fedora/fedora:40 bash <<"EOF"
+podman run -i --rm --net=pasta:--mtu,1500 $container bash <<'EOF'
 set -euxo pipefail
 # Verify the mtu got set to 1500. No /sbin/ip so just use /sys/class/net/<nic>/mtu
 cat /sys/class/net/e*/mtu | grep 1500
 # Download something from the internet. Here we use one of the test
 # fixtures from the ignition.resource.remote test.
-result=$(curl https://ignition-test-fixtures.s3.amazonaws.com/resources/anonymous)
-[ "$result" == "kola-anonymous" ] || exit 1
+result=\$(curl https://ignition-test-fixtures.s3.amazonaws.com/resources/anonymous)
+[ \$result == 'kola-anonymous' ] || exit 1
 EOF
-'
+"
 
 runascoreuser() {
     # NOTE: If we don't use `| cat` the output won't get copied

--- a/tests/kola/podman/rootless-systemd
+++ b/tests/kola/podman/rootless-systemd
@@ -25,7 +25,8 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-runascoreuserscript='
+container=$(get_fedora_container_ref)
+runascoreuserscript="
 #!/bin/bash
 set -euxo pipefail
 
@@ -33,23 +34,23 @@ set -euxo pipefail
 # NOTE: we may want to not build this in the future and run
 #       from a common testutils container. See
 #       https://github.com/coreos/coreos-assembler/issues/1645
-cd $(mktemp -d)
+cd \$(mktemp -d)
 cat <<EOF > Containerfile
-FROM quay.io/fedora/fedora:40
+FROM $container
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf -y update \
 && dnf -y install systemd httpd \
 && dnf clean all \
 && systemctl enable httpd
-ENTRYPOINT [ "/sbin/init" ]
+ENTRYPOINT [ \"/sbin/init\" ]
 EOF
 podman build -t httpd .
 
 # Run systemd container
-# Pass `-t` so systemd will print logs so `podman logs` will work
+# Pass '-t' so systemd will print logs so 'podman logs' will work
 podman run -t -d --name httpd --publish 8080:80 httpd
-'
+"
 
 runascoreuser() {
     # NOTE: If we don't use `| cat` the output won't get copied

--- a/tests/kola/selinux/podman-tmpfs-context
+++ b/tests/kola/selinux/podman-tmpfs-context
@@ -15,7 +15,8 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-context=$(podman run --rm --privileged quay.io/fedora/fedora:40 \
+container=$(get_fedora_minimal_container_ref)
+context=$(podman run --rm --privileged "${container}" \
             bash -c "mount -t tmpfs tmpfs /mnt/ && stat --format '%C' /mnt/")
 if [ "$context" != "system_u:object_r:container_file_t:s0" ]; then
     fatal "SELinux context for files on a tmpfs inside a container is wrong"


### PR DESCRIPTION
This will make it easier to update our tests to use newer Fedora
containers when we are ready.
