### PR TITLE
konflux: update pipeline reference

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -39,7 +39,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
@@ -31,7 +31,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ea80d0ab92471fd4ad5bcaa6961781c3c66ce043e9fc4af7c6cc2b734e8499ca
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -40,7 +40,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/coreos-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:938ebbc9eec9836e2b010304103db8986788cfc9f6db33c1c76fe2e504be9052
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
This is a follow-up of [1]. With this update, the images will start containing `org.opencontainers.image.{source,version}` as label and annotations. This partially enables tagging the image with the version, see [2] for more details.
This update also contains [3] which fixes the issue we are currently hitting in Konflux.
Finally, this pipeline ref is using pinned task as reference, which is required to comply to Conforma `redhat` policy. More details in [4].

[1] https://github.com/coreos/fedora-coreos-config/pull/3732
[2] https://gitlab.com/fedora/infrastructure/konflux/tenants-config/-/merge_requests/72
[3] https://github.com/konflux-ci/build-definitions/pull/2785
[4] https://gitlab.com/fedora/bootc/tekton-catalog/-/issues/5