### PR TITLE
overlay/05core: ignition-ostree dracut: use vendored sgdisk for el10

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -71,8 +71,16 @@ install() {
         rm        \
         sed       \
         sfdisk    \
-        sgdisk    \
         find
+
+    # In some cases we had to vendor gdisk in Ignition.
+    # If this is the case here use that one.
+    # See https://issues.redhat.com/browse/RHEL-56080
+    if [ -f /usr/libexec/ignition-sgdisk ]; then
+        inst /usr/libexec/ignition-sgdisk /usr/sbin/sgdisk
+    else
+        inst sgdisk
+    fi
 
     for x in mount populate; do
         install_ignition_unit ignition-ostree-${x}-var.service


### PR DESCRIPTION
Follow-up of 11cce8c139408d2caf3099b15b195cbf728b1624 See https://github.com/coreos/fedora-coreos-config/pull/3368