### PR TITLE
konflux: update pipeline ref automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,30 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "/^quay.io/bootc-devel/tekton-catalog//"
+      ],
+      "matchBaseBranches": [
+        "testing-devel"
+      ],
+      "enabled": true,
+      "groupName": "Konflux references",
+      "branchPrefix": "renovate/konflux/references/",
+      "group": {
+        "branchTopic": "{{{baseBranch}}}",
+        "commitMessageTopic": "{{{groupName}}}"
+      },
+      "commitMessageTopic": "Konflux references",
+      "prBodyColumns": [
+        "Package",
+        "Change",
+        "Notes"
+      ],
+      "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+      "recreateWhen": "always",
+      "rebaseWhen": "behind-base-branch"
+    },
+    {
       "matchDatasources": ["docker"],
       "matchDepNames": ["quay.io/fedora/fedora"],
       "enabled": false


### PR DESCRIPTION
We apply the Renovate rule only on testing-devel branch as the CoreOS bot will sync changes to the other branches.