### PR TITLE
[s390x] overrides: pin kernel-6.15.0-0.rc2.20250418gitfc96b232f8e7.25.fc43

### DIFF
--- a/manifest-lock.overrides.s390x.yaml
+++ b/manifest-lock.overrides.s390x.yaml
@@ -1,0 +1,21 @@
+packages:
+  kernel:
+    evra: 6.15.0-0.rc2.20250418gitfc96b232f8e7.25.fc43.s390x
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1936
+      type: pin
+  kernel-core:
+    evra: 6.15.0-0.rc2.20250418gitfc96b232f8e7.25.fc43.s390x
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1936
+      type: pin
+  kernel-modules:
+    evra: 6.15.0-0.rc2.20250418gitfc96b232f8e7.25.fc43.s390x
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1936
+      type: pin
+  kernel-modules-core:
+    evra: 6.15.0-0.rc2.20250418gitfc96b232f8e7.25.fc43.s390x
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1936
+      type: pin


### PR DESCRIPTION
Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1936