### PR TITLE
test/validate-symlinks: Remove nfsmount config symlinks from known list

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -18,8 +18,6 @@ set -xeuo pipefail
 # - The symlinks in /usr/lib/firmware are often broken and are typically not an
 #   issue, so let's skip this location altogether.
 # - json-glib -> https://bugzilla.redhat.com/show_bug.cgi?id=2297094
-# - broken symlinks in /etc/nfsmount.conf.d for nfs-client-utils in rawhide
-#   issue: https://github.com/coreos/fedora-coreos-tracker/issues/2012
 #
 list_broken_symlinks_skip=(
     '/etc/mtab'
@@ -34,8 +32,6 @@ list_broken_symlinks_skip=(
     '/usr/share/rhel/secrets/etc-pki-entitlement'
     '/usr/share/rhel/secrets/redhat.repo'
     '/usr/share/rhel/secrets/rhsm'
-    '/etc/nfsmount.conf.d/10-nfsv3.conf'
-    '/etc/nfsmount.conf.d/10-nfsv4.conf'
 )
 
 # If RHCOS, update the array of ignored symlinks


### PR DESCRIPTION
These broken symlinks are fixed in the latest release of nfs-client-utils which recently landed in rawhide.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/2012