### PR TITLE
versionary: support `--dev`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=bind,target=/run/src \
         /run/src/build-rootfs "${MANIFEST}" "${VERSION}" /target-rootfs
 RUN --mount=type=bind,target=/run/src,rw \
-      rpm-ostree compose build-chunked-oci \
+      rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \
         --output oci-archive:/run/src/out.ociarchive
 

--- a/build-rootfs
+++ b/build-rootfs
@@ -37,7 +37,7 @@ def main():
 
     locked_nevras = get_locked_nevras()
     if locked_nevras:
-        modify_pool_repo_if_exists(locked_nevras)
+        modify_pool_repo(locked_nevras)
 
     packages.extend(locked_nevras)
     overlays = gather_overlays(manifest)
@@ -208,7 +208,7 @@ def get_locked_nevras():
     return [f'{k}-{v}' for (k, v) in locks.items()]
 
 
-def modify_pool_repo_if_exists(locked_nevras):
+def modify_pool_repo(locked_nevras):
     # When adding the pool, we only want to _filter in_ locked packages;
     # matching `lockfile-repos` semantics. This is abusing pretty hard the
     # `includepkgs=` semantic but... it works.

--- a/versionary
+++ b/versionary
@@ -50,7 +50,7 @@ def main():
     assert os.path.isdir('builds'), 'Missing builds/ dir'
 
     manifest = get_flattened_manifest()
-    x, y, z = (get_x(manifest), get_y(manifest), get_z(manifest))
+    x, y, z = (get_x(manifest), get_y(manifest), get_z(manifest, args.dev))
     n = get_next_iteration(x, y, z)
     new_version = f'{x}.{y}.{z}.{n}'
 
@@ -62,6 +62,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--workdir', help="path to cosa workdir")
+    parser.add_argument('--dev', action='store_true', help="generate a developer version")
     return parser.parse_args()
 
 
@@ -110,10 +111,13 @@ def get_y(manifest):
     return int(ymd)
 
 
-def get_z(manifest):
+def get_z(manifest, dev):
     """
         Z is the stream indicator.
     """
+    if dev:
+        eprint("z: dev (overridden)")
+        return 'dev'
     stream = manifest['add-commit-metadata']['fedora-coreos.stream']
     assert stream in STREAM_TO_NUM, f"Unknown stream: {stream}"
     mapped = STREAM_TO_NUM[stream]
@@ -154,7 +158,7 @@ def get_flattened_manifest():
 
 
 def parse_version(version):
-    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+)\.([0-9]+)$', version)
+    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+|dev)\.([0-9]+)$', version)
     if m is None:
         return None
     # sanity-check date
@@ -162,7 +166,7 @@ def parse_version(version):
         time.strptime(m.group(2), '%Y%m%d')
     except ValueError:
         return None
-    return tuple(map(int, m.groups()))
+    return tuple(map(lambda x: 'dev' if x == 'dev' else int(x), m.groups()))
 
 
 def eprint(*args):


### PR DESCRIPTION
Add a `--dev` switch which will be used to replace the functionality
lost by `automatic-version-prefix` after moving away from directly
running rpm-ostree composes to the container native path.