### PR TITLE
tests/kola: check only for rhcos based on 9.4 in composefs.enabled test

### DIFF
--- a/tests/kola/composefs/enabled
+++ b/tests/kola/composefs/enabled
@@ -8,8 +8,8 @@ set -euo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-# RHCOS/SCOS based on 9.4 doesn't use composefs, but legacy sysroot.readonly flag
-if ! is_fcos && [[ "$(get_rhel_ver)" = "9.4" ]]; then
+# RHCOS based on 9.4 doesn't use composefs, but legacy sysroot.readonly flag
+if is_rhcos && [[ "$(get_rhel_ver)" = "9.4" ]]; then
     echo "skipping 9.4"
     exit 0
 fi


### PR DESCRIPTION
Only 9.4 doesn't support composefs.
There are other issues on ppc64le and kernel-64k in el9, so this test is denylisted in openshift/os repo.