### PR TITLE
overrides: pin selinux-policy-42.4-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  selinux-policy:
+    evra: 42.4-1.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2007
+      type: pin
+  selinux-policy-targeted:
+    evra: 42.4-1.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2007
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).