### PR TITLE
[rawhide] overrides: pin rpm-4.20.1-3.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,3 +24,18 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
+  rpm:
+    evr: 4.20.1-3.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1929
+      type: pin
+  rpm-libs:
+    evr: 4.20.1-3.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1929
+      type: pin
+  rpm-plugin-selinux:
+    evr: 4.20.1-3.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1929
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).