### PR TITLE
build-rootfs: temporarily inject our passwd/group files

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,8 @@ FROM ${BUILDER_IMG} as builder
 
 ARG VERSION=overridden
 ARG MANIFEST=overridden
+# XXX: see inject_passwd_group() in build-rootfs
+ARG PASSWD_GROUP_DIR
 
 # useful if you're hacking on rpm-ostree/bootc-base-imagectl
 # COPY rpm-ostree /usr/bin/

--- a/Containerfile
+++ b/Containerfile
@@ -6,15 +6,13 @@
 # Note: we should be able to drop the `-v $PWD:/run/src` once
 # https://github.com/containers/buildah/issues/5952 is fixed.
 
-# Overridden by argfile.conf. The values here are invalid on purpose.
-ARG VERSION=overridden
+# Overridden by argfile.conf. The value here in invalid on purpose.
 ARG BUILDER_IMG=overridden
-ARG MANIFEST=overridden
 
 FROM ${BUILDER_IMG} as builder
 
-ARG VERSION
-ARG MANIFEST
+ARG VERSION=overridden
+ARG MANIFEST=overridden
 
 # useful if you're hacking on rpm-ostree/bootc-base-imagectl
 # COPY rpm-ostree /usr/bin/

--- a/build-args.conf
+++ b/build-args.conf
@@ -7,3 +7,5 @@ VERSION="42"
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
 BUILDER_IMG=quay.io/fedora/fedora-bootc:42
 MANIFEST=manifest.yaml
+# XXX: see inject_passwd_group() in build-rootfs
+PASSWD_GROUP_DIR=manifests

--- a/build-rootfs
+++ b/build-rootfs
@@ -67,6 +67,9 @@ def get_treefile(manifest_path):
 
 
 def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
+    passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
+    if passwd_group_dir is not None:
+        inject_passwd_group(os.path.join(CONTEXTDIR, passwd_group_dir))
     with tempfile.NamedTemporaryFile(mode='w') as argsfile:
         for pkg in packages:
             argsfile.write(f"--install={pkg}\n")
@@ -80,6 +83,21 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
                                "--args-file", argsfile.name, "build-rootfs",
                                "--manifest", 'minimal-plus',
                                target_rootfs] + cache_arg)
+
+
+# We want to keep our passwd/group as canonical for now. We should be
+# able to clean this up when we migrate them to sysusers instead. See:
+# https://github.com/coreos/rpm-ostree/pull/5427
+def inject_passwd_group(parent_dir):
+    minimal = '/usr/share/doc/bootc-base-imagectl/manifests/minimal'
+    dst_passwd = os.path.join(minimal, 'passwd')
+    dst_group = os.path.join(minimal, 'group')
+    # unlink first instead of overwriting as a way to confirm they're still there
+    os.unlink(dst_passwd)
+    os.unlink(dst_group)
+    print("Overriding passwd/group files", flush=True)
+    shutil.copy(os.path.join(parent_dir, 'passwd'), dst_passwd)
+    shutil.copy(os.path.join(parent_dir, 'group'), dst_group)
 
 
 def inject_postprocess_scripts(rootfs, manifest):


### PR DESCRIPTION
We want to keep our passwd/group files as canonical for now to eliminate
any changes in our currently fixed UIDs/GIDs as part of the rebase to
the bootc base images.

Obviously not ideal. The medium-term fix for this is to convert our
passwd and group files to sysusers entries instead, and then force
bootc-base-imagectl to treat sysusers as canonical.

See also: https://github.com/coreos/rpm-ostree/pull/5427