### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,12 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  containerd:
-    evr: 2.0.5-2.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-899ce97077
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1918
-      type: fast-track
   coreos-installer:
     evr: 0.24.0-1.fc42
     metadata:
@@ -32,12 +26,6 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
-  docker-cli:
-    evr: 27.5.1-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-fdae28d838
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1918
-      type: fast-track
   libdnf5:
     evr: 5.2.11.0-1.fc42
     metadata:
@@ -48,18 +36,6 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
       type: pin
-  moby-engine:
-    evr: 27.5.1-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-fdae28d838
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1918
-      type: fast-track
-  moby-filesystem:
-    evra: 27.5.1-3.fc42.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-fdae28d838
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1918
-      type: fast-track
   rpm-ostree:
     evr: 2025.7-2.fc42
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).