### PR TITLE
[rawhide] overrides: remove qemu-user-static-x86 pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,11 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  qemu-user-static-x86:
-    evr: 2:9.1.1-2.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1846
-      type: pin
   systemd:
     evr: 257-1.fc42
     metadata:


### PR DESCRIPTION
The issue is fixed on the latest `qemu-x86_64-static` version.

```
[core@cosa-devsh ~]$ qemu-x86_64-static --version
qemu-x86_64 version 9.2.0 (qemu-9.2.0-1.fc42)

[coreos-assembler]$ cosa kola run ext.config.binfmt.qemu
kola -p qemu run ext.config.binfmt.qemu --output-dir tmp/kola
=== RUN   ext.config.binfmt.qemu
--- PASS: ext.config.binfmt.qemu (33.12s)
PASS, output in tmp/kola
```