### PR TITLE
denylist: drop coreos.boot-mirror, extend other snoozes

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,7 +18,7 @@
     - rawhide
 - pattern: ext.config.kdump.crash
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-12
+  snooze: 2025-05-26
   warn: true
   arches:
     - aarch64
@@ -26,7 +26,7 @@
     - rawhide
 - pattern: kdump.crash.ssh
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-12
+  snooze: 2025-05-26
   warn: true
   arches:
     - aarch64
@@ -34,7 +34,7 @@
     - rawhide
 - pattern: kdump.crash.nfs
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-12
+  snooze: 2025-05-26
   warn: true
   arches:
     - aarch64
@@ -42,16 +42,9 @@
     - rawhide
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1926
-  snooze: 2025-05-06
+  snooze: 2025-05-26
   arches:
     - ppc64le
-  streams:
-    - rawhide
-- pattern: coreos.boot-mirror*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1932
-  snooze: 2025-05-06
-  arches:
-    - x86_64
   streams:
     - rawhide
 - pattern: ext.config.multipath.resilient


### PR DESCRIPTION
The coreos.boot-mirror test has been passing since the snooze expired, so we can remove it now and close:
https://github.com/coreos/fedora-coreos-tracker/issues/1932

The kdump.crash and root-reprovision.* tests are still failing, so let's extend the snooze while the issues are investigated.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1925
xref: https://github.com/coreos/fedora-coreos-tracker/issues/1926