### PR TITLE
denylist: add snooze for multipath.partition

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,5 +8,6 @@
     - ppc64le
 - pattern: multipath.partition
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1840
+  snooze: 2025-01-06
   streams:
      - rawhide


### PR DESCRIPTION
The multipath.partition test has been failing with the latest kernel version 6.13.0-0.rc0.20241119git158f238aa69d.2.fc42. Let us snooze this test for a month till January 6, 2025.

Ref: coreos/fedora-coreos-tracker#1840