### PR TITLE
tests: only test gdb extension on stable/testing{,-devel}

### DIFF
--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -15,7 +15,6 @@ set -xeuo pipefail
 . "$KOLA_EXT_DATA/commonlib.sh"
 
 commands=(
-  'gdb'
   'htop'
   'strace'
   'tcpdump'
@@ -29,11 +28,11 @@ commands=(
 # rebases early to the next major Fedora and the other streams operate
 # continuously on non-stable Fedora we'll just limit this to
 # `stable`/`testing`/`testing-devel`. It's possible that this test will
-# fail on one of those streams if we fast track VIM and it's not
-# availabe in any repo, but we can just snooze the entire test in that
-# case.
+# fail on one of those streams if we fast track one of these and they're
+# not availabe in any repo, but we can just snooze the entire test in
+# that case.
 case "$(get_fcos_stream)" in
-    "stable"|"testing"|"testing-devel") commands+=('vim') ;;
+    "stable"|"testing"|"testing-devel") commands+=('vim' 'gdb') ;;
     *) ;;
 esac
 


### PR DESCRIPTION
This is one that can have host bindings that are out of date. Occasionally we see this in rawhide where the repos will be out of sync with what we built:

```
Resolving dependencies...done
Dec 03 11:42:20 qemu0 kola-runext-package[2304]: error: Could not depsolve transaction; 1 problem detected:
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:  Problem: package elfutils-debuginfod-client-0.192-7.fc42.x86_64 from rawhide requires elfutils-libelf(x86-64) = 0.192-7.fc42, but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - package gdb-headless-15.2-3.fc42.x86_64 from rawhide requires libdebuginfod.so.1()(64bit), but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - package gdb-headless-15.2-3.fc42.x86_64 from rawhide requires libdebuginfod.so.1(ELFUTILS_0.178)(64bit), but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - package gdb-headless-15.2-3.fc42.x86_64 from rawhide requires libdebuginfod.so.1(ELFUTILS_0.179)(64bit), but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - package gdb-headless-15.2-3.fc42.x86_64 from rawhide requires libdebuginfod.so.1(ELFUTILS_0.188)(64bit), but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - cannot install both elfutils-libelf-0.192-7.fc42.x86_64 from rawhide and elfutils-libelf-0.192-6.fc42.x86_64 from @System
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - package gdb-15.2-3.fc42.x86_64 from rawhide requires gdb-headless(x86-64) = 15.2-3.fc42, but none of the providers can be installed
Dec 03 11:42:20 qemu0 kola-runext-package[2304]:   - conflicting requests
```