### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,28 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  clevis:
-    evr: 21-7.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: fast-track
-  clevis-dracut:
-    evr: 21-7.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: fast-track
-  clevis-luks:
-    evr: 21-7.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: fast-track
-  clevis-systemd:
-    evr: 21-7.fc41
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2024-57c484d6c1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1836
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).