### PR TITLE
tests/kdump.crash: bump kdump.service activation timeout

### DIFF
--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -19,9 +19,9 @@ set -xeuo pipefail
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
-      # use 120s for this since kdump can take a while to build its initramfs,
+      # use 240s for this since kdump can take a while to build its initramfs,
       # especially if the system is loaded
-      if ! is_service_active kdump.service 120; then
+      if ! is_service_active kdump.service 240; then
           fatal "kdump.service failed to start"
       fi
       # Verify that the crashkernel reserved memory is large enough


### PR DESCRIPTION
We've been seeing this kdump.service activation hit the timeout on the Fedora CoreOS aarch64 builder. 240s seems to be enough to allow the service to activate on the builder, so let's increase the timeout to unblock the FCOS pipeline.