### PR TITLE
[next-devel] overrides: fast-track ignition-2.24.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -47,6 +47,16 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-30a8bc20e9
       type: fast-track
+  ignition:
+    evr: 2.24.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c8b9f97712
+      type: fast-track
+  ignition-grub:
+    evr: 2.24.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c8b9f97712
+      type: fast-track
   libdrm:
     evr: 2.4.126-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).