### PR TITLE
[testing] denylist: deny ext.config.multipath.resilient on all arches

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -62,5 +62,3 @@
     - rawhide
 - pattern: ext.config.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937
-  arches:
-    - s390x


### PR DESCRIPTION
This test is proving to be a bit flaky. Let's denylist it for now while we wait for an upstream fix [1].

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1937#issuecomment-2835517262

(cherry picked from commit 4f3fce5a49fb8e89705d4012f5e830b6637b6e37)