### PR TITLE
[rawhide] Start tracking Fedora 44

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -2,10 +2,10 @@
 # Pass to buildah/podman using `--build-arg-file`.
 
 # This is the developer default version. In pipelines, this is driven by versionary.
-VERSION=43.dev
+VERSION=44.dev
 # XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:43
+BUILDER_IMG=quay.io/fedora/fedora-bootc:44
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ variables:
   stream: rawhide
   prod: false
 
-releasever: 43
+releasever: 44
 
 repos:
   - fedora-rawhide


### PR DESCRIPTION
Fedora 43 is scheduled to branch from rawhide on `2025-08-12`. Update the rawhide branch to begin tracking development of Fedora 44.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1935