### PR TITLE
[next-devel] Revert "lockfiles: drop graduated overrides 🎓"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,30 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
+  dracut:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
+  dracut-network:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
+  dracut-squash:
+    evr: 105-3.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+      type: fast-track
+  ignition:
+    evr: 2.21.0-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
+      reason: https://github.com/coreos/ignition/pull/2037
+      type: fast-track
   ignition-grub:
     evr: 2.21.0-2.fc42
     metadata:


### PR DESCRIPTION
This reverts commit 051e4a801e87df5c3003a0eccfecee06a634ce41.

This shouldn't have happened and was fixed by
https://github.com/coreos/fedora-coreos-config/pull/3445