### PR TITLE
image-base: specify gzip platform compressor for DigitalOcean

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -30,3 +30,6 @@ platform-compressor:
     hyperv: zip
     # On macOS, it's the only compression tool we can rely on.
     applehv: gzip
+    # For DigitalOcean you can upload a qcow2 compressed in either gzip or bzip2
+    # https://docs.digitalocean.com/products/custom-images/how-to/upload/
+    digitalocean: gzip


### PR DESCRIPTION
When we build DigitalOcean using osbuild this will be the part that tells the later `cosa compress` stage to compress the qcow2 using gzip rather than xz.