### PR TITLE
denylist: add `skip-console-warnings` to openstack

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,9 @@
   warn: true
   streams:
     - rawhide
+- pattern: skip-console-warnings
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1924
+  platforms:
+    - openstack
+  streams:
+    - rawhide


### PR DESCRIPTION
Add the pattern to openstack to ignore the kernel warnings we've been seeing on that platform: https://github.com/coreos/fedora-coreos-tracker/issues/1924