### PR TITLE
[next-devel] image.yaml: templatize stream name in container-imgref

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -6,7 +6,7 @@ include: image-base.yaml
 # Move to use OCI images by default
 # https://github.com/coreos/fedora-coreos-tracker/issues/1823
 deploy-via-container: true
-container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:next-devel"
+container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{stream}"
 
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"


### PR DESCRIPTION
Now that COSA supports it [1], let's template in the stream name in the image.yaml.

[1] https://github.com/coreos/coreos-assembler/commit/c61da897b6ac344a3fc9309f53b493732c0312af