### PR TITLE
[rawhide] overrides: pin on xfsprogs-6.12.0-3.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  xfsprogs:
+    evr: 6.12.0-3.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1876
+      type: pin


### PR DESCRIPTION
The newer version xfsprogs-6.13.0-1.fc43 requires python.

https://github.com/coreos/fedora-coreos-tracker/issues/1876