### PR TITLE
fix python test, add denial, drop another

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,3 +10,9 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
+- pattern: ext.config.files.validate-symlinks
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2012
+  snooze: 2025-09-01
+  warn: true
+  streams:
+    - rawhide

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,9 +10,3 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
-- pattern: ext.config.docker*
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1998
-  snooze: 2025-08-14
-  warn: true
-  streams:
-    - rawhide

--- a/tests/kola/python/test.sh
+++ b/tests/kola/python/test.sh
@@ -9,11 +9,12 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
-if verlt "$(get_fedora_ver)" 43; then
+if vereq "$(get_fedora_ver)" 43; then
+    sudo rpm-ostree usroverlay
+    sudo rpm -e nfs-utils nfs-utils-coreos python3 python3-libs python-pip-wheel
+    ok "no extra pytyhon3 dependencies"
+else
     ok "Skipping python3 dependencies test"
     exit 0
 fi
 
-sudo rpm-ostree usroverlay
-sudo rpm -e nfs-utils nfs-utils-coreos python3 python3-libs python-pip-wheel
-ok "no extra pytyhon3 dependencies"


### PR DESCRIPTION
commit 287f15e1b9f8823160ecd2d7a1552557a779fae3
Date:   Thu Aug 21 22:39:07 2025 -0400

    denylist: add denial for ext.config.files.validate-symlinks
    
    The new NFS packages have some broken symlinks so let's snooze this
    test while we try to get it fixed.
    
    See https://github.com/coreos/fedora-coreos-tracker/issues/2012

commit e016cbba7f2ee11aa02774e4211ce0958fc51279
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 21 22:36:51 2025 -0400

    denylist: drop expired snooze for ext.config.docker*
    
    The issue with the rawhide kernel was resolved. See
    https://github.com/coreos/fedora-coreos-tracker/issues/1998

commit 9ce4d0574f6dbee8dc3aa1a7235a3355b65461fe
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 21 22:33:47 2025 -0400

    tests: adjust python test to only run on F43
    
    In 8d4f142 we adjusted it so that F44 gets a different set of packages
    for NFS. Let's make the python check F43 only.
