### PR TITLE
[next-devel] overrides: fast-track downgraded packages

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -37,6 +37,18 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track
+  libdrm:
+    evr: 2.4.126-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-551d41aa4b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  libjcat:
+    evr: 0.2.5-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e8de77a0f9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
   selinux-policy:
     evra: 42.9-1.fc43.noarch
     metadata:
@@ -47,5 +59,23 @@ packages:
     evra: 42.9-1.fc43.noarch
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  skopeo:
+    evr: 1:1.20.0-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e5464b6660
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  vim-data:
+    evra: 2:9.1.1818-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-79abb220af
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  vim-minimal:
+    evr: 2:9.1.1818-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-79abb220af
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track


### PR DESCRIPTION
Some packages in F42 are sorting as newer than F43 due to the juggle of packages in between beta and final freeze. Fast track them in F43 so they don't show as downgraded. Today they are:

- `libdrm 2.4.126-1.fc42 -> 2.4.125-2.fc43`
- `libjcat 0.2.5-1.fc42 -> 0.2.3-2.fc43`
- `skopeo 1:1.20.0-3.fc42 -> 1:1.20.0-2.fc43`
- `vim-data 2:9.1.1818-1.fc42 -> 2:9.1.1775-1.fc43`
- `vim-minimal 2:9.1.1818-1.fc42 -> 2:9.1.1775-1.fc43`