### PR TITLE
coreos-boot-mount-generator: honor `boot=` karg better in multipath case

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -61,21 +61,26 @@ EOF
     add_wants "${unit_name}"
 }
 
-# Copied from
+# Copied and adapted from
 # https://github.com/dracutdevs/dracut/blob/9491e599282d0d6bb12063eddbd192c0d2ce8acf/modules.d/99base/dracut-lib.sh#L586
 # rather than sourcing it.
 label_uuid_to_dev() {
-    local _dev
+    local _dev mpath prefix
     _dev="${1#block:}"
+    mpath=$(karg rd.multipath)
+    prefix=
+    if [ -n "${mpath}" ] && [ "${mpath}" != 0 ]; then
+        prefix=dm-mpath-
+    fi
     case "$_dev" in
         LABEL=*)
-            echo "/dev/disk/by-label/$(echo "${_dev#LABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
+            echo "/dev/disk/by-label/${prefix}$(echo "${_dev#LABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
             ;;
         PARTLABEL=*)
             echo "/dev/disk/by-partlabel/$(echo "${_dev#PARTLABEL=}" | sed 's,/,\\x2f,g;s, ,\\x20,g')"
             ;;
         UUID=*)
-            echo "/dev/disk/by-uuid/$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
+            echo "/dev/disk/by-uuid/${prefix}$(echo "${_dev#UUID=}" | tr "[:upper:]" "[:lower:]")"
             ;;
         PARTUUID=*)
             echo "/dev/disk/by-partuuid/$(echo "${_dev#PARTUUID=}" | tr "[:upper:]" "[:lower:]")"
@@ -83,18 +88,16 @@ label_uuid_to_dev() {
     esac
 }
 
-# If the root device is multipath, hook up /boot to use that too,
-# based on our custom udev rules in 90-coreos-device-mapper.rules
-# that creates "label found on mpath" links.
+# If the root device is multipath, hook up /boot to use that too.
+# Try our best to use the by-label/by-uuid symlinks created by our
+# 90-coreos-device-mapper.rules since that's race free.
 # Otherwise, use the usual by-label symlink.
 # See discussion in https://github.com/coreos/fedora-coreos-config/pull/1022
 bootdev=/dev/disk/by-label/boot
 bootkarg=$(karg boot)
 mpath=$(karg rd.multipath)
-if [ -n "${mpath}" ] && [ "${mpath}" != 0 ]; then
-    bootdev=/dev/disk/by-label/dm-mpath-boot
 # Newer nodes inject boot=UUID=..., but we support a larger subset of the dracut/fips API
-elif [ -n "${bootkarg}" ]; then
+if [ -n "${bootkarg}" ]; then
     # Adapted from https://github.com/dracutdevs/dracut/blob/9491e599282d0d6bb12063eddbd192c0d2ce8acf/modules.d/01fips/fips.sh#L17
     case "$bootkarg" in
         LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
@@ -102,6 +105,12 @@ elif [ -n "${bootkarg}" ]; then
         /dev/*) bootdev=$bootkarg;;
         *) echo "Unknown boot karg '${bootkarg}'; falling back to ${bootdev}";;
     esac
+elif [ -n "${mpath}" ] && [ "${mpath}" != 0 ]; then
+    bootdev=/dev/disk/by-label/dm-mpath-boot
+    # This is used for the first boot only
+    if [ -f /run/coreos/bootfs_uuid ]; then
+        bootdev=/dev/disk/by-uuid/dm-mpath-$(cat /run/coreos/bootfs_uuid)
+    fi
 # This is used for the first boot only
 elif [ -f /run/coreos/bootfs_uuid ]; then
     bootdev=/dev/disk/by-uuid/$(cat /run/coreos/bootfs_uuid)

--- a/tests/kola/multipath/resilient/data/commonlib.sh
+++ b/tests/kola/multipath/resilient/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/multipath/resilient/test.sh
+++ b/tests/kola/multipath/resilient/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+## kola:
+##   # This uses appendKernelArgs and multipath, which is QEMU only
+##   platforms: qemu
+##   description: Verify multipath resiliency against multiple boot labels and no root karg.
+##   primaryDisk: ":mpath"
+##   # notice we don't add a `root=/dev/disk/by-label/dm-mpath-root` karg here
+##   appendKernelArgs: "rd.multipath=default"
+##   additionalDisks: ["1G:serial=fakeboot", "1G:mpath,wwn=11"]
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+# we may race with the /boot mount
+if ! is_service_active boot.mount; then
+  fatal "boot.mount failed to activate"
+fi
+
+# did we mount the right bootfs?
+test -d /boot/ostree
+
+# is it on multipath?
+src=$(findmnt -nvr -o SOURCE /boot)
+udevadm info "$src" | grep DM_MPATH
+
+# was it mounted using dm-mpath-... ?
+systemctl cat boot.mount | tee /tmp/out.txt
+grep What=/dev/disk/by-uuid/dm-mpath- /tmp/out.txt
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+      ok "first boot"
+      mkfs.ext4 -L boot /dev/disk/by-id/virtio-fakeboot
+      mkfs.ext4 -L boot /dev/disk/by-id/wwn-0xx000000000000000b
+      /tmp/autopkgtest-reboot rebooted
+      ;;
+
+  rebooted)
+      cat /proc/cmdline
+      grep boot=UUID= /proc/cmdline
+      grep root=UUID= /proc/cmdline
+      ok "reboot"
+      ;;
+  *) fatal "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}";;
+esac

--- a/tests/kola/root-reprovision/luks/data/luks-test.sh
+++ b/tests/kola/root-reprovision/luks/data/luks-test.sh
@@ -29,12 +29,9 @@ if ! grep -q no_read_workqueue <<< "${table}"; then
 fi
 ok "discard and custom option enabled for root LUKS"
 
-# while we're here, sanity-check that boot is mounted by UUID or by multipath label
-if grep -q "rd.multipath=default" /proc/cmdline; then
-  expected_what=/dev/disk/by-label/dm-mpath-boot
-else
-  expected_what=/dev/disk/by-uuid
-fi
+# while we're here, sanity-check that boot is mounted by UUID
+expected_what=/dev/disk/by-uuid
+
 if ! systemctl cat boot.mount | grep -q What="${expected_what}"; then
   systemctl cat boot.mount
   fatal "boot mounted not by ${expected_what}"


### PR DESCRIPTION
As described in openshift/os#1787, we need to
loosen up our restriction that only a single `boot` and `root` labeled
filesystem exists, at least past the first boot to start.

There is code already that injects `boot` and `root` kargs to specify
the exact UUID we want so this is feasible.

There's currently two ways in which the boot device can be specified:
- the `/run/coreos/bootfs_uuid` file exists; this is written by rdcore
  but is only available on first boot
- a `boot=` karg, which supports the "dracut convention" (i.e.
  `boot=LABEL=` or `boot=UUID=`, etc.), exists; this is usually written
  by rdcore but is only available on subsequent boots

If neither of those are specified, then we just default to
`by-label/boot`.

But currently, if multipath is enabled, we override all that and just
always use `by-label/dm-mpath-boot`. This is not great, because a UUID
might've been specified, and that's much stronger than a label. It also
directly conflicts with the mentioned higher level goal of supporting
multiple `boot` labels.

Instead, rework multipath support so that it respects both `boot=` kargs
and `bootfs_uuid` files. When possible, we use the multipathed version
of the specified UUID/label written by our udev rules because it's less
racy. Otherwise, we just use the non-multipathed one.