### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,18 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  afterburn:
+    evr: 5.7.0-4.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-7d84dba7e2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
+  afterburn-dracut:
+    evr: 5.7.0-4.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-7d84dba7e2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
   dnf5:
     evr: 5.2.11.0-1.fc42
     metadata:
@@ -32,6 +44,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
       type: fast-track
+  hwdata:
+    evra: 0.394-1.fc42.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-5ae9d402c6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
   ignition:
     evr: 2.21.0-2.fc42
     metadata:
@@ -54,3 +72,33 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
+  libxcrypt:
+    evr: 4.4.38-7.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-58918e87b6
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
+  nmstate:
+    evr: 2.2.43-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-99aea8f822
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
+  stalld:
+    evr: 1.19.8-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f9e2214d
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
+  vim-data:
+    evra: 2:9.1.1275-1.fc42.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2c282e22ca
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track
+  vim-minimal:
+    evr: 2:9.1.1275-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2c282e22ca
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
+      type: fast-track


### PR DESCRIPTION
F42 is now in final freeze. This means that some packages in F41 will sort as newer than packages in F42. We'll prevent downgrades by fast-tracking any packages that would violate this "no downgrade" rule.

Today, they are:

```
Downgraded:
  afterburn 5.7.0-4.fc41 -> 5.7.0-3.fc42
  afterburn-dracut 5.7.0-4.fc41 -> 5.7.0-3.fc42
  hwdata 0.394-1.fc41 -> 0.393-1.fc42
  libxcrypt 4.4.38-7.fc41 -> 4.4.38-6.fc42
  nmstate 2.2.42-2.fc41 -> 2.2.42-1.fc42
  stalld 1.19.8-2.fc41 -> 1.19.8-1.fc42
  vim-data 2:9.1.1275-1.fc41 -> 2:9.1.1227-1.fc42
  vim-minimal 2:9.1.1275-1.fc41 -> 2:9.1.1227-1.fc42
```

See: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070