### PR TITLE
Containerfile: add caching for local podman build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,10 +20,8 @@ ARG PASSWD_GROUP_DIR
 # COPY rpm-ostree /usr/bin/
 # COPY bootc-base-imagectl /usr/libexec/
 
-# Note: once we can rely on https://github.com/coreos/rpm-ostree/pull/5391,
-# add this bit to the RUN command to make the developer path less painful.
-# --mount=type=cache,rw,id=coreos-build-cache,target=/cache
-RUN --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
+RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
+    --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
     --mount=type=bind,target=/run/src \
         /run/src/build-rootfs "${MANIFEST}" "${VERSION}" /target-rootfs


### PR DESCRIPTION
Now that rpm-ostree-2025.9-1.fc42 is out we can leverage the work done upstream [1] to make cacheing in the container build workflow more practical. Let's enable it by default!

This leverages the code in build-rootfs that auto adds --cachedir to the bootc-base-imagectl call.

[1] https://github.com/coreos/rpm-ostree/pull/5391