### PR TITLE
overrides: pin kernel-6.15.10-200.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,26 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  kernel:
+    evr: 6.15.10-200.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2023
+      type: pin
+  kernel-core:
+    evr: 6.15.10-200.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2023
+      type: pin
+  kernel-modules:
+    evr: 6.15.10-200.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2023
+      type: pin
+  kernel-modules-core:
+    evr: 6.15.10-200.fc42
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2023
+      type: pin
   vim-data:
     evra: 2:9.1.1623-1.fc42.noarch
     metadata:


### PR DESCRIPTION
Requested by @travier via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).

See: https://github.com/coreos/fedora-coreos-tracker/issues/2023