### PR TITLE
denylist: add entry for azure ignition tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,15 @@
   warn: true
   streams:
     - rawhide
+- pattern: fcos.ignition.v3.noop
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
+  snooze: 2025-09-15
+  warn: true
+  platforms:
+    - azure
+- pattern: fcos.ignition.misc.empty
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
+  snooze: 2025-09-15
+  warn: true
+  platforms:
+    - azure


### PR DESCRIPTION
The `fcos.ignition.v3.noop` and `fcos.ignition.misc.empty` tests are failing on Azure because of issues fetching SSH keys. Let's snooze the tests for now until the issue is resolved.

See:
- https://github.com/coreos/fedora-coreos-tracker/issues/2021
- https://github.com/coreos/afterburn/issues/1217