### PR TITLE
manifests/fedora-coreos: advance OCI migration to `testing` stream

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -38,15 +38,9 @@ conditional-include:
       # All Fedora CoreOS streams share the same pool for locked files.
       lockfile-repos:
         - fedora-coreos-pool
-  - if: stream == "next"
-    include:
-      ostree-layers:
-        - overlay/35oci-migration
-  - if: stream == "next-devel"
-    include:
-      ostree-layers:
-        - overlay/35oci-migration
-  - if: stream == "rawhide"
+  # Roll out the OCI migration slowly
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1890#issuecomment-2881068761
+  - if: stream != "stable"
     include:
       ostree-layers:
         - overlay/35oci-migration


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1890#issuecomment-2881068761