### PR TITLE
buildroot-prep: various enhancements

### DIFF
--- a/buildroot-prep
+++ b/buildroot-prep
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# This script is called in the buildah path to modify the build environment
+# before entering the shared build-rootfs script. Example use cases are to
+# fast-track fixes or work around bugs.
+
 arch=$(uname -m)
 . /etc/os-release
 
-# fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475
+# Fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475.
+# Comment this out if not used to not unnecessarily pay for repo metadata.
+cp /run/src/fedora-coreos-continuous.repo /etc/yum.repos.d
+sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous
 
-case "$VERSION_ID" in
-    43) urls=(https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2025.10/3.fc43/"$arch"/rpm-ostree-{,libs-}2025.10-3.fc43."$arch".rpm);;
-    44) urls=(https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2025.10/3.fc44/"$arch"/rpm-ostree-{,libs-}2025.10-3.fc44."$arch".rpm);;
-    *) exit 0;;
-esac
-
-if rpm -q "rpm-ostree-2025.10-1.fc43.$arch"; then
-    sudo dnf install -y "${urls[@]}"
+# fast-track https://gitlab.com/fedora/bootc/base-images/-/merge_requests/279
+help=$(/usr/libexec/bootc-base-imagectl build-rootfs -h)
+if ! grep -q -- --lock <<< "$help"; then
+    echo "Patching bootc-base-imagectl"
+    curl -L https://gitlab.com/fedora/bootc/base-images/-/commit/35467bdbdcc01a8ad6b42c33c935ffe5c8c74395.patch | patch -p1 -d /usr/libexec
 fi

--- a/fedora-coreos-continuous.repo
+++ b/fedora-coreos-continuous.repo
@@ -1,0 +1,7 @@
+# This is used in the buildah path for fast-tracking build tools
+[fedora-coreos-continuous]
+metadata_expire=1m
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$releasever-coreos-continuous/latest/$basearch/
+gpgcheck=0
+enabled=0
+skip_if_unavailable=False


### PR DESCRIPTION
Add a description of what this script is at the top-level.

Switch to using the continuous repo for fast-tracking the rpm-ostree backport.

Also backport
https://gitlab.com/fedora/bootc/base-images/-/commit/35467bdbdcc01a8ad6b42c33c935ffe5c8c74395 since it seems like fedora-bootc container images have not been respun as quickly as we thought they'd be.