### PR TITLE
Containerfile: switch to quay.io/fedora/fedora-bootc

### DIFF
--- a/.github/workflows/container-native.yml
+++ b/.github/workflows/container-native.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build
         run: podman build --security-opt=label=disable --cap-add=all --device /dev/fuse . -t localhost/fedora-coreos
       - name: Sanity-check
-        run: podman run --rm -ti localhost/fedora-coreos echo hello
+        run: podman run --rm localhost/fedora-coreos echo hello

--- a/Containerfile
+++ b/Containerfile
@@ -8,13 +8,9 @@
 
 # This is the developer default version. In pipelines, this is driven by versionary.
 ARG VERSION="42"
-# XXX: This uses the Konflux-built version until it takes over from pungi and
-# shows up at the official quay.io/fedora/fedora-bootc endpoint since the latter
-# doesn't yet have bootc-base-imagectl.
-# https://gitlab.com/fedora/bootc/base-images/-/issues/44
-# XXX: Note also this should be a digested pull that gets bumped.
+# XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-ARG BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-42-standard:latest
+ARG BUILDER_IMG=quay.io/fedora/fedora-bootc:42
 ARG MANIFEST=manifest.yaml
 
 ### Containerfile.base

--- a/Containerfile.args
+++ b/Containerfile.args
@@ -2,12 +2,8 @@
 
 # This is the developer default version. In pipelines, this is driven by versionary.
 ARG VERSION="42"
-# XXX: This uses the Konflux-built version until it takes over from pungi and
-# shows up at the official quay.io/fedora/fedora-bootc endpoint since the latter
-# doesn't yet have bootc-base-imagectl.
-# https://gitlab.com/fedora/bootc/base-images/-/issues/44
-# XXX: Note also this should be a digested pull that gets bumped.
+# XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-ARG BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-42-standard:latest
+ARG BUILDER_IMG=quay.io/fedora/fedora-bootc:42
 ARG MANIFEST=manifest.yaml
 


### PR DESCRIPTION
Now that we have bootc-base-imgectl in the canonical fedora-bootc image, we can just use that instead. That image also has all the arches which would be a blocker to turning this on for rawhide.