### PR TITLE
denylist: snooze coreos.boot-mirror on rawhide for x86_64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -53,3 +53,10 @@
     - ppc64le
   streams:
     - rawhide
+- pattern: coreos.boot-mirror*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1932
+  snooze: 2025-05-06
+  arches:
+    - x86_64
+  streams:
+    - rawhide


### PR DESCRIPTION
These tests are now failing on rawhide.
Let's snooze them until the issue is resolved.

See: [coreos/fedora-coreos-tracker#1932](https://github.com/coreos/fedora-coreos-tracker/issues/1932)