### PR TITLE
[next-devel] overrides: fast-track rust-bootupd-0.2.31-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -37,6 +37,11 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track
+  bootupd:
+    evr: 0.2.31-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-b163a3c238
+      type: fast-track
   coreos-installer:
     evr: 0.25.0-2.fc43
     metadata:


### PR DESCRIPTION
Requested by @HuijingHei via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).