### PR TITLE
tests/upgrade: adjust for OCI based updates

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -73,10 +73,16 @@ booted_deployment_json=$(rpm-ostree status  --json | \
                          jq -r '.deployments[] | select(.booted == true)')
 version=$(jq -r '.version' <<< "${booted_deployment_json}")
 stream=$(jq -r '.["base-commit-meta"]["fedora-coreos.stream"]' <<< "${booted_deployment_json}")
+if [ "$stream" == "null" ]; then
+    # On a container based deployment we don't have the fedora coreos stream
+    # in the same place it used to be. Try to grab it from the new place.
+    ostree_manifest=$(jq -r '.["base-commit-meta"]["ostree.manifest"]' <<< "${booted_deployment_json}")
+    stream=$(jq -r '.annotations | .["fedora-coreos.stream"]' <<< "${ostree_manifest}")
+fi
 
 # Pick up the last release for the current stream from the update server
 test -f /srv/updateinfo.json || \
-    curl -L "https://updates.coreos.fedoraproject.org/v1/graph?basearch=$(arch)&stream=${stream}&rollout_wariness=0" > /srv/updateinfo.json
+    curl -L "https://updates.coreos.fedoraproject.org/v1/graph?basearch=$(arch)&stream=${stream}&rollout_wariness=0&oci=true" > /srv/updateinfo.json
 last_release=$(jq -r .nodes[-1].version /srv/updateinfo.json)
 last_release_index=$(jq '.nodes | length-1' /srv/updateinfo.json)
 latest_edge=$(jq -r .edges[0][1] /srv/updateinfo.json)
@@ -300,7 +306,7 @@ systemd-run --wait --property=After=coreos-fix-selinux-labels.service \
 # version, which should be in the compose OSTree repo.
 if vereq $version $last_release; then
     systemctl stop zincati
-    rpm-ostree rebase "fedora-compose:fedora/$(arch)/coreos/${target_stream}" $target_version
+    rpm-ostree rebase "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:${target_version}"
     /tmp/autopkgtest-reboot $version # execute the reboot
     sleep infinity
 fi

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -154,14 +154,6 @@ move-to-cgroups-v2() {
     fi
 }
 
-# A helper to wait for the fix-selinux-labels script to finish
-wait-for-coreos-fix-selinux-labels() {
-    # First make sure the migrations/fix script has finished (if it is going
-    # to run) before doing the checks
-    systemd-run --wait --property=After=coreos-fix-selinux-labels.service \
-        echo "Waited for coreos-fix-selinux-labels.service to finish"
-}
-
 # We need to drop the rollback deployment. During upgrade
 # `...-> 40.20240906.1.0 (A)-> 41.20241109.1.0 (B)-> 42.20241114.91.0 (C)`
 # 1) A->B, A has the unfixed ostree, the upgrade will copy dtb files
@@ -186,9 +178,6 @@ drop_rollback_on_aarch64() {
 }
 
 selinux-sanity-check() {
-    # First make sure the migrations/fix script has finished if this is the boot
-    # where the fixes are taking place.
-    wait-for-coreos-fix-selinux-labels
     # Drop the rooback on aarch64 before checking.
     drop_rollback_on_aarch64
     # Verify SELinux labels are sane. Migration scripts should have cleaned
@@ -299,15 +288,19 @@ case "$stream" in
     *) fatal "unexpected stream: $stream";;
 esac
 
+# First, since coreos-fix-selinux-labels.service runs before zincati.service
+# let's wait until that service is finished before proceeding (and potentially
+# timing out below as a result of not waiting here). Note that if we are
+# running on an older release that doesn't have coreos-fix-selinux-labels.service
+# this is essentially a no-op.
+systemd-run --wait --property=After=coreos-fix-selinux-labels.service \
+    echo "Waited for coreos-fix-selinux-labels.service to finish"
+
 # If we have made it all the way to the last release then
 # we have one more test. We'll now rebase to the target
 # version, which should be in the compose OSTree repo.
 if vereq $version $last_release; then
     systemctl stop zincati
-    # In case the SELinux fix script is running this boot let's wait for it to
-    # finish before initiating an `rpm-ostree rebase` so we aren't writing at the
-    # same time it's fixing.
-    wait-for-coreos-fix-selinux-labels
     rpm-ostree rebase "fedora-compose:fedora/$(arch)/coreos/${target_stream}" $target_version
     /tmp/autopkgtest-reboot $version # execute the reboot
     sleep infinity

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -69,11 +69,10 @@ if [ -f /etc/zincati/config.d/90-disable-on-non-production-stream.toml ]; then
     need_restart='true'
 fi
 
-get_booted_deployment_json() {
-    rpm-ostree status  --json | jq -r '.deployments[] | select(.booted == true)'
-}
-version=$(get_booted_deployment_json | jq -r '.version')
-stream=$(get_booted_deployment_json | jq -r '.["base-commit-meta"]["fedora-coreos.stream"]')
+booted_deployment_json=$(rpm-ostree status  --json | \
+                         jq -r '.deployments[] | select(.booted == true)')
+version=$(jq -r '.version' <<< "${booted_deployment_json}")
+stream=$(jq -r '.["base-commit-meta"]["fedora-coreos.stream"]' <<< "${booted_deployment_json}")
 
 # Pick up the last release for the current stream from the update server
 test -f /srv/updateinfo.json || \


### PR DESCRIPTION
This PR updates the test to work with OCI based updates and also fixes a bug related to waiting on the `coreos-fix-selinux-labels.service`. See individual commit messages for more info.