### PR TITLE
denylist: rawhide: remove `skip-console-warnings` for openstack

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
-- pattern: skip-console-warnings
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1924
-  platforms:
-    - openstack
-  streams:
-    - rawhide
 - pattern: ext.config.multipath.resilient
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1980
   snooze: 2025-07-10


### PR DESCRIPTION
It's difficult to reproduce this locally, and the current openstack builds don't show any console warnings. Let's remove this entry because the issue is most likely resolved.