### PR TITLE
[testing] deploy container images by default

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,8 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Move testing to use OCI images by default
+# https://github.com/coreos/fedora-coreos-tracker/issues/1823
+deploy-via-container: true
+container-imgref: "ostree-remote-image:fedora:registry:quay.io/fedora/fedora-coreos:testing"


### PR DESCRIPTION
Switch boot images to use OCI for updates. This is a step towards bootable containers support and bootc rebase.

See https://fedoraproject.org/wiki/Changes/CoreOSOstree2OCIUpdates 
Requires https://github.com/coreos/zincati/pull/1241 
See https://github.com/coreos/fedora-coreos-tracker/issues/1823