### PR TITLE
denylist: snooze root-reprovision on rawhide for ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,3 +46,10 @@
     - aarch64
   streams:
     - rawhide
+- pattern: ext.config.root-reprovision.*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1926
+  snooze: 2025-05-06
+  arches:
+    - ppc64le
+  streams:
+    - rawhide


### PR DESCRIPTION
A number of root-reprovision tests is failing now on rawhide. Let's snooze them until the issue is resolved.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1926