### PR TITLE
[branched] manifest.yaml: default to buildah path

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,6 +2,10 @@ variables:
   stream: branched
   prod: false
 
+metadata:
+  # tell `cosa build` to default to buildah path
+  build_with_buildah: true
+
 releasever: 43
 
 repos:


### PR DESCRIPTION
We switched rawhide over to the buildah path in the pipeline, but we want anyone/anything building rawhide to do the same. cosa recently learned to read `metadata.build_with_buildah` for this.

Make use of it.