### PR TITLE
konflux: update pipeline reference

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -39,7 +39,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
This new reference contains [1] which is not merged yet. Once merged we'll move back to official pipeline reference. We need this to unblock Konflux implementation.

[1] https://gitlab.com/fedora/bootc/tekton-catalog/-/merge_requests/4