### PR TITLE
overrides: fast-track rpm-ostree-2025.11-1.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -36,3 +36,15 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-2a0988eb82
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2030
       type: fast-track
+  rpm-ostree:
+    evr: 2025.11-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-38be2fd733
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2030#issuecomment-3323900308
+      type: fast-track
+  rpm-ostree-libs:
+    evr: 2025.11-1.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-38be2fd733
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2030#issuecomment-3323900308
+      type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).