### PR TITLE
manifests: create a shared-el.yaml manifest

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -4,6 +4,11 @@
 
 variables:
   id: "fedora"
+  # osversion is unused in Fedora for now, but it's needed because we
+  # do some conditional_includes: which do leverage the osversion
+  # defined in rhcos/scos. When https://github.com/coreos/rpm-ostree/pull/5392
+  # merges we can define this with values from other vars: osversion: "${id}-${releasever}"
+  osversion: "unused"
 
 include:
   - kernel.yaml

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -17,8 +17,7 @@ include:
   - file-transfer.yaml
   - networking-tools.yaml
   - user-experience.yaml
-  - shared-el9.yaml
-  - shared-el10.yaml
+  - shared-el.yaml
   - coreos-bootc-minimal-plus.yaml
 
 ostree-layers:

--- a/manifests/shared-el.yaml
+++ b/manifests/shared-el.yaml
@@ -1,0 +1,15 @@
+conditional-include:
+  # Include shared-el9 workarounds on Fedora and EL9
+  - if: id == "fedora"
+    include: shared-el9.yaml
+  - if: osversion == "rhel-9.6"
+    include: shared-el9.yaml
+  - if: osversion == "centos-9"
+    include: shared-el9.yaml
+  # Include shared-el10 workarounds on Fedora and EL10
+  - if: id == "fedora"
+    include: shared-el10.yaml
+  - if: osversion == "rhel-10.1"
+    include: shared-el10.yaml
+  - if: osversion == "centos-10"
+    include: shared-el10.yaml


### PR DESCRIPTION
This manifest will include any misc shared bits with our enterprise linux downstream builds. It will dynamically pick up el9 or el10 specific snippets using conditional includes.

This is prep for adding snippets that we can share with both el9 and el10 and not just one or the other.