### PR TITLE
Containerfile: COPY build context

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,18 @@
+# by default, ignore everything
+*
+
+# only add what we actually need; this provides more accurate layer caching and
+# makes the COPY faster
+!/*.repo
+!/build-args.conf
+!/build-rootfs
+!/buildroot-prep
+!/image-base.yaml
+!/image-default.yaml
+!/image.yaml
+!/live/
+!/manifest-lock.*
+!/manifests/
+!/manifest.yaml
+!/overlay.d/
+!/platforms.yaml

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,7 @@
 # https://github.com/containers/buildah/issues/5952 is fixed.
 #
 # For development convenience, an `overrides/` directory in the context dir, or
-# mounted at `/run/src/overrides` is supported:
+# mounted at `/src/overrides` is supported:
 # - The `overrides/rpm` directory can be a yum repo. Its packages take
 #   precedence over those from remote repos.
 # - The `overrides/rootfs` directory can contain files in a rootfs layout which
@@ -23,9 +23,12 @@ ARG MANIFEST=overridden
 # XXX: see inject_passwd_group() in build-rootfs
 ARG PASSWD_GROUP_DIR
 
+COPY . /src
+# canonicalize permission bits, see also https://gitlab.com/fedora/bootc/base-images/-/merge_requests/274
+RUN chmod -R a=rX,u+w /src
+
 # this allows FCOS/SCOS/RHCOS to do specific things before going into the shared build-rootfs script
-RUN --mount=type=bind,target=/run/src \
-  if test -x /run/src/buildroot-prep; then /run/src/buildroot-prep; fi
+RUN if test -x /src/buildroot-prep; then /src/buildroot-prep; fi
 
 # useful if you're hacking on rpm-ostree/bootc-base-imagectl
 # COPY rpm-ostree /usr/bin/
@@ -37,8 +40,7 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
-    --mount=type=bind,target=/run/src \
-        /run/src/build-rootfs "${MANIFEST}" "${VERSION}" /target-rootfs
+        /src/build-rootfs "${MANIFEST}" "${VERSION}" /target-rootfs
 RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \

--- a/build-rootfs
+++ b/build-rootfs
@@ -18,7 +18,7 @@ import yaml
 
 
 ARCH = os.uname().machine
-CONTEXTDIR = '/run/src'
+SRCDIR = '/src'
 
 
 def main():
@@ -26,7 +26,7 @@ def main():
     version = sys.argv[2]
     target_rootfs = sys.argv[3]
 
-    manifest_path = os.path.join(CONTEXTDIR, manifest_name)
+    manifest_path = os.path.join(SRCDIR, manifest_name)
     manifest = get_treefile(manifest_path)
 
     packages = list(manifest['packages'])
@@ -91,14 +91,14 @@ def inject_yumrepos():
         os.unlink(repo)
 
     # and now inject our repos
-    for repo in glob.glob(f'{CONTEXTDIR}/*.repo'):
+    for repo in glob.glob(f'{SRCDIR}/*.repo'):
         shutil.copy(repo, "/etc/yum.repos.d")
 
 
 def build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays, repos, nodocs):
     passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
     if passwd_group_dir is not None:
-        inject_passwd_group(os.path.join(CONTEXTDIR, passwd_group_dir))
+        inject_passwd_group(os.path.join(SRCDIR, passwd_group_dir))
     with tempfile.NamedTemporaryFile(mode='w') as argsfile:
         for pkg in packages:
             argsfile.write(f"--install={pkg}\n")
@@ -202,7 +202,7 @@ def run_postprocess_scripts(rootfs, manifest):
 
 
 def prepare_local_rpm_overrides(rootfs):
-    overrides_repo = os.path.join(CONTEXTDIR, 'overrides/rpm')
+    overrides_repo = os.path.join(SRCDIR, 'overrides/rpm')
     if not os.path.isdir(f'{overrides_repo}/repodata'):
         return None
 
@@ -244,9 +244,9 @@ def bwrap(rootfs, args):
 
 
 def get_locked_nevras(local_overrides):
-    lockfile_path = os.path.join(CONTEXTDIR, f"manifest-lock.{ARCH}.json")
-    overrides_path = os.path.join(CONTEXTDIR, "manifest-lock.overrides.yaml")
-    overrides_arch_path = os.path.join(CONTEXTDIR, f"manifest-lock.overrides.{ARCH}.yaml")
+    lockfile_path = os.path.join(SRCDIR, f"manifest-lock.{ARCH}.json")
+    overrides_path = os.path.join(SRCDIR, "manifest-lock.overrides.yaml")
+    overrides_arch_path = os.path.join(SRCDIR, f"manifest-lock.overrides.{ARCH}.yaml")
 
     # we go from lowest priority to highest here: base lockfiles, overrides, local overrides
     locks = {}
@@ -308,9 +308,9 @@ def gather_overlays(manifest):
     overlays = []
     for layer in manifest.get('ostree-layers', []):
         assert layer.startswith('overlay/')
-        overlays.append(os.path.join(CONTEXTDIR, 'overlay.d', layer[len('overlay/'):]))
+        overlays.append(os.path.join(SRCDIR, 'overlay.d', layer[len('overlay/'):]))
 
-    rootfs_override = os.path.join(CONTEXTDIR, 'overrides/rootfs')
+    rootfs_override = os.path.join(SRCDIR, 'overrides/rootfs')
     if os.path.isdir(rootfs_override) and len(os.listdir(rootfs_override)) > 0:
         print("Injecting rootfs override")
         overlays.append(rootfs_override)
@@ -321,12 +321,12 @@ def gather_overlays(manifest):
 # Inject live/ bits.
 def inject_live(rootfs):
     target_path = os.path.join(rootfs, 'usr/share/coreos-assembler/live')
-    shutil.copytree(os.path.join(CONTEXTDIR, "live"), target_path)
+    shutil.copytree(os.path.join(SRCDIR, "live"), target_path)
 
 
 def inject_image_json(rootfs, manifest_path):
     manifest_vars = yaml.safe_load(open(manifest_path))['variables']
-    image = flatten_image_yaml(os.path.join(CONTEXTDIR, 'image.yaml'),
+    image = flatten_image_yaml(os.path.join(SRCDIR, 'image.yaml'),
                                format_args=manifest_vars)
     fn = os.path.join(rootfs, 'usr/share/coreos-assembler/image.json')
     with open(fn, 'w') as f:
@@ -427,7 +427,7 @@ def merge_dicts(x, y):
 
 
 def inject_platforms_json(rootfs):
-    with open(os.path.join(CONTEXTDIR, 'platforms.yaml')) as f:
+    with open(os.path.join(SRCDIR, 'platforms.yaml')) as f:
         platforms = yaml.safe_load(f)
     fn = os.path.join(rootfs, 'usr/share/coreos-assembler/platforms.json')
     if ARCH in platforms:

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -10,7 +10,7 @@ arch=$(uname -m)
 
 # Fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475.
 # Comment this out if not used to not unnecessarily pay for repo metadata.
-cp /run/src/fedora-coreos-continuous.repo /etc/yum.repos.d
+cp /src/fedora-coreos-continuous.repo /etc/yum.repos.d
 sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous --releasever "$VERSION_ID"
 
 # fast-track https://gitlab.com/fedora/bootc/base-images/-/merge_requests/279


### PR DESCRIPTION
I like the efficiency of being able to just mount the build context instead of having to copy it in. For example, I often have git worktrees in my git checkout and I don't want `COPY` to dumbly copy those too (though I then realized we could just use a `.containerignore` for it).

However, a down side of mounting is that we render layer caching even more useless because it can't know which files from the mount we're actually using.

More recently, an issue around setgid leaking into the context dir (because OpenShift) came up (see
https://github.com/coreos/coreos-assembler/pull/4277) and it's just not acceptable to chmod the real build context directory.

Of course, `build-rootfs` could e.g. copy the overlay dirs into a temporary location and then adjust the perms there, but at that point, we're quite close to just doing a `COPY` upfront anyway.

So let's just switch to that, strip the bits as we want, but include a `.containerignore` to only copy what we need.

This then limits the build context mounting to just the rechunk and `FROM oci-archive:` hack. Which... hopefully one day we could normalize that.