### PR TITLE
[branched] overrides: fast-track util-linux-2.40.4-7.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,46 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  libblkid:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  libfdisk:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  libmount:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  libsmartcols:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  libuuid:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  util-linux:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track
+  util-linux-core:
+    evr: 2.40.4-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-6ec8dfc721
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1877
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).