### PR TITLE
[next-devel]: overrides: modify crun-wasm override for correct arches

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -13,5 +13,11 @@ packages:
     evra: 1.24-1.fc43.aarch64
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537 
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  crun-wasm:
+    evra: 1.24-1.fc43.aarch64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -15,3 +15,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537 
       type: fast-track
+  crun-wasm:
+    evra: 1.24-1.fc43.x86_64
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -45,12 +45,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track
-  crun-wasm:
-    evr: 1.24-1.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-191b6535ed
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
-      type: fast-track
   fwupd:
     evr: 2.0.16-1.fc43
     metadata:


### PR DESCRIPTION
The override should only exist for `x86_64` and `aarch64`.