### PR TITLE
coreos-bootc-minimal-plus: stop patching prepare-root.conf

### DIFF
--- a/manifests/coreos-bootc-minimal-plus.yaml
+++ b/manifests/coreos-bootc-minimal-plus.yaml
@@ -30,23 +30,6 @@ machineid-compat: false
 opt-usrlocal: var
 
 postprocess:
-  - |
-    #!/usr/bin/bash
-    set -eux -o pipefail
-    # For now, rely on the `sysroot.readonly` knob in /ostree/config only.
-    # Having it in prepare-root.conf too throws off ostree-prepare-root in
-    # live PXE/ISO and we have no easy way to override it when building those.
-    # Really, we need to fix libostree + live ISOs to work well together:
-    # https://github.com/ostreedev/ostree/issues/1921
-    # It's awkward to edit arbitrary keyfile configs. Just rewrite it.
-    if grep -q readonly /usr/lib/ostree/prepare-root.conf; then
-        grep -q '^4 ' <(wc -l /usr/lib/ostree/prepare-root.conf)
-        cat > /usr/lib/ostree/prepare-root.conf <<EOF
-    [composefs]
-    enabled = true
-    EOF
-    fi
-
 # Make `/opt and `/usr/local` symlinks.
 # This is the historical default and what FCOS currently ships. fedora-bootc
 # uses the new `root` value, but migrating FCOS is not that simple...

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/ostree-cmdline.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/ostree-cmdline.sh
@@ -11,13 +11,21 @@ set -euo pipefail
 case "${1:-unset}" in
     start)
         treepath="$(echo /sysroot/ostree/boot.1/*/*/0)"
-        # ostree-prepare-root requires /etc and /var to be writeable for composeFS
-        # which cannot happen in the live ISO. Disable composeFS there
-        # https://github.com/coreos/fedora-coreos-config/pull/3009#issuecomment-2235923719
-        echo "$(cat /proc/cmdline) ostree=${treepath#/sysroot} ostree.prepare-root.composefs=0" > /tmp/cmdline
+        echo "$(cat /proc/cmdline) ostree=${treepath#/sysroot}" > /tmp/cmdline
         mount --bind /tmp/cmdline /proc/cmdline
+        # prepare-root.conf wants to turn on sysroot.readonly and composefs
+        # We can't use composefs in the live ISO because ostree-prepare-root requires /etc and /var to be writeable.
+        # https://github.com/coreos/fedora-coreos-config/pull/3009#issuecomment-2235923719
+        # The sysroot.readonly bit would be fine nowadays (since
+        # https://github.com/ostreedev/ostree/pull/3316) but it also
+        # unnecessarily complicates the mount tree given that we're read-only
+        # anyway but ostree-prepare-root still wants to e.g. remount `/etc`.
+        # Could tweak the logic there, but for now just mask the file entirely.
+        # We have our own /var and /etc transient mounts.
+        mount --bind /dev/null /usr/lib/ostree/prepare-root.conf
         ;;
     stop)
+        umount -l /usr/lib/ostree/prepare-root.conf
         umount -l /proc/cmdline
         rm /tmp/cmdline
         ;;


### PR DESCRIPTION
coreos-bootc-minimal-plus: stop patching prepare-root.conf

I think the issue that motivated this hack was fixed by
https://github.com/ostreedev/ostree/pull/3316.

However, a new issue happens in our live boots when we do this,
which is that because ostree-prepare-root still remounts `/etc` with
`sysroot.readonly`, systemd sees this and auto-generates a mount unit
from that and that shadows _our_ generated `sysroot-etc.mount` which
mounts from the transient XFS loopback hack.

We should be able to tweak ostree-prepare-root for this, but for now
we still need to neuter `prepare-root.conf` in live boots. I think it's
cleaner though to do this directly in `ostree-cmdline.sh` rather than in
a postprocessing script to limit the hacks to just where it's needed and
also so that it transparently works in the container-native case, where
our postprocessing scripts run _after_ dracut. (We could rerun dracut,
but I'm trying to avoid that.)

Another consequence of doing it this way is that this should also allow
us to stop setting `sysroot.readonly` at osbuild time for the disk
images[[1]], and _unsetting_ it at osbuild time for the live media[[2]].

[1]: https://github.com/coreos/coreos-assembler/blob/3615165d645bb7a6f4cd8d004df44e427e2cc1d7/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml#L177
[2]: https://github.com/osbuild/osbuild/blob/67f344fa52c0942a9a4878317458a92cd20dc273/stages/org.osbuild.coreos.live-artifacts.mono#L587

