### PR TITLE
OCPBUGS-56597: Work around missing multipath WWIDs population in dracut

### DIFF
--- a/overlay.d/05custom-multipath-fix/dracut/90custom-multipath-fix/module-setup.sh
+++ b/overlay.d/05custom-multipath-fix/dracut/90custom-multipath-fix/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+check() {
+    require_binaries multipath || return 1
+}
+
+depends() {
+    echo dm
+    return 0
+}
+
+install() {
+    inst_multiple multipath
+    inst_hook pre-mount 90 "$moddir/run-multipath.sh"
+}

--- a/overlay.d/05custom-multipath-fix/dracut/90custom-multipath-fix/run-multipath.sh
+++ b/overlay.d/05custom-multipath-fix/dracut/90custom-multipath-fix/run-multipath.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/sbin/multipath -A

--- a/overlay.d/05custom-multipath-fix/systemd/system/multipathd.service.d/10-multipath-fix.conf
+++ b/overlay.d/05custom-multipath-fix/systemd/system/multipathd.service.d/10-multipath-fix.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStartPre=
+ExecStartPre=-/sbin/modprobe dm-multipath
+ExecStartPre=-/sbin/multipath -A

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -10,6 +10,13 @@ This overlay matches `fedora-coreos-base.yaml`; core Ignition+ostree bits.
 
 This overlay is shared with RHCOS/SCOS 9.
 
+05custom-multipath-fix
+------
+
+Systemd override to apply the fix for multipathd.service
+It should be removed once we have a fix for multipath.
+For now info see: https://issues.redhat.com/browse/RHEL-96106
+
 07fix-selinux-labels
 --------------------
 


### PR DESCRIPTION
- This commit adds a temporary workaround for a bug where dracut fails to populate
/etc/multipath/wwids from the kernel command line, which breaks:

ExecStartPre=-/sbin/multipath -A

This issue affects both FCOS and RHCOS and is
tracked in RHEL-96106.

- It adds a Systemd override to apply the fix for multipathd.service