### PR TITLE
[branched] manifest: bump to F42

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 41
+releasever: 42
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 42 has now branched from rawhide.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1851