### PR TITLE
[next-devel] overrides: fast-track dracut-105-3.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,24 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
+  dracut:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
+  dracut-network:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
+  dracut-squash:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
   ignition:
     evr: 2.21.0-2.fc42
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).