### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,59 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  afterburn:
-    evr: 5.7.0-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-7d84dba7e2
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
-  afterburn-dracut:
-    evr: 5.7.0-4.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-7d84dba7e2
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
   dnf5:
     evr: 5.2.11.0-1.fc42
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
-  dracut:
-    evr: 105-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
-      type: fast-track
-  dracut-network:
-    evr: 105-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
-      type: fast-track
-  dracut-squash:
-    evr: 105-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-20999ea059
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1894
-      type: fast-track
-  hwdata:
-    evra: 0.394-1.fc42.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-5ae9d402c6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
-  ignition:
-    evr: 2.21.0-2.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
-      reason: https://github.com/coreos/ignition/pull/2037
-      type: fast-track
-  ignition-grub:
-    evr: 2.21.0-2.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d721b4d902
-      reason: https://github.com/coreos/ignition/pull/2037
-      type: fast-track
   libdnf5:
     evr: 5.2.11.0-1.fc42
     metadata:
@@ -72,33 +24,9 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
-  libxcrypt:
-    evr: 4.4.38-7.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-58918e87b6
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
-  nmstate:
-    evr: 2.2.43-1.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-99aea8f822
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
   stalld:
     evr: 1.19.8-2.fc42
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f9e2214d
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
-  vim-data:
-    evra: 2:9.1.1275-1.fc42.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2c282e22ca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
-      type: fast-track
-  vim-minimal:
-    evr: 2:9.1.1275-1.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2c282e22ca
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).