### PR TITLE
Remove skip-console-warnings from denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,10 +6,6 @@
   warn: true
   arches:
     - ppc64le
-- pattern: skip-console-warnings
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1889
-  arches:
-    - ppc64le
 - pattern: fcos.ignition.v3.noop
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2021
   snooze: 2025-10-06


### PR DESCRIPTION
Removing skip-console-warnings for ppc64le, as the console kernel warnings are not seen in testing-devel latest build-- see [issue #2045](https://github.com/coreos/fedora-coreos-tracker/issues/2045) and [issue #1889](https://github.com/coreos/fedora-coreos-tracker/issues/1889)