### PR TITLE
manifests/fedora-coreos-base: apply dracut fix in postcript

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,5 +16,3 @@
     - openstack
   streams:
     - rawhide
-- pattern: ext.config.multipath.resilient
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937

--- a/manifests/shared-el.yaml
+++ b/manifests/shared-el.yaml
@@ -13,3 +13,16 @@ conditional-include:
     include: shared-el10.yaml
   - if: osversion == "centos-10"
     include: shared-el10.yaml
+
+# ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
+# See also the version of this in fedora-coreos.yaml
+postprocess:
+  # We apply part of the patch https://github.com/dracut-ng/dracut-ng/pull/1306 here
+  # while awaiting for the new dracut release to land.
+  # This script will start to fail once dracut 107 release available in repo, signaling
+  # to remove this postscript.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1937
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    sed -i '/^ExecStart=\/usr\/sbin\/mpathconf --enable$/,${s//ExecStart=\/usr\/sbin\/mpathconf --enable --user_friendly_names n/;b};$q1' /usr/lib/dracut/modules.d/90multipath/multipathd-configure.service

--- a/tests/kola/root-reprovision/luks/multipath/test.sh
+++ b/tests/kola/root-reprovision/luks/multipath/test.sh
@@ -22,7 +22,7 @@ set -xeuo pipefail
 
 # Check if the child device is part of the parent device
 srcdev=$(findmnt -nvr /sysroot -o SOURCE)
-parent_device="/dev/mapper/mpatha"
+parent_device="/dev/mapper/$(multipath -l -v 1)"
 
 if ! lsblk -pno NAME "$parent_device" | grep -qw "$srcdev"; then
     fatal "$srcdev is NOT a child of $parent_device."


### PR DESCRIPTION
We are awaiting some dracut patches to land in Fedora mirror for [1]. We could wait for it, but we'd need it also for older rhcos branches and those branches won't have the new dracut. So we decided to carry part of the dracut-ng patch [2] in a post-script. This will be backported in older rhcos branches, and will be reverted on testing-devel once new dracut 107 available in mirror.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1937
[2] https://github.com/dracut-ng/dracut-ng/pull/1306