### PR TITLE
overrides: fast-track rust-zincati-0.0.30-3.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -47,8 +47,8 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-96e470a839
       type: fast-track
   zincati:
-    evr: 0.0.30-2.fc42
+    evr: 0.0.30-3.fc42
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-76cc40dcc4
-      reason: https://github.com/coreos/zincati/issues/1280
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-cf818c6cfe
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1938
       type: fast-track


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).