### PR TITLE
build-args.conf: use `42.dev` as default version string

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -2,7 +2,7 @@
 # Pass to buildah/podman using `--build-arg-file`.
 
 # This is the developer default version. In pipelines, this is driven by versionary.
-VERSION=42
+VERSION=42.dev
 # XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
 BUILDER_IMG=quay.io/fedora/fedora-bootc:42


### PR DESCRIPTION
Let's add `.dev` in the default version string for the same reason we have it in the cosa build path; it clearly indicates when a build is from a local development flow.

But also, there is a postprocess script which keys off of `.dev` being present to turn off Zincati for development builds. We want that logic to kick in for the container-native path too.

And finally, this also works around a subtle interaction with `cosa import`. OSTree allows refs that are just numbers, but this confuses e.g. `ostree rev-parse` because it also tries to interpret it as a short commit form and so the result can be ambiguous.