### PR TITLE
overrides: fast-track rust-coreos-installer-0.25.0-2.fc42

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,16 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-dfcddccd45
       type: fast-track
+  coreos-installer:
+    evr: 0.25.0-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d0456e1a08
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.25.0-2.fc42
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-d0456e1a08
+      type: fast-track
   rpm-ostree:
     evr: 2025.11-1.fc42
     metadata:


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).