### PR TITLE
[next-devel] image: enable deploy-via-container for generated images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,6 +3,11 @@
 # streams.
 include: image-base.yaml
 
+# Deploy via container now
+# https://github.com/coreos/fedora-coreos-tracker/issues/1823
+deploy-via-container: true
+container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:next-devel"
+
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"
 live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: next-devel
   prod: false
 
-releasever: 41
+releasever: 42
 
 repos:
   # These repos are there to make it easier to add new packages to the OS and to


### PR DESCRIPTION
Now that we are moving to deploy updates via OCI we'll also change the images we bake to be "deploy-via-container" as well.

This is part of https://github.com/coreos/fedora-coreos-tracker/issues/1823