### PR TITLE
denylist: add denial for toolbox on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,3 +10,9 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
+- pattern: ext.config.toolbox
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1908
+  snooze: 2025-04-07
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
kernel-6.15.0-0.rc0.20250327git1a9239bb4253.5.fc43 seems to have caused the toolbox test to start failing. Let's denylist while we investigate.

https://github.com/coreos/fedora-coreos-tracker/issues/1908