### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,10 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  xfsprogs:
-    evr: 6.13.0-2.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4989b0edf1
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2346282
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).