### PR TITLE
[rawhide] build-args.conf: update for rawhide

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -2,10 +2,10 @@
 # Pass to buildah/podman using `--build-arg-file`.
 
 # This is the developer default version. In pipelines, this is driven by versionary.
-VERSION=42
+VERSION=43.dev
 # XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:42
+BUILDER_IMG=quay.io/fedora/fedora-bootc:43
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests


### PR DESCRIPTION
This file is no longer synced from testing-devel, so we can now update it to its appropriate values for rawhide.