### PR TITLE
tests/kola: add new test to verify composefs is on

### DIFF
--- a/tests/kola/composefs/data/commonlib.sh
+++ b/tests/kola/composefs/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/composefs/enabled
+++ b/tests/kola/composefs/enabled
@@ -1,0 +1,29 @@
+#!/bin/bash
+## kola:
+##   # We now have composefs turned on in CoreOS.
+##   description: Verify that composefs is on.
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+# RHCOS/SCOS based on 9.4 doesn't use composefs, but legacy sysroot.readonly flag
+if ! is_fcos && [[ "$(get_rhel_ver)" = "9.4" ]]; then
+    echo "skipping 9.4"
+    exit 0
+fi
+
+features=$(ostree --version)
+if ! [[ "${features}" =~ "composefs" ]]; then
+    fatal "Error: ostree has no composefs support: ${features}"
+fi
+
+rootfs=$(findmnt -n -o FSTYPE /)
+if [ "${rootfs}" != "overlay" ]; then
+    fatal "Error: Expected overlay on /, found: ${rootfs}"
+fi
+
+journalctl -u ostree-prepare-root.service | grep -q "composefs: mounted successfully"
+
+ok "composefs is on"


### PR DESCRIPTION
We have `composefs` turned on in FCOS. We should have a test that verifies it.
```
$ cosa kola run ext.config.composefs.enabled
=== RUN   ext.config.composefs.enabled
--- PASS: ext.config.composefs.enabled (25.06s)
```