### PR TITLE
[testing] build-args: add description

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -10,3 +10,4 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
+DESCRIPTION=Fedora CoreOS testing


### PR DESCRIPTION
Add the description that is specific to the `testing` stream. See https://github.com/coreos/fedora-coreos-config/pull/3699 for why this is useful.