### PR TITLE
promote container signature verification and migration to it

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -35,7 +35,7 @@ platform-compressor:
     digitalocean: gzip
 
 # Set container-imgref
-container-imgref: "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:{stream}"
+container-imgref: "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{stream}"
 
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -54,30 +54,17 @@ conditional-include:
     include:
       ostree-layers:
         - overlay/50alternatives
-  # Add container signing configuration. Initially rolling this out only
-  # to `next`, `next-devel` and mechanical streams.
-  - if:
-    - stream != "stable"
-    - stream != "testing"
-    - stream != "testing-devel"
-    include:
-      ostree-layers:
-        - overlay/17fcos-container-signing
   # Perform migration to container signing versus ostree commit signing.
   # This is a requirement for moving to build-via-container in F43,
-  # thus it must happen before the switch to F43. Initially rolling out
-  # to `next` and `next-devel`.
-  - if:
-    - stream != "stable"
-    - stream != "testing"
-    - stream != "testing-devel"
-    - releasever < 43
+  # thus it must happen before the switch to F43.
+  - if: releasever < 43
     include:
       ostree-layers:
         - overlay/35container-signing-migration
 
 ostree-layers:
   - overlay/15fcos
+  - overlay/17fcos-container-signing
 
 automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"
 mutate-os-release: "${releasever}"


### PR DESCRIPTION
This has rolled out on the `next` stream. Let's now promote it to our other streams and let the normal promotion progress (i.e. testing-devel -> testing -> stable) take place.

Part of https://github.com/coreos/fedora-coreos-tracker/issues/2029