### PR TITLE
exttests/team-dhcp-via-ignition and nm-ifcg: disable for RHEL 10

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -80,6 +80,13 @@ is_rhcos9() {
     { [ "${ID}" == "rhel" ] && [ "${VERSION_ID%%.*}" -eq 9 ]; }
 }
 
+# rhcos10 && SCOS 10
+is_el10() {
+    source /etc/os-release
+    { [ "${ID}" == "rhel" ] && [ "${VERSION_ID%%.*}" -eq 10 ]; } || \
+    { [ "${ID}" == "centos" ] && [ "${VERSION_ID%%}" -eq 10 ]; }
+}
+
 # scos
 is_scos() {
     source /etc/os-release

--- a/tests/kola/networking/nm-ifcfg-rh-plugin
+++ b/tests/kola/networking/nm-ifcfg-rh-plugin
@@ -17,7 +17,9 @@ set -xeuo pipefail
 exists=0
 busctl status com.redhat.ifcfgrh1 && exists=1
 
-if is_fcos; then
+# ifcfg-rh support is dropped in EL 10
+# See https://gitlab.com/redhat/centos-stream/rpms/NetworkManager/-/commit/0a387cee26a3f61270480b5655014bf0013d0d69
+if is_fcos || is_el10; then
     [ "$exists" == "0" ] || fatal "ifcfg-rh plugin detected on FCOS"
 elif is_rhcos || is_scos; then
     [ "$exists" == "1" ] || fatal "ifcfg-rh plugin not detected on RHCOS/SCOS"

--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -18,6 +18,12 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
+# Teamd is no longer supported in EL10
+# Exit early in that case
+ if is_el10; then
+   exit 0
+fi
+
 team="team0"
 
 # Verify team0 gets dhcp according to config.bu


### PR DESCRIPTION
Teamd is no longer supported in rhel 10.
Also add a helper for rhel10.

See https://github.com/coreos/fedora-coreos-tracker/issues/1727