### PR TITLE
denylist: drop kola reprovision tests for power from denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,12 +16,5 @@
     - openstack
   streams:
     - rawhide
-- pattern: ext.config.root-reprovision.*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1926
-  snooze: 2025-05-26
-  arches:
-    - ppc64le
-  streams:
-    - rawhide
 - pattern: ext.config.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937


### PR DESCRIPTION
Kola tests are now passing since the fix released in 6.15.0-0.rc7, so we can remove it now and close:
https://github.com/coreos/fedora-coreos-tracker/issues/1926