### PR TITLE
tests/quadlet: Fix network name retrieval in podman inspect

### DIFF
--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -35,7 +35,7 @@ container_info=$(podman container inspect systemd-test)
 if [[ "$(jq -r '.[0].ImageName' <<< "$container_info")" != "quay.io/fedora/fedora-minimal:latest" ]]; then
     fatal "Container not using the correct image"
 fi
-if [[ "$(jq -r '.[0].NetworkSettings.Networks[].NetworkID' <<< "$container_info")" != "systemd-test" ]]; then
+if [[ "$(jq -r '.[0].NetworkSettings.Networks | keys[0]' <<< "$container_info")" != "systemd-test" ]]; then
     fatal "Container not using the correct network"
 fi
 if [[ "$(jq -r '.[0].HostConfig.Binds[0]' <<< "$container_info")" != "systemd-test:/data:rw,rprivate,nosuid,nodev,rbind" ]]; then


### PR DESCRIPTION
A recent Podman release updated `podman inspect` to properly return the NetworkID instead of the name `[1]`. Update the retrieval of the network name to use the first key in the dictionary, since there is only one network.

`[1]`: https://github.com/containers/podman/issues/24910