### PR TITLE
tests/python: fix test to allow python in f43+

### DIFF
--- a/tests/kola/python/test.sh
+++ b/tests/kola/python/test.sh
@@ -9,7 +9,7 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-if verlt "$(get_fedora_ver)" 43; then
+if vergte "$(get_fedora_ver)" 43; then
     ok "Skipping python3 dependencies test"
     exit 0
 fi


### PR DESCRIPTION
[1] introduced python dependencies and a test to make sure no python was introduced in earlier releases. The test intended to be skip for versions above 43 but use `verlt`. Update to use `vergte` which will skip the test for f43 and above, as intended.

[1] e70fd15dc08ec1ca2234f513275dd18ca0430206