### PR TITLE
[rawhide] overrides: pin kernel-6.15.0-0.rc1.20250411git900241a5cc15.19.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,26 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
+  kernel:
+    evr: 6.15.0-0.rc1.20250411git900241a5cc15.19.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1925
+      type: pin
+  kernel-core:
+    evr: 6.15.0-0.rc1.20250411git900241a5cc15.19.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1925
+      type: pin
+  kernel-modules:
+    evr: 6.15.0-0.rc1.20250411git900241a5cc15.19.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1925
+      type: pin
+  kernel-modules-core:
+    evr: 6.15.0-0.rc1.20250411git900241a5cc15.19.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1925
+      type: pin
   libdnf5:
     evr: 5.2.11.0-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).