### PR TITLE
tests: fix boot.bootupd-validate on rhel-9.6

### DIFF
--- a/tests/kola/boot/bootupd-validate
+++ b/tests/kola/boot/bootupd-validate
@@ -84,7 +84,7 @@ validate() {
 # should remove this until https://issues.redhat.com/browse/RHEL-66584 is fixed
 set_selinux_permissve() {
     source /etc/os-release
-    if is_scos || ([ "${RHEL_VERSION}" == "9.6" ] && [ "${VARIANT_ID}" == "coreos" ] ); then
+    if is_scos || [ "$(get_rhel_ver)" = "9.6" ]; then
         semanage permissive -a bootupd_t
     fi
 }

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -57,15 +57,20 @@ get_fedora_ver() {
     fi
 }
 
-get_rhel_maj_ver() {
+get_rhel_ver() {
     source /etc/os-release
     if [ "${ID}" == "rhcos" ]; then
-        echo "${RHEL_VERSION%%.*}"
+        echo "${RHEL_VERSION}"
     elif [ "${ID}" == "rhel" ]; then
-        echo "${VERSION_ID%%.*}"
+        echo "${VERSION_ID}"
     else
         fatal "Unknown ID $ID"
     fi
+}
+
+get_rhel_maj_ver() {
+    local ver; ver=$(get_rhel_ver)
+    echo "${ver%%.*}"
 }
 
 # rhcos9


### PR DESCRIPTION
In the el-only variants, there is no `RHEL_VERSION` since the RHEL version _is_ `VERSION_ID`.

Add a new `get_rhel_ver` commonlib function to abstract this away and use that in the test.

Don't bother checking for the `VARIANT_ID`. We only care about the coreos variant in the tests in this repo. (And once we start moving tests to fedora-bootc, we would want to remove these checks anyway.)