### PR TITLE
tests/kola: ignore NIC ordering issues on s390x for team-dhcp-via-ignition

### DIFF
--- a/tests/kola/networking/team-dhcp-via-ignition/test.sh
+++ b/tests/kola/networking/team-dhcp-via-ignition/test.sh
@@ -18,14 +18,31 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-main() {
-    team="team0"
+check_ip() {
+    team="$1"
 
     # Verify team0 gets dhcp according to config.bu
     nic_ip=$(get_ipv4_for_nic ${team})
     if [ "${nic_ip}" != "10.0.2.31" ]; then
-        fatal "Error: get ${team} ip = ${nic_ip}, expected is 10.0.2.31"
+        # On s390x, devices use the CCW bus instead of PCI, which may cause them to appear in the wrong order
+        # https://github.com/coreos/fedora-coreos-tracker/issues/1992
+        if [ $(uname -m) == s390x ] && [ "${nic_ip}" == "10.0.2.32" ]; then
+            eval $(udevadm info --query=property /sys/class/net/eth1 | grep ID_NET_NAME_PATH)
+            if [[ "${ID_NET_NAME_PATH}" != "enc3" ]]; then
+                echo "Warn: CCW bus devices's order is wrong: eth0 altname is ${ID_NET_NAME_PATH}"
+            else
+                fatal "Error: get ${team} ip = ${nic_ip}, expected is 10.0.2.31. eth0 altname is ${ID_NET_NAME_PATH}"
+            fi
+        else
+            fatal "Error: get ${team} ip = ${nic_ip}, expected is 10.0.2.31"
+        fi
     fi
+}
+
+main() {
+    team="team0"
+
+    check_ip "${team}"
 
     expected_state="setup:
   runner: activebackup


### PR DESCRIPTION
On s390x, network interfaces use the CCW bus instead of PCI, which can lead to wrong NIC ordering. This causes the team-dhcp-via-ignition test to fail:
```
07:19:05  Jul 29 07:19:00 qemu0 kola-runext-test.sh[2336]: Error: get team0 ip = 10.0.2.32, expected is 10.0.2.31
```
This happens, because eth1 and eth2 are wrong ordered (altnames):
```
$ ip -o link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff\    altname enc2\    altname enx525400123456
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master team0 state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff\    altname enc4\    altname enx525500d15601
4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master team0 state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff permaddr 52:55:00:d1:56:00\    altname enc3\    altname enx525500d15600
5: team0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff
```

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1992