### PR TITLE
[rawhide] overrides: fast-track grub2-2.12-41.fc44

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-41.fc44.noarch
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools:
+    evra: 1:2.12-41.fc44.aarch64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.12-41.fc44.aarch64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-efi-aa64:
+    evra: 1:2.12-41.fc44.aarch64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,36 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-41.fc44.noarch
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools:
+    evra: 1:2.12-41.fc44.ppc64le
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.12-41.fc44.ppc64le
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-ppc64le:
+    evra: 1:2.12-41.fc44.ppc64le
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-ppc64le-modules:
+    evra: 1:2.12-41.fc44.noarch
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-41.fc44.noarch
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools:
+    evra: 1:2.12-41.fc44.x86_64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-tools-minimal:
+    evra: 1:2.12-41.fc44.x86_64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-pc-modules:
+    evra: 1:2.12-41.fc44.noarch
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-efi-x64:
+    evra: 1:2.12-41.fc44.x86_64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin
+  grub2-pc:
+    evra: 1:2.12-41.fc44.x86_64
+    metadata:
+      reason: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5c1f79161#comment-4276575
+      type: pin


### PR DESCRIPTION
This update needed to ship at the same time as shim-15.8-4 Fast track it until it reaches stable so our tests will pass.