### PR TITLE
[rawhide] overrides: fast-track git-core-2.51.0-2.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,10 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  git-core:
+    evr: 2.51.0-2.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-3bd52fcab8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2011
+      type: fast-track


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/2011