### PR TITLE
denylist: snooze coreos.unique.boot.failure for all aarch64 streams

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,8 +28,3 @@
   warn: true
   arches:
     - aarch64
-  streams:
-    - next
-    - next-devel
-    - branched
-    - rawhide


### PR DESCRIPTION
Journal dumping failed even on `testing-devel` with same error:
```
06:47:19  ---
FAIL: coreos.unique.boot.failure (244.65s)
06:47:19          qemufailure.go:69: Journal dumping during emergency.target failed: context deadline exceeded
```