### PR TITLE
[rawhide] overrides: unpin dnf5-5.2.11.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,21 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  dnf5:
-    evr: 5.2.11.0-1.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
-  libdnf5:
-    evr: 5.2.11.0-1.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
-  libdnf5-cli:
-    evr: 5.2.11.0-1.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1896
-      type: pin
   rpm:
     evr: 4.20.1-3.fc43
     metadata:


### PR DESCRIPTION
The dnf5 rpm can be unpinned as we have refactored systemd preset handling by moving enablement code to the minimal configuration. Also, the dnf-makecache.timer has been disabled by default for minimal images.

Ref:
- https://gitlab.com/fedora/bootc/base-images/-/merge_requests/181
- https://github.com/coreos/fedora-coreos-config/pull/3509
- https://github.com/coreos/fedora-coreos-tracker/issues/1896#issuecomment-2890876017