### PR TITLE
fedora-archive.repo: add archives mirrors

### DIFF
--- a/fedora-archive.repo
+++ b/fedora-archive.repo
@@ -14,6 +14,8 @@ baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/$releasever/Every
         https://dl.fedoraproject.org/pub/fedora-secondary/releases/$releasever/Everything/$basearch/os/
         https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
         https://dl.fedoraproject.org/pub/archive/fedora-secondary/releases/$releasever/Everything/$basearch/os/
+        https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/$releasever/Everything/$basearch/os/
+        https://archives.fedoraproject.org/pub/archive/fedora-secondary/releases/$releasever/Everything/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 enabled=1
 #metadata_expire=7d


### PR DESCRIPTION
Add another set of mirrors for archives in case dl.fedoraproject.org/pub/archive timeouts or flake

We've had the pipeline fail for older releases on that so a set of extra mirrors can help