### PR TITLE
denylist: remove kernel-replace entry for rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,9 +6,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: ext.config.rpm-ostree.kernel-replace
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1870
-  snooze: 2025-02-04
-  warn: true
-  streams:
-    - rawhide


### PR DESCRIPTION
The issue causing this test to fail has been resolved and the test is passing again in rawhide so we can remove the denylist entry for it now.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1870