### PR TITLE
denylist: remove multipath.partition denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,8 +6,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: multipath.partition
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1840
-  snooze: 2025-01-06
-  streams:
-     - rawhide


### PR DESCRIPTION
The `multipath.partition` test seemed to PASS with the latest kernel version `kernel-6.13.0-0.rc3.20241218gitaef25be35d23.31.fc42.x86_64` when checked locally. We can remove this kola test from the denylist.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1840