### PR TITLE
denylist: deny ext.config.multipath.resilient on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -60,3 +60,7 @@
     - x86_64
   streams:
     - rawhide
+- pattern: ext.config.multipath.resilient
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
+  arches:
+    - s390x


### PR DESCRIPTION
This is a new test and it's failing on s390x so let's deny it for now while we investigate.