### PR TITLE
overrides: fast-track rust-bootupd-0.2.28-2.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,11 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  bootupd:
+    evr: 0.2.28-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d35460c984
+      type: fast-track
   glibc:
     evr: 2.41-5.fc42
     metadata:


### PR DESCRIPTION
Requested by @HuijingHei via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).