### PR TITLE
tests/kola/ignition: add azure blob tests

### DIFF
--- a/tests/kola/ignition/resource/authenticated-azure/config.bu
+++ b/tests/kola/ignition/resource/authenticated-azure/config.bu
@@ -1,0 +1,18 @@
+# Objects accessible by any authenticated azure user, such as the credentials
+# associated with the Azure Blob instance
+
+variant: fcos
+version: 1.2.0
+ignition:
+  config:
+    merge:
+      - source: "https://ignitiontestfixtures.blob.core.windows.net/private/authenticated-var.ign"
+storage:
+  files:
+    # Check that anonymous access works with credentials
+    - path: /var/resource/azure-anon
+      contents:
+        source: "https://ignitiontestfixtures.blob.core.windows.net/public/azure-anon"
+    - path: /var/resource/azure-auth
+      contents:
+        source: "https://ignitiontestfixtures.blob.core.windows.net/private/azure-auth"

--- a/tests/kola/ignition/resource/authenticated-azure/data/commonlib.sh
+++ b/tests/kola/ignition/resource/authenticated-azure/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../data/commonlib.sh

--- a/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-anon
+++ b/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-anon
@@ -1,0 +1,1 @@
+kola-anonymous

--- a/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-auth
+++ b/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-auth
@@ -1,0 +1,1 @@
+kola-authenticated

--- a/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-config
+++ b/tests/kola/ignition/resource/authenticated-azure/data/expected/azure-config
@@ -1,0 +1,1 @@
+kola-config

--- a/tests/kola/ignition/resource/authenticated-azure/test.sh
+++ b/tests/kola/ignition/resource/authenticated-azure/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+## kola:
+##   tags: needs-internet
+##   # We authenticate to Azure with the Azure instance's credentials.
+##   platforms: azure
+##   description: Verify that we can fetch resources from Azure.
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if ! diff -rZ $KOLA_EXT_DATA/expected /var/resource; then
+    fatal "fetched data mismatch"
+else
+    ok "fetched data ok"
+fi
+
+# verify that the objects are inaccessible anonymously
+for obj in authenticated authenticated-var.ign; do
+    if curl -sf "https://ignitiontestfixtures.blob.core.windows.net/private/$obj"; then
+        fatal "anonymously fetching authenticated resource should have failed, but did not"
+    fi
+done
+
+# ...but that the anonymous object is accessible
+if ! curl -sf "https://ignitiontestfixtures.blob.core.windows.net/public/azure-anon" > /dev/null; then
+    fatal "anonymous resource is inaccessible"
+fi
+
+ok "resource checks ok"


### PR DESCRIPTION
Test new Azure priv fetching support in Ignition 2.21.0.

Used the gcp platform tests as a skeleton fits pretty well..


Added the fixtures to the fedora coreos subscription