### PR TITLE
denylist: extend snooze for fcos.ignition & coreos.unique.boot.failure tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,7 +24,7 @@
     - azure
 - pattern: coreos.unique.boot.failure
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2019
-  snooze: 2025-09-29
+  snooze: 2025-10-13
   warn: true
   arches:
     - aarch64

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,13 +12,13 @@
     - ppc64le
 - pattern: fcos.ignition.v3.noop
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
-  snooze: 2025-09-29
+  snooze: 2025-10-06
   warn: true
   platforms:
     - azure
 - pattern: fcos.ignition.misc.empty
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
-  snooze: 2025-09-29
+  snooze: 2025-10-06
   warn: true
   platforms:
     - azure


### PR DESCRIPTION
We are waiting for a new afterburn release to address this issue.