### PR TITLE
ci: add step in GHA `container-native.yml` to download overrides packages

### DIFF
--- a/.github/workflows/container-native.yml
+++ b/.github/workflows/container-native.yml
@@ -24,6 +24,25 @@ jobs:
           sudo apt install -y crun/testing podman/testing skopeo/testing
           # Something is confused in latest GHA here
           sudo rm /var/lib/containers -rf
+      - name: Download override packages and create yum repo
+        run: |
+          podman run --rm -v $PWD:/run/src -w /run/src quay.io/fedora/fedora:latest sh -c '
+            set -xeuo pipefail
+            dnf -y install koji createrepo_c python3-dnf python3-PyYAML && dnf clean all
+            overridesdir="rpmoverrides"
+
+            # prepare directory to download override packages
+            [ -d ${overridesdir} ] && rm -rf ${overridesdir}
+            mkdir -p "${overridesdir}"
+
+            curl -LO https://raw.githubusercontent.com/coreos/coreos-assembler/refs/heads/main/src/download-overrides.py
+            python3 download-overrides.py --downloaddir "./${overridesdir}" --lockfiledir "./"
+
+            # create local yum repo
+            if [[ -n $(ls "${overridesdir}/"*.rpm 2> /dev/null) ]]; then
+                cd "${overridesdir}" && createrepo_c .
+            fi
+          '
       - name: Build
         # Note: we should be able to drop the `-v $PWD:/run/src` once
         # https://github.com/containers/buildah/issues/5952 is fixed.

--- a/build-rootfs
+++ b/build-rootfs
@@ -33,6 +33,7 @@ def main():
     locked_nevras = get_locked_nevras()
     if locked_nevras:
         inject_pool_repo_if_exists(locked_nevras)
+        create_and_inject_local_rpm_overrides_repo_if_needed(locked_nevras)
 
     packages.extend(locked_nevras)
     overlays = gather_overlays(manifest)
@@ -47,6 +48,24 @@ def main():
     if version != "":
         inject_version_info(target_rootfs, manifest['mutate-os-release'], version)
     inject_postprocess_scripts(target_rootfs, manifest)
+
+
+def create_and_inject_local_rpm_overrides_repo_if_needed(locked_nevras):
+    rpmoverrides_dir = os.path.join(CONTEXTDIR, 'rpmoverrides')
+    if not os.path.exists(rpmoverrides_dir):
+         return
+
+    # create local-overrides.repo
+    packages = ','.join(locked_nevras)
+    with open("/etc/yum.repos.d/local-overrides.repo", 'w') as f:
+        f.write(f"""
+[local-overrides]
+name=local-overrides
+baseurl=file://{rpmoverrides_dir}/
+gpgcheck=0
+cost=500
+includepkgs={packages}
+""")
 
 
 def get_treefile(manifest_path):


### PR DESCRIPTION
The new step will download override packages and create local repo, which will be injected in the repo by next step.
Fixes https://github.com/coreos/fedora-coreos-config/issues/3568