### PR TITLE
[branched] switch to `ostree-image-signed` refspec for built images

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,7 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Switching to `ostree-image-signed` on select streams for now. Hoist
+# back up into the shared image-base.yaml when it is rolled out everywhere.
+container-imgref: "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{stream}"

--- a/image.yaml
+++ b/image.yaml
@@ -2,12 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# Deploy via container now
-# https://github.com/coreos/fedora-coreos-tracker/issues/1823
-deploy-via-container: true
-container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:branched"
-
-# Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
-live-rootfs-fstype: "erofs"
-live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"


### PR DESCRIPTION
Part of https://github.com/coreos/fedora-coreos-tracker/issues/2029

Also drop the earlier customizations that shouldn't have been there any longer.