### PR TITLE
Remove qcom dtbs on aarch64 again

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -48,6 +48,16 @@ conditional-include:
           ln -sf /usr/sbin/iptables-nft          /etc/alternatives/iptables
           ln -sf /usr/sbin/iptables-nft-restore  /etc/alternatives/iptables-restore
           ln -sf /usr/sbin/iptables-nft-save     /etc/alternatives/iptables-save
+  - if: releasever > 42
+    include:
+      postprocess:
+        # Hack to avoid running out of space on aarch64. This should save us about 29M.
+        # https://github.com/coreos/fedora-coreos-tracker/issues/2004
+        - |
+          #!/usr/bin/env bash
+          set -eux -o pipefail
+          rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/
+
 
 # Be minimal
 recommends: false


### PR DESCRIPTION
According to Peter Robinson the qcom dtbs are the least likely to actually be used because they are for chromebooks or phones. Let's drop these for now to help us with our space in /boot problem on ARM.

https://github.com/coreos/fedora-coreos-tracker/issues/2004