### PR TITLE
denylist: snooze docker tests for now on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,9 @@
   warn: true
   arches:
     - s390x
+- pattern: ext.config.docker*
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1998
+  snooze: 2025-08-14
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
There is a behavior change in the 6.17 kernel that needs investigation.
- https://github.com/coreos/fedora-coreos-tracker/issues/1998