### PR TITLE
[rawhide] overrides: pin dnf5-5.2.11.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,19 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  dnf5:
+    evr: 5.2.11.0-1.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin
+  libdnf5:
+    evr: 5.2.11.0-1.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin
+  libdnf5-cli:
+    evr: 5.2.11.0-1.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).