### PR TITLE
konflux: add Tekton pipelines for fcos-buildroot builds

### DIFF
--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "branched"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "branched" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/branched/on-pull-request/kustomization.yaml
+++ b/.tekton/branched/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-branched-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "branched"'
+        value: 'event == "pull_request" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/branched/on-pull-request/kustomization.yaml
+++ b/.tekton/branched/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-branched-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "branched" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "branched" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "branched"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/branched/on-push/kustomization.yaml
+++ b/.tekton/branched/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-branched-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "branched"'
+        value: 'event == "push" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/branched/on-push/kustomization.yaml
+++ b/.tekton/branched/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-branched-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "branched" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "branched" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
@@ -1,19 +1,21 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: fedora-coreos-testing-on-push
+  name: fcos-buildroot-on-pull-request
   namespace: coreos-tenant
   labels:
-    appstudio.openshift.io/application: fedora-coreos-testing
-    appstudio.openshift.io/component: fedora-coreos-testing
+    appstudio.openshift.io/application: fcos-buildroot
+    appstudio.openshift.io/component: fcos-buildroot
     pipelines.appstudio.openshift.io/type: build
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/coreos/fedora-coreos-config?rev={{revision}}
-    build.appstudio.redhat.com/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "testing-devel" && (".tekton/fcos-buildroot-pull-request.yaml".pathChanged() || "ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:
@@ -22,21 +24,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/konflux-fedora/coreos-tenant/fedora-coreos-{{target_branch}}:{{revision}}
+    value: quay.io/konflux-fedora/coreos-tenant/fcos-buildroot:on-pr-{{revision}}
   - name: dockerfile
-    value: Containerfile
+    value: ./ci/buildroot/Dockerfile
   - name: path-context
-    value: .
-  - name: privileged-nested
-    value: true
-  - name: build-args-file
-    value: build-args.conf
-  - name: workingdir-mount
-    value: /run/src
-  - name: build-platforms
-    value:
-    - linux/amd64
-    - linux/arm64
+    value: ci/buildroot
+  - name: image-expires-after
+    value: 5d
   pipelineRef:
     params:
     - name: bundle
@@ -47,4 +41,4 @@ spec:
       value: pipeline
     resolver: bundles
   taskRunTemplate:
-    serviceAccountName: build-pipeline-fedora-coreos-testing
+    serviceAccountName: build-pipeline-fcos-buildroot

--- a/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
@@ -1,19 +1,20 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: fedora-coreos-testing-on-push
+  name: fcos-buildroot-on-push
   namespace: coreos-tenant
   labels:
-    appstudio.openshift.io/application: fedora-coreos-testing
-    appstudio.openshift.io/component: fedora-coreos-testing
+    appstudio.openshift.io/application: fcos-buildroot
+    appstudio.openshift.io/component: fcos-buildroot
     pipelines.appstudio.openshift.io/type: build
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/coreos/fedora-coreos-config?rev={{revision}}
-    build.appstudio.redhat.com/cancel-in-progress: "false"
+    build.appstudio.openshift.io/repo: https://github.com/Roshan-R/fedora-coreos-config?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "testing-devel" && (".tekton/fcos-buildroot-push.yaml".pathChanged() ||  "ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:
@@ -22,21 +23,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/konflux-fedora/coreos-tenant/fedora-coreos-{{target_branch}}:{{revision}}
+    value: quay.io/konflux-fedora/coreos-tenant/fcos-buildroot:{{revision}}
   - name: dockerfile
-    value: Containerfile
+    value: ./ci/buildroot/Dockerfile
   - name: path-context
-    value: .
-  - name: privileged-nested
-    value: true
-  - name: build-args-file
-    value: build-args.conf
-  - name: workingdir-mount
-    value: /run/src
-  - name: build-platforms
-    value:
-    - linux/amd64
-    - linux/arm64
+    value: ci/buildroot
   pipelineRef:
     params:
     - name: bundle
@@ -47,4 +38,4 @@ spec:
       value: pipeline
     resolver: bundles
   taskRunTemplate:
-    serviceAccountName: build-pipeline-fedora-coreos-testing
+    serviceAccountName: build-pipeline-fcos-buildroot

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next-devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next-devel/on-pull-request/kustomization.yaml
+++ b/.tekton/next-devel/on-pull-request/kustomization.yaml
@@ -26,6 +26,6 @@ patches:
         value: 'fedora-coreos-next-devel-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "next-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 
 

--- a/.tekton/next-devel/on-pull-request/kustomization.yaml
+++ b/.tekton/next-devel/on-pull-request/kustomization.yaml
@@ -26,5 +26,6 @@ patches:
         value: 'fedora-coreos-next-devel-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "next-devel"'
+        value: 'event == "pull_request" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())'
+
 

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next-devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next-devel/on-push/kustomization.yaml
+++ b/.tekton/next-devel/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-devel-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "next-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/next-devel/on-push/kustomization.yaml
+++ b/.tekton/next-devel/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-devel-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "next-devel"'
+        value: 'event == "push" && target_branch == "next-devel" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next/on-pull-request/kustomization.yaml
+++ b/.tekton/next/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "next"'
+        value: 'event == "pull_request" && target_branch == "next" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/next/on-pull-request/kustomization.yaml
+++ b/.tekton/next/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "next" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "next" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/next/on-push/kustomization.yaml
+++ b/.tekton/next/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "next" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "next" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/next/on-push/kustomization.yaml
+++ b/.tekton/next/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-next-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "next"'
+        value: 'event == "push" && target_branch == "next" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rawhide"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "rawhide" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/rawhide/on-pull-request/kustomization.yaml
+++ b/.tekton/rawhide/on-pull-request/kustomization.yaml
@@ -26,5 +26,6 @@ patches:
         value: 'fedora-coreos-rawhide-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "rawhide"'
+        value: 'event == "pull_request" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())'
+
 

--- a/.tekton/rawhide/on-pull-request/kustomization.yaml
+++ b/.tekton/rawhide/on-pull-request/kustomization.yaml
@@ -26,6 +26,6 @@ patches:
         value: 'fedora-coreos-rawhide-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "rawhide" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 
 

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rawhide" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rawhide"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/rawhide/on-push/kustomization.yaml
+++ b/.tekton/rawhide/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-rawhide-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "rawhide" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/rawhide/on-push/kustomization.yaml
+++ b/.tekton/rawhide/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-rawhide-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "rawhide"'
+        value: 'event == "push" && target_branch == "rawhide" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "stable" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "stable"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/stable/on-pull-request/kustomization.yaml
+++ b/.tekton/stable/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-stable-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "stable" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/stable/on-pull-request/kustomization.yaml
+++ b/.tekton/stable/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-stable-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "stable"'
+        value: 'event == "pull_request" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "stable" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "stable"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/stable/on-push/kustomization.yaml
+++ b/.tekton/stable/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-stable-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "stable" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/stable/on-push/kustomization.yaml
+++ b/.tekton/stable/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-stable-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "stable"'
+        value: 'event == "push" && target_branch == "stable" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-pull-request/kustomization.yaml
+++ b/.tekton/testing-devel/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/testing-devel/on-pull-request/kustomization.yaml
+++ b/.tekton/testing-devel/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "testing-devel"'
+        value: 'event == "pull_request" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-push/kustomization.yaml
+++ b/.tekton/testing-devel/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "testing-devel"'
+        value: 'event == "push" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/testing-devel/on-push/kustomization.yaml
+++ b/.tekton/testing-devel/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "testing-devel" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing/on-pull-request/kustomization.yaml
+++ b/.tekton/testing/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "pull_request" && target_branch == "testing" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 

--- a/.tekton/testing/on-pull-request/kustomization.yaml
+++ b/.tekton/testing/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "testing"'
+        value: 'event == "pull_request" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing" && !(files.all.all(f, f.matches("ci/buildroot/")))
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing/on-push/kustomization.yaml
+++ b/.tekton/testing/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "testing"'
+        value: 'event == "push" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())'
 

--- a/.tekton/testing/on-push/kustomization.yaml
+++ b/.tekton/testing/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "testing" && !("ci/buildroot/**".pathChanged())'
+        value: 'event == "push" && target_branch == "testing" && !(files.all.all(f, f.matches("ci/buildroot/")))'
 


### PR DESCRIPTION
Add new Tekton pipelines to build the fcos-buildroot image on push and pull requests to the testing-devel.
These pipelines only run when files in ci/buildroot change. Other pipelines are set to ignore changes in this path.
