### PR TITLE
overrides: pin vim-9.1.1623-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  vim-data:
+    evra: 2:9.1.1623-1.fc42.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2020
+      type: pin
+  vim-minimal:
+    evr: 2:9.1.1623-1.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2020
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).