### PR TITLE
build-rootfs: add com.coreos.inputhash label

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,8 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \
-        --output oci-archive:/run/src/out.ociarchive
+        --output oci-archive:/run/src/out.ociarchive \
+        --label com.coreos.inputhash=$(cat /run/inputhash)
 
 FROM oci-archive:./out.ociarchive
 ARG VERSION

--- a/build-rootfs
+++ b/build-rootfs
@@ -8,6 +8,7 @@
 # 5. It runs the postprocess scripts defined in the manifest.
 
 import glob
+import hashlib
 import json
 import os
 import shutil
@@ -19,6 +20,7 @@ import yaml
 
 ARCH = os.uname().machine
 SRCDIR = '/src'
+INPUTHASH = '/run/inputhash'
 
 
 def main():
@@ -66,6 +68,7 @@ def main():
     inject_content_manifest(target_rootfs, manifest)
 
     if version != "":
+        overlays.remove(dracut_tmpd.name)
         cleanup_dracut_version(target_rootfs, dracut_tmpd)
         inject_version_info(target_rootfs, manifest['mutate-os-release'], version)
 
@@ -74,6 +77,8 @@ def main():
         verify_strict_mode(target_rootfs, locked_nevras)
     run_postprocess_scripts(target_rootfs, manifest)
     cleanup_extraneous_files(target_rootfs)
+
+    calculate_inputhash(target_rootfs, overlays, manifest)
 
 
 def get_treefile(manifest_path):
@@ -432,6 +437,35 @@ def cleanup_extraneous_files(rootfs):
 
     # for now just this
     unlink_optional('usr/share/rpm/.rpm.lock')
+
+
+def calculate_inputhash(rootfs, overlays, manifest):
+    h = hashlib.sha256()
+
+    # rpms
+    rpms = bwrap(rootfs, ['rpm', '-qa', '--qf', '%{NEVRA}\n'], capture=True)
+    rpms = sorted(rpms.splitlines())
+    h.update(''.join(rpms).encode('utf-8'))
+
+    # overlays
+    for overlay in overlays:
+        all_files = []
+        for root, _, files in os.walk(overlay):
+            for file in files:
+                all_files.append(os.path.join(root, file))
+        all_files = sorted(all_files)
+        for file in all_files:
+            with open(file, 'rb') as f:
+                h.update(hashlib.file_digest(f, 'sha256').digest())
+                has_x_bit = os.stat(f.fileno()).st_mode & 0o111 != 0
+                h.update(bytes([has_x_bit]))
+
+    # postprocess
+    for script in manifest.get('postprocess', []):
+        h.update(script.encode('utf-8'))
+
+    with open(INPUTHASH, 'w', encoding='utf-8') as f:
+        f.write(h.hexdigest())
 
 
 # Imported from cosa

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -8,11 +8,12 @@ set -euo pipefail
 arch=$(uname -m)
 . /etc/os-release
 
-# Fast-track backport of https://github.com/coreos/rpm-ostree/pull/5475.
-# Comment this out if not used to not unnecessarily pay for repo metadata.
 cp /src/fedora-coreos-continuous.repo /etc/yum.repos.d
-if [ "${VERSION_ID}" == 42 ]; then
+
+# NOTE: try to remove anything that queries repos here once it's no longer
+# needed so that we don't unnecessarily pay for repo metadata.
+
+# make sure we have https://github.com/coreos/rpm-ostree/pull/5454
+if ! rpm-ostree compose build-chunked-oci -h | grep -q -- --label; then
     sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous --releasever "$VERSION_ID"
-else
-    sudo dnf install rpm-ostree-2025.10 --allow-downgrade -y --repo fedora-coreos-continuous --releasever "$VERSION_ID"
 fi


### PR DESCRIPTION
Right now, there is no change detection in our builds. We just always do a new build, which is wasteful.

Let's re-implement a concept similar to rpm-ostree's inputhash, which just hashes all the relevant inputs. We then add a label to the final image with that input. On the cosa side, we can compare the hash to the previous build to know if to no-op.

One major difference from rpm-ostree's inputhash is that it could know the hash right after doing the depsolve (to have the final list of RPMs) and thus avoid a full build. It's possible to do this here too though it'd require bootc-base-imagectl and rpm-ostree changes. We'd need to also define an API for having a `podman build` actually signal "no-op"; e.g. writing a file in the build context and erroring the build... awkward.

Much more interesting and related to this is reproducible builds; if our builds were reproducible, we wouldn't have to worry about this because we'd just build the exact same artifact everytime. There's some work required to get there though, and likely we'd have to rework how we calculate our versions, since that's a dynamic value which affects the rootfs and OCI labels (e.g. always have the same version for the set of inputs; see also discussions in https://github.com/coreos/fedora-coreos-tracker/issues/2015).

---

Requires rpm-ostree v2025.11 in the buildroot.