### PR TITLE
some riscv enablement 

### DIFF
--- a/fedora-riscv-staging.repo
+++ b/fedora-riscv-staging.repo
@@ -1,0 +1,21 @@
+# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6289e6a44e1c897beeacaa363307a1b2d11db1c3/fedora-riscv-staging.repo
+[fedora-riscv-staging]
+name=Fedora RISC-V $releasever - Staging
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/$basearch/
+enabled=1
+gpgcheck=0
+priority=98
+
+[fedora-riscv-staging-debuginfo]
+name=Fedora RISC-V $releasever - Staging - Debug
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/$basearch/debug/
+enabled=0
+gpgcheck=0
+priority=98
+
+[fedora-riscv-staging-source]
+name=Fedora RISC-V $releasever - Staging - Source
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/src/
+enabled=0
+gpgcheck=0
+priority=98

--- a/fedora-riscv.repo
+++ b/fedora-riscv.repo
@@ -1,0 +1,21 @@
+# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6289e6a44e1c897beeacaa363307a1b2d11db1c3/fedora-riscv.repo
+[fedora-riscv]
+name=Fedora RISC-V $releasever
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/$basearch/
+enabled=1
+gpgcheck=0
+priority=99
+
+[fedora-riscv-debuginfo]
+name=Fedora RISC-V $releasever - Debug
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/$basearch/debug/
+enabled=0
+gpgcheck=0
+priority=99
+
+[fedora-riscv-source]
+name=Fedora RISC-V $releasever - Source
+baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/src/
+enabled=0
+gpgcheck=0
+priority=99

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,12 +4,25 @@ variables:
 
 releasever: 42
 
-repos:
-  # These repos are there to make it easier to add new packages to the OS and to
-  # use `cosa fetch --update-lockfile`; but note that all package versions are
-  # still pinned. These repos are also used by the remove-graduated-overrides
-  # GitHub Action.
-  - fedora
-  - fedora-updates
+conditional-include:
+  # TODO: There is no coreos-pool for RISCV yet
+  #       https://github.com/coreos/fedora-coreos-tracker/issues/1931
+  - if: basearch != "riscv64"
+    include:
+      repos:
+        # These repos are there to make it easier to add new packages to the OS and to
+        # use `cosa fetch --update-lockfile`; but note that all package versions are
+        # still pinned. These repos are also used by the remove-graduated-overrides
+        # GitHub Action.
+        - fedora
+        - fedora-updates
+  - if: basearch == "riscv64"
+    include:
+      repos:
+        # These repos are provided by the RISCV SIG from a shadow koji instance
+        # https://fedoraproject.org/wiki/Architectures/RISC-V
+        - fedora-riscv
+        # The staging repo has the unsigned shim in it so we need it here too.
+        - fedora-riscv-staging
 
 include: manifests/fedora-coreos.yaml

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -14,11 +14,18 @@ add-commit-metadata:
 
 include: fedora-coreos-base.yaml
 conditional-include:
-  - if: prod == false
-    # long-term, would be good to support specifying a nested TreeComposeConfig
-    include: disable-zincati.yaml
   - if: releasever >= 41
     include: selinux-workaround.yaml
+  # If not production then disable Zincati
+  - if: prod == false
+    include:
+      postprocess:
+        - |
+          #!/usr/bin/env bash
+          cat > /etc/zincati/config.d/90-disable-on-non-production-stream.toml << EOF
+          # https://github.com/coreos/fedora-coreos-tracker/issues/163
+          updates.enabled = false
+          EOF
 
 ostree-layers:
   - overlay/15fcos

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -26,16 +26,20 @@ conditional-include:
           # https://github.com/coreos/fedora-coreos-tracker/issues/163
           updates.enabled = false
           EOF
+  # TODO: There is no coreos-pool tag/repo for RISCV yet
+  #       https://github.com/coreos/fedora-coreos-tracker/issues/1931
+  - if: basearch != "riscv64"
+    include:
+      # All Fedora CoreOS streams share the same pool for locked files.
+      lockfile-repos:
+        - fedora-coreos-pool
+
 
 ostree-layers:
   - overlay/15fcos
 
 automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
 mutate-os-release: "${releasever}"
-
-# All Fedora CoreOS streams share the same pool for locked files.
-lockfile-repos:
-  - fedora-coreos-pool
 
 packages:
   - fedora-release-coreos

--- a/manifests/shared-el10.yaml
+++ b/manifests/shared-el10.yaml
@@ -2,7 +2,3 @@
 packages:
   # GPU Firmware files (not broken out into subpackage of linux-firmware in RHEL yet)
   - amd-gpu-firmware intel-gpu-firmware nvidia-gpu-firmware
-  # makedumpfile and kexec were split into subpackages in kexec-tools 0.2.28-7
-  # These should be with kexec-tools in the user-experience manifest
-  - makedumpfile
-  - kdump-utils

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -20,17 +20,6 @@ packages:
   # Improved MOTD experience
   - console-login-helper-messages-issuegen
   - console-login-helper-messages-profile
-  # kdump support
-  # https://github.com/coreos/fedora-coreos-tracker/issues/622
-  # The makedumpfile and kdump-utils RPMs were broken out in
-  # Fedora and EL10+. To be able to use the same package list
-  # Across EL9 + Fedora + EL10 let's just name paths for now.
-  # We can go back to just specifying the RPM names when we
-  # no longer support EL9.
-  - kexec-tools
-  - /usr/share/makedumpfile # makedumpfile RPM
-  - /usr/bin/kdumpctl       # kdump-utils RPM
-  # Container tooling
   - toolbox
   # passt provides user-mode networking daemons for namespaces
   - passt
@@ -42,3 +31,20 @@ packages:
   - which
   # provides utilities for inspecting/setting devices connected to the PCI bus
   - pciutils
+
+conditional-include:
+  - if: basearch != "riscv64"
+    include:
+      packages:
+        # kdump support
+        # https://github.com/coreos/fedora-coreos-tracker/issues/622
+        # The makedumpfile and kdump-utils RPMs were broken out in
+        # Fedora and EL10+. To be able to use the same package list
+        # Across EL9 + Fedora + EL10 let's just name paths for now.
+        # We can go back to just specifying the RPM names when we
+        # no longer support EL9.
+        # TODO: Not built for riscv yet
+        #       https://github.com/coreos/fedora-coreos-tracker/issues/1931
+        - kexec-tools
+        - /usr/share/makedumpfile # makedumpfile RPM
+        - /usr/bin/kdumpctl       # kdump-utils RPM

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -22,7 +22,15 @@ packages:
   - console-login-helper-messages-profile
   # kdump support
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
+  # The makedumpfile and kdump-utils RPMs were broken out in
+  # Fedora and EL10+. To be able to use the same package list
+  # Across EL9 + Fedora + EL10 let's just name paths for now.
+  # We can go back to just specifying the RPM names when we
+  # no longer support EL9.
   - kexec-tools
+  - /usr/share/makedumpfile # makedumpfile RPM
+  - /usr/bin/kdumpctl       # kdump-utils RPM
+  # Container tooling
   - toolbox
   # passt provides user-mode networking daemons for namespaces
   - passt

--- a/overlay.d/16disable-zincati/etc/zincati/config.d/90-disable-on-non-production-stream.toml
+++ b/overlay.d/16disable-zincati/etc/zincati/config.d/90-disable-on-non-production-stream.toml
@@ -1,2 +1,0 @@
-# https://github.com/coreos/fedora-coreos-tracker/issues/163
-updates.enabled = false

--- a/overlay.d/16disable-zincati/statoverride
+++ b/overlay.d/16disable-zincati/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -36,12 +36,6 @@ Things that are more closely "Fedora CoreOS":
 * display warnings on the console if no ignition config was provided or no ssh
   key found.
 
-16disable-zincati
------------------
-
-Disable Zincati on non-production streams:
-https://github.com/coreos/fedora-coreos-tracker/issues/163
-
 20platform-chrony
 -----------------
 

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -175,3 +175,13 @@ x86_64:
     kernel_arguments:
       - console=ttyS0,115200n8
       - console=tty0
+riscv64:
+  qemu:
+    # https://github.com/coreos/fedora-coreos-tracker/issues/954
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8


### PR DESCRIPTION
There is an effort to build all of Fedora using the RISCV architecture.
This comment adds the yum repo files and also conditionalizes some
manifest items to make it possible to build for `riscv64`.

There are still some other pieces that need to land before builds
will succeed (like bootupd support for riscv64), but this is a start
in the right direction.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1931

---

inline the 16disable-zincati overlay

Now that we have support for inlining manifests [1] in
conditional-include blocks we can drop the 16disable-zincati
and just write out the file in a postprocess.

This just makes it so there's much less scaffolding that
needs to be in place for something simple like this.

[1] https://github.com/coreos/rpm-ostree/pull/5351
