### PR TITLE
denylist: skip console warnings on ppc

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,3 +6,7 @@
   warn: true
   arches:
     - ppc64le
+- pattern: skip-console-warnings
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
+  arches:
+    - ppc64le


### PR DESCRIPTION
We are getting a bunch of kernel warnings on ppc64le and it's blocking us from getting new updates for all architectures (i.e. bump-lockfile won't pass). Let's skip console warnings for now on ppc64le.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1889