### PR TITLE
tests/kola/containers/quadlet: make volume test less specific

### DIFF
--- a/tests/kola/containers/quadlet/test.sh
+++ b/tests/kola/containers/quadlet/test.sh
@@ -38,7 +38,7 @@ fi
 if [[ "$(jq -r '.[0].NetworkSettings.Networks | keys[0]' <<< "$container_info")" != "systemd-test" ]]; then
     fatal "Container not using the correct network"
 fi
-if [[ "$(jq -r '.[0].HostConfig.Binds[0]' <<< "$container_info")" != "systemd-test:/data:rw,rprivate,nosuid,nodev,rbind" ]]; then
+if [[ ! "$(jq -r '.[0].HostConfig.Binds[0]' <<< "$container_info")" =~ systemd-test:/data: ]]; then
     fatal "Container not using the correct volume"
 fi
 


### PR DESCRIPTION
The defaults upstream changed for what is displayed from podman inspect so the test is currently failing:

```
[[ systemd-test:/data:rprivate,nosuid,nodev,rbind != systemd\-test\:/data\:rw,rprivate,nosuid,nodev,rbind ]]
```

The added `rw` is now causing issues. Let's adjust our test here to be less strict since we just accept the defaults anyway.