### PR TITLE
overrides: unpin dnf5-5.2.11.0-1.fc41

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,21 +19,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-a6b3188e64
       type: fast-track
-  dnf5:
-    evr: 5.2.11.0-1.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
-  libdnf5:
-    evr: 5.2.11.0-1.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
-  libdnf5-cli:
-    evr: 5.2.11.0-1.fc42
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
   zincati:
     evr: 0.0.30-3.fc42
     metadata:


### PR DESCRIPTION
The dnf5 rpm can be unpinned  as we have refactored systemd preset handling by moving enablement code to the minimal configuration. Also, the dnf-makecache.timer has been disabled  by default for minimal images.

Ref:
https://gitlab.com/fedora/bootc/base-images/-/merge_requests/181 
https://github.com/coreos/fedora-coreos-config/pull/3509

https://github.com/coreos/fedora-coreos-tracker/issues/1896#issuecomment-2890876017