### PR TITLE
[rawhide] overrides: fast-track xfsprogs-6.13.0-2.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,7 +10,8 @@
 
 packages:
   xfsprogs:
-    evr: 6.12.0-3.fc42
+    evr: 6.13.0-2.fc43
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1876
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4989b0edf1
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2346282
+      type: fast-track


### PR DESCRIPTION
Requested by @travier via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).