### PR TITLE
build-rootfs: rework lockfile handling

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,6 +23,10 @@ ARG MANIFEST=overridden
 # XXX: see inject_passwd_group() in build-rootfs
 ARG PASSWD_GROUP_DIR
 
+# this allows FCOS/SCOS/RHCOS to do specific things before going into the shared build-rootfs script
+RUN --mount=type=bind,target=/run/src \
+  if test -x /run/src/buildroot-prep; then /run/src/buildroot-prep; fi
+
 # useful if you're hacking on rpm-ostree/bootc-base-imagectl
 # COPY rpm-ostree /usr/bin/
 # COPY bootc-base-imagectl /usr/libexec/

--- a/build-rootfs
+++ b/build-rootfs
@@ -191,14 +191,14 @@ def prepare_local_rpm_overrides(rootfs):
     pkglist = subprocess.check_output(['dnf', 'repoquery', f'--repofrompath=overrides,file://{overrides_repo}',
                                        '--repo=overrides', '--latest-limit=1', f'--arch={ARCH},noarch',
                                        '--qf', 'pkg: %{name} %{evr} %{arch}\n'], encoding='utf-8')
-    lockfile = {"packages": {}}
+    lockfile = {}
     for line in pkglist.splitlines():
         if not line.startswith("pkg: "):
             continue
         _, name, evr, arch = line.strip().split()
-        lockfile["packages"][name] = {"evra": f"{evr}.{arch}"}
+        lockfile[name] = {"evra": f"{evr}.{arch}"}
 
-    if len(lockfile['packages']) == 0:
+    if len(lockfile) == 0:
         return None
 
     with open('/etc/yum.repos.d/overrides.repo', 'w') as f:
@@ -211,7 +211,7 @@ cost=500
 priority=1
 ''')
 
-    print("Injected", len(lockfile['packages']), 'package overrides')
+    print("Injected", len(lockfile), 'package overrides')
     return lockfile
 
 
@@ -248,7 +248,7 @@ def get_locked_nevras(local_overrides):
         # want to support dumb `koji download-build` flows. For everything else
         # that's unlocked, we rely on the overrides repo having priority=1.
         locks.update({pkgname: v['evra'] if 'evra' in v else v['evr']
-                      for (pkgname, v) in local_overrides['packages'].items()
+                      for (pkgname, v) in local_overrides.items()
                       if pkgname in locks})
     return [f'{k}-{v}' for (k, v) in locks.items()]
 

--- a/build-rootfs
+++ b/build-rootfs
@@ -40,13 +40,10 @@ def main():
         repos += ['overrides']
 
     locked_nevras = get_locked_nevras(local_overrides)
-    if locked_nevras:
-        modify_pool_repo(locked_nevras)
 
-    packages.extend(locked_nevras)
     overlays = gather_overlays(manifest)
     nodocs = (manifest.get('documentation') is False)
-    build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs)
+    build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays, repos, nodocs)
 
     inject_live(target_rootfs)
     inject_image_json(target_rootfs, manifest_path)
@@ -88,7 +85,7 @@ def inject_yumrepos():
         shutil.copy(repo, "/etc/yum.repos.d")
 
 
-def build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs):
+def build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays, repos, nodocs):
     passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
     if passwd_group_dir is not None:
         inject_passwd_group(os.path.join(CONTEXTDIR, passwd_group_dir))
@@ -104,6 +101,9 @@ def build_rootfs(target_rootfs, manifest_path, packages, overlays, repos, nodocs
         if repos and repo_arg_supported():
             for repo in repos:
                 argsfile.write(f"--repo={repo}\n")
+        if locked_nevras and lock_arg_supported():
+            for locked_nevra in locked_nevras:
+                argsfile.write(f"--lock={locked_nevra}\n")
         argsfile.flush()
         cache_arg = []
         if os.path.isdir('/cache') and rpm_ostree_has_cachedir_fix():
@@ -123,6 +123,14 @@ def repo_arg_supported():
     # the mounted secret repo file.
     help = subprocess.check_output(['/usr/libexec/bootc-base-imagectl', 'build-rootfs', '-h'], encoding='utf-8')
     return '--repo REPO' in help
+
+
+def lock_arg_supported():
+    # Detect if we have https://gitlab.com/fedora/bootc/base-images/-/merge_requests/279.
+    # If not, then we can't use `--lock`. That should only happen in RHCOS,
+    # where we only use this for autolocking and not base lockfile management.
+    help = subprocess.check_output(['/usr/libexec/bootc-base-imagectl', 'build-rootfs', '-h'], encoding='utf-8')
+    return '--lock NEVRA' in help
 
 
 def workaround_rhel_97826(argsfile):
@@ -243,25 +251,9 @@ def get_locked_nevras(local_overrides):
                 locks.update({pkgname: v['evra'] if 'evra' in v else v['evr']
                               for (pkgname, v) in data['packages'].items()})
     if local_overrides:
-        # Note here we only add the minimal number of overrides needed to
-        # nullify the base locks rather than take all of them wholesale. We
-        # don't want to force-install everything in `overrides/rpm` -- e.g. we
-        # want to support dumb `koji download-build` flows. For everything else
-        # that's unlocked, we rely on the overrides repo having priority=1.
         locks.update({pkgname: v['evra'] if 'evra' in v else v['evr']
-                      for (pkgname, v) in local_overrides.items()
-                      if pkgname in locks})
+                      for (pkgname, v) in local_overrides.items()})
     return [f'{k}-{v}' for (k, v) in locks.items()]
-
-
-def modify_pool_repo(locked_nevras):
-    # When adding the pool, we only want to _filter in_ locked packages;
-    # matching `lockfile-repos` semantics. This is abusing pretty hard the
-    # `includepkgs=` semantic but... it works.
-    repo = os.path.join('/etc/yum.repos.d/fedora-coreos-pool.repo')
-    packages = ','.join(locked_nevras)
-    with open(repo, 'a') as f:
-        f.write(f"\nincludepkgs={packages}\n")
 
 
 # This re-implements rpm-ostree's mutate-os-release to preserve the historical

--- a/build-rootfs
+++ b/build-rootfs
@@ -230,6 +230,7 @@ def get_locked_nevras(local_overrides):
     overrides_path = os.path.join(CONTEXTDIR, "manifest-lock.overrides.yaml")
     overrides_arch_path = os.path.join(CONTEXTDIR, f"manifest-lock.overrides.{ARCH}.yaml")
 
+    # we go from lowest priority to highest here: base lockfiles, overrides, local overrides
     locks = {}
     for path in [lockfile_path, overrides_path, overrides_arch_path]:
         if os.path.exists(path):

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+arch=$(uname -m)
+. /etc/os-release
+
+# fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475
+
+case "$VERSION_ID" in
+    43) urls=(https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2025.10/3.fc43/"$arch"/rpm-ostree-{,libs-}2025.10-3.fc43."$arch".rpm);;
+    44) urls=(https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2025.10/3.fc44/"$arch"/rpm-ostree-{,libs-}2025.10-3.fc44."$arch".rpm);;
+    *) exit 0;;
+esac
+
+if rpm -q "rpm-ostree-2025.10-1.fc43.$arch"; then
+    sudo dnf install -y "${urls[@]}"
+fi

--- a/fedora-coreos-pool.repo
+++ b/fedora-coreos-pool.repo
@@ -1,5 +1,5 @@
 [fedora-coreos-pool]
-name=Fedora coreos pool repository - $basearch
+name=Fedora CoreOS Pool - $basearch
 baseurl=https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/$basearch/
 enabled=1
 repo_gpgcheck=0


### PR DESCRIPTION
We weren't quite matching the cosa semantics of lockfiles, and this
was causing us trouble. Notably, doing `dnf install -y` for all locked
packages doesn't work for autolocked packages because those lockfiles
may contain packages that don't exist at all on other arches.

It also meant that e.g. even if removing a package from the manifest,
you'd still have it installed if you didn't also remove it from the
lockfiles.

Really, we need the `packages` list to be canonical and the lockfiles to
only act as filters.

There is a new `--lock` switch now in bootc-base-imagectl that we can
use for that (which underneath just uses rpm-ostree lockfiles, like we
do now). So let's use that.

This also allows us to drop the hack around modifying the pool repo by
adding `includepkgs` manually. As well as the caveat around local RPM
overrides handling.

---

Requires: https://gitlab.com/fedora/bootc/base-images/-/merge_requests/279 and https://github.com/coreos/rpm-ostree/pull/5475