### PR TITLE
[next-devel] overrides: fast-track rust-coreos-installer-0.25.0-2.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -37,6 +37,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track
+  coreos-installer:
+    evr: 0.25.0-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-30a8bc20e9
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.25.0-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-30a8bc20e9
+      type: fast-track
   libdrm:
     evr: 2.4.126-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).