### PR TITLE
[rhcos-4.19] manifests: Add trustee-guest-components

### DIFF
--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -35,6 +35,9 @@ packages:
   - stalld
   # Ignition aware SSH key management
   - ssh-key-dir
+  # Provides tools that run in a confidential VM, 
+  # gather confidential-computing evidence and send it to Trustee and get secrets.
+  - trustee-guest-components
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first


### PR DESCRIPTION
In order to run Remote Attestation on RHEL CoreOS node we need to have the trustee-guest-component rpm package in RHCOS.