### PR TITLE
[branched] Start tracking Fedora 43

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -2,10 +2,10 @@
 # Pass to buildah/podman using `--build-arg-file`.
 
 # This is the developer default version. In pipelines, this is driven by versionary.
-VERSION=42
+VERSION=43.dev
 # XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:42
+BUILDER_IMG=quay.io/fedora/fedora-bootc:43
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: branched
   prod: false
 
-releasever: 42
+releasever: 43
 
 repos:
   - fedora-next


### PR DESCRIPTION
Fedora 43 branches from rawhide on `2025-08-12`. Bump the branched manifest to track Fedora 43.