### PR TITLE
denylist: add ext.config.multipath.resilient denial for s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,9 @@
     - openstack
   streams:
     - rawhide
+- pattern: ext.config.multipath.resilient
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1980
+  snooze: 2025-07-10
+  warn: true
+  arches:
+    - s390x


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/1980