### PR TITLE
[next-devel] image.yaml: drop OCI and erofs customizations

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,12 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# Move to use OCI images by default
-# https://github.com/coreos/fedora-coreos-tracker/issues/1823
-deploy-via-container: true
-container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{stream}"
-
-# Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
-live-rootfs-fstype: "erofs"
-live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"


### PR DESCRIPTION
These are now part of image-base.yaml [1] so we can drop the settings here.

[1] https://github.com/coreos/fedora-coreos-config/commit/5d3d7deac2216c81dbafdb54622caddf84931f81