### PR TITLE
overlay/05core: coreos-ignition dracut: use vendored sgdisk for el10

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -23,8 +23,17 @@ install() {
         lsblk \
         sed \
         grep \
-        sgdisk \
         uname
+
+
+    # In some cases we had to vendor gdisk in Ignition.
+    # If this is the case here use that one.
+    # See https://issues.redhat.com/browse/RHEL-56080
+    if [ -f /usr/libexec/ignition-sgdisk ]; then
+        inst /usr/libexec/ignition-sgdisk /usr/sbin/sgdisk
+    else
+        inst sgdisk
+    fi
 
     # For IBM SecureExecution
     if [[ $(uname -m) = s390x ]]; then


### PR DESCRIPTION
sgdisk is dropped from RHEL10/c10s, so we vendored it in ignition in [1]. Condiontionnaly include in the initramfs the vendored binary for EL10 variants only.

[1] https://gitlab.com/redhat/centos-stream/rpms/ignition/-/commit/6e48bd528cce5e227352fd375f95393322dcfef0

See https://issues.redhat.com/browse/RHEL-56080