### PR TITLE
build-rootfs: mutate /usr/lib/initrd-release in initrd

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,11 +57,11 @@ RUN --mount=type=bind,from=builder,target=/var/tmp \
     --mount=type=bind,target=/run/src,rw \
       rm /run/src/out.ociarchive
 
-LABEL containers.bootc=1
-LABEL ostree.bootable=1
-LABEL org.opencontainers.image.version=$VERSION
-LABEL com.coreos.osname=$NAME
-LABEL org.opencontainers.image.title=$DESCRIPTION
-LABEL org.opencontainers.image.description=$DESCRIPTION
+LABEL containers.bootc=1 \
+      ostree.bootable=1 \
+      org.opencontainers.image.version=$VERSION \
+      com.coreos.osname=$NAME \
+      org.opencontainers.image.title=$DESCRIPTION \
+      org.opencontainers.image.description=$DESCRIPTION
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/build-rootfs
+++ b/build-rootfs
@@ -53,6 +53,11 @@ def main():
 
     overlays = gather_overlays(manifest)
     nodocs = (manifest.get('documentation') is False)
+
+    if version != "":
+        dracut_tmpd = inject_dracut_version(manifest['mutate-os-release'], version)
+        overlays += [dracut_tmpd.name]
+
     build_rootfs(target_rootfs, manifest_path, packages, locked_nevras, overlays, repos, nodocs)
 
     inject_live(target_rootfs)
@@ -61,7 +66,9 @@ def main():
     inject_content_manifest(target_rootfs, manifest)
 
     if version != "":
+        cleanup_dracut_version(target_rootfs, dracut_tmpd)
         inject_version_info(target_rootfs, manifest['mutate-os-release'], version)
+
     strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':
         verify_strict_mode(target_rootfs, locked_nevras)
@@ -298,6 +305,8 @@ def inject_version_info(rootfs, base_version, version):
             (k, v) = line.split('=', 1)
             os_release[k] = v
 
+    # The fields modified here match those in inject_dracut_version below. Keep
+    # them in sync.
     for key in ['VERSION', 'PRETTY_NAME']:
         os_release[key] = os_release[key].replace(base_version, version)
     os_release['OSTREE_VERSION'] = f"'{version}'"
@@ -306,6 +315,39 @@ def inject_version_info(rootfs, base_version, version):
     with open(os_release_path, mode='w', encoding='utf-8') as f:
         for (k, v) in os_release.items():
             f.write(f'{k}={v}\n')
+
+
+# This dynamically generates a dracut module which doesn't actually install
+# anything in the initrd. It just mutates the initrd-release installed by
+# dracut-systemd in the same way we mutate os-release above. Normally, we'd
+# only need inject_version_info above and dracut would create its initrd-release
+# based on that. But injection happens after the rpm-ostree compose and we want
+# to avoid regenerating the initramfs just for that.
+def inject_dracut_version(base_version, version):
+    tmpd = tempfile.TemporaryDirectory()
+    # we use 99 here so we run last, i.e. after initrd-release exists
+    module_setup = os.path.join(tmpd.name, 'usr/lib/dracut/modules.d/99dracut-coreos-version/module-setup.sh')
+    os.makedirs(os.path.dirname(module_setup), exist_ok=True)
+    with open(module_setup, 'w', encoding='utf-8') as f:
+        # The fields modified here match those in inject_version_info above.
+        # Keep them in sync.
+        f.write(f'''
+check() {{ return 0; }}
+install() {{
+    sed -i -E -e '/^(PRETTY_NAME|VERSION)=/ s/{base_version}/{version}/' $initdir/usr/lib/initrd-release
+    echo "OSTREE_VERSION='{version}'" >> $initdir/usr/lib/initrd-release
+    echo "IMAGE_VERSION='{version}'" >> $initdir/usr/lib/initrd-release
+}}
+''')
+    return tmpd
+
+
+def cleanup_dracut_version(rootfs, tmpd):
+    # we can nuke this from the rootfs now; any dracut regeneration from this
+    # point on (e.g. in derived builds, or client side) will be able to see the
+    # os-release changes done by inject_version_info
+    shutil.rmtree(f'{rootfs}/usr/lib/dracut/modules.d/99dracut-coreos-version')
+    del tmpd
 
 
 # This re-implements cosa's overlay logic.

--- a/build-rootfs
+++ b/build-rootfs
@@ -66,6 +66,7 @@ def main():
     if strict_mode == '1':
         verify_strict_mode(target_rootfs, locked_nevras)
     run_postprocess_scripts(target_rootfs, manifest)
+    cleanup_extraneous_files(target_rootfs)
 
 
 def get_treefile(manifest_path):
@@ -378,6 +379,17 @@ def verify_strict_mode(rootfs, locked_nevras):
         if nevra not in locked_nevras and nevr not in locked_nevras:
             raise Exception(f"found unlocked RPM in strict mode: {rpm}")
     print("Strict mode: all installed packages were locked")
+
+
+def cleanup_extraneous_files(rootfs):
+    def unlink_optional(f):
+        try:
+            os.unlink(os.path.join(rootfs, f))
+        except FileNotFoundError:
+            pass
+
+    # for now just this
+    unlink_optional('usr/share/rpm/.rpm.lock')
 
 
 # Imported from cosa

--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -55,4 +55,9 @@ for kmod in "${required_initrd_kmods[@]}"; do
     fi
 done
 
+if ! grep OSTREE_VERSION "${tmpd}/usr/lib/initrd-release"; then
+    cat "${tmpd}/usr/lib/initrd-release"
+    fatal "no OSTREE_VERSION found in /usr/lib/initrd-release in initrd"
+fi
+
 ok "Found expected initrd files"


### PR DESCRIPTION
In the legacy path, rpm-ostree handles `mutate-os-release` before
calling dracut. So the initrd-release in the initramfs (built from
os-release) contains the updated values.

In the buildah path, we handle version mutation after the rpm-ostree
compose done by bootc-base-imagectl and so the initrd doesn't have the
updated values.

I find that versioning information in the initrd useful because systemd
will print it out on the console (the "Welcome to ..." string), and a
lot of our bug reports are from failures in the initramfs.

So this patch restores this information for the buildah path, but does
it in a subtle way to avoid having to regenerate the initramfs just
for that: we create a temporary dracut module and then delete it in
postprocessing.