### PR TITLE
konflux: use build-args-file instead of build-args

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -27,12 +27,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: 'build-args.conf'
   # This is required until https://github.com/containers/buildah/issues/5952 is fixed
   # For now we are using this workaround https://github.com/konflux-ci/buildah-container/issues/134
   - name: workingdir-mount
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -46,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -28,12 +28,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -43,7 +39,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/kustomization.yaml
+++ b/.tekton/rawhide/kustomization.yaml
@@ -4,4 +4,3 @@ kind: Kustomization
 resources:
   - on-pull-request
   - on-push
-  - patch.yaml

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=43
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:43
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-pull-request/kustomization.yaml
+++ b/.tekton/rawhide/on-pull-request/kustomization.yaml
@@ -18,9 +18,6 @@ transformers:
     - kind: PipelineRun
       path: spec/taskRunTemplate/serviceAccountName
 patches:
-  - path: patch.yaml
-    target:
-      kind: PipelineRun
   - target:
       kind: PipelineRun
     patch: |-

--- a/.tekton/rawhide/on-pull-request/patch.yaml
+++ b/.tekton/rawhide/on-pull-request/patch.yaml
@@ -1,8 +1,0 @@
----
-- op: replace
-  path: /spec/params/6/value
-  value:
-    - VERSION=43
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:43
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=43
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:43
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-push/kustomization.yaml
+++ b/.tekton/rawhide/on-push/kustomization.yaml
@@ -18,9 +18,6 @@ transformers:
     - kind: PipelineRun
       path: spec/taskRunTemplate/serviceAccountName
 patches:
-  - path: patch.yaml
-    target:
-      kind: PipelineRun
   - target:
       kind: PipelineRun
     patch: |-

--- a/.tekton/rawhide/on-push/patch.yaml
+++ b/.tekton/rawhide/on-push/patch.yaml
@@ -1,8 +1,0 @@
----
-- op: replace
-  path: /spec/params/6/value
-  value:
-    - VERSION=43
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:43
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests

--- a/.tekton/rawhide/patch.yaml
+++ b/.tekton/rawhide/patch.yaml
@@ -1,8 +1,0 @@
----
-- op: replace
-  path: /spec/params/6/value
-  value:
-    - VERSION=43
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:43
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -30,12 +30,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -47,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -29,12 +29,8 @@ spec:
     value: .
   - name: privileged-nested
     value: true
-  - name: build-args
-    value:
-    - VERSION=42
-    - BUILDER_IMG=quay.io/fedora/fedora-bootc:42
-    - MANIFEST=manifest.yaml
-    - PASSWD_GROUP_DIR=manifests
+  - name: build-args-file
+    value: build-args.conf
   - name: workingdir-mount
     value: /run/src
   - name: build-platforms
@@ -44,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:5cd05ed32a5f547459a6816eae31b215defeb16df5455292182ef6180d3cd9e0
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
The podman/buildah build args are already defined in the 'build-args.conf' file. 
Se we better have to configure Konflux to get them from this file instead of duplicating them in the pipeline params.

We also update the pipeline bundle to get the latest required change [1].

[1] https://gitlab.com/fedora/bootc/tekton-catalog/-/merge_requests/5