### PR TITLE
dracut: Ignore ignition modules if building kdump initrd

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/module-setup.sh
@@ -2,6 +2,12 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     echo systemd network ignition coreos-live
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-live/module-setup.sh
@@ -1,3 +1,9 @@
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     # We need the rdcore binary
     echo rdcore

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/module-setup.sh
@@ -2,6 +2,12 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     echo multipath
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
@@ -1,3 +1,9 @@
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 install_and_enable_unit() {
     unit="$1"; shift
     target="$1"; shift

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-network/module-setup.sh
@@ -4,6 +4,10 @@ check() {
     fi
 }
 
+depends() {
+    echo afterburn
+}
+
 install_and_enable_unit() {
     unit="$1"; shift
     target="$1"; shift

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-conf/module-setup.sh
@@ -2,6 +2,13 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     echo ignition
 }

--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/module-setup.sh
@@ -2,6 +2,12 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     echo ignition rdcore
 }

--- a/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
+++ b/overlay.d/15fcos/usr/lib/dracut/modules.d/50ignition-conf-fcos/module-setup.sh
@@ -2,6 +2,13 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+
+check() {
+    if [[ $IN_KDUMP == 1 ]]; then
+        return 1
+    fi
+}
+
 depends() {
     echo ignition
 }


### PR DESCRIPTION
Fixes: coreos/fedora-coreos-tracker#1832

Also needs 
https://github.com/coreos/afterburn/pull/1216
~~https://github.com/coreos/ignition/pull/2090~~

Kdump initrd size before patch 66M, after patch 39M