### PR TITLE
overlay.d/40grub: remove 70_coreos-user.cfg

### DIFF
--- a/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/70_coreos-user.cfg
+++ b/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/70_coreos-user.cfg
@@ -1,6 +1,0 @@
-
-# Import user defined configuration
-# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
-if [ -f $prefix/user.cfg ]; then
-  source $prefix/user.cfg
-fi


### PR DESCRIPTION
bootupd sources user.cfg since before it allows configs.d https://github.com/coreos/bootupd/commit/1475f2587d7fb652f21b07f8defb4581d6c50754