### PR TITLE
feat(pipeline): enable ppc64le and s390x architectures

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -36,6 +36,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   pipelineRef:

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -37,6 +37,8 @@ spec:
     value:
     - linux/amd64
     - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   pipelineRef:
     params:
     - name: bundle


### PR DESCRIPTION
Now that PowerPC (ppc64le) and s390x architectures are supported in the Fedora Konflux cluster, this commit enables them across all Fedora CoreOS Tekton pipeline configurations.