### PR TITLE
overlay.d/20platform-chrony: add support for Oracle Cloud

### DIFF
--- a/overlay.d/20platform-chrony/usr/lib/systemd/system/coreos-platform-chrony-config.service
+++ b/overlay.d/20platform-chrony/usr/lib/systemd/system/coreos-platform-chrony-config.service
@@ -8,6 +8,7 @@ ConditionKernelCommandLine=|ignition.platform.id=ec2
 # RHCOS 4.1/4.2 bootimages
 ConditionKernelCommandLine=|ignition.platform.id=gce
 ConditionKernelCommandLine=|ignition.platform.id=gcp
+ConditionKernelCommandLine=|ignition.platform.id=oraclecloud
 ConditionKernelCommandLine=|ignition.platform.id=qemu
 Before=NetworkManager.service
 Before=chronyd.service

--- a/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
+++ b/overlay.d/20platform-chrony/usr/libexec/coreos-platform-chrony-config
@@ -8,6 +8,7 @@ set -euo pipefail
 # AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html
 # Azure: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
 # GCP: https://cloud.google.com/compute/docs/instances/managing-instances#configure-ntp
+# Oracle Cloud Infrastructure: https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringntpservice.htm
 #
 # Originally spawned from discussion in https://github.com/openshift/installer/pull/3513
 
@@ -91,6 +92,10 @@ case "${platform}" in
         (echo '# See also https://cloud.google.com/compute/docs/instances/managing-instances#configure-ntp'
          echo '# and https://cloud.google.com/compute/docs/images/configuring-imported-images'
          echo 'server metadata.google.internal prefer iburst'
+        ) >> "${confpath}" ;;
+    oraclecloud)
+        (echo '# See also https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringntpservice.htm'
+         echo 'server 169.254.169.254 prefer iburst'
         ) >> "${confpath}" ;;
     qemu)
         sed -i s,'^#pool,pool,' "${confpath}"

--- a/tests/kola/ntp/chrony/coreos-platform-chrony-config
+++ b/tests/kola/ntp/chrony/coreos-platform-chrony-config
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
 ##   exclusive: false
-##   platforms: "aws azure gcp qemu"
+##   platforms: "aws azure gcp qemu oraclecloud"
 ##   description: Verify the coreos-platform-chrony generator works on cloud.
 
 set -xeuo pipefail
@@ -14,6 +14,7 @@ case "${platform}" in
     aws) chronyc -n sources |grep '169.254.169.123'; echo "ok chrony aws" ;;
     azure) chronyc -n sources |grep 'PHC'; echo "ok chrony azure" ;;
     gcp) chronyc -n sources | grep '169.254.169.254'; echo "ok chrony gcp" ;;
+    oraclecloud) chronyc -n sources | grep '169.254.169.254'; echo "ok chrony oraclecloud" ;;
     qemu)
         # ptp_kvm isn't available on all arches nor all hosts, so don't assume it's always there; see
         # https://github.com/coreos/fedora-coreos-config/pull/2263#discussion_r1157694192


### PR DESCRIPTION
Similar to AWS/GCP, OCI runs an NTP implementation at metadata IP.

Ref: https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringntpservice.htm