### PR TITLE
overrides: drop selinux-policy pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,14 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  selinux-policy:
-    evra: 42.4-1.fc42.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2007
-      type: pin
-  selinux-policy-targeted:
-    evra: 42.4-1.fc42.noarch
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2007
-      type: pin
+packages: {}


### PR DESCRIPTION
We decided to change the scope of our selinux labels check to not consider the rollback deployment in be78a69 so we can drop this pin.

This reverts commit 34c50b271e08a493d5aa74c4068b37d967d1d873.