### PR TITLE
overrides: fast-track rust-zincati-0.0.30-2.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -30,3 +30,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f9e2214d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1851#issuecomment-2730109070
       type: fast-track
+  zincati:
+    evr: 0.0.30-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-76cc40dcc4
+      reason: https://github.com/coreos/zincati/issues/1280
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).