### PR TITLE
tests: limit the lockdown test to running on qemu

### DIFF
--- a/tests/kola/security/lockdown
+++ b/tests/kola/security/lockdown
@@ -1,5 +1,8 @@
 #!/bin/bash
 ## kola:
+##   # qemu is the only platform where setting a 'secure-boot' tag will cause
+##   # secureboot to get turned on for that instance.
+##   platforms: qemu
 ##   # Mark as exclusive since we are requesting secureboot and that won't take effect when we're
 ##   # running non-exclusively.
 ##   exclusive: true


### PR DESCRIPTION
qemu is the only platform where setting a 'secure-boot' tag will cause secureboot to get turned on for that instance run.