### PR TITLE
tests/kola: disable yum repos for kernel-replace test

### DIFF
--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -102,6 +102,10 @@ build_derived_ociarchive() {
 
     cat > Containerfile << EOF
 FROM $imagespec
+# Disable yum repos since we are overriding local files and we don't
+# want to reach out to the repos. This is done in a way such that if
+# there are no repo files (i.e. like on RHCOS) then it succeeds anyway.
+RUN ls /etc/yum.repos.d/*.repo 2>/dev/null | xargs --no-run-if-empty sed -i s/enabled=1/enabled=0/
 RUN rpm-ostree override replace /tmp/buildcontext/*rpm && \
     rpm-ostree cleanup -m && \
     ostree container commit

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -65,8 +65,6 @@ build_base_ociarchive() {
     if [[ "$imgref" != null ]]; then
       encapsulate_args+=("--label" "ostree.bootable=true")
     fi
-    # Since we're switching OS update stream, turn off zincati
-    systemctl mask --now zincati
     ostree container encapsulate "${encapsulate_args[@]}" --repo=/ostree/repo ${checksum} "${imagespec}"
 }
 


### PR DESCRIPTION
Even though all the rpms that we are replacing are local rpm-ostree
will still reach out to the repos during the operation. Let's just
disable all the repos to prevent this from happening.

This was causing issues in our RHCOS pipeline because we have more
strict egress rules there and it was trying to hit the CentOS mirrors
when testing on c9s since the yum repos are there in c9s by default.

xref: https://github.com/openshift/os/issues/1673


----

also a second commit in there to fix a copy/paste error from 6f86533
