### PR TITLE
Konflux: generate rpm-lockfile-prototype input file

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -15,6 +15,10 @@ import sys
 import tempfile
 import yaml
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)) + '/ci')
+from manifest_utils import get_treefile, get_locked_nevras
+sys.path.pop(0)
+
 
 ARCH = os.uname().machine
 CONTEXTDIR = '/run/src'
@@ -26,11 +30,11 @@ def main():
     target_rootfs = sys.argv[3]
 
     manifest_path = os.path.join(CONTEXTDIR, manifest_name)
-    manifest = get_treefile(manifest_path)
+    manifest = get_treefile(manifest_path, deriving=True)
 
     packages = list(manifest['packages'])
 
-    locked_nevras = get_locked_nevras()
+    locked_nevras = get_locked_nevras(CONTEXTDIR, ARCH, as_strings=True)
     if locked_nevras:
         inject_pool_repo_if_exists(locked_nevras)
 
@@ -47,23 +51,6 @@ def main():
     if version != "":
         inject_version_info(target_rootfs, manifest['mutate-os-release'], version)
     run_postprocess_scripts(target_rootfs, manifest)
-
-
-def get_treefile(manifest_path):
-    with tempfile.NamedTemporaryFile(suffix='.json', mode='w') as tmp_manifest:
-        # This ensures that the treefile represents only the CoreOS bits and
-        # doesn't recurse into fedora-bootc. We can drop this once we've fully
-        # cut over to derivation.
-        json.dump({
-            "variables": {
-                "deriving": True
-            },
-            "include": manifest_path
-        }, tmp_manifest)
-        tmp_manifest.flush()
-        data = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
-                                        '--print-only', tmp_manifest.name])
-    return json.loads(data)
 
 
 def build_rootfs(target_rootfs, manifest_path, packages, overlays, nodocs):
@@ -143,25 +130,6 @@ def bwrap(rootfs, args):
                            '--tmpfs', '/tmp', '--tmpfs', '/var', '--tmpfs', '/run',
                            '--bind', '/run/.containerenv', '/run/.containerenv',
                            '--'] + args)
-
-
-def get_locked_nevras():
-    lockfile_path = os.path.join(CONTEXTDIR, f"manifest-lock.{ARCH}.json")
-    overrides_path = os.path.join(CONTEXTDIR, "manifest-lock.overrides.yaml")
-    overrides_arch_path = os.path.join(CONTEXTDIR, f"manifest-lock.overrides.{ARCH}.yaml")
-
-    locks = {}
-    for path in [lockfile_path, overrides_path, overrides_arch_path]:
-        if os.path.exists(path):
-            with open(path) as f:
-                if path.endswith('.yaml'):
-                    data = yaml.safe_load(f)
-                else:
-                    data = json.load(f)
-                # this essentially re-implements the merge semantics of rpm-ostree
-                locks.update({pkgname: v['evra'] if 'evra' in v else v['evr']
-                              for (pkgname, v) in data['packages'].items()})
-    return [f'{k}-{v}' for (k, v) in locks.items()]
 
 
 def inject_pool_repo_if_exists(locked_nevras):

--- a/ci/generate_rpm_lockfile_config
+++ b/ci/generate_rpm_lockfile_config
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+
+import argparse
+import os
+import re
+import sys
+import yaml
+
+# Correctly import get_treefile from the specified path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from manifest_utils import get_treefile, get_locked_nevras
+sys.path.pop(0)
+
+
+WORKDIR = os.getcwd()
+ARCH = os.uname().machine
+
+
+def filter_repofile(repos, locked_nevras, repo_path):
+    if not os.path.exists(repo_path):
+        print(f"Error: {repo_path} not found. Cannot inject includepkg filter.")
+        return
+
+    include_str = ','.join(locked_nevras)
+
+    with open(repo_path, 'r') as f:
+        repofile= f.read()
+
+    # We use a regex that looks for [reo_name] on a line by itself,
+    # possibly with whitespace.
+    sections = re.split(r'^\s*(\[.+\])\s*', repofile, flags=re.MULTILINE)
+
+    new_content = sections[0]  # part before any section
+    keep = False
+
+    # sections will be [before, section1_name, section1_content, section2_name, section2_content, ...]
+    for i in range(1, len(sections), 2):
+        name = sections[i]
+        # ignore repos that don't match the repos we want to use
+        if name.strip("[]") in repos:
+            repodef = sections[i+1]
+            if 'includepkgs=' not in repodef:
+                # We only keep the repo definition that we edited
+                # to avoid accidentaly taking in other packages
+                # from a repofile already having an includepkgs
+                # directive.
+                keep = True
+                new_content += name + '\n'
+                repodef += f"includepkgs={include_str}\n"
+                new_content += repodef
+
+    if keep:
+        with open(repo_path, 'w') as f:
+            f.write(new_content)
+
+    return keep
+
+
+def build_rpm_lockfile_config(packages, repo_files):
+    """
+    Augments package names in rpm_in_data with version numbers from locks.
+    Populates contentOrigin and repofiles.
+    """
+    # Initialize the structure for rpm_lockfile_input, similar to write_rpms_input_file
+    # This ensures consistency whether it comes from a manifest or directly
+    rpm_lockfile_config = {
+        'contentOrigin': {
+            'repofiles': repo_files
+        },
+        'installWeakDeps': False,
+        'context': {
+            'bare': True,
+        },
+        'packages': packages
+    }
+
+    return rpm_lockfile_config
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate rpm-lockfile-prototype input file from rpm-ostree manifest and augment with version overrides."
+    )
+
+    parser.add_argument(
+        'manifest',
+        help='Path to the rpm-ostree manifest (e.g., fedora-coreos-config/manifest.yaml)'
+    )
+    parser.add_argument(
+        '--output',
+        default='./rpms.in.yaml',
+        help="Path for the final rpm-lockfile-protoype config file. (default: './rpms.in.yaml')"
+    )
+
+    args = parser.parse_args()
+    contextdir = os.path.dirname(os.path.join(WORKDIR, args.manifest))
+
+    manifest_path = os.path.join(contextdir, os.path.basename(args.manifest))
+    # 1. Get initial manifest data from get_treefile
+    manifest_data = get_treefile(manifest_path, deriving=False)
+    repos = manifest_data.get('repos', [])
+    repos += manifest_data.get('lockfile-repos', [])
+
+    packages = manifest_data.get('packages', [])
+
+    # 2 Get locked NEVRAs from manifest-lock.overrides.yaml
+    locks = get_locked_nevras(contextdir, ARCH)
+
+    # Gather list of *.repo files
+    repofiles = [file for file in os.listdir(contextdir) if file.endswith('.repo')]
+    relevant_repofiles = []
+
+    # 3 inject filters to relevant repofiles
+    if locks:
+        locked_nevras = [f'{k}-{v}' for (k, v) in locks.items()]
+        for repofile in repofiles:
+            if filter_repofile(repos, locked_nevras, os.path.join(contextdir, repofile)):
+                print(f"\u2705 filter injected in: {os.path.join(contextdir, repofile)}")
+                relevant_repofiles.append(repofile)
+
+    # 4 generate rpm-lockfile-prototype input file
+    augmented_rpm_in = build_rpm_lockfile_config(packages, relevant_repofiles)
+
+    try:
+        with open(args.output, 'w') as f:
+            yaml.safe_dump(augmented_rpm_in, f, default_flow_style=False)
+        print(f"\u2705  RPM lock data saved to: {args.output}")
+    except IOError as e:
+        print(f"\u274c Error: Could not write to final output file '{args.output}'. Reason: {e}")
+        exit(1)

--- a/ci/manifest_utils.py
+++ b/ci/manifest_utils.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+
+# This script provides utility functions for handling FCOS manifests and lockfiles.
+
+import json
+import os
+import subprocess
+import tempfile
+import yaml
+
+
+def get_treefile(manifest_path, deriving=False):
+    """
+    Parses an rpm-ostree manifest using 'rpm-ostree compose tree'.
+    If deriving is True, it ensures that the treefile represents only the
+    CoreOS bits and doesn't recurse into fedora-bootc.
+    """
+    with tempfile.NamedTemporaryFile(suffix='.json', mode='w') as tmp_manifest:
+        json.dump({
+            "variables": {
+                "deriving": deriving
+            },
+            "include": manifest_path
+        }, tmp_manifest)
+        tmp_manifest.flush()
+        data = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
+                                        '--print-only', tmp_manifest.name])
+    return json.loads(data)
+
+
+def get_locked_nevras(contextdir, arch, as_strings=False):
+    """
+    Gathers all locked packages from the manifest-lock files.
+    The return format can be a dictionary of {pkgname: evr} or a list
+    of strings in the format 'pkgname-evr'.
+    For example:
+    - as_strings=False: {'rpm-ostree': '2024.4-1.fc40'}
+    - as_strings=True: ['rpm-ostree-2024.4-1.fc40']
+    """
+    lockfile_path = os.path.join(contextdir, f"manifest-lock.{arch}.json")
+    overrides_path = os.path.join(contextdir, "manifest-lock.overrides.yaml")
+    overrides_arch_path = os.path.join(contextdir, f"manifest-lock.overrides.{arch}.json")
+
+    locks = {}
+    for path in [lockfile_path, overrides_path, overrides_arch_path]:
+        if os.path.exists(path):
+            with open(path) as f:
+                if path.endswith('.yaml'):
+                    data = yaml.safe_load(f)
+                else:
+                    data = json.load(f)
+                # this essentially re-implements the merge semantics of rpm-ostree
+                locks.update({pkgname: v.get('evra') or v.get('evr')
+                              for (pkgname, v) in data['packages'].items()})
+
+    if as_strings:
+        return [f'{k}-{v}' for (k, v) in locks.items()]
+    return locks

--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -8,7 +8,10 @@ import json
 import requests
 from urllib.parse import urlparse
 import yaml
-import subprocess
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(sys.argv[0])))
+from manifest_utils import get_treefile as get_manifest_treefile
+sys.path.pop(0)
 
 import bodhi.client.bindings
 import libdnf5
@@ -156,10 +159,7 @@ def do_graduate(_args):
 
 
 def get_treefile():
-    treefile = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
-                                        '--print-only',
-                                        os.path.join(basedir, 'manifest.yaml')])
-    return json.loads(treefile)
+    return get_manifest_treefile(os.path.join(basedir, 'manifest.yaml'))
 
 
 def get_dnf_base(treefile):


### PR DESCRIPTION
The resulting config file will be fed to `rpm-lockfile-protype` which in turns will generate the hermeto config.
This will allow us to enable hermetic builds in Konflux.

Run with :
```
 ./ci/generate_rpm_lockfile_config manifest.yaml
````

This creates `rpm.in.yaml`.

The intent is to trigger this in the `bump-lockfile` job of jenkins.

Requires https://github.com/konflux-ci/rpm-lockfile-prototype/pull/107 And https://github.com/konflux-ci/rpm-lockfile-prototype/pull/104