### PR TITLE
build-rootfs: inject our repo definitions into build stage

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -101,7 +101,9 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs
             for repo in repos:
                 argsfile.write(f"--repo={repo}\n")
         argsfile.flush()
-        cache_arg = ['--cachedir=/cache'] if os.path.isdir('/cache') else []
+        cache_arg = []
+        if os.path.isdir('/cache') and rpm_ostree_has_cachedir_fix():
+            cache_arg = ['--cachedir=/cache']
         subprocess.check_call(["/usr/libexec/bootc-base-imagectl",
                                "--args-file", argsfile.name, "build-rootfs",
                                "--manifest", 'minimal-plus',
@@ -133,6 +135,18 @@ def workaround_rhel_97826(argsfile):
     shutil.copytree(f'/{basedir}', os.path.join(tmpd.name, basedir), symlinks=True)
     argsfile.write(f'--add-dir={tmpd.name}\n')
     return tmpd
+
+
+def rpm_ostree_has_cachedir_fix():
+    # we can only use --cachedir if we have rpm-ostree >= 2025.9 which has
+    # https://github.com/coreos/rpm-ostree/pull/5391
+    out = subprocess.check_output(['rpm-ostree', '--version'], encoding='utf-8')
+    data = yaml.safe_load(out)
+    version_str = data['rpm-ostree']['Version']
+    # ideally, we could use `packaging.version`, but that's not in centos-bootc
+    # but conveniently, Python list comparisons do the right thing here
+    version = [int(c) for c in version_str.split('.')]
+    return version >= [2025, 9]
 
 
 # We want to keep our passwd/group as canonical for now. We should be

--- a/build-rootfs
+++ b/build-rootfs
@@ -131,7 +131,7 @@ def workaround_rhel_97826(argsfile):
     print("Working around RHEL-97826", flush=True)
     tmpd = tempfile.TemporaryDirectory()
     shutil.copytree(f'/{basedir}', os.path.join(tmpd.name, basedir), symlinks=True)
-    argsfile.write(f'--add-dir={tmpd.name}')
+    argsfile.write(f'--add-dir={tmpd.name}\n')
     return tmpd
 
 

--- a/build-rootfs
+++ b/build-rootfs
@@ -7,6 +7,7 @@
 # 4. It injects various metadata (e.g. image.json, live/ bits, and platforms.json).
 # 5. It runs the postprocess scripts defined in the manifest.
 
+import glob
 import json
 import os
 import shutil
@@ -30,14 +31,18 @@ def main():
 
     packages = list(manifest['packages'])
 
+    repos = manifest.get('repos', []) + manifest.get('lockfile-repos', [])
+    if repos:
+        inject_yumrepos()
+
     locked_nevras = get_locked_nevras()
     if locked_nevras:
-        inject_pool_repo_if_exists(locked_nevras)
+        modify_pool_repo_if_exists(locked_nevras)
 
     packages.extend(locked_nevras)
     overlays = gather_overlays(manifest)
     nodocs = (manifest.get('documentation') is False)
-    build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs)
+    build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs)
 
     inject_live(target_rootfs)
     inject_image_json(target_rootfs, manifest_path)
@@ -66,7 +71,20 @@ def get_treefile(manifest_path):
     return json.loads(data)
 
 
-def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
+def inject_yumrepos():
+    # first delete all the default repos
+    for repo in glob.glob('/etc/yum.repos.d/*.repo'):
+        if os.path.basename(repo) == 'secret.repo':
+            # this is a supported podman secret to inject repo files; see Containerfile
+            continue
+        os.unlink(repo)
+
+    # and now inject our repos
+    for repo in glob.glob(f'{CONTEXTDIR}/*.repo'):
+        shutil.copy(repo, "/etc/yum.repos.d")
+
+
+def build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs):
     passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
     if passwd_group_dir is not None:
         inject_passwd_group(os.path.join(CONTEXTDIR, passwd_group_dir))
@@ -79,6 +97,9 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
             argsfile.write("--no-docs\n")
             # temporarily work around https://issues.redhat.com/browse/RHEL-97826
             tmpd = workaround_rhel_97826(argsfile)
+        if repos and repo_arg_supported():
+            for repo in repos:
+                argsfile.write(f"--repo={repo}\n")
         argsfile.flush()
         cache_arg = ['--cachedir=/cache'] if os.path.isdir('/cache') else []
         subprocess.check_call(["/usr/libexec/bootc-base-imagectl",
@@ -87,6 +108,15 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
                                target_rootfs] + cache_arg)
     if nodocs and tmpd is not None:
         del tmpd
+
+
+def repo_arg_supported():
+    # Detect if we have https://gitlab.com/fedora/bootc/base-images/-/merge_requests/248.
+    # If not, then we can't use `--repo`. That's OK because that should only
+    # happen on RHEL, where we don't have any default repos anyway and only rely on
+    # the mounted secret repo file.
+    help = subprocess.check_output(['/usr/libexec/bootc-base-imagectl', 'build-rootfs', '-h'], encoding='utf-8')
+    return '--repo REPO' in help
 
 
 def workaround_rhel_97826(argsfile):
@@ -164,17 +194,13 @@ def get_locked_nevras():
     return [f'{k}-{v}' for (k, v) in locks.items()]
 
 
-def inject_pool_repo_if_exists(locked_nevras):
-    srcrepo = os.path.join(CONTEXTDIR, "fedora-coreos-pool.repo")
-    if not os.path.exists(srcrepo):
-        return
-
+def modify_pool_repo_if_exists(locked_nevras):
     # When adding the pool, we only want to _filter in_ locked packages;
     # matching `lockfile-repos` semantics. This is abusing pretty hard the
     # `includepkgs=` semantic but... it works.
-    shutil.copyfile(srcrepo, "/etc/yum.repos.d/pool.repo")
+    repo = os.path.join('/etc/yum.repos.d/fedora-coreos-pool.repo')
     packages = ','.join(locked_nevras)
-    with open("/etc/yum.repos.d/pool.repo", 'a') as f:
+    with open(repo, 'a') as f:
         f.write(f"\nincludepkgs={packages}\n")
 
 

--- a/fedora-archive.repo
+++ b/fedora-archive.repo
@@ -20,7 +20,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-archive-updates]
@@ -35,5 +35,5 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/fedora-candidate-compose.repo
+++ b/fedora-candidate-compose.repo
@@ -17,5 +17,5 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/fedora-next.repo
+++ b/fedora-next.repo
@@ -11,7 +11,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-next-updates]
@@ -24,7 +24,7 @@ repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-next-updates-testing]
@@ -35,5 +35,5 @@ baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releaseve
 enabled=1
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/fedora.repo
+++ b/fedora.repo
@@ -11,7 +11,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates]
@@ -24,7 +24,7 @@ repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates-testing]
@@ -35,5 +35,5 @@ baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releaseve
 enabled=1
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False


### PR DESCRIPTION
So far, we've been using the default repos in the bootc base image. But e.g. those repo files use mirrors and so are subject to lag/inconsistencies across runs.

In the end, we want our repo files to be canonical.

Do this by nuking any default repo file and injecting our own. Also use the new `bootc-base-imagectl build-rootfs --repo` switch to control enablement.