### PR TITLE
[next-devel] manifest: add fedora-candidate-compose to list of repos for F43

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -15,5 +15,5 @@ repos:
   # GitHub Action.
   - fedora-next
   - fedora-next-updates
-  #- fedora-candidate-compose
+  - fedora-candidate-compose
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Late in the Fedora major release process adding this repo will allow us to pull in candidate RPMs that are proposed to fix release blocking or freeze exception issues. We will be able to test out these proposed fixes sooner and also be more prepared for releasing our final `next` release once the release is deemed "Go".

See https://github.com/coreos/fedora-coreos-config/pull/2705