### PR TITLE
[rawhide] overrides: pin grub2-2.12-15.fc42 on aarch64

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-15.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1862
+      type: pin
+  grub2-tools:
+    evra: 1:2.12-15.fc42.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1862
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.12-15.fc42.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1862
+      type: pin
+  grub2-efi-aa64:
+    evra: 1:2.12-15.fc42.aarch64
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1862
+      type: pin


### PR DESCRIPTION
Right now our Live ISO tests are failing to even get to a GRUB menu. Let's revert to grub2-2.12-15.fc42 for now while we investigate what the problem is.

https://github.com/coreos/fedora-coreos-tracker/issues/1862