### PR TITLE
[rawhide] overrides: drop nfs-utils-coreos pin in rawhide

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,11 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  nfs-utils-coreos:
-    evr: 1:2.8.2-1.rc8.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1942
-      type: pin
   selinux-policy:
     evra: 41.41-1.fc43.noarch
     metadata:


### PR DESCRIPTION
For now we loosened the requirement of "no python" in Fedora 43+ so we can drop this pin.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1942#issuecomment-2881075898