### PR TITLE
build-rootfs: add workaround for RHEL-97826

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,7 @@
 # Note: we should be able to drop the `-v $PWD:/run/src` once
 # https://github.com/containers/buildah/issues/5952 is fixed.
 
-# Overridden by argfile.conf. The value here in invalid on purpose.
+# Overridden by build-args.conf. The value here is invalid on purpose.
 ARG BUILDER_IMG=overridden
 
 FROM ${BUILDER_IMG} as builder

--- a/build-rootfs
+++ b/build-rootfs
@@ -96,12 +96,32 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
             argsfile.write(f"--add-dir={overlay}\n")
         if nodocs:
             argsfile.write("--no-docs\n")
+            # temporarily work around https://issues.redhat.com/browse/RHEL-97826
+            tmpd = workaround_rhel_97826(argsfile)
         argsfile.flush()
         cache_arg = ['--cachedir=/cache'] if os.path.isdir('/cache') else []
         subprocess.check_call(["/usr/libexec/bootc-base-imagectl",
                                "--args-file", argsfile.name, "build-rootfs",
                                "--manifest", 'minimal-plus',
                                target_rootfs] + cache_arg)
+    if nodocs and tmpd is not None:
+        del tmpd
+
+
+def workaround_rhel_97826(argsfile):
+    basedir = 'usr/share/doc/bootc/baseimage/base'
+    # Detect if we have https://github.com/bootc-dev/bootc/pull/1352.
+    # This is not strictly correct because we're checking the _builder
+    # image_ which could be different from the target. In practice, we don't
+    # "cross-compose" and we're always going to be fetching equal or newer
+    # NEVRAs from the repos so this is fine.
+    if os.path.exists(f'/{basedir}/sysroot/.keepdir'):
+        return
+    print("Working around RHEL-97826", flush=True)
+    tmpd = tempfile.TemporaryDirectory()
+    shutil.copytree(f'/{basedir}', os.path.join(tmpd.name, basedir), symlinks=True)
+    argsfile.write(f'--add-dir={tmpd.name}')
+    return tmpd
 
 
 # We want to keep our passwd/group as canonical for now. We should be


### PR DESCRIPTION
bootc owns files in `/usr/share/doc` which are correctly marked as documentation, but because of a bug in rpm-ostree, the subdirectories are still installed even with `documentation: false`. This throws off `bootc container lint`.

This is fixed in newer bootc, but not RHEL 9.6.

Work around this there by checking if documentation is turned off whether the issue is fixed, and if not, just "pass through" the docs into the installed target via another overlay. This then will only activate when building RHCOS 9.6. (Also c9s currently until bootc is rebased there.)