### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,24 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  dracut:
-    evr: 107-1.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f93702f0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1937
-      type: fast-track
-  dracut-network:
-    evr: 107-1.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f93702f0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1937
-      type: fast-track
-  dracut-squash:
-    evr: 107-1.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-22f93702f0
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1937
-      type: fast-track
   ignition:
     evr: 2.22.0-3.fc42
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).