### PR TITLE
test/files/setgid: add file to exception list for EL9

### DIFF
--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -14,6 +14,12 @@ list_setgid_files=(
     '/usr/bin/write'
     '/usr/libexec/utempter/utempter'
 )
+# Drop '/usr/libexec/openssh/ssh-keysign' after
+# https://src.fedoraproject.org/rpms/openssh/c/b615362fd0b4da657d624571441cb74983de6e3f?branch=rawhide
+# landed in EL9 (it's in Fedora and EL10 already).
+if match_maj_ver "9"; then
+    list_setgid_files+=('/usr/libexec/openssh/ssh-keysign')
+fi
 
 unknown_setgid_files=""
 while IFS= read -r -d '' e; do


### PR DESCRIPTION
This reverts commit 4eb342e7f8f2da5a3eee73d108fd8afb80330d10.

That patch was included in Fedora, but it isn't in EL9 and likely won't be backported.