### PR TITLE
ci/overrides.py: fix comparison of nevra

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -378,7 +378,9 @@ def sack_has_nevra_greater_or_equal(base, nevra):
         r = libdnf5.rpm.rpmvercmp(getattr(nevra, attr)(),
                                   getattr(nevra_latest, attr)())
         if r != 0:
-            return r > 0
+            # Description of 'rpmvercmp' is wrong, proper one:
+            # https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmvercmp.cc#L16
+            return r == -1
     return True
 
 


### PR DESCRIPTION
[Documentation](https://github.com/rpm-software-management/dnf5/blob/main/include/libdnf5/rpm/nevra.hpp#L189) has a wrong function description:
```
/// Compare alpha and numeric segments of two versions.
/// @return 1 if `lhs` < `rhs`, -1 if `lhs` > `rhs`, 0 if they are equal
LIBDNF_API int rpmvercmp(const char * lhs, const char * rhs);
```

When in [here](https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmvercmp.cc):
```
// Returns
//    +1 if a is "newer", 0 if equal, -1 if b is "newer"
int rpmvercmp(const char *a, const char *b)
```