### PR TITLE
denylist: extend snooze for kdump.crash*

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,7 +18,7 @@
     - rawhide
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-04-30
+  snooze: 2025-05-12
   warn: true
   arches:
     - aarch64
@@ -26,7 +26,7 @@
     - rawhide
 - pattern: kdump.crash.ssh
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-04-30
+  snooze: 2025-05-12
   warn: true
   arches:
     - aarch64
@@ -34,7 +34,7 @@
     - rawhide
 - pattern: kdump.crash.nfs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-04-30
+  snooze: 2025-05-12
   warn: true
   arches:
     - aarch64


### PR DESCRIPTION
These tests are still failing. Let's extend the snooze again so we can continue to test the latest RC kernels in rawhide.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1925