### PR TITLE
Revert "manifests/shared-el: apply dracut fix in postcript"

### DIFF
--- a/manifests/shared-el.yaml
+++ b/manifests/shared-el.yaml
@@ -13,16 +13,3 @@ conditional-include:
     include: shared-el10.yaml
   - if: osversion == "centos-10"
     include: shared-el10.yaml
-
-# ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
-# See also the version of this in fedora-coreos.yaml
-postprocess:
-  # We apply part of the patch https://github.com/dracut-ng/dracut-ng/pull/1306 here
-  # while awaiting for the new dracut release to land.
-  # This script will start to fail once dracut 107 release available in repo, signaling
-  # to remove this postscript.
-  # https://github.com/coreos/fedora-coreos-tracker/issues/1937
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    sed -i '/^ExecStart=\/usr\/sbin\/mpathconf --enable$/,${s//ExecStart=\/usr\/sbin\/mpathconf --enable --user_friendly_names n/;b};$q1' /usr/lib/dracut/modules.d/90multipath/multipathd-configure.service


### PR DESCRIPTION
This reverts commit 6c746ba8ab36da3d0e833b0dad4eaaa10bc6d3be.

dracut-107-1.fc42 containing the fix is landing in F42 [1], we can then remove the postprocess here.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f93702f0