### PR TITLE
secex-tests: fix test by appending env "CPI_PERMIT_ON_PVGUEST=1"

### DIFF
--- a/tests/kola/secex/ensure/config.bu
+++ b/tests/kola/secex/ensure/config.bu
@@ -1,0 +1,9 @@
+variant: fcos
+version: 1.6.0
+storage:
+  files:
+    - path: /etc/sysconfig/cpi
+      overwrite: false
+      append:
+        - inline: |
+            CPI_PERMIT_ON_PVGUEST=1

--- a/tests/kola/secex/reboot/config.bu
+++ b/tests/kola/secex/reboot/config.bu
@@ -1,0 +1,9 @@
+variant: fcos
+version: 1.6.0
+storage:
+  files:
+    - path: /etc/sysconfig/cpi
+      overwrite: false
+      append:
+        - inline: |
+            CPI_PERMIT_ON_PVGUEST=1


### PR DESCRIPTION
Inspired by https://github.com/coreos/rhel-coreos-config/issues/64#issuecomment-3249336317