### PR TITLE
denylist: drop toolbox test denial on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
-- pattern: ext.config.toolbox
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1908
-  snooze: 2025-04-14
-  warn: true
-  streams:
-    - rawhide
 - pattern: skip-console-warnings
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1924
   platforms:

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -56,5 +56,3 @@
     - rawhide
 - pattern: ext.config.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
-  arches:
-    - s390x


### PR DESCRIPTION
The fixed kernel shipped in rawhide so we can remove this entry. See https://github.com/coreos/fedora-coreos-tracker/issues/1908#issuecomment-2835865801