### PR TITLE
overrides.ppc64le: pin grub 2 to 1:2.12-15.fc41

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,36 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+    grub2-common:
+      evra: 1:2.12-15.fc41.noarch 
+      metadata:
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+        type: pin
+    grub2-ppc64le:
+      evra: 1:2.12-15.fc41.ppc64le
+      metadata:
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+        type: pin
+    grub2-ppc64le-modules:
+      evra: 1:2.12-15.fc41.noarch
+      metadata:
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+        type: pin
+    grub2-tools:
+      evra: 1:2.12-15.fc41.ppc64le
+      metadata:
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+        type: pin
+    grub2-tools-minimal:
+      evra: 1:2.12-15.fc41.ppc64le
+      metadata:
+        reason: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+        type: pin


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1886