### PR TITLE
[rawhide] switch to `ostree-image-signed` refspec for built images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,7 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Switching to `ostree-image-signed` on select streams for now. Hoist
+# back up into the shared image-base.yaml when it is rolled out everywhere.
+container-imgref: "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{stream}"


### PR DESCRIPTION
Part of https://github.com/coreos/fedora-coreos-tracker/issues/2029