### PR TITLE
[next-devel] overrides: fast-track audit-4.1.2-2.fc43, selinux-policy-42.9-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,24 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  audit:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  audit-libs:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  audit-rules:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
   ignition:
     evr: 2.23.0-1.fc43
     metadata:
@@ -19,5 +37,17 @@ packages:
     evr: 2.23.0-1.fc43
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-85840ed9d8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  selinux-policy:
+    evra: 42.9-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 42.9-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).