### PR TITLE
[next-devel] overrides: fast-track ignition-2.21.0-2.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,10 +10,16 @@
 
 packages:
   ignition:
-    evr: 2.21.0-1.fc42
+    evr: 2.21.0-2.fc42
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4dc7e4fec0
-      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4dc7e4fec0
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
+      reason: https://github.com/coreos/ignition/pull/2037
+      type: fast-track
+  ignition-grub:
+    evr: 2.21.0-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
+      reason: https://github.com/coreos/ignition/pull/2037
       type: fast-track
   rpm-ostree:
     evr: 2025.6-4.fc42


### PR DESCRIPTION
This one has the renamed RPM to `ignition-grub` and the renamed grub fragment file to 05_ignition.cfg.