### PR TITLE
denylist: add pxe-offline-install.4k.ppcfw for PPC64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,3 +6,9 @@
   warn: true
   arches:
     - ppc64le
+- pattern: pxe-offline-install.4k.ppcfw
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1886
+  warn: true
+  snooze: 2025-03-27
+  arches:
+    - ppc64le


### PR DESCRIPTION
This is broken on all streams for a few days, let denylist for now so we can get some builds out.

See https://github.com/coreos/fedora-coreos-tracker/issues/1886