### PR TITLE
s390x: treat EXIT_NO_PERMIT_CPI from cpi.service as success under Secure Execution

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/01-secex.ign
@@ -76,6 +76,15 @@
       {
         "mask": true,
         "name": "autovt@.service"
+      },
+      {
+        "dropins": [
+          {
+            "contents": "# CPI may exit with code 6 (EXIT_NO_PERMIT_CPI)if permission is not granted\n[Service]\nSuccessExitStatus=6",
+            "name": "secex.conf"
+          }
+        ],
+        "name": "cpi.service"
       }
     ]
   }

--- a/tests/kola/secex/ensure/config.bu
+++ b/tests/kola/secex/ensure/config.bu
@@ -1,9 +1,0 @@
-variant: fcos
-version: 1.6.0
-storage:
-  files:
-    - path: /etc/sysconfig/cpi
-      overwrite: false
-      append:
-        - inline: |
-            CPI_PERMIT_ON_PVGUEST=1

--- a/tests/kola/secex/reboot/config.bu
+++ b/tests/kola/secex/reboot/config.bu
@@ -1,9 +1,0 @@
-variant: fcos
-version: 1.6.0
-storage:
-  files:
-    - path: /etc/sysconfig/cpi
-      overwrite: false
-      append:
-        - inline: |
-            CPI_PERMIT_ON_PVGUEST=1


### PR DESCRIPTION

Since commit https://github.com/ibm-s390-linux/s390-tools/commit/ce9c518b977925cc4c9eb92a3e508762fd57f551
CPI no longer sends data for Secure Execution guests. This causes `cpi.service` to exit with `EXIT_NO_PERMIT_CPI`,
which `systemd` interprets as a failure. Adjust the unit to consider this exit code successful.

Issue: https://github.com/coreos/rhel-coreos-config/issues/64