### PR TITLE
overlay: migrate existing systems to OCI

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -33,7 +33,18 @@ conditional-include:
       # All Fedora CoreOS streams share the same pool for locked files.
       lockfile-repos:
         - fedora-coreos-pool
-
+  - if: stream == "next"
+    include:
+      ostree-layers:
+        - overlay/35oci-migration
+  - if: stream == "next-devel"
+    include:
+      ostree-layers:
+        - overlay/35oci-migration
+  - if: stream == "rawhide"
+    include:
+      ostree-layers:
+        - overlay/35oci-migration
 
 ostree-layers:
   - overlay/15fcos

--- a/overlay.d/35oci-migration/usr/lib/systemd/system-preset/35-oci-migration.preset
+++ b/overlay.d/35oci-migration/usr/lib/systemd/system-preset/35-oci-migration.preset
@@ -1,0 +1,2 @@
+# show a motd if the OCI migration cannot be done automatically
+enable coreos-oci-migration-motd.service

--- a/overlay.d/35oci-migration/usr/lib/systemd/system/coreos-oci-migration-motd.service
+++ b/overlay.d/35oci-migration/usr/lib/systemd/system/coreos-oci-migration-motd.service
@@ -1,0 +1,12 @@
+# This service is used for printing a message if
+# the oci migration failed or was opted out.
+[Unit]
+Description=Warn based on oci migration status
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/coreos-oci-migration-motd
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/35oci-migration/usr/lib/systemd/system/zincati.service.d/010-oci-migration.conf
+++ b/overlay.d/35oci-migration/usr/lib/systemd/system/zincati.service.d/010-oci-migration.conf
@@ -1,0 +1,5 @@
+[Service]
+StateDirectory=coreos-oci-migration
+ExecStartPre=-/usr/libexec/coreos-oci-rebase
+# wait for 3 min
+TimeoutStartSec=300

--- a/overlay.d/35oci-migration/usr/libexec/coreos-oci-migration-motd
+++ b/overlay.d/35oci-migration/usr/libexec/coreos-oci-migration-motd
@@ -1,0 +1,78 @@
+#!/usr/bin/bash
+# This script checks if oci migration failed
+# or was opted-out and prints the appropriate message
+# to the console.
+#
+# See https://github.com/coreos/fedora-coreos-tracker/issues/1890
+# See migration script discussion in https://github.com/coreos/fedora-coreos-config/pull/3355
+
+OCI_MIGRATION_OPT_OUT=/var/lib/coreos-oci-migration/opt-out.stamp
+OCI_MIGRATION_FAILED=/var/lib/coreos-oci-migration/failed.stamp
+
+ZINCATI_ENABLED=$(systemctl is-enabled zincati.service)
+
+MOTD_PATH=/run/motd.d/30_oci_migration.motd
+# Start by deleting any previous motd we created,
+# e.g. if the migration failed then the user opted out, or fixed it.
+rm -f $MOTD_PATH
+
+opt_out_message="
+This system has been opted out of the migration to OCI images for
+updates as the opt-out stamp file exists.
+
+This system will keep updating using the legacy OSTree repository,
+but later this year new Fedora CoreOS updates will cease to be pushed
+to the OSTree repository.
+
+When ready, the migration can be resumed by deleting
+${OCI_MIGRATION_OPT_OUT}, then restarting zincati.service"
+
+failed_message="
+The migration to OCI images for updates failed. Check the logs of
+zincati.service for more details.
+
+This system will keep updating using the legacy OSTree repository,
+but later this year new Fedora CoreOS updates will cease to be pushed
+to the OSTree repository.
+
+When ready, the migration can be retried by deleting
+${OCI_MIGRATION_FAILED}, then restarting zincati.service"
+
+zincati_disabled_message="
+The zincati service is disabled on this system.
+
+If not done so already please migrate the system to the OCI backend
+for updates by running:
+
+stream=stable # or testing or next
+target=ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:\$stream
+sudo rpm-ostree rebase \$target --reboot
+
+Where \$stream matches the Fedora CoreOS stream the system is following."
+
+write_motd () {
+
+# Change the output color to yellow
+warn=$(echo -e '\033[0;33m')
+# No color
+nc=$(echo -e '\033[0m')
+
+cat << EOF > "${MOTD_PATH}"
+${warn}
+##########################################################################
+${1}
+
+To disable this warning, use:
+sudo systemctl disable coreos-oci-migration-motd.service
+##########################################################################
+${nc}
+EOF
+}
+
+if [ -e $OCI_MIGRATION_OPT_OUT ]; then
+  write_motd "$opt_out_message"
+elif [ -e $OCI_MIGRATION_FAILED ]; then
+  write_motd "$failed_message"
+elif [ "$ZINCATI_ENABLED" == "disabled" ]; then
+  write_motd "$zincati_disabled_message"
+fi

--- a/overlay.d/35oci-migration/usr/libexec/coreos-oci-rebase
+++ b/overlay.d/35oci-migration/usr/libexec/coreos-oci-rebase
@@ -8,6 +8,20 @@
 # see https://fedoraproject.org/wiki/Changes/CoreOSOstree2OCIUpdates
 # and https://github.com/coreos/fedora-coreos-tracker/issues/1823
 
+
+OCI_MIGRATION_OPT_OUT=/var/lib/coreos-oci-migration/opt-out.stamp
+OCI_MIGRATION_FAILED=/var/lib/coreos-oci-migration/failed.stamp
+
+if [ -e $OCI_MIGRATION_OPT_OUT ]; then
+    echo "${OCI_MIGRATION_OPT_OUT} to opt out of migration exists, doing nothing."
+    exit 0
+fi
+
+# create the failed stamp file as a precaution
+touch $OCI_MIGRATION_FAILED
+# if something goes wrong, exit the script so the failed stamp will remain
+set -euxo pipefail
+
 CINCINNATI_URL="${CINCINNATI_URL:-https://raw-updates.coreos.fedoraproject.org/v1/graph}"
 
 # Save the rpm-ostree status.
@@ -19,6 +33,7 @@ booted_imgref=$(jq -r '.deployments[0]."container-image-reference"' <<< "$status
 
 if [ "$booted_imgref" != "null" ]; then
     echo "The booted deployment is already an OCI container."
+    rm $OCI_MIGRATION_FAILED
     exit 0
 fi
 
@@ -27,7 +42,7 @@ origin=$(jq -r '.deployments[0].origin' <<< "$status" | cut -d ':' -f 1)
 origin_url=$(ostree remote show-url "$origin")
 if [ "$origin_url" != "https://ostree.fedoraproject.org" ]; then
     echo "ERROR: The OSTree origin is not matching the default Fedora CoreOS."
-    exit 0
+    exit 1
 fi
 
 # fetch the SHA checksum of the matching OCI image for the booted deployment
@@ -37,15 +52,20 @@ checksum=$(jq -r '.deployments[0].checksum' <<< "$status")
 arch=$(arch)
 cin_url="$CINCINNATI_URL?basearch=$arch&stream=$stream&oci=true"
 
+# Wait for the network to be online
+echo "Waiting for the network to be online."
+nm-online --timeout 120
+
 # Grab the OCI update graph that matches our stream and arch.
 echo "Fetching cincinnati update graph for stream $stream on $arch"
 cincinnati_graph=$(curl "$cin_url" -s)
 imgref=$(echo "$cincinnati_graph" | jq --arg VERSION "$version" -r '.nodes[]  | select(.version==$VERSION) | .payload')
 if [ "$imgref" == "" ]; then
     echo "ERROR: Could not find the current deployment in the update graph from cincinnati."
-    echo "   If it is proxied, you can override the cincinnati url with an environment varable."
+    echo "   If it is proxied, you can override the cincinnati url with an environment variable."
     echo "   e.g. CINCINNATI_URL=https://custom-cincinnati-address.com/v1/graph /usr/libexec/coreos-oci-rebase"
-    exit 0
+    echo "   Or add a drop-in to zincati with 'Environment=...'"
+    exit 1
 fi
 
 echo "Found OCI image $imgref in the update graph that matches the local deployment version."
@@ -69,3 +89,6 @@ cat > /run/zincati/booted-status-override.json << EOF
 EOF
 
 echo "Zincati will rebase to an OCI image for the next update."
+
+# All went well, delete the failed stamp
+rm $OCI_MIGRATION_FAILED

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -70,3 +70,16 @@ pre-existing LVM devices attached. See the tracker issue [1] for more
 information.
 
 [1] https://github.com/coreos/fedora-coreos-tracker/issues/1517
+
+35oci-migration
+-------------------
+
+Trigger a migration script to instruct Zincati to rebase the system
+to using OCI images from quay.io/fedora/fedora-coreos for future
+updates. [1]
+This is composed of a migration script [2] and a motd generator to
+instruct the user if something go wrong or show a reminder if the
+user opted out.
+
+[1] https://github.com/coreos/fedora-coreos-tracker/issues/1890
+[2] https://github.com/coreos/fedora-coreos-config/pull/3355


### PR DESCRIPTION
In [1] we moved newly provisioned systems to be
deployed via container and thus retrieving updates via zincati from the OCI registry (quay.io/fedora/fedora-coreos).

This starts the migration script shipped in [2]
before Zincati to set up the migration at the next update.

A way to override this is to add another drop-in
with `ExecStartPre=` with a higher ranking name
under the systemd drop in path, e.g.
`/etc/systemd/system/zincati.service.d/90-no-oci.conf`.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1823
[2] https://github.com/coreos/fedora-coreos-config/pull/3355

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1890