### PR TITLE
denylist: add snooze for kdump.crash.nfs

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -38,3 +38,11 @@
     - aarch64
   streams:
     - rawhide
+- pattern: kdump.crash.nfs
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
+  snooze: 2025-04-30
+  warn: true
+  arches:
+    - aarch64
+  streams:
+    - rawhide


### PR DESCRIPTION
kdump.crash.ssh test has been failing in [rawhide][aarch64] builds after the kernel upgrade to
kernel-6.15.0-0.rc2.20250415git834a4a689699.23.fc43. Since this is still an RC kernel set and we want to continue to test new RC kernels as they come in, let us snooze this test for two weeks till April 30, 2025.