### PR TITLE
Use sysusers only at compose-time for container-native path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_IMG} as builder
 ARG VERSION=overridden
 ARG MANIFEST=overridden
 # XXX: see inject_passwd_group() in build-rootfs
-ARG PASSWD_GROUP_DIR
+ARG PASSWD_GROUP_DIR=none
 ARG STRICT_MODE=0
 
 COPY . /src

--- a/build-rootfs
+++ b/build-rootfs
@@ -112,8 +112,8 @@ def inject_yumrepos():
 
 
 def build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays, repos, nodocs):
-    passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
-    if passwd_group_dir is not None:
+    passwd_group_dir = os.getenv('PASSWD_GROUP_DIR', 'none')
+    if passwd_group_dir != 'none':
         inject_passwd_group(os.path.join(SRCDIR, passwd_group_dir))
     with tempfile.NamedTemporaryFile(mode='w') as argsfile:
         for pkg in packages:
@@ -130,6 +130,9 @@ def build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays
         if locked_nevras and lock_arg_supported():
             for locked_nevra in locked_nevras:
                 argsfile.write(f"--lock={locked_nevra}\n")
+        if passwd_group_dir == 'none':
+            argsfile.write("--sysusers\n")
+            argsfile.write("--nobody-99\n")
         argsfile.flush()
         cache_arg = []
         if os.path.isdir('/cache') and rpm_ostree_has_cachedir_fix():

--- a/manifests/group
+++ b/manifests/group
@@ -1,3 +1,6 @@
+# Note this file is used by the non-container native path only. We can remove it
+# once we've fully switched over.
+
 root:x:0:
 bin:x:1:
 daemon:x:2:

--- a/manifests/passwd
+++ b/manifests/passwd
@@ -1,3 +1,6 @@
+# Note this file is used by the non-container native path only. We can remove it
+# once we've fully switched over.
+
 adm:x:3:4:adm:/var/adm:/usr/sbin/nologin
 avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/usr/sbin/nologin
 bin:x:1:1:bin:/bin:/usr/sbin/nologin

--- a/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
+++ b/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
@@ -1,32 +1,32 @@
 # These are pinned users/groups whose static IDs are only used
-# this way on CoreOS nodes.
+# this way on CoreOS nodes. Sort sections using `sort --key 3 -g`.
 
-g cgred 996
-g chrony 992
-g cockpit-ws 987
-g dockerroot 986
-g etcd 997
+g sudo 16
 g input 104
+g dockerroot 986
+g cockpit-ws 987
+g systemd-bus-proxy 988
+g systemd-resolve 989
+g systemd-network 990
+g systemd-timesync 991
+g chrony 992
+g sssd 993
 g kube 994
-g nfsnobody 65534
+g cgred 996
+g etcd 997
 g polkitd 998
 g ssh_keys 999
-g sssd 993
-g sudo 16
-g systemd-bus-proxy 988
-g systemd-network 990
-g systemd-resolve 989
-g systemd-timesync 991
+g nfsnobody 65534
 
-u chrony            994:992     -                              /var/lib/chrony -
 u cockpit-ws        988:987     "User for cockpit-ws"          -               -
+u systemd-bus-proxy 989:988     "systemd Bus Proxy"            -               -
+u systemd-resolve   990:989     "systemd Resolver"             -               -
+u systemd-network   991:990     "systemd Network Management"   -               -
+u systemd-timesync  993:991     "systemd Time Synchronization" -               -
+u chrony            994:992     -                              /var/lib/chrony -
+u sssd              995:993     "User for sssd"                -               -
+u kube              996:994     "Kubernetes user"              -               -
 u dockerroot        997:986     "Docker User"                  /var/lib/docker -
 u etcd              998:997     "etcd user"                    /var/lib/etcd   -
-u kube              996:994     "Kubernetes user"              -               -
-u nfsnobody         65534:65534 "Anonymous NFS User"           /var/lib/nfs    -
 u polkitd           999:998     "User for polkitd"             -               -
-u sssd              995:993     "User for sssd"                -               -
-u systemd-bus-proxy 989:988     "systemd Bus Proxy"            -               -
-u systemd-network   991:990     "systemd Network Management"   -               -
-u systemd-resolve   990:989     "systemd Resolver"             -               -
-u systemd-timesync  993:991     "systemd Time Synchronization" -               -
+u nfsnobody         65534:65534 "Anonymous NFS User"           /var/lib/nfs    -

--- a/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
+++ b/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
@@ -3,6 +3,13 @@
 
 g sudo 16
 g input 104
+g systemd-oom 979
+g systemd-coredump 980
+g dnsmasq 981
+g clevis 982
+g zincati 983
+g printadmin 984
+g docker 985
 g dockerroot 986
 g cockpit-ws 987
 g systemd-bus-proxy 988
@@ -18,6 +25,11 @@ g polkitd 998
 g ssh_keys 999
 g nfsnobody 65534
 
+u systemd-oom       979:979     "systemd Userspace OOM Killer"                  -                 -
+u systemd-coredump  980:980     "systemd Core Dumper"                           -                 -
+u dnsmasq           981:981     "Dnsmasq DHCP and DNS server"                   var/lib/dnsmasq   -
+u clevis            982:982     "Clevis Decryption Framework unprivileged user" /var/cache/clevis -
+u zincati           983:983     "Zincati user for auto-updates"                 -                 -
 u cockpit-ws        988:987     "User for cockpit-ws"                           -                 -
 u systemd-bus-proxy 989:988     "systemd Bus Proxy"                             -                 -
 u systemd-resolve   990:989     "systemd Resolver"                              -                 -

--- a/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
+++ b/overlay.d/15fcos/usr/lib/sysusers.d/00-coreos-static.conf
@@ -18,15 +18,15 @@ g polkitd 998
 g ssh_keys 999
 g nfsnobody 65534
 
-u cockpit-ws        988:987     "User for cockpit-ws"          -               -
-u systemd-bus-proxy 989:988     "systemd Bus Proxy"            -               -
-u systemd-resolve   990:989     "systemd Resolver"             -               -
-u systemd-network   991:990     "systemd Network Management"   -               -
-u systemd-timesync  993:991     "systemd Time Synchronization" -               -
-u chrony            994:992     -                              /var/lib/chrony -
-u sssd              995:993     "User for sssd"                -               -
-u kube              996:994     "Kubernetes user"              -               -
-u dockerroot        997:986     "Docker User"                  /var/lib/docker -
-u etcd              998:997     "etcd user"                    /var/lib/etcd   -
-u polkitd           999:998     "User for polkitd"             -               -
-u nfsnobody         65534:65534 "Anonymous NFS User"           /var/lib/nfs    -
+u cockpit-ws        988:987     "User for cockpit-ws"                           -                 -
+u systemd-bus-proxy 989:988     "systemd Bus Proxy"                             -                 -
+u systemd-resolve   990:989     "systemd Resolver"                              -                 -
+u systemd-network   991:990     "systemd Network Management"                    -                 -
+u systemd-timesync  993:991     "systemd Time Synchronization"                  -                 -
+u chrony            994:992     -                                               /var/lib/chrony   -
+u sssd              995:993     "User for sssd"                                 -                 -
+u kube              996:994     "Kubernetes user"                               -                 -
+u dockerroot        997:986     "Docker User"                                   /var/lib/docker   -
+u etcd              998:997     "etcd user"                                     /var/lib/etcd     -
+u polkitd           999:998     "User for polkitd"                              -                 -
+u nfsnobody         65534:65534 "Anonymous NFS User"                            /var/lib/nfs      -


### PR DESCRIPTION
fedora-bootc today defines its own passwd/group files which were originally based on the Fedora CoreOS ones (which in turn came from Fedora Atomic).

The main problem with that is that we have our own passwd/group files which we want to be able to use. There is no interface for passing this to bootc-base-imagectl and it would be awkward to add one. Hence the `PASSWD_GROUP_DIR` hack.

More recently, `bootc-base-imagectl` learned a new `--sysusers` option in which we can opt-out of the centralized passwd/group file and have full control over UID allocation via sysusers dropins. Use it. Also use the hidden `--nobody-99` option for backwards compatibility.

All the entries in our passwd/group files are already present in our sysusers dropins, so this is in fact functionally equivalent. Notably this does not change anything about nss-altfiles. The entries in `/usr/lib/{passwd,group}` remain the exact same.

This allows us to stop using the `PASSWD_GROUP_DIR` hack for FCOS at least. For RHCOS, we'll have to keep it for RHEL 9.6. But because buildah prints a warning if a build arg is undefined, set the default value to "none".

Note this does not affect the legacy cosa build path. The in-tree passwd/group files are still used there.

For more information, see:
- https://github.com/coreos/rpm-ostree/pull/5427
- https://gitlab.com/fedora/bootc/base-images/-/merge_requests/242
- https://gitlab.com/fedora/bootc/base-images/-/merge_requests/243

