### PR TITLE
overrides: fast-track clevis-21-7.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,22 +10,26 @@
 
 packages:
   clevis:
-    evr: 21-5.fc41
+    evr: 21-7.fc41
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
+      type: fast-track
   clevis-dracut:
-    evr: 21-5.fc41
+    evr: 21-7.fc41
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
+      type: fast-track
   clevis-luks:
-    evr: 21-5.fc41
+    evr: 21-7.fc41
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
+      type: fast-track
   clevis-systemd:
-    evr: 21-5.fc41
+    evr: 21-7.fc41
     metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: pin
+      type: fast-track


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).