### PR TITLE
tests: bump kernel-replace to 20G

### DIFF
--- a/tests/kola/files/alternatives
+++ b/tests/kola/files/alternatives
@@ -1,5 +1,7 @@
 #!/bin/bash
 ## kola:
+##   # we install iptables-legacy
+##   tags: "platform-independent needs-internet"
 ##   description: Verify that the alternatives config is properly migrated and test the migration
 ##   distros: fcos
 # See

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -5,6 +5,8 @@
 ##   # We've seen some OOM when 1024M is used:
 ##   # https://github.com/coreos/fedora-coreos-tracker/issues/1506
 ##   minMemory: 2048
+##   # We do a bunch of copies/rebuilds of the whole OS.
+##   minDisk: 20
 ##   # Needs internet access as we fetch files from koji
 ##   # We add the "reprovision" tag here even though we aren't
 ##   # reprovisioning as a hack so that in our pipeline the test


### PR DESCRIPTION
We've been hitting ENOSPC on this test all over the place and have been
adding workarounds a bit everywhere. Hit it again today as part of the
f43 container-native work.

Let's just bump its disk size.