### PR TITLE
Update riscv repos

### DIFF
--- a/fedora-riscv-koji.repo
+++ b/fedora-riscv-koji.repo
@@ -1,0 +1,7 @@
+# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6cdced6f3c08dcf2c2bc82406868cfc9f83b55be/fedora-riscv-koji.repo
+[fedora-riscv-koji]
+name=Fedora RISC-V $releasever - Koji
+baseurl=https://riscv-koji.fedoraproject.org/repos/f$releasever-build/latest/$basearch/
+enabled=0
+gpgcheck=0
+priority=97

--- a/fedora-riscv-staging.repo
+++ b/fedora-riscv-staging.repo
@@ -1,21 +1,21 @@
-# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6289e6a44e1c897beeacaa363307a1b2d11db1c3/fedora-riscv-staging.repo
+# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6cdced6f3c08dcf2c2bc82406868cfc9f83b55be/fedora-riscv-staging.repo
 [fedora-riscv-staging]
 name=Fedora RISC-V $releasever - Staging
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/$basearch/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever-staging/latest/$basearch/
 enabled=1
 gpgcheck=0
 priority=98
 
 [fedora-riscv-staging-debuginfo]
 name=Fedora RISC-V $releasever - Staging - Debug
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/$basearch/debug/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever-staging/latest/$basearch/debug/
 enabled=0
 gpgcheck=0
 priority=98
 
 [fedora-riscv-staging-source]
 name=Fedora RISC-V $releasever - Staging - Source
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever-staging/latest/src/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever-staging/latest/src/
 enabled=0
 gpgcheck=0
 priority=98

--- a/fedora-riscv.repo
+++ b/fedora-riscv.repo
@@ -1,21 +1,21 @@
-# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6289e6a44e1c897beeacaa363307a1b2d11db1c3/fedora-riscv.repo
+# Pulled from http://fedora.riscv.rocks:3000/rpms/fedora-repos/src/commit/6cdced6f3c08dcf2c2bc82406868cfc9f83b55be/fedora-riscv.repo
 [fedora-riscv]
 name=Fedora RISC-V $releasever
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/$basearch/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever/latest/$basearch/
 enabled=1
 gpgcheck=0
 priority=99
 
 [fedora-riscv-debuginfo]
 name=Fedora RISC-V $releasever - Debug
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/$basearch/debug/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever/latest/$basearch/debug/
 enabled=0
 gpgcheck=0
 priority=99
 
 [fedora-riscv-source]
 name=Fedora RISC-V $releasever - Source
-baseurl=http://fedora.riscv.rocks/repos-dist/f$releasever/latest/src/
+baseurl=https://riscv-koji.fedoraproject.org/repos-dist/f$releasever/latest/src/
 enabled=0
 gpgcheck=0
 priority=99

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -19,7 +19,7 @@ conditional-include:
   - if: basearch == "riscv64"
     include:
       repos:
-        # These repos are provided by the RISCV SIG from a shadow koji instance
+        # These repos are provided by the RISCV SIG from secondary koji instance
         # https://fedoraproject.org/wiki/Architectures/RISC-V
         - fedora-riscv
         # The staging repo has the unsigned shim in it so we need it here too.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,5 +24,8 @@ conditional-include:
         - fedora-riscv
         # The staging repo has the unsigned shim in it so we need it here too.
         - fedora-riscv-staging
+        # The fedora-riscv-koji repo allows us to get the latest built packages.
+        # The other repos aren't updated frequently.
+        - fedora-riscv-koji
 
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Now pointing at the secondary riscv koji in the Fedora datacenter and not the shadow koji.