### PR TITLE
konflux: update pipeline reference

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -41,7 +41,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
+++ b/.tekton/fcos-buildroot/fcos-buildroot-push.yaml
@@ -34,7 +34,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:ba3c2d68b527da50d06619c34f15341081c3969aa305f181ecb08e40226e3a28
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:49a26e077686af4597fb94ed687fb135ad62058aa014db8950653e83b74189b4
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
Switched to latest pipeline bundle digest to satisfy
Conforma's tasks.pinned_task_refs validation.