### PR TITLE
.cci.jenkinsfile: drop downloading ostree for previous build

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -19,7 +19,7 @@ cosaPod(cpus: 4, memory: "9Gi") {
         cosa init ${env.WORKSPACE}/config
         python3 /usr/lib/coreos-assembler/download-overrides.py
         # prep from the latest builds so that we generate a diff on PRs that add packages
-        cosa buildfetch --stream=${env.CHANGE_TARGET} --artifact=ostree
+        cosa buildfetch --stream=${env.CHANGE_TARGET}
     """)
 
     // use a --parent-build arg so we can diff later and it matches prod


### PR DESCRIPTION
Now that we can generate an rpmdiff from commitmeta.json alone [1] we can stop downloading the ostree ociarchive on every build.

[1] https://github.com/coreos/coreos-assembler/pull/4327