### PR TITLE
overrides: fast-track moby-engine-28.3.0-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,6 +14,12 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d35460c984
       type: fast-track
+  docker-cli:
+    evr: 28.3.0-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-ae9b685d28
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1973
+      type: fast-track
   glibc:
     evr: 2.41-8.fc42
     metadata:
@@ -37,4 +43,16 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-88ce2d977b
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1974
+      type: fast-track
+  moby-engine:
+    evr: 28.3.0-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-ae9b685d28
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1973
+      type: fast-track
+  moby-filesystem:
+    evra: 28.3.0-1.fc42.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-ae9b685d28
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1973
       type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).