### PR TITLE
denylist: remove multipath.resilient

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
-- pattern: ext.config.multipath.resilient
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1980
-  snooze: 2025-07-10
-  warn: true
-  arches:
-    - s390x
 - pattern: ext.config.docker*
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1998
   snooze: 2025-08-14


### PR DESCRIPTION
This test is passing again on s390x.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1980