### PR TITLE
tests/kola: extend upgrade test timeout; fix early exit

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -389,5 +389,7 @@ systemd-run -u refchanged                      \
 # While we wait, loop to show status of zincati and rpm-ostreed
 while true; do
     sleep 30
-    systemctl status rpm-ostreed zincati --lines=0
+    # Ignore error here. Older systemd (~F32) errors here if one of
+    # the services isn't active.
+    systemctl status rpm-ostreed zincati --lines=0 || true
 done

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -3,7 +3,7 @@
 ##   # - needs-internet: to pull updates
 ##   tags: "needs-internet"
 ##   # Extend the timeout since a lot of updates/reboots can happen.
-##   timeoutMin: 45
+##   timeoutMin: 75
 ##   # Only run this test when specifically requested.
 ##   requiredTag: extended-upgrade
 ##   description: Verify upgrade works.


### PR DESCRIPTION
```
commit 2f30fc6ab254f80d8aa714ea449cee911723d697
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 22 15:37:25 2025 -0400

    tests/kola: fix early error in upgrade test
    
    In some older versions of FCOS `systemctl status foo.service` would
    output an error if foo.service wasn't active. Let's account for this
    by adding an `|| true` so our script doesn't exit with an error here.

commit 6d944edc4c5e0db796f43ee64e718f173bd5b871
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 22 15:36:11 2025 -0400

    tests/kola: bump timeout for the upgrade test
    
    We've added a lot of barriers recently and our upgrades are taking
    longer. I think part of this is because the performance downloading
    from the OSTree repo (for older barriers) is pretty bad.
    
    Either way let's bump this to try to limit some of the timeouts we
    are seeing.
```