### PR TITLE
tests/validate-symlinks: Add broken symlinks from nfs-client-utils

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,12 +10,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
   arches:
     - ppc64le
-- pattern: ext.config.files.validate-symlinks
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2012
-  snooze: 2025-09-10
-  warn: true
-  streams:
-    - rawhide
 - pattern: fcos.ignition.v3.noop
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
   snooze: 2025-09-15

--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -18,6 +18,8 @@ set -xeuo pipefail
 # - The symlinks in /usr/lib/firmware are often broken and are typically not an
 #   issue, so let's skip this location altogether.
 # - json-glib -> https://bugzilla.redhat.com/show_bug.cgi?id=2297094
+# - broken symlinks in /etc/nfsmount.conf.d for nfs-client-utils in rawhide
+#   issue: https://github.com/coreos/fedora-coreos-tracker/issues/2012
 #
 list_broken_symlinks_skip=(
     '/etc/mtab'
@@ -32,6 +34,8 @@ list_broken_symlinks_skip=(
     '/usr/share/rhel/secrets/etc-pki-entitlement'
     '/usr/share/rhel/secrets/redhat.repo'
     '/usr/share/rhel/secrets/rhsm'
+    '/etc/nfsmount.conf.d/10-nfsv3.conf'
+    '/etc/nfsmount.conf.d/10-nfsv4.conf'
 )
 
 # If RHCOS, update the array of ignored symlinks


### PR DESCRIPTION
Broken links:
	1. /etc/nfsmount.conf.d/10-nfsv3.conf
	2. /etc/nfsmount.conf.d/10-nfsv4.conf

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/2012

Remove the test from denylist