### PR TITLE
overrides: fast-track ignition-2.22.0-2.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -38,12 +38,12 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1937
       type: fast-track
   ignition:
-    evr: 2.22.0-1.fc42
+    evr: 2.22.0-2.fc42
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-701017a410
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4b417b05f4
       type: fast-track
   ignition-grub:
-    evr: 2.22.0-1.fc42
+    evr: 2.22.0-2.fc42
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-701017a410
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4b417b05f4
       type: fast-track


### PR DESCRIPTION
Requested by @tlbueno via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).