### PR TITLE
manifests/fedora-coreos: allow python in F43+ for now

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -159,8 +159,6 @@ remove-files:
 # hard requirement, in which case the build will fail.
 exclude-packages:
   - python
-  - python2
-  - python2-libs
   - python3
   - python3-libs
   - perl

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -46,6 +46,14 @@ conditional-include:
     include:
       ostree-layers:
         - overlay/35oci-migration
+  # Allow python in F43 for now until nfs package gets fixed.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1942#issuecomment-2881075898
+  - if: releasever < 43
+    include:
+      exclude-packages:
+        - python
+        - python3
+        - python3-libs
 
 ostree-layers:
   - overlay/15fcos
@@ -158,9 +166,6 @@ remove-files:
 # have recommends: false so these could only come in via
 # hard requirement, in which case the build will fail.
 exclude-packages:
-  - python
-  - python3
-  - python3-libs
   - perl
   - perl-interpreter
   - nodejs

--- a/tests/kola/python/data/commonlib.sh
+++ b/tests/kola/python/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/python/test.sh
+++ b/tests/kola/python/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   description: Make sure python is only pulled in by nfs-utils
+##   distros: fcos
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if verlt "$(get_fedora_ver)" 43; then
+    ok "Skipping python3 dependencies test"
+    exit 0
+fi
+
+sudo rpm-ostree usroverlay
+sudo rpm -e nfs-utils nfs-utils-coreos python3 python3-libs python-pip-wheel
+ok "no extra pytyhon3 dependencies"


### PR DESCRIPTION
`nfs-utils-coreos` grew a dependency for `nfs-utils`, which requires
`python`. Let's allow it in rawhide and hopefully the dependency
will get cleaned up before it reaches production FCOS streams.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1942#issuecomment-2881075898
