### PR TITLE
make postprocess more consistent; drop preset from postprocess

### DIFF
--- a/manifests/coreos-bootc-minimal-plus.yaml
+++ b/manifests/coreos-bootc-minimal-plus.yaml
@@ -25,8 +25,8 @@ opt-usrlocal: var
 
 postprocess:
   - |
-    #!/usr/bin/env bash
-    set -euo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     # For now, rely on the `sysroot.readonly` knob in /ostree/config only.
     # Having it in prepare-root.conf too throws off ostree-prepare-root in
     # live PXE/ISO and we have no easy way to override it when building those.

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -59,8 +59,8 @@ postprocess:
   # Enable SELinux booleans used by OpenShift
   # https://github.com/coreos/fedora-coreos-tracker/issues/284
   - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     setsebool -P -N container_use_cephfs on  # RHBZ#1692369
     setsebool -P -N virt_use_samba on  # RHBZ#1754825
 
@@ -69,7 +69,8 @@ postprocess:
   # use it as an external dns server. We prefer they use a container for that.
   # https://github.com/coreos/fedora-coreos-tracker/issues/519
   - |
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
+    set -eux -o pipefail
     systemctl mask dnsmasq.service
 
   # Default to iptables-nft. Otherwise, legacy wins. We can drop this once/if we
@@ -77,8 +78,8 @@ postprocess:
   # https://github.com/coreos/fedora-coreos-tracker/issues/677
   # https://github.com/coreos/fedora-coreos-tracker/issues/676
   - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     ln -sf /usr/sbin/ip6tables-nft         /etc/alternatives/ip6tables
     ln -sf /usr/sbin/ip6tables-nft-restore /etc/alternatives/ip6tables-restore
     ln -sf /usr/sbin/ip6tables-nft-save    /etc/alternatives/ip6tables-save
@@ -91,8 +92,8 @@ postprocess:
   # See https://github.com/coreos/fedora-coreos-tracker/issues/1473
   # We should remove this after the next barrier release.
   - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     mkdir -p /usr/lib/systemd/system/ssh-host-keys-migration.service.d
     cat <<'EOF' > /usr/lib/systemd/system/ssh-host-keys-migration.service.d/coreos-force-migration-on-every-boot.conf
     # Force the ssh-host-keys-migration to happen on every boot

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -21,7 +21,8 @@ conditional-include:
     include:
       postprocess:
         - |
-          #!/usr/bin/env bash
+          #!/usr/bin/bash
+          set -eux -o pipefail
           cat > /etc/zincati/config.d/90-disable-on-non-production-stream.toml << EOF
           # https://github.com/coreos/fedora-coreos-tracker/issues/163
           updates.enabled = false

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -20,8 +20,8 @@ postprocess:
   # Undo RPM scripts enabling units; we want the presets to be canonical
   # https://github.com/projectatomic/rpm-ostree/issues/1803
   - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     rm -rf /etc/systemd/system/*
     systemctl preset-all
     rm -rf /etc/systemd/user/*

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -15,14 +15,3 @@ packages:
 packages-s390x:
   # for Secure Execution
   - veritysetup
-
-postprocess:
-  # Undo RPM scripts enabling units; we want the presets to be canonical
-  # https://github.com/projectatomic/rpm-ostree/issues/1803
-  - |
-    #!/usr/bin/bash
-    set -eux -o pipefail
-    rm -rf /etc/systemd/system/*
-    systemctl preset-all
-    rm -rf /etc/systemd/user/*
-    systemctl --user --global preset-all

--- a/manifests/selinux-workaround.yaml
+++ b/manifests/selinux-workaround.yaml
@@ -6,8 +6,8 @@
 # altogether
 postprocess:
   - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
+    #!/usr/bin/bash
+    set -eux -o pipefail
     cat > /tmp/fcos-workarounds.cil << EOF
     ; https://bugzilla.redhat.com/show_bug.cgi?id=2300306
     (typeattributeset cil_gen_require bootupd_t)

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -41,5 +41,6 @@ postprocess:
   # boot and does not use systemd-repart currently. See also
   # https://github.com/coreos/fedora-coreos-tracker/issues/570
   - |
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
+    set -eux -o pipefail
     systemctl mask systemd-repart.service


### PR DESCRIPTION
```
manifests: make postprocess preamble more consistent

We always want set -x so we can see more information if things either
fail during a postprocess or if things in the final image somehow don't
turn out how we inpsect. The logs will help us figure out what is going
on.
```

---

```
manifests: drop preset-all from postprocess

This is done in bootc now as of [1] and we've bumped
the bootc submodule since then so we can drop it here now.

[1] https://gitlab.com/fedora/bootc/base-images/commit/4888be4e199583664fe32264f16ff9e166372c34
```