### PR TITLE
Enable `bootloader-update.service` since F43

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -52,6 +52,16 @@ conditional-include:
         - python
         - python3
         - python3-libs
+  # We will enable bootloader-update.service on F43+.
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1468#issuecomment-2996654547
+  # https://fedoraproject.org/wiki/Changes/AutomaticBootloaderUpdatesBootc
+  - if: releasever >= 43
+    include:
+      postprocess:
+        - |
+          #!/usr/bin/bash
+          set -eux -o pipefail
+          echo "enable bootloader-update.service" >> /usr/lib/systemd/system-preset/45-fcos.preset
 
 ostree-layers:
   - overlay/15fcos


### PR DESCRIPTION
`bootloader-update.service` is shipped in `rust-bootupd-0.2.26-3.fc42` (https://src.fedoraproject.org/rpms/rust-bootupd/c/28a98663eabd21cb9e9ff334700d554d36c0b0aa?branch=rawhide) but it is disabled by default.
Track issue: https://github.com/coreos/fedora-coreos-tracker/issues/1468