### PR TITLE
[rawhide] overrides: pin selinux-policy-41.41-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,13 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1942
       type: pin
+  selinux-policy:
+    evra: 41.41-1.fc43.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1965
+      type: pin
+  selinux-policy-targeted:
+    evra: 41.41-1.fc43.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1965
+      type: pin


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).