### PR TITLE
fix(fcos-buildroot): correct file path in CEL expressions for triggers

### DIFF
--- a/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "testing-devel" && (".tekton/fcos-buildroot-pull-request.yaml".pathChanged() || "ci/buildroot/**".pathChanged())
+      == "testing-devel" && (".tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml".pathChanged() || "ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "testing-devel" && (".tekton/fcos-buildroot-push.yaml".pathChanged() ||  "ci/buildroot/**".pathChanged())
+      == "testing-devel" && (".tekton/fcos-buildroot/fcos-buildroot-push.yaml".pathChanged() ||  "ci/buildroot/**".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/"))) && !(".tekton/fcos-buildroot".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-pull-request/kustomization.yaml
+++ b/.tekton/testing-devel/on-pull-request/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-pull-request'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
+        value: 'event == "pull_request" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/"))) && !(".tekton/fcos-buildroot".pathChanged())'
 

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -13,7 +13,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/"))) && !(".tekton/fcos-buildroot".pathChanged())
   creationTimestamp: null
 spec:
   params:

--- a/.tekton/testing-devel/on-push/kustomization.yaml
+++ b/.tekton/testing-devel/on-push/kustomization.yaml
@@ -26,5 +26,5 @@ patches:
         value: 'fedora-coreos-testing-devel-on-push'
       - op: replace
         path: /metadata/annotations/pipelinesascode.tekton.dev~1on-cel-expression
-        value: 'event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/")))'
+        value: 'event == "push" && target_branch == "testing-devel" && !(files.all.all(f, f.matches("ci/buildroot/"))) && !(".tekton/fcos-buildroot".pathChanged())'
 


### PR DESCRIPTION
The CEL expressions were referencing incorrect paths:
- `.tekton/fcos-buildroot-pull-request.yaml` instead of `.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml`
- `.tekton/fcos-buildroot-push.yaml` instead of `.tekton/fcos-buildroot/fcos-buildroot-push.yaml`

This caused the Tekton triggers to not fire as expected on changes. Fixed the paths to match the actual file locations.