### PR TITLE
workflows/remove-graduated-overrides: Install python3-libdnf5

### DIFF
--- a/.github/workflows/remove-graduated-overrides.yml
+++ b/.github/workflows/remove-graduated-overrides.yml
@@ -50,7 +50,7 @@ jobs:
           version_id=$(. /etc/os-release && echo ${VERSION_ID})
           echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
       - name: Install dependencies
-        run: dnf install -y python3-bodhi-client rpm-ostree # see related TODO above
+        run: dnf install -y python3-bodhi-client rpm-ostree python3-libdnf5 # see related TODO above
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The github [action](https://github.com/coreos/fedora-coreos-config/actions/runs/14316272652/job/40123032450) 'Remove Graduates Overrides' has been failing due to missing libdnf5 pkg. The installation of libdnf5 pkg would address this failure. The python3 libraries don't get installed by default so we need to name them here.