### PR TITLE
[rawhide] overrides: fast-track systemd-257.2-4.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,32 +10,38 @@
 
 packages:
   systemd:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track
   systemd-container:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track
   systemd-libs:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track
   systemd-pam:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track
   systemd-resolved:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track
   systemd-udev:
-    evr: 257-1.fc42
+    evr: 257.2-4.fc42
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
+      type: fast-track


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).