### PR TITLE
manifests: adjust NFS package specification

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -152,8 +152,6 @@ packages:
   # provide `container-network-stack`.
   # https://github.com/coreos/fedora-coreos-tracker/issues/1128#issuecomment-1071458717
   - netavark
-  # Minimal NFS client
-  - nfs-utils-coreos
   # Active Directory support
   - adcli
   # Additional firewall support; we aren't including these in RHCOS or they

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -55,6 +55,16 @@ conditional-include:
         - python
         - python3
         - python3-libs
+  # In F43 and older pull in the nfs-utils-coreos package
+  - if: releasever <= 43
+    include:
+      packages:
+        - nfs-utils-coreos
+  # In F44 we can use the nfs-client-utils package, which obsoletes nfs-utils-coreos
+  - if: releasever >= 44
+    include:
+      packages:
+        - nfs-client-utils
 
   # Do the alternatives migration from 43
   - if: releasever >= 43


### PR DESCRIPTION
In F44 the NFS package was adjusted [1] such that there is now a nfs-client-utils package and the specific nfs-utils-coreos package (i.e. a package specific to coreos) is no longer needed.

[1] https://src.fedoraproject.org/rpms/nfs-utils/c/4b4eb333ac24c2e393ca1022c29752024b864d82?branch=rawhide