### PR TITLE
snooze  issue 2021 for 2 more week

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,13 +12,13 @@
     - ppc64le
 - pattern: fcos.ignition.v3.noop
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
-  snooze: 2025-09-15
+  snooze: 2025-09-29
   warn: true
   platforms:
     - azure
 - pattern: fcos.ignition.misc.empty
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
-  snooze: 2025-09-15
+  snooze: 2025-09-29
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
Snooze https://github.com/coreos/fedora-coreos-tracker/issues/2021 for 2 more weeks since we still waiting for the fix