### PR TITLE
image-base,image-default: drop references to deploy-via-container

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -34,9 +34,7 @@ platform-compressor:
     # https://docs.digitalocean.com/products/custom-images/how-to/upload/
     digitalocean: gzip
 
-# Move to use OCI images by default
-# https://github.com/coreos/fedora-coreos-tracker/issues/1823
-deploy-via-container: true
+# Set container-imgref
 container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{stream}"
 
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts

--- a/image-default.yaml
+++ b/image-default.yaml
@@ -16,8 +16,6 @@ extra-kargs: []
 ostree-format: oci-chunked-v1
 # Inject io.openshift.build.version-display-names for OpenShift CVO
 ostree-container-inject-openshift-cvo-labels: false
-# True if we should use `ostree container image deploy`
-deploy-via-container: false
 
 # Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
 # container-imgref: ""


### PR DESCRIPTION
This is no longer used. See also [1] [2].

[1] https://github.com/coreos/coreos-assembler/commit/43b99d51a7bf201575699e603ed9214d43b9f4a0
[2] https://github.com/coreos/coreos-assembler/commit/a876a9b592c375d64c33277f23c8d4a3efa412ac