### PR TITLE
denylist: re-enable aarch64 kdump tests for rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,30 +16,6 @@
     - openstack
   streams:
     - rawhide
-- pattern: ext.config.kdump.crash
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-26
-  warn: true
-  arches:
-    - aarch64
-  streams:
-    - rawhide
-- pattern: kdump.crash.ssh
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-26
-  warn: true
-  arches:
-    - aarch64
-  streams:
-    - rawhide
-- pattern: kdump.crash.nfs
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1925
-  snooze: 2025-05-26
-  warn: true
-  arches:
-    - aarch64
-  streams:
-    - rawhide
 - pattern: ext.config.root-reprovision.*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1926
   snooze: 2025-05-26


### PR DESCRIPTION
Kdump got fixed in the latest release, fixing aarch64

See https://bodhi.fedoraproject.org/updates/FEDORA-2025-dfef3c08fb Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1925