### PR TITLE
05core: Add weak dependency on coreo-multipath-wait.target for sysroot.mount

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-diskful-generator
@@ -89,6 +89,7 @@ if test -n "$(cmdline_arg ostree)" && test -z "$(cmdline_arg root)" && ! dracut_
 [Unit]
 Before=initrd-root-fs.target
 After=coreos-rootflags.service
+After=coreos-multipath-wait.target
 [Mount]
 EnvironmentFile=/run/coreos-rootflags
 What=/dev/disk/by-label/root

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-multipath/coreos-multipath-wait.target
@@ -1,9 +1,11 @@
 [Unit]
-Description=CoreOS Wait For Multipathed Boot
+Description=CoreOS Wait For Multipathed Boot & Root
 DefaultDependencies=false
 After=dracut-cmdline.service
 Requires=dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device
 After=dev-disk-by\x2dlabel-dm\x2dmpath\x2dboot.device
+Requires=dev-disk-by\x2dlabel-dm\x2dmpath\x2droot.device
+After=dev-disk-by\x2dlabel-dm\x2dmpath\x2droot.device
 Requires=multipathd.service
 After=multipathd.service
 


### PR DESCRIPTION

This fixes a race condition where the symlink `/dev/disk/by-label/root` was not updated in time by udev/multipathd for the device-mapper target `root`. As a result, the `sysroot.mount` unit occasionally failed to mount the root filesystem.

The issue was first observed on s390x builders under high system load, where `ext.config.multipath.resilient` would intermittently fail.