### PR TITLE
tests/kola/root-reprovision/luks: don't use `root` label for LUKS device

### DIFF
--- a/tests/kola/root-reprovision/luks/config.ign
+++ b/tests/kola/root-reprovision/luks/config.ign
@@ -12,7 +12,7 @@
         },
         "discard": true,
         "openOptions": ["--perf-no_read_workqueue"],
-        "label": "root",
+        "label": "luks-root",
         "wipeVolume": true
       }
     ],


### PR DESCRIPTION
LUKS devices can have labels, separate from names, and this shows up as the "filesystem label" and e.g. competes for `/dev/disk/by-label/root` for the real root.

The Butane LUKS sugar doesn't do that. The storage docs don't do that. So don't do that in our tests here either.

Likely fixes the testing issues in
https://github.com/coreos/fedora-coreos-config/pull/3124.