### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -24,18 +24,6 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2b6a50d3c4
       type: fast-track
-  libselinux:
-    evr: 3.8-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2a0988eb82
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2030
-      type: fast-track
-  libselinux-utils:
-    evr: 3.8-3.fc42
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2a0988eb82
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2030
-      type: fast-track
   rpm-ostree:
     evr: 2025.11-1.fc42
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).