### PR TITLE
[rawhide] image.yaml: drop container-imgref override

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# Switching to `ostree-image-signed` on select streams for now. Hoist
-# back up into the shared image-base.yaml when it is rolled out everywhere.
-container-imgref: "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{stream}"


### PR DESCRIPTION
The image-base.yaml was updated to use this as the default value in b7e75bd so we don't need to carry this stream specific override here any longer.