### PR TITLE
overlay/core: update target for coreos-live module

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
@@ -48,8 +48,8 @@ install() {
         "ignition-complete.target"
 
     install_and_enable_unit "coreos-liveiso-persist-osmet.service" \
-        "default.target"
+        "initrd.target"
 
     install_and_enable_unit "coreos-livepxe-persist-osmet.service" \
-        "default.target"
+        "initrd.target"
 }


### PR DESCRIPTION
The default target in the initrd is `initrd.target` [1]. `default.target` is an alias symlinked to that, and it's not recommended to order on it as it is a moving target [2].

`default.target` is not present in c10s/RHEL10 initrd so it breaks the initramfs build.

[1] https://www.freedesktop.org/software/systemd/man/latest/bootup.html
[2] https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#default.target