### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,40 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  systemd:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
-  systemd-container:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
-  systemd-libs:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
-  systemd-pam:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
-  systemd-resolved:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
-  systemd-udev:
-    evr: 257.2-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c146da0204
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1857#issuecomment-2585193695
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).