### PR TITLE
kola-denylist.yaml: add x86_64 on coreos.unique.boot.failure

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,3 +24,4 @@
   warn: true
   arches:
     - aarch64
+    - x86_64


### PR DESCRIPTION
Since it is failing on x86_64 as well I am adding it to the deny list.