### PR TITLE
image.yaml: switch to EROFS; deploying via container

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,12 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Move to use OCI images by default
+# https://github.com/coreos/fedora-coreos-tracker/issues/1823
+deploy-via-container: true
+container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{stream}"
+
+# Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
+live-rootfs-fstype: "erofs"
+live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"


### PR DESCRIPTION
These changes are ones that we are adopting for F42+ and since F42 GA is a GO for Tuesday 04/15 we'll go ahead and make the change for `testing-devel` now.

- https://github.com/coreos/fedora-coreos-tracker/issues/1823
- https://github.com/coreos/fedora-coreos-tracker/issues/1852