### PR TITLE
tests: mark lockdown test as exclusive

### DIFF
--- a/tests/kola/security/lockdown
+++ b/tests/kola/security/lockdown
@@ -1,6 +1,8 @@
 #!/bin/bash
 ## kola:
-##   exclusive: false
+##   # Mark as exclusive since we are requesting secureboot and that won't take effect when we're
+##   # running non-exclusively.
+##   exclusive: true
 ##   tags: secure-boot
 ##   architectures: x86_64
 ##   description: Verify that the lockdown LSM is set to integrity when booted using Secure Boot


### PR DESCRIPTION
Mark as exclusive since we are requesting secureboot and that won't take effect when we're running non-exclusively.

Partial fix for https://github.com/coreos/fedora-coreos-tracker/issues/1966