### PR TITLE
[branched] deploy container images by default

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -6,3 +6,8 @@ include: image-base.yaml
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"
 live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"
+
+# use OCI images by default
+# https://github.com/coreos/fedora-coreos-tracker/issues/1823
+deploy-via-container: true
+container-imgref: "ostree-remote-image:fedora:registry:quay.io/fedora/fedora-coreos:branched"


### PR DESCRIPTION
Switch boot images to use OCI for updates. This is a step towards bootable containers support and bootc rebase.

See https://fedoraproject.org/wiki/Changes/CoreOSOstree2OCIUpdates Requires https://github.com/coreos/zincati/pull/1241 See https://github.com/coreos/fedora-coreos-tracker/issues/1823