### PR TITLE
denylist: re-enable ppc64le pxe test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,9 +6,3 @@
   warn: true
   arches:
     - ppc64le
-- pattern: pxe-offline-install.4k.ppcfw
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1886
-  warn: true
-  snooze: 2025-03-27
-  arches:
-    - ppc64le


### PR DESCRIPTION
This was caused by COSA.

Fixed with https://github.com/coreos/coreos-assembler/pull/4040