### PR TITLE
Add org.opencontainers.image.title OCI label

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,6 +47,7 @@ RUN --mount=type=bind,target=/run/src,rw \
 FROM oci-archive:./out.ociarchive
 ARG VERSION
 ARG NAME=overridden
+ARG DESCRIPTION=overridden
 # Need to reference builder here to force ordering. But since we have to run
 # something anyway, we might as well cleanup after ourselves.
 RUN --mount=type=bind,from=builder,target=/var/tmp \
@@ -57,5 +58,7 @@ LABEL containers.bootc=1
 LABEL ostree.bootable=1
 LABEL org.opencontainers.image.version=$VERSION
 LABEL com.coreos.osname=$NAME
+LABEL org.opencontainers.image.title=$DESCRIPTION
+LABEL org.opencontainers.image.description=$DESCRIPTION
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/build-args.conf
+++ b/build-args.conf
@@ -10,3 +10,4 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
+DESCRIPTION=Fedora CoreOS testing-devel


### PR DESCRIPTION
Aside from the OS codename like `fedora-coreos`, we also have a human-friendly version that's used for e.g. cloud uploads. We want to retain that in the buildah path.

Let's use the standard org.opencontainers.image.title label for this purpose.