### PR TITLE
manifests/fedora-coreos: remove systemd-gpt-auto-generator again

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -342,6 +342,13 @@ install() {{
     sed -i -E -e '/^(PRETTY_NAME|VERSION)=/ s/{base_version}/{version}/' $initdir/usr/lib/initrd-release
     echo "OSTREE_VERSION='{version}'" >> $initdir/usr/lib/initrd-release
     echo "IMAGE_VERSION='{version}'" >> $initdir/usr/lib/initrd-release
+
+    # XXX SUPER HACK to stamp out the systemd-gpt-auto-generator in the
+    # initramfs. The rm of the file in a postprocess we do runs after
+    # the initramfs is generated so we need something like this
+    # delivered via a dracut module that gets into an overlay in the
+    # original rpm-ostree compose.
+    rm -v $initdir/usr/lib/systemd/system-generators/systemd-gpt-auto-generator
 }}
 ''')
     return tmpd

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -225,9 +225,3 @@ packages-aarch64:
   - crun-wasm wasmedge-rt
 packages-s390x:
   - qemu-user-static-x86
-
-remove-from-packages:
-  # Hopefully short-term hack -- see https://github.com/coreos/fedora-coreos-config/pull/1206#discussion_r705425869.
-  # This keeps the size down and ensures nothing tries to use it, preventing us
-  # from shedding the dep eventually.
-  - [cracklib-dicts, .*]

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -235,3 +235,10 @@ postprocess:
         echo "${actuals}" 1>&2
         exit 1
     fi
+
+  # We don't want auto-generated mount units. See also
+  # https://github.com/systemd/systemd/issues/13099
+  - |
+    #!/usr/bin/env bash
+    set -x
+    rm -vf /usr/lib/systemd/system-generators/systemd-gpt-auto-generator


### PR DESCRIPTION
This was being done at the bootc level but got changed in
https://gitlab.com/fedora/bootc/base-images/-/merge_requests/310
so we need to do it here again.

Do it in a postprocess because that's the way we can do it in a
container build (i.e. where `remove-from-packages:` isn't supported).

---

also:

- drop obsolete remove-from-packages entry for cracklib-dicts
- Bump fedora-bootc submodule