### PR TITLE
[next-devel] Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,7 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
+live-rootfs-fstype: "erofs"
+live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"


### PR DESCRIPTION
(cherry picked from commit 3f2f955fa9122a277290f469657ca391437a7398)