### PR TITLE
[next-devel] overrides: pin dnf5-5.2.11.0-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  dnf5:
+    evr: 5.2.11.0-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin
   ignition:
     evr: 2.21.0-2.fc42
     metadata:
@@ -21,6 +26,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
       reason: https://github.com/coreos/ignition/pull/2037
       type: fast-track
+  libdnf5:
+    evr: 5.2.11.0-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin
+  libdnf5-cli:
+    evr: 5.2.11.0-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
+      type: pin
   rpm-ostree:
     evr: 2025.6-6.fc42
     metadata:


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).