### PR TITLE
live: update readme with more accurate comment

### DIFF
--- a/live/README-devel.md
+++ b/live/README-devel.md
@@ -1,7 +1,7 @@
-These files will be copied to the target live ISO
-via the CoreOS Assembler buildextend-live call. It
-picks up all files in the coreos/fedora-coreos-config/live/
-directory and copies them to the base of the ISO.
+These files will be copied into the built OSTree at
+/usr/share/coreos-assembler/live/ by CoreOS Assembler.
+The file will then be picked up when building live media
+and copied to the base of the ISO.
 
 Files currently copied are:
 


### PR DESCRIPTION
This changed slightly in https://github.com/coreos/coreos-assembler/pull/3846 and we are now using it from this new location when building live media using OSBuild https://github.com/osbuild/osbuild/pull/1947