### PR TITLE
40ignition-ostree: bind mount stateroot_var_path rw

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-var.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/40ignition-ostree/ignition-ostree-mount-var.sh
@@ -41,7 +41,9 @@ do_mount() {
     fi
 
     echo "Mounting $stateroot_var_path"
+    # older mount ignore 'rw' when using '-o bind,rw', so make 2 calls for now
     mount --bind "$stateroot_var_path" /sysroot/var
+    mount -o remount,bind,rw /sysroot/var
 }
 
 do_umount() {


### PR DESCRIPTION
From man mount(8):

    Since util-linux 2.39, mount may use the new kernel mount API if
    it is available. This new kernel interface provides a more precise
    way to work with mountpoint attributes. For example, the -o
    bind,rw operation will create a read-write node even if the
    original node was read-only.

ostree-prepare-root is creating a rw bind mount at stateroot_var_path because in the past, if a mount unit had 'Options=bind,rw', the 'rw' option was ignored.

Remount /sysroot/var rw so we can remove the stateroot_var_path rw
bind mount from ostree-prepare-root.