### PR TITLE
Remove iptables-legacy starting with Fedora 43

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -180,9 +180,6 @@ packages:
   - console-login-helper-messages-motdgen
   # i18n
   - kbd
-  # In F35+ need `iptables-legacy` package
-  # See https://github.com/coreos/fedora-coreos-tracker/issues/676#issuecomment-928028451
-  - iptables-legacy
   # NIC firmware we've traditionally shipped but then were split out of linux-firmware in Fedora
   - qed-firmware # https://github.com/coreos/fedora-coreos-tracker/issues/1746
   # Include udev rules for NVMe backed Azure Instances

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -46,8 +46,12 @@ conditional-include:
         - overlay/35oci-migration
   # Allow python in F43 for now until nfs package gets fixed.
   # https://github.com/coreos/fedora-coreos-tracker/issues/1942#issuecomment-2881075898
+  # iptables-legacy is not included from 43
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1818
   - if: releasever < 43
     include:
+      packages:
+        - iptables-legacy
       exclude-packages:
         - python
         - python3


### PR DESCRIPTION
iptables-legacy package is to be removed from 43.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1818

Merge after https://github.com/coreos/fedora-coreos-config/pull/3253