### PR TITLE
Add the `azure-vm-utils` package to support Azure NVMe Disks

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  azure-vm-utils:
+    evr: 0.5.1-1.fc41
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-b24d671634
+      type: fast-track

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -168,7 +168,10 @@ packages:
   - iptables-legacy
   # NIC firmware we've traditionally shipped but then were split out of linux-firmware in Fedora
   - qed-firmware # https://github.com/coreos/fedora-coreos-tracker/issues/1746
-
+  # Include udev rules for NVMe backed Azure Instances
+  # see: https://issues.redhat.com/browse/COS-3124
+  # This package is not available in RHCOS yet
+  - azure-vm-utils
 
 # - irqbalance
 #   - This thing is crying out to be pulled into systemd, but that hasn't happened


### PR DESCRIPTION
Add the `azure-vm-utils` package to include udev rules to support certain VM types (e.g. Standard_M16bds_v3, Standard_M16bs_v3, Standard_L8s_v4) that present managed disks as NVMe devices instead of traditional SCSI disks. Without these rules, LUN-based disk detection fails in the Azure Disk CSI driver, causing volume mount failures.

Add the azure provided udev rules[1] through the `azure-vm-utils` package. This package was recently built for Fedora 41, so let's also fast-track it in testing-devel to start consuming it sooner.

`[1]`: https://github.com/Azure/azure-vm-utils/blob/6fb0ae1d047c0f06e19aab8f1e27e2cd588a6f9f/udev/80-azure-disk.rules