### PR TITLE
OCPEDGE-1752: [TNF] Add podman-etcd resource agent to the expected broken symlinks in RHCOS

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -42,6 +42,8 @@ if is_scos || is_rhcos; then
         '/etc/pki/tls/'
         '/etc/rhsm-host'
         '/etc/sysconfig/grub'
+        # this will be dropped as part of https://issues.redhat.com/browse/OCPEDGE-1706
+        '/usr/lib/ocf/resource.d/ocp-tnf/podman-etcd'
     )
     list_broken_symlinks_skip+=("${rhcos_list[@]}")
 fi


### PR DESCRIPTION
In https://github.com/openshift/os/pull/1796 we introduce a symbolic link for the purpose of allowing a pacemaker resource agent to be introduced into OCP via the MCO when installing Two Node OpenShift with Fencing (TNF). The kola test that verifies symlinks fails, so we overrode this test entirely for those builds. The patch updates the test to be more granular so that we can reenable it in RHCOS builds until the symlink is removed with the completion of https://issues.redhat.com/browse/OCPEDGE-1706.