### PR TITLE
buildroot-prep: fixups to get it to work for rawhide

### DIFF
--- a/buildroot-prep
+++ b/buildroot-prep
@@ -11,11 +11,12 @@ arch=$(uname -m)
 # Fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475.
 # Comment this out if not used to not unnecessarily pay for repo metadata.
 cp /run/src/fedora-coreos-continuous.repo /etc/yum.repos.d
-sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous
+sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous --releasever "$VERSION_ID"
 
 # fast-track https://gitlab.com/fedora/bootc/base-images/-/merge_requests/279
 help=$(/usr/libexec/bootc-base-imagectl build-rootfs -h)
 if ! grep -q -- --lock <<< "$help"; then
     echo "Patching bootc-base-imagectl"
+    sudo dnf install -y patch
     curl -L https://gitlab.com/fedora/bootc/base-images/-/commit/35467bdbdcc01a8ad6b42c33c935ffe5c8c74395.patch | patch -p1 -d /usr/libexec
 fi


### PR DESCRIPTION
In rawhide $releasever evaluates to `rawhide` but we need it to be `44`. Let's use the VERSION_ID here.

Also install `patch` if we need to patch. This passed in CI on 5040a32 because I guess the 42 bootc image had been built in the past day.

Fixes 5040a32