### PR TITLE
[ppc] kola-denylist: extend snooze for root-reprovision.* until 2025-05-12

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -42,7 +42,7 @@
     - rawhide
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1926
-  snooze: 2025-05-06
+  snooze: 2025-05-12
   arches:
     - ppc64le
   streams:


### PR DESCRIPTION
Original snooze expired, but the kernel fix has not yet been merged, causing the pipeline to break. This commit extends the snooze by one week.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1926