### PR TITLE
[next] build-args.conf: fix stream name in DESCRIPTION

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -10,4 +10,4 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
-DESCRIPTION=Fedora CoreOS testing-devel
+DESCRIPTION=Fedora CoreOS next


### PR DESCRIPTION
This was clobbered by accident during the last promotion.