### PR TITLE
[next-devel] disable candidate-compose repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,6 +11,6 @@ repos:
   # GitHub Action.
   - fedora-next
   - fedora-next-updates
-  - fedora-candidate-compose
+ #- fedora-candidate-compose
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1851