### PR TITLE
Prep patches for container-native path

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -42,3 +42,5 @@ container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{s
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"
 live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"
+
+include: image-default.yaml

--- a/image-default.yaml
+++ b/image-default.yaml
@@ -1,0 +1,36 @@
+# This file contains defaults for image.yaml and historically lived in
+# coreos-assembler.
+
+# related: https://github.com/osbuild/bootc-image-builder/pull/932
+bootfs: "ext4"
+rootfs: "xfs"
+# Add arguments here that will be passed to e.g. mkfs.xfs
+rootfs-args: ""
+# Set to "true" to enable composefs
+composefs: false
+
+# Additional default kernel arguments injected into disk images
+extra-kargs: []
+
+# Can also be oci-chunked
+ostree-format: oci-chunked-v1
+# Inject io.openshift.build.version-display-names for OpenShift CVO
+ostree-container-inject-openshift-cvo-labels: false
+# True if we should use `ostree container image deploy`
+deploy-via-container: false
+
+# Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
+# container-imgref: ""
+
+# Format used when generating a squashfs image.  Can also be e.g. gzip or lz4
+squashfs-compression: zstd
+
+# Defaults for VMware OVA, matching historical behavior
+vmware-hw-version: 13
+vmware-os-type: rhel7_64Guest
+vmware-secure-boot: true
+
+# Defaults for AWS
+aws-imdsv2-only: true
+aws-volume-type: "gp3"
+aws-x86-boot-mode: "uefi-preferred"

--- a/manifests/coreos-bootc-minimal-plus.yaml
+++ b/manifests/coreos-bootc-minimal-plus.yaml
@@ -18,6 +18,8 @@ conditional-include:
 # the future... For more details, see
 # https://github.com/CentOS/centos-bootc/issues/167
 # https://coreos.github.io/rpm-ostree/treefile/#experimental-options
+# This is re-implemented below for the container-native flow. Nuke this once
+# that's the only path we support.
 machineid-compat: false
 
 # This is the historical default and what FCOS currently ships. fedora-bootc
@@ -42,3 +44,16 @@ postprocess:
     enabled = true
     EOF
     fi
+
+  # Required by Ignition, and makes the system not compatible with Anaconda.
+  # Note this deviates from fedora-bootc and means `systemctl enable` doesn't
+  # work in a container build. We'll have to resolve that issue some other way in
+  # the future... For more details, see
+  # https://github.com/CentOS/centos-bootc/issues/167
+  # https://coreos.github.io/rpm-ostree/treefile/#experimental-options
+  # We can nuke `machineid-compat: false` above once we only support the
+  # container-native path.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rm -vf /etc/machine-id

--- a/manifests/coreos-bootc-minimal-plus.yaml
+++ b/manifests/coreos-bootc-minimal-plus.yaml
@@ -25,6 +25,8 @@ machineid-compat: false
 # This is the historical default and what FCOS currently ships. fedora-bootc
 # uses the new `root` value, but migrating FCOS is not that simple...
 # https://coreos.github.io/rpm-ostree/treefile/#experimental-options
+# This is re-implemented below for the container-native flow. Nuke this once
+# that's the only path we support.
 opt-usrlocal: var
 
 postprocess:
@@ -43,6 +45,21 @@ postprocess:
     [composefs]
     enabled = true
     EOF
+    fi
+
+# Make `/opt and `/usr/local` symlinks.
+# This is the historical default and what FCOS currently ships. fedora-bootc
+# uses the new `root` value, but migrating FCOS is not that simple...
+# https://coreos.github.io/rpm-ostree/treefile/#experimental-options
+# We can nuke `opt-usrlocal: var` above once this is the only path we support.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    if [ -f /run/.containerenv ]; then
+        rm -vrf /opt;
+        ln -vs var/opt /opt
+        rm -vrf /usr/local
+        ln -vs ../var/usrlocal /usr/local
     fi
 
   # Required by Ignition, and makes the system not compatible with Anaconda.

--- a/manifests/coreos-bootc-minimal-plus.yaml
+++ b/manifests/coreos-bootc-minimal-plus.yaml
@@ -1,13 +1,15 @@
 # Here, we include bootc minimal-plus, but override some key settings.
 
-include: ../fedora-bootc/minimal-plus/manifest.yaml
-
 # If we are fedora there are a few more settings in
 # fedora-includes/generic.yaml that fedora-minimal-plus.yaml
 # pulls in. We need to monitor fedora-minimal-plus.yaml to
 # make sure we update our strategy here if that file changes.
 conditional-include:
-  - if: id == "fedora"
+  - if: deriving == false
+    include: ../fedora-bootc/minimal-plus/manifest.yaml
+  - if:
+    - id == "fedora"
+    - deriving == false
     include: ../fedora-bootc/fedora-includes/generic.yaml
 
 # Required by Ignition, and makes the system not compatible with Anaconda.

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -11,7 +11,6 @@ variables:
   osversion: "unused"
 
 include:
-  - kernel.yaml
   - system-configuration.yaml
   - ignition-and-ostree.yaml
   - file-transfer.yaml

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -102,6 +102,15 @@ postprocess:
     ConditionPathExists=
     EOF
 
+  # sudo prefers its config files to be mode 440, and some security scanners
+  # complain if /etc/sudoers.d files are world-readable.
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1981979
+  # This is added by the 05core overlay listed above.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    chmod 440 /etc/sudoers.d/coreos-sudo-group
+
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go
 # into one of the sub-manifests listed at the top.

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -47,8 +47,6 @@ check-groups:
   type: "file"
   filename: "group"
 
-default-target: multi-user.target
-
 # we can drop this when it's the rpm-ostree default
 rpmdb: sqlite
 
@@ -111,6 +109,12 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     chmod 440 /etc/sudoers.d/coreos-sudo-group
+
+  # Set the default systemd target to `multi-user.target`.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    ln -sf multi-user.target /usr/lib/systemd/system/default.target
 
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -34,11 +34,11 @@ ignore-removed-users:
   - root
 ignore-removed-groups:
   - root
+# Add the sudo group to /etc/group
+# This is re-implemented below for the container-native flow. Nuke this once
+# that's the only path we support.
 etc-group-members:
-  - wheel
   - sudo
-  - systemd-journal
-  - adm
 
 check-passwd:
   type: "file"
@@ -115,6 +115,15 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     ln -sf multi-user.target /usr/lib/systemd/system/default.target
+
+  # Add the sudo group to /etc/group in container-native flow.
+  # We can nuke `etc-group-members` once this is the only supported path.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    if [ -f /run/.containerenv ]; then
+      grep sudo /usr/lib/group >> /etc/group
+    fi
 
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -62,6 +62,7 @@ postprocess:
     set -eux -o pipefail
     setsebool -P -N container_use_cephfs on  # RHBZ#1692369
     setsebool -P -N virt_use_samba on  # RHBZ#1754825
+    rm -f /etc/selinux/targeted/semanage.*.LOCK
 
   # Mask dnsmasq. We include dnsmasq for host services that use the dnsmasq
   # binary but intentionally mask the systemd service so users can't easily

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -165,13 +165,22 @@ postprocess:
         done
     done
 
+  # Delete documentation. (Note that fedora-bootc doesn't explicitly set
+  # `documentation`, and neither do we, so the rpm-ostree default is true. We
+  # historically have effectively done `the equivalent of `documentation: false`
+  # though.)
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
 
-remove-files:
-  # We don't ship man(1) or info(1)
-  - usr/share/info
-  - usr/share/man
-  # Drop text docs too
-  - usr/share/doc
+    # We don't ship man(1) or info(1)
+    rm -rf /usr/share/info
+    rm -rf /usr/share/man
+    # Drop text docs too
+    rm -rf /usr/share/doc
+
+    # Nuke broken alternatives links
+    rm -f /etc/alternatives/*-man
 
   # Add the docker group to /etc/group
   # https://github.com/coreos/fedora-coreos-tracker/issues/2

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -80,11 +80,13 @@ packages:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1567
   - bash-color-prompt
 
+# Add the docker group to /etc/group
+# https://github.com/coreos/fedora-coreos-tracker/issues/2
+# This will be no longer needed when systemd-sysusers has been implemented:
+# https://github.com/projectatomic/rpm-ostree/issues/49
+# This is re-implemented below for the container-native flow. Nuke this once
+# that's the only path we support.
 etc-group-members:
-  # Add the docker group to /etc/group
-  # https://github.com/coreos/fedora-coreos-tracker/issues/2
-  # This will be no longer needed when systemd-sysusers has been implemented:
-  # https://github.com/projectatomic/rpm-ostree/issues/49
   - docker
 
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
@@ -165,6 +167,18 @@ remove-files:
   - usr/share/man
   # Drop text docs too
   - usr/share/doc
+
+  # Add the docker group to /etc/group
+  # https://github.com/coreos/fedora-coreos-tracker/issues/2
+  # This will be no longer needed when systemd-sysusers has been implemented:
+  # https://github.com/projectatomic/rpm-ostree/issues/49
+  # We can nuke `etc-group-members` once this is the only path we support.
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    if [ -f /run/.containerenv ]; then
+      grep docker /usr/lib/group >> /etc/group
+    fi
 
 # Things we don't expect to ship on the host.  We currently
 # have recommends: false so these could only come in via

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -11,6 +11,10 @@ metadata:
 add-commit-metadata:
   fedora-coreos.stream: ${stream}
 
+variables:
+  # upper manifests can override this when deriving from minimal-plus instead of
+  # doing a base compose
+  deriving: false
 
 include: fedora-coreos-base.yaml
 conditional-include:

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -115,8 +115,13 @@ postprocess:
     # information.
 
     EOF
-    cat /usr/etc/rpm-ostreed.conf >> /tmp/rpm-ostreed.conf
-    cp /tmp/rpm-ostreed.conf /usr/etc/rpm-ostreed.conf
+    conf_file=/usr/etc/rpm-ostreed.conf
+    # if we're deriving, then the config is in /etc already
+    if [ -f /run/.containerenv ]; then
+      conf_file=/etc/rpm-ostreed.conf
+    fi
+    cat "${conf_file}" >> /tmp/rpm-ostreed.conf
+    cp /tmp/rpm-ostreed.conf "${conf_file}"
     rm /tmp/rpm-ostreed.conf
   # Make sure that we do not ship broken symlinks:
   # https://github.com/coreos/fedora-coreos-config/issues/1782

--- a/manifests/kernel.yaml
+++ b/manifests/kernel.yaml
@@ -1,3 +1,0 @@
-packages:
-  # We use the default kernel package, but note c9s may differ
-  - kernel

--- a/overlay.d/05core/statoverride
+++ b/overlay.d/05core/statoverride
@@ -1,7 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>
-
-# sudo prefers its config files to be mode 440, and some security scanners
-# complain if /etc/sudoers.d files are world-readable.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1981979
-=288 /etc/sudoers.d/coreos-sudo-group

--- a/overlay.d/08nouveau/statoverride
+++ b/overlay.d/08nouveau/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/09misc/statoverride
+++ b/overlay.d/09misc/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15fcos/statoverride
+++ b/overlay.d/15fcos/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/20platform-chrony/statoverride
+++ b/overlay.d/20platform-chrony/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25azure-udev-rules/statoverride
+++ b/overlay.d/25azure-udev-rules/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/30lvmdevices/statoverride
+++ b/overlay.d/30lvmdevices/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>


### PR DESCRIPTION
These commits were split out of https://github.com/coreos/fedora-coreos-config/pull/3348.