### PR TITLE
konflux: enable ARM architecture builds

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -37,6 +37,10 @@ spec:
   # For now we are using this workaround https://github.com/konflux-ci/buildah-container/issues/134
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -36,6 +36,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -38,6 +38,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -37,6 +37,10 @@ spec:
     - PASSWD_GROUP_DIR=manifests
   - name: workingdir-mount
     value: /run/src
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
   pipelineRef:
     params:
     - name: bundle


### PR DESCRIPTION
We want to build against ARM architecture as well.
Currently, PowerPC and s390x archs are still not supported in Fedora
Konflux cluster [1]. We'll enable them once available.

[1] https://gitlab.com/fedora/infrastructure/konflux/infra-deployments/-/issues/9