### PR TITLE
workflows/add-overrides: install python3-libdnf5

### DIFF
--- a/.github/workflows/add-override.yml
+++ b/.github/workflows/add-override.yml
@@ -40,7 +40,7 @@ jobs:
     container: quay.io/fedora/fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git jq python3-bodhi-client python3-pyyaml
+        run: dnf install -y git jq python3-bodhi-client python3-pyyaml python3-libdnf5
       - name: Check out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We need the libdnf5 python3 library for ab42e75 and because dnf5 is no longer python based the python3 libraries don't get installed by default so we need to name them here.