### PR TITLE
ci/overrides.py: don't fail with `KeyError` when manifest has no `repos`

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -292,7 +292,7 @@ def setup_repos(base, treefile):
         repo.disable()
 
     eprint("Enabled repos:")
-    for repo in treefile['repos']:
+    for repo in treefile.get('repos', []):
         query = libdnf5.repo.RepoQuery(base)
         query.filter_id(repo)
         query.get().enable()


### PR DESCRIPTION
I've noticed, that `manifest.yaml` in some [branches](https://github.com/coreos/fedora-coreos-config/blob/next/manifest.yaml) doesn't contain the `repos` list, which leads to an error:
```
Traceback (most recent call last):                                                                                                                                
  File "fedora-coreos-config/./ci/overrides.py", line 295, in setup_repos
    for repo in treefile['repos']:                                                                                                                             
                ~~~~~~~~^^^^^^^^^    
KeyError: 'repos'       
```