### PR TITLE
[rawhide] overrides: unpin selinux-policy-41.41-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,14 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  selinux-policy:
-    evra: 41.41-1.fc43.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1965
-      type: pin
-  selinux-policy-targeted:
-    evra: 41.41-1.fc43.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1965
-      type: pin
+packages: {}


### PR DESCRIPTION
The latest selinux-policy pkg is expected to address the `non-exclusive-test-bucket-`0 kola test failure caused by selinux-policy rpm upgrade

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1965#issuecomment-2941545684