### PR TITLE
overlay.d: Update ignition.firstboot services for soft-reboots

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/coreos-ignition-firstboot-complete.service
+++ b/overlay.d/05core/usr/lib/systemd/system/coreos-ignition-firstboot-complete.service
@@ -3,6 +3,10 @@ Description=CoreOS Mark Ignition Boot Complete
 Documentation=https://docs.fedoraproject.org/en-US/fedora-coreos/
 ConditionKernelCommandLine=ignition.firstboot
 ConditionPathExists=!/run/ostree-live
+# This condition is required for cases where a soft-reboot is issued on the
+# firstboot. Soft reboot do not change the kernel or its command-line arguments,
+# which would cause this service to fail after the soft-reboot completes.
+ConditionPathExists=/boot/ignition.firstboot
 RequiresMountsFor=/boot
 
 [Service]

--- a/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
+++ b/overlay.d/15fcos/usr/lib/systemd/system/coreos-check-ssh-keys.service
@@ -11,7 +11,7 @@ After=afterburn-sshkeys.target
 # before Ignition/Afterburn started logging structured data don't
 # get misleading messages. Also handles the case where the journal
 # gets rotated and no longer has the structured log messages.
-ConditionKernelCommandLine=ignition.firstboot
+ConditionFirstBoot=true
 # Run before user sessions to avoid reloading agetty
 Before=systemd-user-sessions.service
 


### PR DESCRIPTION
https://github.com/coreos/coreos-assembler/pull/4119 surfaced that this service would fail on soft-reboots, it's non fatal but would make the Kola tests fail. It looks like originally this was set to fail instead of risking not running it:
https://github.com/coreos/fedora-coreos-config/blob/20feb176f19c3142b7256c1eb5bf1cb7c53b29b9/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete#L14