### PR TITLE
tests/coreos-update-ca-trust: change location to check existance

### DIFF
--- a/tests/kola/security/coreos-update-ca-trust/test.sh
+++ b/tests/kola/security/coreos-update-ca-trust/test.sh
@@ -12,7 +12,7 @@ set -xeuo pipefail
 if ! systemctl show coreos-update-ca-trust.service -p ActiveState | grep ActiveState=active; then
     fatal "coreos-update-ca-trust.service not active"
 fi
-if ! grep '^# coreos.com$' /etc/pki/tls/certs/ca-bundle.crt; then
-    fatal "expected coreos.com in ca-bundle"
+if ! grep '^# coreos.com$' /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; then
+    fatal "expected coreos.com certificate not found in tls-ca-bundle.pem"
 fi
 ok "coreos-update-ca-trust.service"


### PR DESCRIPTION
With the latest changes on rawhide fedora no longer has the file located in /etc/pki/tls/certs/ca-bundle.crt.  Instead check the extracted location /etc/pki/ca-trust/extracted/pem to verify existence.

https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile
42 and rawhide pass testing.