### PR TITLE
test/files/setgid: avoid erroring for FCOS

### DIFF
--- a/tests/kola/files/setgid
+++ b/tests/kola/files/setgid
@@ -17,7 +17,7 @@ list_setgid_files=(
 # Drop '/usr/libexec/openssh/ssh-keysign' after
 # https://src.fedoraproject.org/rpms/openssh/c/b615362fd0b4da657d624571441cb74983de6e3f?branch=rawhide
 # landed in EL9 (it's in Fedora and EL10 already).
-if match_maj_ver "9"; then
+if ! is_fcos && match_maj_ver "9"; then
     list_setgid_files+=('/usr/libexec/openssh/ssh-keysign')
 fi
 


### PR DESCRIPTION
As a follow-up of #3772.