### PR TITLE
denylist: add snooze for coreos.unique.boot.failure on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -22,3 +22,14 @@
   warn: true
   platforms:
     - azure
+- pattern: coreos.unique.boot.failure
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2019
+  snooze: 2025-09-29
+  warn: true
+  arches:
+    - aarch64
+  streams:
+    - next
+    - next-devel
+    - branched
+    - rawhide


### PR DESCRIPTION
Something changed in F43+ to cause this test to be very flaky. This is documented over in https://github.com/coreos/fedora-coreos-tracker/issues/2019

Let's add it to the denylist while we investigate.