### PR TITLE
[next-devel] build-args: pin on a specific bootc builder image

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -3,9 +3,7 @@
 
 # This is the developer default version. In pipelines, this is driven by versionary.
 VERSION=43.dev
-# XXX: This should be a digested pull that gets bumped.
-# https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:43
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:baa3341e56cd2ce1251c348fc6256c49978facaa71a87a3bc8947a0f82a5a3c4
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests


### PR DESCRIPTION
This will guaruantee when things are promoted later we have have consistency when those builds are done.