### PR TITLE
Move to Fedora 43

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -2,10 +2,10 @@
 # Pass to buildah/podman using `--build-arg-file`.
 
 # This is the developer default version. In pipelines, this is driven by versionary.
-VERSION=42.dev
+VERSION=43.dev
 # XXX: This should be a digested pull that gets bumped.
 # https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:42
+BUILDER_IMG=quay.io/fedora/fedora-bootc:43
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/build-args.conf
+++ b/build-args.conf
@@ -3,9 +3,7 @@
 
 # This is the developer default version. In pipelines, this is driven by versionary.
 VERSION=43.dev
-# XXX: This should be a digested pull that gets bumped.
-# https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:43
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:b7ad5bc503ead71c091f41e0c4faf2d3726563a6aa61fb50875e15ab900ae5f4
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,7 +5,7 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:43
 # Work around for https://bugzilla.redhat.com/show_bug.cgi?id=2278652
 ENV container=oci
 COPY . /src

--- a/ci/buildroot/install-buildroot.sh
+++ b/ci/buildroot/install-buildroot.sh
@@ -27,14 +27,8 @@ brs=$(grep -v '^#' "${dn}"/buildroot-buildreqs.txt)
  echo "${brs}" | xargs dnf download --source
  # rebuild the SRPM for this arch; see
  # https://bugzilla.redhat.com/show_bug.cgi?id=1402784#c6
- # Add workaround if on F42 for https://github.com/coreos/fedora-coreos-tracker/issues/1901
- source /etc/os-release
- workaround=""
- if [ "${VERSION_ID}" == "42" ]; then
-    workaround="--noclean"
- fi
  find . -name '*.src.rpm' -print0 | xargs -0n 1 rpmbuild -rs --nodeps \
-    -D "%_topdir $PWD/rpmbuild" -D "%_tmppath %{_topdir}/tmp" ${workaround}
+    -D "%_topdir $PWD/rpmbuild" -D "%_tmppath %{_topdir}/tmp"
  dnf builddep -y rpmbuild/SRPMS/*.src.rpm)
 rm -rf "${tmpd:?}"/*
 

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,697 +1,691 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.52.1-1.fc42.aarch64",
+      "evra": "1:1.54.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.52.1-1.fc42.aarch64",
+      "evra": "1:1.54.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.52.1-1.fc42.aarch64",
+      "evra": "1:1.54.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.52.1-1.fc42.aarch64",
+      "evra": "1:1.54.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.52.1-1.fc42.aarch64",
+      "evra": "1:1.54.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.13.1.1-1.fc42.noarch",
+      "evra": "2.14.0.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.16.0-1.fc42.aarch64",
+      "evra": "2:1.16.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-3.fc42.aarch64",
+      "evra": "2.3.2-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-9.fc42.aarch64",
+      "evra": "0.9.2-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.10.0-1.fc42.aarch64",
+      "evra": "5.10.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-1.fc42.aarch64",
+      "evra": "5.10.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.33-1.fc42.aarch64",
+      "evra": "1.33-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-5.fc42.aarch64",
+      "evra": "2.5.2-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.1.1-1.fc42.aarch64",
+      "evra": "4.1.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.1.1-1.fc42.aarch64",
+      "evra": "4.1.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.1.1-1.fc42.aarch64",
+      "evra": "4.1.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.1-1.fc42.aarch64",
+      "evra": "1.6.2-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.1-1.fc42.aarch64",
+      "evra": "1.6.2-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.9~rc2-2.fc42.aarch64",
+      "evra": "0.9~rc2-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "azure-vm-utils": {
-      "evra": "0.6.0-1.fc42.aarch64",
+      "evra": "0.7.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "azure-vm-utils"
       }
     },
-    "basesystem": {
-      "evra": "11-22.fc42.noarch",
-      "metadata": {
-        "sourcerpm": "basesystem"
-      }
-    },
     "bash": {
-      "evra": "5.2.37-1.fc42.aarch64",
+      "evra": "5.3.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-1.fc42.noarch",
+      "evra": "0.7.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.16-1.fc42.noarch",
+      "evra": "1:2.16-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.39-3.fc42.aarch64",
+      "evra": "32:9.18.39-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.39-3.fc42.aarch64",
+      "evra": "32:9.18.39-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootc": {
-      "evra": "1.8.0-1.fc42.aarch64",
+      "evra": "1.8.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bootc"
       }
     },
     "bootupd": {
-      "evra": "0.2.31-1.fc42.aarch64",
+      "evra": "0.2.31-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "bsdtar": {
-      "evra": "3.8.1-1.fc42.aarch64",
+      "evra": "3.8.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.16.1-1.fc42.aarch64",
+      "evra": "6.17-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc42.aarch64",
+      "evra": "0.11.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-20.fc42.aarch64",
+      "evra": "1.0.8-21.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-20.fc42.aarch64",
+      "evra": "1.0.8-21.fc43.aarch64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.34.5-1.fc42.aarch64",
+      "evra": "1.34.5-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.0.fc42.noarch",
+      "evra": "2025.2.80_v9.0.304-1.1.fc43.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.2.1-1.fc42.aarch64",
+      "evra": "0.2.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.8-1.fc42.aarch64",
+      "evra": "4.8-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.2-1.fc42.aarch64",
+      "evra": "7.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "21-10.fc42.aarch64",
+      "evra": "21-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "21-10.fc42.aarch64",
+      "evra": "21-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "21-10.fc42.aarch64",
+      "evra": "21-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-9.fc42.aarch64",
+      "evra": "0.5.3-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "21-10.fc42.aarch64",
+      "evra": "21-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-10.fc42.noarch",
+      "evra": "0.33-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.8-2.fc42.aarch64",
+      "evra": "1.0.8-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.8-2.fc42.aarch64",
+      "evra": "1.0.8-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.13-1.fc42.aarch64",
+      "evra": "2:2.1.13-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "4:2.242.0-1.fc42.noarch",
+      "evra": "4:2.242.0-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "2.0.6-1.fc42.aarch64",
+      "evra": "2.1.4-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.25.0-2.fc42.aarch64",
+      "evra": "0.25.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-2.fc42.aarch64",
+      "evra": "0.25.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.6-6.fc42.aarch64",
+      "evra": "9.7-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.6-6.fc42.aarch64",
+      "evra": "9.7-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-4.fc42.aarch64",
+      "evra": "2.15-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-7.fc42.aarch64",
+      "evra": "2.9.11-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.1.1-1.fc42.aarch64",
+      "evra": "4.1.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.1.1-1.fc42.aarch64",
+      "evra": "4.1.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.24-1.fc42.aarch64",
+      "evra": "1.24-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.24-1.fc42.aarch64",
+      "evra": "1.24-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20250707-1.gitad370a8.fc42.noarch",
+      "evra": "20250714-5.gitcd6043a.fc43.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.8.1-1.fc42.aarch64",
+      "evra": "2.8.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.8.1-1.fc42.aarch64",
+      "evra": "2.8.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.11.1-6.fc42.aarch64",
+      "evra": "8.15.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-30.fc42.aarch64",
+      "evra": "2.1.28-33.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-30.fc42.aarch64",
+      "evra": "2.1.28-33.fc43.aarch64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.16.0-3.fc42.aarch64",
+      "evra": "1:1.16.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-6.fc42.aarch64",
+      "evra": "37-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.16.0-3.fc42.noarch",
+      "evra": "1:1.16.0-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-3.fc42.aarch64",
+      "evra": "1:1.16.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.204-3.fc42.aarch64",
+      "evra": "1.02.208-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.204-3.fc42.aarch64",
+      "evra": "1.02.208-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.204-3.fc42.aarch64",
+      "evra": "1.02.208-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.204-3.fc42.aarch64",
+      "evra": "1.02.208-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.10.0-5.fc42.aarch64",
+      "evra": "0.11.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.10.0-5.fc42.aarch64",
+      "evra": "0.11.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-3.fc42.aarch64",
+      "evra": "1.1.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.12-1.fc42.aarch64",
+      "evra": "3.12-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnf5": {
-      "evra": "5.2.16.0-1.fc42.aarch64",
+      "evra": "5.2.17.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-6.fc42.aarch64",
+      "evra": "2.90-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "docker-cli": {
-      "evra": "28.5.1-2.fc42.aarch64",
+      "evra": "28.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "dosfstools": {
-      "evra": "4.2-15.fc42.aarch64",
+      "evra": "4.2-16.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "107-4.fc42.aarch64",
+      "evra": "107-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "107-4.fc42.aarch64",
+      "evra": "107-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "107-4.fc42.aarch64",
+      "evra": "107-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-9.fc42.aarch64",
+      "evra": "2.7.0-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.2-3.fc42.aarch64",
+      "evra": "1.47.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.2-3.fc42.aarch64",
+      "evra": "1.47.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "6-3.fc42.noarch",
+      "evra": "6-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-9.fc42.aarch64",
+      "evra": "18-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-8.fc42.aarch64",
+      "evra": "39-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.193-2.fc42.noarch",
+      "evra": "0.193-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.193-2.fc42.aarch64",
+      "evra": "0.193-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.193-2.fc42.aarch64",
+      "evra": "0.193-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.15-3.fc42.aarch64",
+      "evra": "2:6.15-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.7.2-1.fc42.aarch64",
+      "evra": "2.7.2-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.46-3.fc42.aarch64",
+      "evra": "5.46-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.46-3.fc42.aarch64",
+      "evra": "5.46-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-47.fc42.aarch64",
+      "evra": "3.18-50.fc43.aarch64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.10.0-5.fc42.aarch64",
+      "evra": "1:4.10.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.16.1-1.fc42.aarch64",
+      "evra": "1.16.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "11.1.4-1.fc42.aarch64",
+      "evra": "11.2.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-12.fc42.aarch64",
+      "evra": "0.6.1-13.fc43.aarch64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
@@ -703,13 +697,13 @@
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-3.fc42.aarch64",
+      "evra": "1.13-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-11.fc42.aarch64",
+      "evra": "3.7.3-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
@@ -727,1033 +721,1057 @@
       }
     },
     "fwupd": {
-      "evra": "2.0.16-1.fc42.aarch64",
+      "evra": "2.0.16-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.1-1.fc42.aarch64",
+      "evra": "5.3.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-9.fc42.aarch64",
+      "evra": "1:1.23-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-9.fc42.aarch64",
+      "evra": "1:1.23-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-3.fc42.aarch64",
+      "evra": "1.0.10-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.23.1-2.fc42.aarch64",
+      "evra": "0.25.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.23.1-2.fc42.aarch64",
+      "evra": "0.25.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.23.1-2.fc42.aarch64",
+      "evra": "0.25.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.51.0-2.fc42.aarch64",
+      "evra": "2.51.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.84.4-1.fc42.aarch64",
+      "evra": "2.86.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.41-11.fc42.aarch64",
+      "evra": "2.42-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.41-11.fc42.aarch64",
+      "evra": "2.42-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.41-11.fc42.aarch64",
+      "evra": "2.42-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.41-11.fc42.aarch64",
+      "evra": "2.42-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc42.aarch64",
+      "evra": "1:6.3.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc42.noarch",
+      "evra": "20241231-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "gnulib-l10n"
       }
     },
     "gnupg2": {
-      "evra": "2.4.7-2.fc42.aarch64",
+      "evra": "2.4.8-4.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-dirmngr": {
+      "evra": "2.4.8-4.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpg-agent": {
+      "evra": "2.4.8-4.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpgconf": {
+      "evra": "2.4.8-4.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-keyboxd": {
+      "evra": "2.4.8-4.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-verify": {
+      "evra": "2.4.8-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.10-1.fc42.aarch64",
+      "evra": "3.8.10-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250107.00-2.fc42.noarch",
+      "evra": "20250221.00-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.24.3-1.fc42.aarch64",
+      "evra": "1.24.3-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-10.fc42.aarch64",
+      "evra": "3.12-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.12-32.fc42.noarch",
+      "evra": "1:2.12-40.fc43.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.12-32.fc42.aarch64",
+      "evra": "1:2.12-40.fc43.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.12-32.fc42.aarch64",
+      "evra": "1:2.12-40.fc43.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-32.fc42.aarch64",
+      "evra": "1:2.12-40.fc43.aarch64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-3.fc42.aarch64",
+      "evra": "1.13-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.25-2.fc42.aarch64",
+      "evra": "3.25-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.400-1.fc42.noarch",
+      "evra": "0.400-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.24.0-1.fc42.aarch64",
+      "evra": "2.24.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "ignition-grub": {
-      "evra": "2.24.0-1.fc42.aarch64",
+      "evra": "2.24.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "62-1.fc42.aarch64",
+      "evra": "62-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-11.fc42.aarch64",
+      "evra": "1.0.3-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.12.0-3.fc42.aarch64",
+      "evra": "6.14.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.12.0-3.fc42.aarch64",
+      "evra": "6.14.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
-    "iptables-legacy": {
-      "evra": "1.8.11-8.fc42.aarch64",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
-    "iptables-legacy-libs": {
-      "evra": "1.8.11-8.fc42.aarch64",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
     "iptables-libs": {
-      "evra": "1.8.11-8.fc42.aarch64",
+      "evra": "1.8.11-11.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.11-8.fc42.aarch64",
+      "evra": "1.8.11-11.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.11-8.fc42.noarch",
+      "evra": "1.8.11-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.11-8.fc42.aarch64",
+      "evra": "1.8.11-11.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20250605-1.fc42.aarch64",
+      "evra": "20250605-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-6.fc42.aarch64",
+      "evra": "2:1.9.4-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.aarch64",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.aarch64",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.aarch64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.103-2.fc42.aarch64",
+      "evra": "0.103-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.14-2.fc42.aarch64",
+      "evra": "2.14-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jose": {
-      "evra": "14-4.fc42.aarch64",
+      "evra": "14-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-11.fc42.aarch64",
+      "evra": "1.7.1-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.18-2.fc42.aarch64",
+      "evra": "0.18-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.10.8-1.fc42.aarch64",
+      "evra": "1.10.8-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.7.1-3.fc42.aarch64",
+      "evra": "2.8.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.56-1.fc42.aarch64",
+      "evra": "1.0.56-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.16.12-200.fc42.aarch64",
+      "evra": "6.17.1-300.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.16.12-200.fc42.aarch64",
+      "evra": "6.17.1-300.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.16.12-200.fc42.aarch64",
+      "evra": "6.17.1-300.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.16.12-200.fc42.aarch64",
+      "evra": "6.17.1-300.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.31-2.fc42.aarch64",
+      "evra": "2.0.31-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-5.fc42.aarch64",
+      "evra": "1.6.3-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-5.fc42.aarch64",
+      "evra": "1.6.3-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "33-3.fc42.aarch64",
+      "evra": "34.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "33-3.fc42.aarch64",
+      "evra": "34.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.10.0-5.fc42.aarch64",
+      "evra": "0.11.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-6.fc42.aarch64",
+      "evra": "1.21.3-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "679-1.fc42.aarch64",
+      "evra": "679-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-3.fc42.aarch64",
+      "evra": "2.3.2-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-21.fc42.aarch64",
+      "evra": "0.3.111-22.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.8.1-1.fc42.aarch64",
+      "evra": "3.8.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-3.fc42.aarch64",
+      "evra": "2.5.7-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libatomic": {
-      "evra": "15.2.1-1.fc42.aarch64",
+      "evra": "15.2.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libattr": {
-      "evra": "2.5.2-5.fc42.aarch64",
+      "evra": "2.5.2-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-58.fc42.aarch64",
+      "evra": "0.1.1-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.5.0-2.fc42.aarch64",
+      "evra": "2:1.6.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-5.fc42.aarch64",
+      "evra": "0.12.2-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.73-2.fc42.aarch64",
+      "evra": "2.76-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.5-4.fc42.aarch64",
+      "evra": "0.8.5-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-3.fc42.aarch64",
+      "evra": "0.12.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-58.fc42.aarch64",
+      "evra": "0.7.0-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.2-3.fc42.aarch64",
+      "evra": "1.47.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.11.1-6.fc42.aarch64",
+      "evra": "8.15.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-31.fc42.aarch64",
+      "evra": "0.14-32.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-58.fc42.aarch64",
+      "evra": "0.5.0-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libdnf5": {
-      "evra": "5.2.16.0-1.fc42.aarch64",
+      "evra": "5.2.17.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdnf5-cli": {
-      "evra": "5.2.16.0-1.fc42.aarch64",
+      "evra": "5.2.17.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdrm": {
-      "evra": "2.4.126-1.fc42.aarch64",
+      "evra": "2.4.126-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libdrm"
       }
     },
     "libeconf": {
-      "evra": "0.7.6-2.fc42.aarch64",
+      "evra": "0.7.9-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-55.20250104cvs.fc42.aarch64",
+      "evra": "3.1-56.20250104cvs.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-15.fc42.aarch64",
+      "evra": "2.1.12-16.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.6-5.fc42.aarch64",
+      "evra": "3.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.15.0-3.fc42.aarch64",
+      "evra": "1.16.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "15.2.1-1.fc42.aarch64",
+      "evra": "15.2.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.11.0-5.fc42.aarch64",
+      "evra": "1.11.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.51-2.fc42.aarch64",
+      "evra": "1.55-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libibverbs": {
-      "evra": "55.0-1.fc42.aarch64",
+      "evra": "58.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "76.1-4.fc42.aarch64",
+      "evra": "77.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.8-1.fc42.aarch64",
+      "evra": "2.3.8-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-58.fc42.aarch64",
+      "evra": "1.3.1-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.5-1.fc42.aarch64",
+      "evra": "0.2.5-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-4.fc42.aarch64",
+      "evra": "14-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-5.fc42.aarch64",
+      "evra": "1.5.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-5.fc42.aarch64",
+      "evra": "1.5.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-5.fc42.aarch64",
+      "evra": "1.5.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.7-3.fc42.aarch64",
+      "evra": "1.6.7-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
+    "liblastlog2": {
+      "evra": "2.41.1-17.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "util-linux"
+      }
+    },
     "libldb": {
-      "evra": "2:4.22.4-1.fc42.aarch64",
+      "evra": "2:4.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-24.fc42.aarch64",
+      "evra": "9-25.fc43.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.12.2-3.fc42.aarch64",
+      "evra": "1.12.2-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-7.fc42.aarch64",
+      "evra": "1.1.0-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-7.fc42.aarch64",
+      "evra": "1.0.5-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.2-1.fc42.aarch64",
+      "evra": "2.15.2-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.9-3.fc42.aarch64",
+      "evra": "1.9-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-5.fc42.aarch64",
+      "evra": "1.3-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-8.fc42.aarch64",
+      "evra": "1.0.9-9.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-30.fc42.aarch64",
+      "evra": "1.0.1-31.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.8.4-0.fc42.aarch64",
+      "evra": "1:2.8.4-0.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.8-4.fc42.aarch64",
+      "evra": "1.2.9-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.64.0-3.fc42.aarch64",
+      "evra": "1.66.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.11.0-3.fc42.aarch64",
+      "evra": "3.11.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.11.0-3.fc42.aarch64",
+      "evra": "3.11.0-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-3.fc42.aarch64",
+      "evra": "2.0.1-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.15-2.fc42.aarch64",
+      "evra": "1.15-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-58.fc42.aarch64",
+      "evra": "0.2.1-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-2.fc42.aarch64",
+      "evra": "14:1.10.5-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpciaccess": {
-      "evra": "0.16-15.fc42.aarch64",
+      "evra": "0.16-16.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libpciaccess"
       }
     },
     "libpkgconf": {
-      "evra": "2.3.0-2.fc42.aarch64",
+      "evra": "2.3.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-5.fc42.aarch64",
+      "evra": "0.21.5-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-12.fc42.aarch64",
+      "evra": "1.4.5-14.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-58.fc42.aarch64",
+      "evra": "0.1.5-59.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.20.0-1.fc42.aarch64",
+      "evra": "1.20.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-5.fc42.noarch",
+      "evra": "2.17.15-9.fc43.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-2.fc41.aarch64",
+      "evra": "2.6.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.8-3.fc42.aarch64",
+      "evra": "3.9-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.8-3.fc42.aarch64",
+      "evra": "3.9-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.8.1-2.fc42.aarch64",
+      "evra": "3.9-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.8-1.fc42.aarch64",
+      "evra": "3.9-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.8.0-3.fc42.aarch64",
+      "evra": "4.9.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.22.4-1.fc42.aarch64",
+      "evra": "2:4.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.34-1.fc42.aarch64",
+      "evra": "0.7.34-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.2-3.fc42.aarch64",
+      "evra": "1.47.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "15.2.1-1.fc42.aarch64",
+      "evra": "15.2.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.3-2.fc42.aarch64",
+      "evra": "2.4.3-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.20.0-1.fc42.aarch64",
+      "evra": "4.20.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.13-2.fc42.aarch64",
+      "evra": "1.4.14-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-11.fc42.aarch64",
+      "evra": "1.32-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.2-2.fc42.aarch64",
+      "evra": "0.17.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.23.1-2.fc42.aarch64",
+      "evra": "0.25.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.7-0.fc42.aarch64",
+      "evra": "1.3.7-0.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-4.fc42.aarch64",
+      "evra": "2.5.4-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-9.fc42.aarch64",
+      "evra": "1.1-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc42.aarch64",
+      "evra": "1.0.29-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libuuid": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.51.0-1.fc42.aarch64",
+      "evra": "1:1.51.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-10.fc42.aarch64",
+      "evra": "0.3.2-11.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.22.4-1.fc42.aarch64",
+      "evra": "2:4.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.38-7.fc42.aarch64",
+      "evra": "4.4.38-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.10-1.fc42.aarch64",
+      "evra": "2.12.10-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.24-1.fc42.aarch64",
+      "evra": "0.3.24-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-16.fc42.aarch64",
+      "evra": "0.2.5-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.7-1.fc42.aarch64",
+      "evra": "1.5.7-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lld18-libs": {
-      "evra": "18.1.8-6.fc42.aarch64",
+      "evra": "18.1.8-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lld18"
       }
@@ -1765,547 +1783,559 @@
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-3.fc42.aarch64",
+      "evra": "0.9.33-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.22.0-3.fc42.aarch64",
+      "evra": "3.22.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-7.fc42.aarch64",
+      "evra": "4.98.0-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.8-1.fc42.aarch64",
+      "evra": "5.4.8-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-24.fc42.aarch64",
+      "evra": "9-25.fc43.aarch64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.30-3.fc42.aarch64",
+      "evra": "2.03.34-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.30-3.fc42.aarch64",
+      "evra": "2.03.34-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.10.0-2.fc42.aarch64",
+      "evra": "1.10.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-14.fc42.aarch64",
+      "evra": "2.10-15.fc43.aarch64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.7-1.fc42.aarch64",
+      "evra": "1.7.7-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.3-8.fc42.aarch64",
+      "evra": "4.3-9.fc43.aarch64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "28.5.1-2.fc42.aarch64",
+      "evra": "28.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "moby-filesystem": {
-      "evra": "28.5.1-2.fc42.noarch",
+      "evra": "28.5.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.7.1-5.fc42.aarch64",
+      "evra": "2:0.7.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.2-1.fc42.aarch64",
+      "evra": "4.2.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "nano": {
-      "evra": "8.3-3.fc42.aarch64",
+      "evra": "8.5-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "8.3-3.fc42.noarch",
+      "evra": "8.5-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.5-5.20250125.fc42.aarch64",
+      "evra": "6.5-7.20250614.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.5-5.20250125.fc42.noarch",
+      "evra": "6.5-7.20250614.fc43.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.5-5.20250125.fc42.aarch64",
+      "evra": "6.5-7.20250614.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.73.20160912git.fc42.aarch64",
+      "evra": "2.0-0.74.20160912git.fc43.aarch64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.16.1-1.fc42.aarch64",
+      "evra": "2:1.16.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.10.1-1.fc42.aarch64",
+      "evra": "3.10.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.25-1.fc42.aarch64",
+      "evra": "0.52.25-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.8.4-0.fc42.aarch64",
+      "evra": "1:2.8.4-0.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.1.1-3.fc42.aarch64",
+      "evra": "1:1.1.3-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
+    "nftables-services": {
+      "evra": "1:1.1.3-5.fc43.noarch",
+      "metadata": {
+        "sourcerpm": "nftables"
+      }
+    },
+    "ngtcp2": {
+      "evra": "1.15.1-1.fc43.aarch64",
+      "metadata": {
+        "sourcerpm": "ngtcp2"
+      }
+    },
     "nmstate": {
-      "evra": "2.2.52-2.fc42.aarch64",
+      "evra": "2.2.52-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.8-2.fc42.aarch64",
+      "evra": "1.8-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-6.fc42.aarch64",
+      "evra": "2.23.0-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.19-2.fc42.aarch64",
+      "evra": "2.0.19-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.15-2.fc42.aarch64",
+      "evra": "2.15-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "oniguruma": {
-      "evra": "6.9.10-2.fc42.aarch64",
+      "evra": "6.9.10-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.10-1.fc42.aarch64",
+      "evra": "2.6.10-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.9p1-11.fc42.aarch64",
+      "evra": "10.0p1-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.9p1-11.fc42.aarch64",
+      "evra": "10.0p1-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.9p1-11.fc42.aarch64",
+      "evra": "10.0p1-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.6-2.fc42.aarch64",
+      "evra": "1:3.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.6-2.fc42.aarch64",
+      "evra": "1:3.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-9.fc42.aarch64",
+      "evra": "1.81-10.fc43.aarch64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2025.6-1.fc42.aarch64",
+      "evra": "2025.6-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2025.6-1.fc42.aarch64",
+      "evra": "2025.6-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.8-1.fc42.aarch64",
+      "evra": "0.25.8-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.8-1.fc42.aarch64",
+      "evra": "0.25.8-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.7.0-6.fc42.aarch64",
+      "evra": "1.7.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.7.0-6.fc42.aarch64",
+      "evra": "1.7.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.10-1.fc42.aarch64",
+      "evra": "0.1.10-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20250919.g623dbf6-1.fc42.aarch64",
+      "evra": "0^20250919.g623dbf6-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20250919.g623dbf6-1.fc42.noarch",
+      "evra": "0^20250919.g623dbf6-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.14.0-1.fc42.aarch64",
+      "evra": "3.14.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.14.0-1.fc42.aarch64",
+      "evra": "3.14.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.45-1.fc42.aarch64",
+      "evra": "10.46-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.45-1.fc42.noarch",
+      "evra": "10.46-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-6.fc42.aarch64",
+      "evra": "2.8-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.3.0-2.fc42.aarch64",
+      "evra": "2.3.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-2.fc42.noarch",
+      "evra": "2.3.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-2.fc42.aarch64",
+      "evra": "2.3.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.6.2-1.fc42.aarch64",
+      "evra": "5:5.6.2-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.8-1.fc42.aarch64",
+      "evra": "3.9-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "126-3.fc42.1.aarch64",
+      "evra": "126-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "126-3.fc42.1.aarch64",
+      "evra": "126-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "popt": {
-      "evra": "1.19-8.fc42.aarch64",
+      "evra": "1.19-9.fc43.aarch64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-6.fc42.1.aarch64",
+      "evra": "4.0.4-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.1-1.fc42.aarch64",
+      "evra": "1.5.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.7-5.fc42.aarch64",
+      "evra": "23.7-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20250616-1.fc42.noarch",
+      "evra": "20250616-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:9.2.4-2.fc42.aarch64",
+      "evra": "2:10.1.0-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-13.fc42.aarch64",
+      "evra": "8.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc42.aarch64",
+      "evra": "1.2.8-0.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.20.1-1.fc42.aarch64",
+      "evra": "6.0.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.20.1-1.fc42.aarch64",
+      "evra": "6.0.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2025.11-1.fc42.aarch64",
+      "evra": "2025.11-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2025.11-1.fc42.aarch64",
+      "evra": "2025.11-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.20.1-1.fc42.aarch64",
+      "evra": "6.0.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-5.fc42.aarch64",
+      "evra": "1.9.0-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.4.1-3.fc42.aarch64",
+      "evra": "3.4.1-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.3.2-1.fc42.aarch64",
+      "evra": "2:1.3.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.22.4-1.fc42.aarch64",
+      "evra": "2:4.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.22.4-1.fc42.noarch",
+      "evra": "2:4.23.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.22.4-1.fc42.aarch64",
+      "evra": "2:4.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sdbus-cpp": {
-      "evra": "1.5.0-4.fc42.aarch64",
+      "evra": "2.1.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sdbus-cpp"
       }
     },
     "sed": {
-      "evra": "4.9-4.fc42.aarch64",
+      "evra": "4.9-5.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.15.0-13.fc42.noarch",
+      "evra": "2.15.0-26.fc43.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-5.fc42.aarch64",
+      "evra": "1.48-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-5.fc42.aarch64",
+      "evra": "1.48-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.17.4-1.fc42.aarch64",
+      "evra": "2:4.18.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.17.4-1.fc42.aarch64",
+      "evra": "2:4.18.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-7.fc42.aarch64",
+      "evra": "2.4-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2317,341 +2347,344 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.20.0-3.fc42.aarch64",
+      "evra": "1:1.20.0-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-7.fc42.aarch64",
+      "evra": "2.3.3-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.3.1-2.fc42.aarch64",
+      "evra": "1.3.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.2.1-4.fc42.aarch64",
+      "evra": "1.2.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc42.aarch64",
+      "evra": "1.8.0.3-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.15.3-1.fc42.aarch64",
+      "evra": "1.15.3-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.47.2-5.fc42.aarch64",
+      "evra": "3.50.2-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-6.fc42.aarch64",
+      "evra": "4.6.1-7.fc43.aarch64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.5-2.fc42.aarch64",
+      "evra": "0.1.5-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.11.1-1.fc42.aarch64",
+      "evra": "2.11.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.23.1-1.fc42.aarch64",
+      "evra": "1.23.1-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.17-2.p1.fc42.aarch64",
+      "evra": "1.9.17-5.p1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-shared": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-sysusers": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "257.10-1.fc42.aarch64",
+      "evra": "258-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-5.fc42.aarch64",
+      "evra": "2:1.35-6.fc43.aarch64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-11.fc42.aarch64",
+      "evra": "1.32-12.fc43.aarch64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tini-static": {
-      "evra": "0.19.0-10.fc42.aarch64",
+      "evra": "0.19.0-11.fc43.aarch64",
       "metadata": {
         "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.3-1.fc42.aarch64",
+      "evra": "0.3-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-3.fc42.aarch64",
+      "evra": "5.7-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-6.fc42.aarch64",
+      "evra": "4.1.3-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-6.fc42.aarch64",
+      "evra": "4.1.3-8.fc43.aarch64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2025b-1.fc42.noarch",
+      "evra": "2025b-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.15.0-1.fc42.aarch64",
+      "evra": "0.15.3-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.4-7.fc42.aarch64",
+      "evra": "2.41.1-17.fc43.aarch64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.1818-1.fc42.noarch",
+      "evra": "2:9.1.1818-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.1818-1.fc42.aarch64",
+      "evra": "2:9.1.1818-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.15.0-1.fc42.aarch64",
+      "evra": "0.15.0-1.fc43.aarch64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.23-2.fc42.aarch64",
+      "evra": "2.23-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-9.fc42.aarch64",
+      "evra": "1.0.20250521-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.12.0-3.fc42.aarch64",
+      "evra": "6.15.0-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.3-2.fc42.aarch64",
+      "evra": "0.8.3-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.8.1-2.fc42.aarch64",
+      "evra": "1:5.8.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.8.1-2.fc42.aarch64",
+      "evra": "1:5.8.1-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-25.fc42.aarch64",
+      "evra": "2.1.0-38.fc43.aarch64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-2.fc42.aarch64",
+      "evra": "1.5.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.30-3.fc42.aarch64",
+      "evra": "0.0.30-4.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.2.5-2.fc42.aarch64",
+      "evra": "2.2.5-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.2.1-2.fc42.aarch64",
+      "evra": "1.2.1-3.fc43.aarch64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.7-1.fc42.aarch64",
+      "evra": "1.5.7-2.fc43.aarch64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2025-10-21T00:00:00Z",
+    "generated": "2025-10-24T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2025-04-09T11:06:58Z"
+      "fedora-candidate-compose": {
+        "generated": "2025-10-23T03:37:18Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2025-10-19T20:39:14Z"
+        "generated": "2025-10-23T12:40:17Z"
       },
-      "fedora-updates": {
-        "generated": "2025-10-21T00:56:36Z"
+      "fedora-next": {
+        "generated": "2025-10-23T07:45:43Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2018-02-20T19:13:29Z"
       }
     }
   }

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,13 +9,116 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  ignition:
-    evr: 2.24.0-1.fc42
+  afterburn:
+    evr: 5.10.0-1.fc43
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-423aeca2ee
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-72eea5362d
+      type: fast-track
+  afterburn-dracut:
+    evr: 5.10.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-72eea5362d
+      type: fast-track
+  audit:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  audit-libs:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  audit-rules:
+    evr: 4.1.2-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  bootupd:
+    evr: 0.2.31-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-b163a3c238
+      type: fast-track
+  coreos-installer:
+    evr: 0.25.0-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-30a8bc20e9
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.25.0-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-30a8bc20e9
+      type: fast-track
+  docker-cli:
+    evr: 28.5.1-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-57239b5d90
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  hwdata:
+    evra: 0.400-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-5d0490d32e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  ignition:
+    evr: 2.24.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c8b9f97712
       type: fast-track
   ignition-grub:
-    evr: 2.24.0-1.fc42
+    evr: 2.24.0-1.fc43
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-423aeca2ee
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c8b9f97712
+      type: fast-track
+  libdrm:
+    evr: 2.4.126-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-551d41aa4b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  moby-engine:
+    evr: 28.5.1-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-57239b5d90
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  moby-filesystem:
+    evra: 28.5.1-2.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-57239b5d90
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  nmstate:
+    evr: 2.2.52-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-c64e240483
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  selinux-policy:
+    evra: 42.13-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-231a03fb59
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  selinux-policy-targeted:
+    evra: 42.13-1.fc43.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-231a03fb59
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  skopeo:
+    evr: 1:1.20.0-4.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-4930235e51
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
+      type: fast-track
+  stalld:
+    evr: 1.23.1-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-fae0c0199c
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
       type: fast-track

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,679 +1,673 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.52.1-1.fc42.ppc64le",
+      "evra": "1:1.54.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.52.1-1.fc42.ppc64le",
+      "evra": "1:1.54.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.52.1-1.fc42.ppc64le",
+      "evra": "1:1.54.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.52.1-1.fc42.ppc64le",
+      "evra": "1:1.54.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.52.1-1.fc42.ppc64le",
+      "evra": "1:1.54.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.13.1.1-1.fc42.noarch",
+      "evra": "2.14.0.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.16.0-1.fc42.ppc64le",
+      "evra": "2:1.16.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-3.fc42.ppc64le",
+      "evra": "2.3.2-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-9.fc42.ppc64le",
+      "evra": "0.9.2-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.10.0-1.fc42.ppc64le",
+      "evra": "5.10.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-1.fc42.ppc64le",
+      "evra": "5.10.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.33-1.fc42.ppc64le",
+      "evra": "1.33-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-5.fc42.ppc64le",
+      "evra": "2.5.2-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.1.1-1.fc42.ppc64le",
+      "evra": "4.1.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.1.1-1.fc42.ppc64le",
+      "evra": "4.1.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.1.1-1.fc42.ppc64le",
+      "evra": "4.1.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.1-1.fc42.ppc64le",
+      "evra": "1.6.2-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.1-1.fc42.ppc64le",
+      "evra": "1.6.2-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.9~rc2-2.fc42.ppc64le",
+      "evra": "0.9~rc2-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "azure-vm-utils": {
-      "evra": "0.6.0-1.fc42.ppc64le",
+      "evra": "0.7.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "azure-vm-utils"
       }
     },
-    "basesystem": {
-      "evra": "11-22.fc42.noarch",
-      "metadata": {
-        "sourcerpm": "basesystem"
-      }
-    },
     "bash": {
-      "evra": "5.2.37-1.fc42.ppc64le",
+      "evra": "5.3.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-1.fc42.noarch",
+      "evra": "0.7.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.16-1.fc42.noarch",
+      "evra": "1:2.16-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bc": {
-      "evra": "1.08.1-2.fc42.ppc64le",
+      "evra": "1.08.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bc"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.39-3.fc42.ppc64le",
+      "evra": "32:9.18.39-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.39-3.fc42.ppc64le",
+      "evra": "32:9.18.39-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootc": {
-      "evra": "1.8.0-1.fc42.ppc64le",
+      "evra": "1.8.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bootc"
       }
     },
     "bootupd": {
-      "evra": "0.2.31-1.fc42.ppc64le",
+      "evra": "0.2.31-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "bsdtar": {
-      "evra": "3.8.1-1.fc42.ppc64le",
+      "evra": "3.8.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.16.1-1.fc42.ppc64le",
+      "evra": "6.17-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc42.ppc64le",
+      "evra": "0.11.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-20.fc42.ppc64le",
+      "evra": "1.0.8-21.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-20.fc42.ppc64le",
+      "evra": "1.0.8-21.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.34.5-1.fc42.ppc64le",
+      "evra": "1.34.5-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.0.fc42.noarch",
+      "evra": "2025.2.80_v9.0.304-1.1.fc43.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.2.1-1.fc42.ppc64le",
+      "evra": "0.2.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.8-1.fc42.ppc64le",
+      "evra": "4.8-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.2-1.fc42.ppc64le",
+      "evra": "7.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "21-10.fc42.ppc64le",
+      "evra": "21-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "21-10.fc42.ppc64le",
+      "evra": "21-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "21-10.fc42.ppc64le",
+      "evra": "21-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-9.fc42.ppc64le",
+      "evra": "0.5.3-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "21-10.fc42.ppc64le",
+      "evra": "21-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-10.fc42.noarch",
+      "evra": "0.33-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.8-2.fc42.ppc64le",
+      "evra": "1.0.8-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.8-2.fc42.ppc64le",
+      "evra": "1.0.8-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.13-1.fc42.ppc64le",
+      "evra": "2:2.1.13-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "4:2.242.0-1.fc42.noarch",
+      "evra": "4:2.242.0-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "2.0.6-1.fc42.ppc64le",
+      "evra": "2.1.4-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.25.0-2.fc42.ppc64le",
+      "evra": "0.25.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-2.fc42.ppc64le",
+      "evra": "0.25.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.6-6.fc42.ppc64le",
+      "evra": "9.7-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.6-6.fc42.ppc64le",
+      "evra": "9.7-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-4.fc42.ppc64le",
+      "evra": "2.15-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-7.fc42.ppc64le",
+      "evra": "2.9.11-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.1.1-1.fc42.ppc64le",
+      "evra": "4.1.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.1.1-1.fc42.ppc64le",
+      "evra": "4.1.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.24-1.fc42.ppc64le",
+      "evra": "1.24-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20250707-1.gitad370a8.fc42.noarch",
+      "evra": "20250714-5.gitcd6043a.fc43.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.8.1-1.fc42.ppc64le",
+      "evra": "2.8.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.8.1-1.fc42.ppc64le",
+      "evra": "2.8.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.11.1-6.fc42.ppc64le",
+      "evra": "8.15.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-30.fc42.ppc64le",
+      "evra": "2.1.28-33.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-30.fc42.ppc64le",
+      "evra": "2.1.28-33.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.16.0-3.fc42.ppc64le",
+      "evra": "1:1.16.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-6.fc42.ppc64le",
+      "evra": "37-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.16.0-3.fc42.noarch",
+      "evra": "1:1.16.0-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-3.fc42.ppc64le",
+      "evra": "1:1.16.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.204-3.fc42.ppc64le",
+      "evra": "1.02.208-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.204-3.fc42.ppc64le",
+      "evra": "1.02.208-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.204-3.fc42.ppc64le",
+      "evra": "1.02.208-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.204-3.fc42.ppc64le",
+      "evra": "1.02.208-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.10.0-5.fc42.ppc64le",
+      "evra": "0.11.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.10.0-5.fc42.ppc64le",
+      "evra": "0.11.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-3.fc42.ppc64le",
+      "evra": "1.1.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.12-1.fc42.ppc64le",
+      "evra": "3.12-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnf5": {
-      "evra": "5.2.16.0-1.fc42.ppc64le",
+      "evra": "5.2.17.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-6.fc42.ppc64le",
+      "evra": "2.90-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "docker-cli": {
-      "evra": "28.5.1-2.fc42.ppc64le",
+      "evra": "28.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "dosfstools": {
-      "evra": "4.2-15.fc42.ppc64le",
+      "evra": "4.2-16.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "107-4.fc42.ppc64le",
+      "evra": "107-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "107-4.fc42.ppc64le",
+      "evra": "107-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "107-4.fc42.ppc64le",
+      "evra": "107-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-9.fc42.ppc64le",
+      "evra": "2.7.0-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.2-3.fc42.ppc64le",
+      "evra": "1.47.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.2-3.fc42.ppc64le",
+      "evra": "1.47.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.193-2.fc42.noarch",
+      "evra": "0.193-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.193-2.fc42.ppc64le",
+      "evra": "0.193-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.193-2.fc42.ppc64le",
+      "evra": "0.193-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.15-3.fc42.ppc64le",
+      "evra": "2:6.15-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.7.2-1.fc42.ppc64le",
+      "evra": "2.7.2-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.46-3.fc42.ppc64le",
+      "evra": "5.46-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.46-3.fc42.ppc64le",
+      "evra": "5.46-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-47.fc42.ppc64le",
+      "evra": "3.18-50.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.10.0-5.fc42.ppc64le",
+      "evra": "1:4.10.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.16.1-1.fc42.ppc64le",
+      "evra": "1.16.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "11.1.4-1.fc42.ppc64le",
+      "evra": "11.2.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-12.fc42.ppc64le",
+      "evra": "0.6.1-13.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "fstrm"
       }
@@ -685,13 +679,13 @@
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-3.fc42.ppc64le",
+      "evra": "1.13-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-11.fc42.ppc64le",
+      "evra": "3.7.3-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
@@ -709,1925 +703,1964 @@
       }
     },
     "fwupd": {
-      "evra": "2.0.16-1.fc42.ppc64le",
+      "evra": "2.0.16-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.1-1.fc42.ppc64le",
+      "evra": "5.3.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-9.fc42.ppc64le",
+      "evra": "1:1.23-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-9.fc42.ppc64le",
+      "evra": "1:1.23-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-3.fc42.ppc64le",
+      "evra": "1.0.10-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.23.1-2.fc42.ppc64le",
+      "evra": "0.25.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.23.1-2.fc42.ppc64le",
+      "evra": "0.25.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.23.1-2.fc42.ppc64le",
+      "evra": "0.25.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.51.0-2.fc42.ppc64le",
+      "evra": "2.51.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.84.4-1.fc42.ppc64le",
+      "evra": "2.86.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.41-11.fc42.ppc64le",
+      "evra": "2.42-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.41-11.fc42.ppc64le",
+      "evra": "2.42-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.41-11.fc42.ppc64le",
+      "evra": "2.42-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.41-11.fc42.ppc64le",
+      "evra": "2.42-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc42.ppc64le",
+      "evra": "1:6.3.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc42.noarch",
+      "evra": "20241231-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "gnulib-l10n"
       }
     },
     "gnupg2": {
-      "evra": "2.4.7-2.fc42.ppc64le",
+      "evra": "2.4.8-4.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-dirmngr": {
+      "evra": "2.4.8-4.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpg-agent": {
+      "evra": "2.4.8-4.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpgconf": {
+      "evra": "2.4.8-4.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-keyboxd": {
+      "evra": "2.4.8-4.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-verify": {
+      "evra": "2.4.8-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.10-1.fc42.ppc64le",
+      "evra": "3.8.10-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.24.3-1.fc42.ppc64le",
+      "evra": "1.24.3-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-10.fc42.ppc64le",
+      "evra": "3.12-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.12-32.fc42.noarch",
+      "evra": "1:2.12-40.fc43.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le": {
-      "evra": "1:2.12-32.fc42.ppc64le",
+      "evra": "1:2.12-40.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.12-32.fc42.noarch",
+      "evra": "1:2.12-40.fc43.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.12-32.fc42.ppc64le",
+      "evra": "1:2.12-40.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-32.fc42.ppc64le",
+      "evra": "1:2.12-40.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-3.fc42.ppc64le",
+      "evra": "1.13-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.25-2.fc42.ppc64le",
+      "evra": "3.25-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.400-1.fc42.noarch",
+      "evra": "0.400-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.24.0-1.fc42.ppc64le",
+      "evra": "2.24.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "ignition-grub": {
-      "evra": "2.24.0-1.fc42.ppc64le",
+      "evra": "2.24.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "62-1.fc42.ppc64le",
+      "evra": "62-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-11.fc42.ppc64le",
+      "evra": "1.0.3-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.12.0-3.fc42.ppc64le",
+      "evra": "6.14.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.12.0-3.fc42.ppc64le",
+      "evra": "6.14.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
-    "iptables-legacy": {
-      "evra": "1.8.11-8.fc42.ppc64le",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
-    "iptables-legacy-libs": {
-      "evra": "1.8.11-8.fc42.ppc64le",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
     "iptables-libs": {
-      "evra": "1.8.11-8.fc42.ppc64le",
+      "evra": "1.8.11-11.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.11-8.fc42.ppc64le",
+      "evra": "1.8.11-11.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.11-8.fc42.noarch",
+      "evra": "1.8.11-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.11-8.fc42.ppc64le",
+      "evra": "1.8.11-11.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20250605-1.fc42.ppc64le",
+      "evra": "20250605-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-6.fc42.ppc64le",
+      "evra": "2:1.9.4-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.ppc64le",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.ppc64le",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.ppc64le",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.103-2.fc42.ppc64le",
+      "evra": "0.103-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.14-2.fc42.ppc64le",
+      "evra": "2.14-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jose": {
-      "evra": "14-4.fc42.ppc64le",
+      "evra": "14-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-11.fc42.ppc64le",
+      "evra": "1.7.1-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.18-2.fc42.ppc64le",
+      "evra": "0.18-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.10.8-1.fc42.ppc64le",
+      "evra": "1.10.8-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.7.1-3.fc42.ppc64le",
+      "evra": "2.8.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.56-1.fc42.ppc64le",
+      "evra": "1.0.56-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.16.12-200.fc42.ppc64le",
+      "evra": "6.17.1-300.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.16.12-200.fc42.ppc64le",
+      "evra": "6.17.1-300.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.16.12-200.fc42.ppc64le",
+      "evra": "6.17.1-300.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.16.12-200.fc42.ppc64le",
+      "evra": "6.17.1-300.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.31-2.fc42.ppc64le",
+      "evra": "2.0.31-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-5.fc42.ppc64le",
+      "evra": "1.6.3-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-5.fc42.ppc64le",
+      "evra": "1.6.3-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "33-3.fc42.ppc64le",
+      "evra": "34.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "33-3.fc42.ppc64le",
+      "evra": "34.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.10.0-5.fc42.ppc64le",
+      "evra": "0.11.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-6.fc42.ppc64le",
+      "evra": "1.21.3-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "679-1.fc42.ppc64le",
+      "evra": "679-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-3.fc42.ppc64le",
+      "evra": "2.3.2-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-21.fc42.ppc64le",
+      "evra": "0.3.111-22.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.8.1-1.fc42.ppc64le",
+      "evra": "3.8.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-3.fc42.ppc64le",
+      "evra": "2.5.7-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libatomic": {
-      "evra": "15.2.1-1.fc42.ppc64le",
+      "evra": "15.2.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libattr": {
-      "evra": "2.5.2-5.fc42.ppc64le",
+      "evra": "2.5.2-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-58.fc42.ppc64le",
+      "evra": "0.1.1-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.5.0-2.fc42.ppc64le",
+      "evra": "2:1.6.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-5.fc42.ppc64le",
+      "evra": "0.12.2-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.73-2.fc42.ppc64le",
+      "evra": "2.76-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.5-4.fc42.ppc64le",
+      "evra": "0.8.5-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-3.fc42.ppc64le",
+      "evra": "0.12.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-58.fc42.ppc64le",
+      "evra": "0.7.0-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.2-3.fc42.ppc64le",
+      "evra": "1.47.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.11.1-6.fc42.ppc64le",
+      "evra": "8.15.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-31.fc42.ppc64le",
+      "evra": "0.14-32.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-58.fc42.ppc64le",
+      "evra": "0.5.0-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libdnf5": {
-      "evra": "5.2.16.0-1.fc42.ppc64le",
+      "evra": "5.2.17.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdnf5-cli": {
-      "evra": "5.2.16.0-1.fc42.ppc64le",
+      "evra": "5.2.17.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdrm": {
-      "evra": "2.4.126-1.fc42.ppc64le",
+      "evra": "2.4.126-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libdrm"
       }
     },
     "libeconf": {
-      "evra": "0.7.6-2.fc42.ppc64le",
+      "evra": "0.7.9-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-55.20250104cvs.fc42.ppc64le",
+      "evra": "3.1-56.20250104cvs.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-15.fc42.ppc64le",
+      "evra": "2.1.12-16.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.6-5.fc42.ppc64le",
+      "evra": "3.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.15.0-3.fc42.ppc64le",
+      "evra": "1.16.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "15.2.1-1.fc42.ppc64le",
+      "evra": "15.2.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.11.0-5.fc42.ppc64le",
+      "evra": "1.11.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.51-2.fc42.ppc64le",
+      "evra": "1.55-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libibverbs": {
-      "evra": "55.0-1.fc42.ppc64le",
+      "evra": "58.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "76.1-4.fc42.ppc64le",
+      "evra": "77.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.8-1.fc42.ppc64le",
+      "evra": "2.3.8-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-58.fc42.ppc64le",
+      "evra": "1.3.1-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.5-1.fc42.ppc64le",
+      "evra": "0.2.5-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-4.fc42.ppc64le",
+      "evra": "14-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-5.fc42.ppc64le",
+      "evra": "1.5.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-5.fc42.ppc64le",
+      "evra": "1.5.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-5.fc42.ppc64le",
+      "evra": "1.5.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.7-3.fc42.ppc64le",
+      "evra": "1.6.7-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
+    "liblastlog2": {
+      "evra": "2.41.1-17.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "util-linux"
+      }
+    },
     "libldb": {
-      "evra": "2:4.22.4-1.fc42.ppc64le",
+      "evra": "2:4.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-24.fc42.ppc64le",
+      "evra": "9-25.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.12.2-3.fc42.ppc64le",
+      "evra": "1.12.2-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-7.fc42.ppc64le",
+      "evra": "1.1.0-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-7.fc42.ppc64le",
+      "evra": "1.0.5-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.2-1.fc42.ppc64le",
+      "evra": "2.15.2-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.9-3.fc42.ppc64le",
+      "evra": "1.9-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-5.fc42.ppc64le",
+      "evra": "1.3-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-8.fc42.ppc64le",
+      "evra": "1.0.9-9.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-30.fc42.ppc64le",
+      "evra": "1.0.1-31.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.8.4-0.fc42.ppc64le",
+      "evra": "1:2.8.4-0.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.8-4.fc42.ppc64le",
+      "evra": "1.2.9-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.64.0-3.fc42.ppc64le",
+      "evra": "1.66.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.11.0-3.fc42.ppc64le",
+      "evra": "3.11.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.11.0-3.fc42.ppc64le",
+      "evra": "3.11.0-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnvme": {
-      "evra": "1.15-2.fc42.ppc64le",
+      "evra": "1.15-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-58.fc42.ppc64le",
+      "evra": "0.2.1-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-2.fc42.ppc64le",
+      "evra": "14:1.10.5-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpciaccess": {
-      "evra": "0.16-15.fc42.ppc64le",
+      "evra": "0.16-16.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libpciaccess"
       }
     },
     "libpkgconf": {
-      "evra": "2.3.0-2.fc42.ppc64le",
+      "evra": "2.3.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-5.fc42.ppc64le",
+      "evra": "0.21.5-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-12.fc42.ppc64le",
+      "evra": "1.4.5-14.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-58.fc42.ppc64le",
+      "evra": "0.1.5-59.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.20.0-1.fc42.ppc64le",
+      "evra": "1.20.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-5.fc42.noarch",
+      "evra": "2.17.15-9.fc43.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "librtas": {
-      "evra": "2.0.6-3.fc42.ppc64le",
+      "evra": "2.0.6-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "librtas"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-2.fc41.ppc64le",
+      "evra": "2.6.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.8-3.fc42.ppc64le",
+      "evra": "3.9-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.8-3.fc42.ppc64le",
+      "evra": "3.9-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.8.1-2.fc42.ppc64le",
+      "evra": "3.9-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.8-1.fc42.ppc64le",
+      "evra": "3.9-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libservicelog": {
-      "evra": "1.1.19-13.fc42.ppc64le",
+      "evra": "1.1.19-16.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libservicelog"
       }
     },
     "libslirp": {
-      "evra": "4.8.0-3.fc42.ppc64le",
+      "evra": "4.9.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.22.4-1.fc42.ppc64le",
+      "evra": "2:4.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.34-1.fc42.ppc64le",
+      "evra": "0.7.34-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.2-3.fc42.ppc64le",
+      "evra": "1.47.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "15.2.1-1.fc42.ppc64le",
+      "evra": "15.2.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.3-2.fc42.ppc64le",
+      "evra": "2.4.3-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.20.0-1.fc42.ppc64le",
+      "evra": "4.20.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.13-2.fc42.ppc64le",
+      "evra": "1.4.14-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-11.fc42.ppc64le",
+      "evra": "1.32-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.2-2.fc42.ppc64le",
+      "evra": "0.17.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.23.1-2.fc42.ppc64le",
+      "evra": "0.25.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.7-0.fc42.ppc64le",
+      "evra": "1.3.7-0.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-4.fc42.ppc64le",
+      "evra": "2.5.4-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-9.fc42.ppc64le",
+      "evra": "1.1-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc42.ppc64le",
+      "evra": "1.0.29-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libuuid": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.51.0-1.fc42.ppc64le",
+      "evra": "1:1.51.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-10.fc42.ppc64le",
+      "evra": "0.3.2-11.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.22.4-1.fc42.ppc64le",
+      "evra": "2:4.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.38-7.fc42.ppc64le",
+      "evra": "4.4.38-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.10-1.fc42.ppc64le",
+      "evra": "2.12.10-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.24-1.fc42.ppc64le",
+      "evra": "0.3.24-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-16.fc42.ppc64le",
+      "evra": "0.2.5-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.7-1.fc42.ppc64le",
+      "evra": "1.5.7-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-3.fc42.ppc64le",
+      "evra": "0.9.33-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.22.0-3.fc42.ppc64le",
+      "evra": "3.22.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-7.fc42.ppc64le",
+      "evra": "4.98.0-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.8-1.fc42.ppc64le",
+      "evra": "5.4.8-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-24.fc42.ppc64le",
+      "evra": "9-25.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.30-3.fc42.ppc64le",
+      "evra": "2.03.34-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.30-3.fc42.ppc64le",
+      "evra": "2.03.34-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.10.0-2.fc42.ppc64le",
+      "evra": "1.10.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-14.fc42.ppc64le",
+      "evra": "2.10-15.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.7-1.fc42.ppc64le",
+      "evra": "1.7.7-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.3-8.fc42.ppc64le",
+      "evra": "4.3-9.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "28.5.1-2.fc42.ppc64le",
+      "evra": "28.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "moby-filesystem": {
-      "evra": "28.5.1-2.fc42.noarch",
+      "evra": "28.5.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.2-1.fc42.ppc64le",
+      "evra": "4.2.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "nano": {
-      "evra": "8.3-3.fc42.ppc64le",
+      "evra": "8.5-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "8.3-3.fc42.noarch",
+      "evra": "8.5-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.5-5.20250125.fc42.ppc64le",
+      "evra": "6.5-7.20250614.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.5-5.20250125.fc42.noarch",
+      "evra": "6.5-7.20250614.fc43.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.5-5.20250125.fc42.ppc64le",
+      "evra": "6.5-7.20250614.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.73.20160912git.fc42.ppc64le",
+      "evra": "2.0-0.74.20160912git.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.16.1-1.fc42.ppc64le",
+      "evra": "2:1.16.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.10.1-1.fc42.ppc64le",
+      "evra": "3.10.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.25-1.fc42.ppc64le",
+      "evra": "0.52.25-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.8.4-0.fc42.ppc64le",
+      "evra": "1:2.8.4-0.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.1.1-3.fc42.ppc64le",
+      "evra": "1:1.1.3-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
+    "nftables-services": {
+      "evra": "1:1.1.3-5.fc43.noarch",
+      "metadata": {
+        "sourcerpm": "nftables"
+      }
+    },
+    "ngtcp2": {
+      "evra": "1.15.1-1.fc43.ppc64le",
+      "metadata": {
+        "sourcerpm": "ngtcp2"
+      }
+    },
     "nmstate": {
-      "evra": "2.2.52-2.fc42.ppc64le",
+      "evra": "2.2.52-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.8-2.fc42.ppc64le",
+      "evra": "1.8-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-6.fc42.ppc64le",
+      "evra": "2.23.0-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.19-2.fc42.ppc64le",
+      "evra": "2.0.19-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.15-2.fc42.ppc64le",
+      "evra": "2.15-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "oniguruma": {
-      "evra": "6.9.10-2.fc42.ppc64le",
+      "evra": "6.9.10-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.10-1.fc42.ppc64le",
+      "evra": "2.6.10-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.9p1-11.fc42.ppc64le",
+      "evra": "10.0p1-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.9p1-11.fc42.ppc64le",
+      "evra": "10.0p1-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.9p1-11.fc42.ppc64le",
+      "evra": "10.0p1-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.6-2.fc42.ppc64le",
+      "evra": "1:3.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.6-2.fc42.ppc64le",
+      "evra": "1:3.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-9.fc42.ppc64le",
+      "evra": "1.81-10.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2025.6-1.fc42.ppc64le",
+      "evra": "2025.6-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-grub2": {
-      "evra": "2025.6-1.fc42.ppc64le",
+      "evra": "2025.6-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2025.6-1.fc42.ppc64le",
+      "evra": "2025.6-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.8-1.fc42.ppc64le",
+      "evra": "0.25.8-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.8-1.fc42.ppc64le",
+      "evra": "0.25.8-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.7.0-6.fc42.ppc64le",
+      "evra": "1.7.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.7.0-6.fc42.ppc64le",
+      "evra": "1.7.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.10-1.fc42.ppc64le",
+      "evra": "0.1.10-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20250919.g623dbf6-1.fc42.ppc64le",
+      "evra": "0^20250919.g623dbf6-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20250919.g623dbf6-1.fc42.noarch",
+      "evra": "0^20250919.g623dbf6-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.14.0-1.fc42.ppc64le",
+      "evra": "3.14.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.14.0-1.fc42.ppc64le",
+      "evra": "3.14.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.45-1.fc42.ppc64le",
+      "evra": "10.46-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.45-1.fc42.noarch",
+      "evra": "10.46-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-6.fc42.ppc64le",
+      "evra": "2.8-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.3.0-2.fc42.ppc64le",
+      "evra": "2.3.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-2.fc42.noarch",
+      "evra": "2.3.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-2.fc42.ppc64le",
+      "evra": "2.3.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.6.2-1.fc42.ppc64le",
+      "evra": "5:5.6.2-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.8-1.fc42.ppc64le",
+      "evra": "3.9-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "126-3.fc42.1.ppc64le",
+      "evra": "126-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "126-3.fc42.1.ppc64le",
+      "evra": "126-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "popt": {
-      "evra": "1.19-8.fc42.ppc64le",
+      "evra": "1.19-9.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "powerpc-utils-core": {
-      "evra": "1.3.13-3.fc42.ppc64le",
+      "evra": "1.3.13-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "powerpc-utils"
       }
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.10-4.fc42.ppc64le",
+      "evra": "2.7.10-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "ppc64-diag"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-6.fc42.1.ppc64le",
+      "evra": "4.0.4-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.1-1.fc42.ppc64le",
+      "evra": "1.5.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.7-5.fc42.ppc64le",
+      "evra": "23.7-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20250616-1.fc42.noarch",
+      "evra": "20250616-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:9.2.4-2.fc42.ppc64le",
+      "evra": "2:10.1.0-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-13.fc42.ppc64le",
+      "evra": "8.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc42.ppc64le",
+      "evra": "1.2.8-0.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.20.1-1.fc42.ppc64le",
+      "evra": "6.0.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.20.1-1.fc42.ppc64le",
+      "evra": "6.0.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2025.11-1.fc42.ppc64le",
+      "evra": "2025.11-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2025.11-1.fc42.ppc64le",
+      "evra": "2025.11-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.20.1-1.fc42.ppc64le",
+      "evra": "6.0.0-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-5.fc42.ppc64le",
+      "evra": "1.9.0-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.4.1-3.fc42.ppc64le",
+      "evra": "3.4.1-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.3.2-1.fc42.ppc64le",
+      "evra": "2:1.3.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.22.4-1.fc42.ppc64le",
+      "evra": "2:4.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.22.4-1.fc42.noarch",
+      "evra": "2:4.23.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.22.4-1.fc42.ppc64le",
+      "evra": "2:4.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sdbus-cpp": {
-      "evra": "1.5.0-4.fc42.ppc64le",
+      "evra": "2.1.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sdbus-cpp"
       }
     },
     "sed": {
-      "evra": "4.9-4.fc42.ppc64le",
+      "evra": "4.9-5.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "servicelog": {
-      "evra": "1.1.16-8.fc42.ppc64le",
+      "evra": "1.1.16-9.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "servicelog"
       }
     },
     "setup": {
-      "evra": "2.15.0-13.fc42.noarch",
+      "evra": "2.15.0-26.fc43.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-5.fc42.ppc64le",
+      "evra": "1.48-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-5.fc42.ppc64le",
+      "evra": "1.48-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.17.4-1.fc42.ppc64le",
+      "evra": "2:4.18.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.17.4-1.fc42.ppc64le",
+      "evra": "2:4.18.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-7.fc42.ppc64le",
+      "evra": "2.4-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.20.0-3.fc42.ppc64le",
+      "evra": "1:1.20.0-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-7.fc42.ppc64le",
+      "evra": "2.3.3-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.3.1-2.fc42.ppc64le",
+      "evra": "1.3.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.2.1-4.fc42.ppc64le",
+      "evra": "1.2.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc42.ppc64le",
+      "evra": "1.8.0.3-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.47.2-5.fc42.ppc64le",
+      "evra": "3.50.2-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-6.fc42.ppc64le",
+      "evra": "4.6.1-7.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.5-2.fc42.ppc64le",
+      "evra": "0.1.5-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.11.1-1.fc42.ppc64le",
+      "evra": "2.11.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.23.1-1.fc42.ppc64le",
+      "evra": "1.23.1-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.17-2.p1.fc42.ppc64le",
+      "evra": "1.9.17-5.p1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-shared": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-sysusers": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "257.10-1.fc42.ppc64le",
+      "evra": "258-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-5.fc42.ppc64le",
+      "evra": "2:1.35-6.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-11.fc42.ppc64le",
+      "evra": "1.32-12.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tini-static": {
-      "evra": "0.19.0-10.fc42.ppc64le",
+      "evra": "0.19.0-11.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.3-1.fc42.ppc64le",
+      "evra": "0.3-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-3.fc42.ppc64le",
+      "evra": "5.7-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-6.fc42.ppc64le",
+      "evra": "4.1.3-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-6.fc42.ppc64le",
+      "evra": "4.1.3-8.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2025b-1.fc42.noarch",
+      "evra": "2025b-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.15.0-1.fc42.ppc64le",
+      "evra": "0.15.3-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.4-7.fc42.ppc64le",
+      "evra": "2.41.1-17.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.1818-1.fc42.noarch",
+      "evra": "2:9.1.1818-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.1818-1.fc42.ppc64le",
+      "evra": "2:9.1.1818-1.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.23-2.fc42.ppc64le",
+      "evra": "2.23-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-9.fc42.ppc64le",
+      "evra": "1.0.20250521-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.12.0-3.fc42.ppc64le",
+      "evra": "6.15.0-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.3-2.fc42.ppc64le",
+      "evra": "0.8.3-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.8.1-2.fc42.ppc64le",
+      "evra": "1:5.8.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.8.1-2.fc42.ppc64le",
+      "evra": "1:5.8.1-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-25.fc42.ppc64le",
+      "evra": "2.1.0-38.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-2.fc42.ppc64le",
+      "evra": "1.5.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.30-3.fc42.ppc64le",
+      "evra": "0.0.30-4.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.2.5-2.fc42.ppc64le",
+      "evra": "2.2.5-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.2.1-2.fc42.ppc64le",
+      "evra": "1.2.1-3.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.7-1.fc42.ppc64le",
+      "evra": "1.5.7-2.fc43.ppc64le",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2025-10-21T00:00:00Z",
+    "generated": "2025-10-24T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2025-04-09T11:06:58Z"
+      "fedora-candidate-compose": {
+        "generated": "2025-10-23T03:37:18Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2025-10-19T20:35:29Z"
+        "generated": "2025-10-23T12:37:44Z"
       },
-      "fedora-updates": {
-        "generated": "2025-10-21T00:56:39Z"
+      "fedora-next": {
+        "generated": "2025-10-23T07:45:43Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2018-02-28T16:06:00Z"
       }
     }
   }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,673 +1,667 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.52.1-1.fc42.s390x",
+      "evra": "1:1.54.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.52.1-1.fc42.s390x",
+      "evra": "1:1.54.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.52.1-1.fc42.s390x",
+      "evra": "1:1.54.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.52.1-1.fc42.s390x",
+      "evra": "1:1.54.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.52.1-1.fc42.s390x",
+      "evra": "1:1.54.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.13.1.1-1.fc42.noarch",
+      "evra": "2.14.0.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.16.0-1.fc42.s390x",
+      "evra": "2:1.16.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-3.fc42.s390x",
+      "evra": "2.3.2-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-9.fc42.s390x",
+      "evra": "0.9.2-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.10.0-1.fc42.s390x",
+      "evra": "5.10.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-1.fc42.s390x",
+      "evra": "5.10.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.33-1.fc42.s390x",
+      "evra": "1.33-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-5.fc42.s390x",
+      "evra": "2.5.2-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.1.1-1.fc42.s390x",
+      "evra": "4.1.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.1.1-1.fc42.s390x",
+      "evra": "4.1.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.1.1-1.fc42.s390x",
+      "evra": "4.1.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.1-1.fc42.s390x",
+      "evra": "1.6.2-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.1-1.fc42.s390x",
+      "evra": "1.6.2-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.9~rc2-2.fc42.s390x",
+      "evra": "0.9~rc2-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "azure-vm-utils": {
-      "evra": "0.6.0-1.fc42.s390x",
+      "evra": "0.7.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "azure-vm-utils"
       }
     },
-    "basesystem": {
-      "evra": "11-22.fc42.noarch",
-      "metadata": {
-        "sourcerpm": "basesystem"
-      }
-    },
     "bash": {
-      "evra": "5.2.37-1.fc42.s390x",
+      "evra": "5.3.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-1.fc42.noarch",
+      "evra": "0.7.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.16-1.fc42.noarch",
+      "evra": "1:2.16-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.39-3.fc42.s390x",
+      "evra": "32:9.18.39-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.39-3.fc42.s390x",
+      "evra": "32:9.18.39-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootc": {
-      "evra": "1.8.0-1.fc42.s390x",
+      "evra": "1.8.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "bootc"
       }
     },
     "bootupd": {
-      "evra": "0.2.31-1.fc42.s390x",
+      "evra": "0.2.31-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "bsdtar": {
-      "evra": "3.8.1-1.fc42.s390x",
+      "evra": "3.8.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.16.1-1.fc42.s390x",
+      "evra": "6.17-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc42.s390x",
+      "evra": "0.11.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-20.fc42.s390x",
+      "evra": "1.0.8-21.fc43.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-20.fc42.s390x",
+      "evra": "1.0.8-21.fc43.s390x",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.34.5-1.fc42.s390x",
+      "evra": "1.34.5-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.0.fc42.noarch",
+      "evra": "2025.2.80_v9.0.304-1.1.fc43.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.2.1-1.fc42.s390x",
+      "evra": "0.2.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.8-1.fc42.s390x",
+      "evra": "4.8-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.2-1.fc42.s390x",
+      "evra": "7.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "21-10.fc42.s390x",
+      "evra": "21-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "21-10.fc42.s390x",
+      "evra": "21-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "21-10.fc42.s390x",
+      "evra": "21-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-9.fc42.s390x",
+      "evra": "0.5.3-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "21-10.fc42.s390x",
+      "evra": "21-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-10.fc42.noarch",
+      "evra": "0.33-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.8-2.fc42.s390x",
+      "evra": "1.0.8-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.8-2.fc42.s390x",
+      "evra": "1.0.8-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.13-1.fc42.s390x",
+      "evra": "2:2.1.13-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "4:2.242.0-1.fc42.noarch",
+      "evra": "4:2.242.0-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "2.0.6-1.fc42.s390x",
+      "evra": "2.1.4-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.25.0-2.fc42.s390x",
+      "evra": "0.25.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-2.fc42.s390x",
+      "evra": "0.25.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.6-6.fc42.s390x",
+      "evra": "9.7-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.6-6.fc42.s390x",
+      "evra": "9.7-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-4.fc42.s390x",
+      "evra": "2.15-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-7.fc42.s390x",
+      "evra": "2.9.11-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.1.1-1.fc42.s390x",
+      "evra": "4.1.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.1.1-1.fc42.s390x",
+      "evra": "4.1.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.24-1.fc42.s390x",
+      "evra": "1.24-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20250707-1.gitad370a8.fc42.noarch",
+      "evra": "20250714-5.gitcd6043a.fc43.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.8.1-1.fc42.s390x",
+      "evra": "2.8.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.8.1-1.fc42.s390x",
+      "evra": "2.8.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.11.1-6.fc42.s390x",
+      "evra": "8.15.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-30.fc42.s390x",
+      "evra": "2.1.28-33.fc43.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-30.fc42.s390x",
+      "evra": "2.1.28-33.fc43.s390x",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.16.0-3.fc42.s390x",
+      "evra": "1:1.16.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-6.fc42.s390x",
+      "evra": "37-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.16.0-3.fc42.noarch",
+      "evra": "1:1.16.0-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-3.fc42.s390x",
+      "evra": "1:1.16.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.204-3.fc42.s390x",
+      "evra": "1.02.208-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.204-3.fc42.s390x",
+      "evra": "1.02.208-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.204-3.fc42.s390x",
+      "evra": "1.02.208-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.204-3.fc42.s390x",
+      "evra": "1.02.208-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.10.0-5.fc42.s390x",
+      "evra": "0.11.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.10.0-5.fc42.s390x",
+      "evra": "0.11.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-3.fc42.s390x",
+      "evra": "1.1.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.12-1.fc42.s390x",
+      "evra": "3.12-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnf5": {
-      "evra": "5.2.16.0-1.fc42.s390x",
+      "evra": "5.2.17.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-6.fc42.s390x",
+      "evra": "2.90-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "docker-cli": {
-      "evra": "28.5.1-2.fc42.s390x",
+      "evra": "28.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "dosfstools": {
-      "evra": "4.2-15.fc42.s390x",
+      "evra": "4.2-16.fc43.s390x",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "107-4.fc42.s390x",
+      "evra": "107-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "107-4.fc42.s390x",
+      "evra": "107-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "107-4.fc42.s390x",
+      "evra": "107-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-9.fc42.s390x",
+      "evra": "2.7.0-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.2-3.fc42.s390x",
+      "evra": "1.47.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.2-3.fc42.s390x",
+      "evra": "1.47.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.193-2.fc42.noarch",
+      "evra": "0.193-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.193-2.fc42.s390x",
+      "evra": "0.193-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.193-2.fc42.s390x",
+      "evra": "0.193-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.15-3.fc42.s390x",
+      "evra": "2:6.15-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.7.2-1.fc42.s390x",
+      "evra": "2.7.2-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.46-3.fc42.s390x",
+      "evra": "5.46-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.46-3.fc42.s390x",
+      "evra": "5.46-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-47.fc42.s390x",
+      "evra": "3.18-50.fc43.s390x",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.10.0-5.fc42.s390x",
+      "evra": "1:4.10.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.16.1-1.fc42.s390x",
+      "evra": "1.16.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "11.1.4-1.fc42.s390x",
+      "evra": "11.2.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-12.fc42.s390x",
+      "evra": "0.6.1-13.fc43.s390x",
       "metadata": {
         "sourcerpm": "fstrm"
       }
@@ -679,13 +673,13 @@
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-3.fc42.s390x",
+      "evra": "1.13-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-11.fc42.s390x",
+      "evra": "3.7.3-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
@@ -703,1823 +697,1862 @@
       }
     },
     "fwupd": {
-      "evra": "2.0.16-1.fc42.s390x",
+      "evra": "2.0.16-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.1-1.fc42.s390x",
+      "evra": "5.3.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-9.fc42.s390x",
+      "evra": "1:1.23-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-9.fc42.s390x",
+      "evra": "1:1.23-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-3.fc42.s390x",
+      "evra": "1.0.10-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "git-core": {
-      "evra": "2.51.0-2.fc42.s390x",
+      "evra": "2.51.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.84.4-1.fc42.s390x",
+      "evra": "2.86.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.41-11.fc42.s390x",
+      "evra": "2.42-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.41-11.fc42.s390x",
+      "evra": "2.42-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.41-11.fc42.s390x",
+      "evra": "2.42-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.41-11.fc42.s390x",
+      "evra": "2.42-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc42.s390x",
+      "evra": "1:6.3.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc42.noarch",
+      "evra": "20241231-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "gnulib-l10n"
       }
     },
     "gnupg2": {
-      "evra": "2.4.7-2.fc42.s390x",
+      "evra": "2.4.8-4.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-dirmngr": {
+      "evra": "2.4.8-4.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpg-agent": {
+      "evra": "2.4.8-4.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpgconf": {
+      "evra": "2.4.8-4.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-keyboxd": {
+      "evra": "2.4.8-4.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-verify": {
+      "evra": "2.4.8-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.10-1.fc42.s390x",
+      "evra": "3.8.10-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "gpgme": {
-      "evra": "1.24.3-1.fc42.s390x",
+      "evra": "1.24.3-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-10.fc42.s390x",
+      "evra": "3.12-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "gzip": {
-      "evra": "1.13-3.fc42.s390x",
+      "evra": "1.13-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.25-2.fc42.s390x",
+      "evra": "3.25-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.400-1.fc42.noarch",
+      "evra": "0.400-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.24.0-1.fc42.s390x",
+      "evra": "2.24.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "ignition-grub": {
-      "evra": "2.24.0-1.fc42.s390x",
+      "evra": "2.24.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "62-1.fc42.s390x",
+      "evra": "62-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-11.fc42.s390x",
+      "evra": "1.0.3-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.12.0-3.fc42.s390x",
+      "evra": "6.14.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.12.0-3.fc42.s390x",
+      "evra": "6.14.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
-    "iptables-legacy": {
-      "evra": "1.8.11-8.fc42.s390x",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
-    "iptables-legacy-libs": {
-      "evra": "1.8.11-8.fc42.s390x",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
     "iptables-libs": {
-      "evra": "1.8.11-8.fc42.s390x",
+      "evra": "1.8.11-11.fc43.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.11-8.fc42.s390x",
+      "evra": "1.8.11-11.fc43.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.11-8.fc42.noarch",
+      "evra": "1.8.11-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.11-8.fc42.s390x",
+      "evra": "1.8.11-11.fc43.s390x",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20250605-1.fc42.s390x",
+      "evra": "20250605-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.s390x",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.s390x",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.s390x",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.103-2.fc42.s390x",
+      "evra": "0.103-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.14-2.fc42.s390x",
+      "evra": "2.14-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jose": {
-      "evra": "14-4.fc42.s390x",
+      "evra": "14-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-11.fc42.s390x",
+      "evra": "1.7.1-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.18-2.fc42.s390x",
+      "evra": "0.18-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.10.8-1.fc42.s390x",
+      "evra": "1.10.8-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.7.1-3.fc42.s390x",
+      "evra": "2.8.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.56-1.fc42.s390x",
+      "evra": "1.0.56-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.16.12-200.fc42.s390x",
+      "evra": "6.17.1-300.fc43.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.16.12-200.fc42.s390x",
+      "evra": "6.17.1-300.fc43.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.16.12-200.fc42.s390x",
+      "evra": "6.17.1-300.fc43.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.16.12-200.fc42.s390x",
+      "evra": "6.17.1-300.fc43.s390x",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.31-2.fc42.s390x",
+      "evra": "2.0.31-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-5.fc42.s390x",
+      "evra": "1.6.3-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-5.fc42.s390x",
+      "evra": "1.6.3-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "33-3.fc42.s390x",
+      "evra": "34.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "33-3.fc42.s390x",
+      "evra": "34.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.10.0-5.fc42.s390x",
+      "evra": "0.11.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-6.fc42.s390x",
+      "evra": "1.21.3-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "679-1.fc42.s390x",
+      "evra": "679-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-3.fc42.s390x",
+      "evra": "2.3.2-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-21.fc42.s390x",
+      "evra": "0.3.111-22.fc43.s390x",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.8.1-1.fc42.s390x",
+      "evra": "3.8.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-3.fc42.s390x",
+      "evra": "2.5.7-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.2-5.fc42.s390x",
+      "evra": "2.5.2-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-58.fc42.s390x",
+      "evra": "0.1.1-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.5.0-2.fc42.s390x",
+      "evra": "2:1.6.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-5.fc42.s390x",
+      "evra": "0.12.2-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.73-2.fc42.s390x",
+      "evra": "2.76-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.5-4.fc42.s390x",
+      "evra": "0.8.5-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-3.fc42.s390x",
+      "evra": "0.12.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-58.fc42.s390x",
+      "evra": "0.7.0-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.2-3.fc42.s390x",
+      "evra": "1.47.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.11.1-6.fc42.s390x",
+      "evra": "8.15.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-31.fc42.s390x",
+      "evra": "0.14-32.fc43.s390x",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-58.fc42.s390x",
+      "evra": "0.5.0-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libdnf5": {
-      "evra": "5.2.16.0-1.fc42.s390x",
+      "evra": "5.2.17.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdnf5-cli": {
-      "evra": "5.2.16.0-1.fc42.s390x",
+      "evra": "5.2.17.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdrm": {
-      "evra": "2.4.126-1.fc42.s390x",
+      "evra": "2.4.126-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "libdrm"
       }
     },
     "libeconf": {
-      "evra": "0.7.6-2.fc42.s390x",
+      "evra": "0.7.9-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-55.20250104cvs.fc42.s390x",
+      "evra": "3.1-56.20250104cvs.fc43.s390x",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-15.fc42.s390x",
+      "evra": "2.1.12-16.fc43.s390x",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.6-5.fc42.s390x",
+      "evra": "3.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.15.0-3.fc42.s390x",
+      "evra": "1.16.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "15.2.1-1.fc42.s390x",
+      "evra": "15.2.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.11.0-5.fc42.s390x",
+      "evra": "1.11.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.51-2.fc42.s390x",
+      "evra": "1.55-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libibverbs": {
-      "evra": "55.0-1.fc42.s390x",
+      "evra": "58.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "76.1-4.fc42.s390x",
+      "evra": "77.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.8-1.fc42.s390x",
+      "evra": "2.3.8-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-58.fc42.s390x",
+      "evra": "1.3.1-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.5-1.fc42.s390x",
+      "evra": "0.2.5-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-4.fc42.s390x",
+      "evra": "14-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-5.fc42.s390x",
+      "evra": "1.5.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-5.fc42.s390x",
+      "evra": "1.5.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-5.fc42.s390x",
+      "evra": "1.5.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.7-3.fc42.s390x",
+      "evra": "1.6.7-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
+    "liblastlog2": {
+      "evra": "2.41.1-17.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "util-linux"
+      }
+    },
     "libldb": {
-      "evra": "2:4.22.4-1.fc42.s390x",
+      "evra": "2:4.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-24.fc42.s390x",
+      "evra": "9-25.fc43.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.12.2-3.fc42.s390x",
+      "evra": "1.12.2-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-7.fc42.s390x",
+      "evra": "1.1.0-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-7.fc42.s390x",
+      "evra": "1.0.5-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.2-1.fc42.s390x",
+      "evra": "2.15.2-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.9-3.fc42.s390x",
+      "evra": "1.9-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-5.fc42.s390x",
+      "evra": "1.3-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-8.fc42.s390x",
+      "evra": "1.0.9-9.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-30.fc42.s390x",
+      "evra": "1.0.1-31.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.8.4-0.fc42.s390x",
+      "evra": "1:2.8.4-0.fc43.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.8-4.fc42.s390x",
+      "evra": "1.2.9-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.64.0-3.fc42.s390x",
+      "evra": "1.66.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.11.0-3.fc42.s390x",
+      "evra": "3.11.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.11.0-3.fc42.s390x",
+      "evra": "3.11.0-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnvme": {
-      "evra": "1.15-2.fc42.s390x",
+      "evra": "1.15-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-58.fc42.s390x",
+      "evra": "0.2.1-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-2.fc42.s390x",
+      "evra": "14:1.10.5-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpciaccess": {
-      "evra": "0.16-15.fc42.s390x",
+      "evra": "0.16-16.fc43.s390x",
       "metadata": {
         "sourcerpm": "libpciaccess"
       }
     },
     "libpkgconf": {
-      "evra": "2.3.0-2.fc42.s390x",
+      "evra": "2.3.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-5.fc42.s390x",
+      "evra": "0.21.5-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-12.fc42.s390x",
+      "evra": "1.4.5-14.fc43.s390x",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-58.fc42.s390x",
+      "evra": "0.1.5-59.fc43.s390x",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.20.0-1.fc42.s390x",
+      "evra": "1.20.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-5.fc42.noarch",
+      "evra": "2.17.15-9.fc43.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-2.fc41.s390x",
+      "evra": "2.6.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.8-3.fc42.s390x",
+      "evra": "3.9-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.8-3.fc42.s390x",
+      "evra": "3.9-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.8.1-2.fc42.s390x",
+      "evra": "3.9-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.8-1.fc42.s390x",
+      "evra": "3.9-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.8.0-3.fc42.s390x",
+      "evra": "4.9.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.22.4-1.fc42.s390x",
+      "evra": "2:4.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.34-1.fc42.s390x",
+      "evra": "0.7.34-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.2-3.fc42.s390x",
+      "evra": "1.47.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "15.2.1-1.fc42.s390x",
+      "evra": "15.2.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.3-2.fc42.s390x",
+      "evra": "2.4.3-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.20.0-1.fc42.s390x",
+      "evra": "4.20.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.13-2.fc42.s390x",
+      "evra": "1.4.14-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-11.fc42.s390x",
+      "evra": "1.32-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.2-2.fc42.s390x",
+      "evra": "0.17.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtirpc": {
-      "evra": "1.3.7-0.fc42.s390x",
+      "evra": "1.3.7-0.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-4.fc42.s390x",
+      "evra": "2.5.4-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-9.fc42.s390x",
+      "evra": "1.1-10.fc43.s390x",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc42.s390x",
+      "evra": "1.0.29-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libuuid": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.51.0-1.fc42.s390x",
+      "evra": "1:1.51.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-10.fc42.s390x",
+      "evra": "0.3.2-11.fc43.s390x",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.22.4-1.fc42.s390x",
+      "evra": "2:4.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.38-7.fc42.s390x",
+      "evra": "4.4.38-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.10-1.fc42.s390x",
+      "evra": "2.12.10-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.24-1.fc42.s390x",
+      "evra": "0.3.24-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-16.fc42.s390x",
+      "evra": "0.2.5-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.7-1.fc42.s390x",
+      "evra": "1.5.7-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-3.fc42.s390x",
+      "evra": "0.9.33-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.22.0-3.fc42.s390x",
+      "evra": "3.22.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-7.fc42.s390x",
+      "evra": "4.98.0-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.8-1.fc42.s390x",
+      "evra": "5.4.8-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-24.fc42.s390x",
+      "evra": "9-25.fc43.s390x",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.30-3.fc42.s390x",
+      "evra": "2.03.34-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.30-3.fc42.s390x",
+      "evra": "2.03.34-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.10.0-2.fc42.s390x",
+      "evra": "1.10.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-14.fc42.s390x",
+      "evra": "2.10-15.fc43.s390x",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.7-1.fc42.s390x",
+      "evra": "1.7.7-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.3-8.fc42.s390x",
+      "evra": "4.3-9.fc43.s390x",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "moby-engine": {
-      "evra": "28.5.1-2.fc42.s390x",
+      "evra": "28.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "moby-filesystem": {
-      "evra": "28.5.1-2.fc42.noarch",
+      "evra": "28.5.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mpfr": {
-      "evra": "4.2.2-1.fc42.s390x",
+      "evra": "4.2.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "nano": {
-      "evra": "8.3-3.fc42.s390x",
+      "evra": "8.5-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "8.3-3.fc42.noarch",
+      "evra": "8.5-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.5-5.20250125.fc42.s390x",
+      "evra": "6.5-7.20250614.fc43.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.5-5.20250125.fc42.noarch",
+      "evra": "6.5-7.20250614.fc43.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.5-5.20250125.fc42.s390x",
+      "evra": "6.5-7.20250614.fc43.s390x",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.73.20160912git.fc42.s390x",
+      "evra": "2.0-0.74.20160912git.fc43.s390x",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.16.1-1.fc42.s390x",
+      "evra": "2:1.16.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.10.1-1.fc42.s390x",
+      "evra": "3.10.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.25-1.fc42.s390x",
+      "evra": "0.52.25-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.8.4-0.fc42.s390x",
+      "evra": "1:2.8.4-0.fc43.s390x",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.1.1-3.fc42.s390x",
+      "evra": "1:1.1.3-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
+    "nftables-services": {
+      "evra": "1:1.1.3-5.fc43.noarch",
+      "metadata": {
+        "sourcerpm": "nftables"
+      }
+    },
+    "ngtcp2": {
+      "evra": "1.15.1-1.fc43.s390x",
+      "metadata": {
+        "sourcerpm": "ngtcp2"
+      }
+    },
     "nmstate": {
-      "evra": "2.2.52-2.fc42.s390x",
+      "evra": "2.2.52-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.8-2.fc42.s390x",
+      "evra": "1.8-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-6.fc42.s390x",
+      "evra": "2.23.0-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.15-2.fc42.s390x",
+      "evra": "2.15-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "oniguruma": {
-      "evra": "6.9.10-2.fc42.s390x",
+      "evra": "6.9.10-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.10-1.fc42.s390x",
+      "evra": "2.6.10-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.9p1-11.fc42.s390x",
+      "evra": "10.0p1-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.9p1-11.fc42.s390x",
+      "evra": "10.0p1-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.9p1-11.fc42.s390x",
+      "evra": "10.0p1-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.6-2.fc42.s390x",
+      "evra": "1:3.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.6-2.fc42.s390x",
+      "evra": "1:3.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "ostree": {
-      "evra": "2025.6-1.fc42.s390x",
+      "evra": "2025.6-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2025.6-1.fc42.s390x",
+      "evra": "2025.6-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.8-1.fc42.s390x",
+      "evra": "0.25.8-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.8-1.fc42.s390x",
+      "evra": "0.25.8-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.7.0-6.fc42.s390x",
+      "evra": "1.7.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.7.0-6.fc42.s390x",
+      "evra": "1.7.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.10-1.fc42.s390x",
+      "evra": "0.1.10-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20250919.g623dbf6-1.fc42.s390x",
+      "evra": "0^20250919.g623dbf6-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20250919.g623dbf6-1.fc42.noarch",
+      "evra": "0^20250919.g623dbf6-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.14.0-1.fc42.s390x",
+      "evra": "3.14.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.14.0-1.fc42.s390x",
+      "evra": "3.14.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.45-1.fc42.s390x",
+      "evra": "10.46-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.45-1.fc42.noarch",
+      "evra": "10.46-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-6.fc42.s390x",
+      "evra": "2.8-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.3.0-2.fc42.s390x",
+      "evra": "2.3.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-2.fc42.noarch",
+      "evra": "2.3.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-2.fc42.s390x",
+      "evra": "2.3.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.6.2-1.fc42.s390x",
+      "evra": "5:5.6.2-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.8-1.fc42.s390x",
+      "evra": "3.9-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "126-3.fc42.1.s390x",
+      "evra": "126-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "126-3.fc42.1.s390x",
+      "evra": "126-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "popt": {
-      "evra": "1.19-8.fc42.s390x",
+      "evra": "1.19-9.fc43.s390x",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-6.fc42.1.s390x",
+      "evra": "4.0.4-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.1-1.fc42.s390x",
+      "evra": "1.5.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.7-5.fc42.s390x",
+      "evra": "23.7-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20250616-1.fc42.noarch",
+      "evra": "20250616-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "qemu-user-static-x86": {
-      "evra": "2:9.2.4-2.fc42.s390x",
+      "evra": "2:10.1.0-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "qemu"
       }
     },
     "readline": {
-      "evra": "8.2-13.fc42.s390x",
+      "evra": "8.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc42.s390x",
+      "evra": "1.2.8-0.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.20.1-1.fc42.s390x",
+      "evra": "6.0.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.20.1-1.fc42.s390x",
+      "evra": "6.0.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2025.11-1.fc42.s390x",
+      "evra": "2025.11-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2025.11-1.fc42.s390x",
+      "evra": "2025.11-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.20.1-1.fc42.s390x",
+      "evra": "6.0.0-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-5.fc42.s390x",
+      "evra": "1.9.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.4.1-3.fc42.s390x",
+      "evra": "3.4.1-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.3.2-1.fc42.s390x",
+      "evra": "2:1.3.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "s390utils-core": {
-      "evra": "2:2.35.0-5.fc42.s390x",
+      "evra": "2:2.38.0-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "s390utils"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.22.4-1.fc42.s390x",
+      "evra": "2:4.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.22.4-1.fc42.noarch",
+      "evra": "2:4.23.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.22.4-1.fc42.s390x",
+      "evra": "2:4.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sdbus-cpp": {
-      "evra": "1.5.0-4.fc42.s390x",
+      "evra": "2.1.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sdbus-cpp"
       }
     },
     "sed": {
-      "evra": "4.9-4.fc42.s390x",
+      "evra": "4.9-5.fc43.s390x",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.15.0-13.fc42.noarch",
+      "evra": "2.15.0-26.fc43.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-5.fc42.s390x",
+      "evra": "1.48-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-5.fc42.s390x",
+      "evra": "1.48-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.17.4-1.fc42.s390x",
+      "evra": "2:4.18.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.17.4-1.fc42.s390x",
+      "evra": "2:4.18.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-7.fc42.s390x",
+      "evra": "2.4-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
     },
     "skopeo": {
-      "evra": "1:1.20.0-3.fc42.s390x",
+      "evra": "1:1.20.0-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-7.fc42.s390x",
+      "evra": "2.3.3-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.3.1-2.fc42.s390x",
+      "evra": "1.3.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.2.1-4.fc42.s390x",
+      "evra": "1.2.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc42.s390x",
+      "evra": "1.8.0.3-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "sqlite-libs": {
-      "evra": "3.47.2-5.fc42.s390x",
+      "evra": "3.50.2-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-6.fc42.s390x",
+      "evra": "4.6.1-7.fc43.s390x",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.5-2.fc42.s390x",
+      "evra": "0.1.5-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.11.1-1.fc42.s390x",
+      "evra": "2.11.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.23.1-1.fc42.s390x",
+      "evra": "1.23.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.17-2.p1.fc42.s390x",
+      "evra": "1.9.17-5.p1.fc43.s390x",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-shared": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-sysusers": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "257.10-1.fc42.s390x",
+      "evra": "258-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-5.fc42.s390x",
+      "evra": "2:1.35-6.fc43.s390x",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-11.fc42.s390x",
+      "evra": "1.32-12.fc43.s390x",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tini-static": {
-      "evra": "0.19.0-10.fc42.s390x",
+      "evra": "0.19.0-11.fc43.s390x",
       "metadata": {
         "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.3-1.fc42.s390x",
+      "evra": "0.3-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-3.fc42.s390x",
+      "evra": "5.7-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-6.fc42.s390x",
+      "evra": "4.1.3-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-6.fc42.s390x",
+      "evra": "4.1.3-8.fc43.s390x",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2025b-1.fc42.noarch",
+      "evra": "2025b-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.15.0-1.fc42.s390x",
+      "evra": "0.15.3-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.4-7.fc42.s390x",
+      "evra": "2.41.1-17.fc43.s390x",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "veritysetup": {
-      "evra": "2.8.1-1.fc42.s390x",
+      "evra": "2.8.1-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.1818-1.fc42.noarch",
+      "evra": "2:9.1.1818-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.1818-1.fc42.s390x",
+      "evra": "2:9.1.1818-1.fc43.s390x",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "which": {
-      "evra": "2.23-2.fc42.s390x",
+      "evra": "2.23-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-9.fc42.s390x",
+      "evra": "1.0.20250521-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.12.0-3.fc42.s390x",
+      "evra": "6.15.0-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.3-2.fc42.s390x",
+      "evra": "0.8.3-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.8.1-2.fc42.s390x",
+      "evra": "1:5.8.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.8.1-2.fc42.s390x",
+      "evra": "1:5.8.1-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-25.fc42.s390x",
+      "evra": "2.1.0-38.fc43.s390x",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-2.fc42.s390x",
+      "evra": "1.5.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.30-3.fc42.s390x",
+      "evra": "0.0.30-4.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.2.5-2.fc42.s390x",
+      "evra": "2.2.5-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.2.1-2.fc42.s390x",
+      "evra": "1.2.1-3.fc43.s390x",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.7-1.fc42.s390x",
+      "evra": "1.5.7-2.fc43.s390x",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2025-10-21T00:00:00Z",
+    "generated": "2025-10-24T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2025-04-09T11:06:57Z"
+      "fedora-candidate-compose": {
+        "generated": "2025-10-23T03:37:17Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2025-10-19T20:34:56Z"
+        "generated": "2025-10-23T12:34:50Z"
       },
-      "fedora-updates": {
-        "generated": "2025-10-21T00:56:43Z"
+      "fedora-next": {
+        "generated": "2025-10-23T07:45:42Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2018-02-28T16:06:49Z"
       }
     }
   }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,703 +1,697 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.52.1-1.fc42.x86_64",
+      "evra": "1:1.54.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.52.1-1.fc42.x86_64",
+      "evra": "1:1.54.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.52.1-1.fc42.x86_64",
+      "evra": "1:1.54.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-team": {
-      "evra": "1:1.52.1-1.fc42.x86_64",
+      "evra": "1:1.54.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "NetworkManager-tui": {
-      "evra": "1:1.52.1-1.fc42.x86_64",
+      "evra": "1:1.54.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "NetworkManager"
       }
     },
     "WALinuxAgent-udev": {
-      "evra": "2.13.1.1-1.fc42.noarch",
+      "evra": "2.14.0.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "WALinuxAgent"
       }
     },
     "aardvark-dns": {
-      "evra": "2:1.16.0-1.fc42.x86_64",
+      "evra": "2:1.16.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "aardvark-dns"
       }
     },
     "acl": {
-      "evra": "2.3.2-3.fc42.x86_64",
+      "evra": "2.3.2-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "adcli": {
-      "evra": "0.9.2-9.fc42.x86_64",
+      "evra": "0.9.2-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "adcli"
       }
     },
     "afterburn": {
-      "evra": "5.10.0-1.fc42.x86_64",
+      "evra": "5.10.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-1.fc42.x86_64",
+      "evra": "5.10.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-afterburn"
       }
     },
     "alternatives": {
-      "evra": "1.33-1.fc42.x86_64",
+      "evra": "1.33-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "chkconfig"
       }
     },
     "amd-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "amd-ucode-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "attr": {
-      "evra": "2.5.2-5.fc42.x86_64",
+      "evra": "2.5.2-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "audit": {
-      "evra": "4.1.1-1.fc42.x86_64",
+      "evra": "4.1.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-libs": {
-      "evra": "4.1.1-1.fc42.x86_64",
+      "evra": "4.1.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "audit-rules": {
-      "evra": "4.1.1-1.fc42.x86_64",
+      "evra": "4.1.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "audit"
       }
     },
     "authselect": {
-      "evra": "1.5.1-1.fc42.x86_64",
+      "evra": "1.6.2-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "authselect-libs": {
-      "evra": "1.5.1-1.fc42.x86_64",
+      "evra": "1.6.2-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "authselect"
       }
     },
     "avahi-libs": {
-      "evra": "0.9~rc2-2.fc42.x86_64",
+      "evra": "0.9~rc2-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "avahi"
       }
     },
     "azure-vm-utils": {
-      "evra": "0.6.0-1.fc42.x86_64",
+      "evra": "0.7.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "azure-vm-utils"
       }
     },
-    "basesystem": {
-      "evra": "11-22.fc42.noarch",
-      "metadata": {
-        "sourcerpm": "basesystem"
-      }
-    },
     "bash": {
-      "evra": "5.2.37-1.fc42.x86_64",
+      "evra": "5.3.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bash"
       }
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-1.fc42.noarch",
+      "evra": "0.7.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "shell-color-prompt"
       }
     },
     "bash-completion": {
-      "evra": "1:2.16-1.fc42.noarch",
+      "evra": "1:2.16-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "bash-completion"
       }
     },
     "bind-libs": {
-      "evra": "32:9.18.39-3.fc42.x86_64",
+      "evra": "32:9.18.39-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bind-utils": {
-      "evra": "32:9.18.39-3.fc42.x86_64",
+      "evra": "32:9.18.39-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bind"
       }
     },
     "bootc": {
-      "evra": "1.8.0-1.fc42.x86_64",
+      "evra": "1.8.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bootc"
       }
     },
     "bootupd": {
-      "evra": "0.2.31-1.fc42.x86_64",
+      "evra": "0.2.31-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-bootupd"
       }
     },
     "bsdtar": {
-      "evra": "3.8.1-1.fc42.x86_64",
+      "evra": "3.8.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "btrfs-progs": {
-      "evra": "6.16.1-1.fc42.x86_64",
+      "evra": "6.17-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "btrfs-progs"
       }
     },
     "bubblewrap": {
-      "evra": "0.10.0-1.fc42.x86_64",
+      "evra": "0.11.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bubblewrap"
       }
     },
     "bzip2": {
-      "evra": "1.0.8-20.fc42.x86_64",
+      "evra": "1.0.8-21.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "bzip2-libs": {
-      "evra": "1.0.8-20.fc42.x86_64",
+      "evra": "1.0.8-21.fc43.x86_64",
       "metadata": {
         "sourcerpm": "bzip2"
       }
     },
     "c-ares": {
-      "evra": "1.34.5-1.fc42.x86_64",
+      "evra": "1.34.5-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "c-ares"
       }
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.0.fc42.noarch",
+      "evra": "2025.2.80_v9.0.304-1.1.fc43.noarch",
       "metadata": {
         "sourcerpm": "ca-certificates"
       }
     },
     "catatonit": {
-      "evra": "0.2.1-1.fc42.x86_64",
+      "evra": "0.2.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "catatonit"
       }
     },
     "chrony": {
-      "evra": "4.8-1.fc42.x86_64",
+      "evra": "4.8-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "chrony"
       }
     },
     "cifs-utils": {
-      "evra": "7.2-1.fc42.x86_64",
+      "evra": "7.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cifs-utils"
       }
     },
     "clevis": {
-      "evra": "21-10.fc42.x86_64",
+      "evra": "21-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-dracut": {
-      "evra": "21-10.fc42.x86_64",
+      "evra": "21-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-luks": {
-      "evra": "21-10.fc42.x86_64",
+      "evra": "21-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-9.fc42.x86_64",
+      "evra": "0.5.3-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "clevis-pin-tpm2"
       }
     },
     "clevis-systemd": {
-      "evra": "21-10.fc42.x86_64",
+      "evra": "21-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "clevis"
       }
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-10.fc42.noarch",
+      "evra": "0.33-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "cloud-utils"
       }
     },
     "composefs": {
-      "evra": "1.0.8-2.fc42.x86_64",
+      "evra": "1.0.8-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "composefs-libs": {
-      "evra": "1.0.8-2.fc42.x86_64",
+      "evra": "1.0.8-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "composefs"
       }
     },
     "conmon": {
-      "evra": "2:2.1.13-1.fc42.x86_64",
+      "evra": "2:2.1.13-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "conmon"
       }
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-10.fc42.noarch",
+      "evra": "0.21.3-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "console-login-helper-messages"
       }
     },
     "container-selinux": {
-      "evra": "4:2.242.0-1.fc42.noarch",
+      "evra": "4:2.242.0-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "container-selinux"
       }
     },
     "containerd": {
-      "evra": "2.0.6-1.fc42.x86_64",
+      "evra": "2.1.4-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "containerd"
       }
     },
     "containers-common": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "containers-common-extra": {
-      "evra": "5:0.64.2-1.fc42.noarch",
+      "evra": "5:0.64.2-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "containers-common"
       }
     },
     "coreos-installer": {
-      "evra": "0.25.0-2.fc42.x86_64",
+      "evra": "0.25.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-2.fc42.x86_64",
+      "evra": "0.25.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-coreos-installer"
       }
     },
     "coreutils": {
-      "evra": "9.6-6.fc42.x86_64",
+      "evra": "9.7-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "coreutils-common": {
-      "evra": "9.6-6.fc42.x86_64",
+      "evra": "9.7-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "coreutils"
       }
     },
     "cpio": {
-      "evra": "2.15-4.fc42.x86_64",
+      "evra": "2.15-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cpio"
       }
     },
     "cracklib": {
-      "evra": "2.9.11-7.fc42.x86_64",
+      "evra": "2.9.11-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cracklib"
       }
     },
     "criu": {
-      "evra": "4.1.1-1.fc42.x86_64",
+      "evra": "4.1.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "criu-libs": {
-      "evra": "4.1.1-1.fc42.x86_64",
+      "evra": "4.1.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "criu"
       }
     },
     "crun": {
-      "evra": "1.24-1.fc42.x86_64",
+      "evra": "1.24-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crun-wasm": {
-      "evra": "1.24-1.fc42.x86_64",
+      "evra": "1.24-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "crun"
       }
     },
     "crypto-policies": {
-      "evra": "20250707-1.gitad370a8.fc42.noarch",
+      "evra": "20250714-5.gitcd6043a.fc43.noarch",
       "metadata": {
         "sourcerpm": "crypto-policies"
       }
     },
     "cryptsetup": {
-      "evra": "2.8.1-1.fc42.x86_64",
+      "evra": "2.8.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "cryptsetup-libs": {
-      "evra": "2.8.1-1.fc42.x86_64",
+      "evra": "2.8.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cryptsetup"
       }
     },
     "curl": {
-      "evra": "8.11.1-6.fc42.x86_64",
+      "evra": "8.15.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-30.fc42.x86_64",
+      "evra": "2.1.28-33.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-30.fc42.x86_64",
+      "evra": "2.1.28-33.fc43.x86_64",
       "metadata": {
         "sourcerpm": "cyrus-sasl"
       }
     },
     "dbus": {
-      "evra": "1:1.16.0-3.fc42.x86_64",
+      "evra": "1:1.16.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-broker": {
-      "evra": "36-6.fc42.x86_64",
+      "evra": "37-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dbus-broker"
       }
     },
     "dbus-common": {
-      "evra": "1:1.16.0-3.fc42.noarch",
+      "evra": "1:1.16.0-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-3.fc42.x86_64",
+      "evra": "1:1.16.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dbus"
       }
     },
     "device-mapper": {
-      "evra": "1.02.204-3.fc42.x86_64",
+      "evra": "1.02.208-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event": {
-      "evra": "1.02.204-3.fc42.x86_64",
+      "evra": "1.02.208-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.204-3.fc42.x86_64",
+      "evra": "1.02.208-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-libs": {
-      "evra": "1.02.204-3.fc42.x86_64",
+      "evra": "1.02.208-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "device-mapper-multipath": {
-      "evra": "0.10.0-5.fc42.x86_64",
+      "evra": "0.11.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.10.0-5.fc42.x86_64",
+      "evra": "0.11.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-3.fc42.x86_64",
+      "evra": "1.1.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-persistent-data"
       }
     },
     "diffutils": {
-      "evra": "3.12-1.fc42.x86_64",
+      "evra": "3.12-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "diffutils"
       }
     },
     "dnf5": {
-      "evra": "5.2.16.0-1.fc42.x86_64",
+      "evra": "5.2.17.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "dnsmasq": {
-      "evra": "2.90-6.fc42.x86_64",
+      "evra": "2.90-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dnsmasq"
       }
     },
     "docker-cli": {
-      "evra": "28.5.1-2.fc42.x86_64",
+      "evra": "28.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "dosfstools": {
-      "evra": "4.2-15.fc42.x86_64",
+      "evra": "4.2-16.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dosfstools"
       }
     },
     "dracut": {
-      "evra": "107-4.fc42.x86_64",
+      "evra": "107-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-network": {
-      "evra": "107-4.fc42.x86_64",
+      "evra": "107-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "dracut-squash": {
-      "evra": "107-4.fc42.x86_64",
+      "evra": "107-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dracut"
       }
     },
     "duktape": {
-      "evra": "2.7.0-9.fc42.x86_64",
+      "evra": "2.7.0-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "duktape"
       }
     },
     "e2fsprogs": {
-      "evra": "1.47.2-3.fc42.x86_64",
+      "evra": "1.47.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.2-3.fc42.x86_64",
+      "evra": "1.47.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "efi-filesystem": {
-      "evra": "6-3.fc42.noarch",
+      "evra": "6-4.fc43.noarch",
       "metadata": {
         "sourcerpm": "efi-rpm-macros"
       }
     },
     "efibootmgr": {
-      "evra": "18-9.fc42.x86_64",
+      "evra": "18-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "efibootmgr"
       }
     },
     "efivar-libs": {
-      "evra": "39-8.fc42.x86_64",
+      "evra": "39-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "efivar"
       }
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.193-2.fc42.noarch",
+      "evra": "0.193-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libelf": {
-      "evra": "0.193-2.fc42.x86_64",
+      "evra": "0.193-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "elfutils-libs": {
-      "evra": "0.193-2.fc42.x86_64",
+      "evra": "0.193-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "elfutils"
       }
     },
     "ethtool": {
-      "evra": "2:6.15-3.fc42.x86_64",
+      "evra": "2:6.15-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ethtool"
       }
     },
     "expat": {
-      "evra": "2.7.2-1.fc42.x86_64",
+      "evra": "2.7.2-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "expat"
       }
     },
     "fedora-gpg-keys": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-release-common": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-release-identity-coreos": {
-      "evra": "42-30.noarch",
+      "evra": "43-25.noarch",
       "metadata": {
         "sourcerpm": "fedora-release"
       }
     },
     "fedora-repos": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-archive": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "fedora-repos-ostree": {
-      "evra": "42-1.noarch",
+      "evra": "43-1.noarch",
       "metadata": {
         "sourcerpm": "fedora-repos"
       }
     },
     "file": {
-      "evra": "5.46-3.fc42.x86_64",
+      "evra": "5.46-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "file-libs": {
-      "evra": "5.46-3.fc42.x86_64",
+      "evra": "5.46-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "file"
       }
     },
     "filesystem": {
-      "evra": "3.18-47.fc42.x86_64",
+      "evra": "3.18-50.fc43.x86_64",
       "metadata": {
         "sourcerpm": "filesystem"
       }
     },
     "findutils": {
-      "evra": "1:4.10.0-5.fc42.x86_64",
+      "evra": "1:4.10.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "findutils"
       }
     },
     "flatpak-session-helper": {
-      "evra": "1.16.1-1.fc42.x86_64",
+      "evra": "1.16.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "flatpak"
       }
     },
     "fmt": {
-      "evra": "11.1.4-1.fc42.x86_64",
+      "evra": "11.2.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "fmt"
       }
     },
     "fstrm": {
-      "evra": "0.6.1-12.fc42.x86_64",
+      "evra": "0.6.1-13.fc43.x86_64",
       "metadata": {
         "sourcerpm": "fstrm"
       }
@@ -709,13 +703,13 @@
       }
     },
     "fuse-overlayfs": {
-      "evra": "1.13-3.fc42.x86_64",
+      "evra": "1.13-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "fuse-overlayfs"
       }
     },
     "fuse-sshfs": {
-      "evra": "3.7.3-11.fc42.x86_64",
+      "evra": "3.7.3-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "fuse-sshfs"
       }
@@ -733,1039 +727,1063 @@
       }
     },
     "fwupd": {
-      "evra": "2.0.16-1.fc42.x86_64",
+      "evra": "2.0.16-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "fwupd"
       }
     },
     "gawk": {
-      "evra": "5.3.1-1.fc42.x86_64",
+      "evra": "5.3.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gawk"
       }
     },
     "gdbm": {
-      "evra": "1:1.23-9.fc42.x86_64",
+      "evra": "1:1.23-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdbm-libs": {
-      "evra": "1:1.23-9.fc42.x86_64",
+      "evra": "1:1.23-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gdbm"
       }
     },
     "gdisk": {
-      "evra": "1.0.10-3.fc42.x86_64",
+      "evra": "1.0.10-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gdisk"
       }
     },
     "gettext-envsubst": {
-      "evra": "0.23.1-2.fc42.x86_64",
+      "evra": "0.25.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-libs": {
-      "evra": "0.23.1-2.fc42.x86_64",
+      "evra": "0.25.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "gettext-runtime": {
-      "evra": "0.23.1-2.fc42.x86_64",
+      "evra": "0.25.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "git-core": {
-      "evra": "2.51.0-2.fc42.x86_64",
+      "evra": "2.51.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "git"
       }
     },
     "glib2": {
-      "evra": "2.84.4-1.fc42.x86_64",
+      "evra": "2.86.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "glib2"
       }
     },
     "glibc": {
-      "evra": "2.41-11.fc42.x86_64",
+      "evra": "2.42-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-common": {
-      "evra": "2.41-11.fc42.x86_64",
+      "evra": "2.42-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-gconv-extra": {
-      "evra": "2.41-11.fc42.x86_64",
+      "evra": "2.42-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "glibc-minimal-langpack": {
-      "evra": "2.41-11.fc42.x86_64",
+      "evra": "2.42-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "glibc"
       }
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc42.x86_64",
+      "evra": "1:6.3.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gmp"
       }
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc42.noarch",
+      "evra": "20241231-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "gnulib-l10n"
       }
     },
     "gnupg2": {
-      "evra": "2.4.7-2.fc42.x86_64",
+      "evra": "2.4.8-4.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-dirmngr": {
+      "evra": "2.4.8-4.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpg-agent": {
+      "evra": "2.4.8-4.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-gpgconf": {
+      "evra": "2.4.8-4.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-keyboxd": {
+      "evra": "2.4.8-4.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "gnupg2"
+      }
+    },
+    "gnupg2-verify": {
+      "evra": "2.4.8-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gnupg2"
       }
     },
     "gnutls": {
-      "evra": "3.8.10-1.fc42.x86_64",
+      "evra": "3.8.10-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gnutls"
       }
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250107.00-2.fc42.noarch",
+      "evra": "20250221.00-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "google-compute-engine-guest-configs"
       }
     },
     "gpgme": {
-      "evra": "1.24.3-1.fc42.x86_64",
+      "evra": "1.24.3-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gpgme"
       }
     },
     "grep": {
-      "evra": "3.11-10.fc42.x86_64",
+      "evra": "3.12-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "grep"
       }
     },
     "grub2-common": {
-      "evra": "1:2.12-32.fc42.noarch",
+      "evra": "1:2.12-40.fc43.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-32.fc42.x86_64",
+      "evra": "1:2.12-40.fc43.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc": {
-      "evra": "1:2.12-32.fc42.x86_64",
+      "evra": "1:2.12-40.fc43.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-32.fc42.noarch",
+      "evra": "1:2.12-40.fc43.noarch",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools": {
-      "evra": "1:2.12-32.fc42.x86_64",
+      "evra": "1:2.12-40.fc43.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-32.fc42.x86_64",
+      "evra": "1:2.12-40.fc43.x86_64",
       "metadata": {
         "sourcerpm": "grub2"
       }
     },
     "gzip": {
-      "evra": "1.13-3.fc42.x86_64",
+      "evra": "1.13-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gzip"
       }
     },
     "hostname": {
-      "evra": "3.25-2.fc42.x86_64",
+      "evra": "3.25-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "hostname"
       }
     },
     "hwdata": {
-      "evra": "0.400-1.fc42.noarch",
+      "evra": "0.400-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "hwdata"
       }
     },
     "ignition": {
-      "evra": "2.24.0-1.fc42.x86_64",
+      "evra": "2.24.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "ignition-grub": {
-      "evra": "2.24.0-1.fc42.x86_64",
+      "evra": "2.24.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ignition"
       }
     },
     "inih": {
-      "evra": "62-1.fc42.x86_64",
+      "evra": "62-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "inih"
       }
     },
     "intel-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "ipcalc": {
-      "evra": "1.0.3-11.fc42.x86_64",
+      "evra": "1.0.3-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ipcalc"
       }
     },
     "iproute": {
-      "evra": "6.12.0-3.fc42.x86_64",
+      "evra": "6.14.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
     "iproute-tc": {
-      "evra": "6.12.0-3.fc42.x86_64",
+      "evra": "6.14.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iproute"
       }
     },
-    "iptables-legacy": {
-      "evra": "1.8.11-8.fc42.x86_64",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
-    "iptables-legacy-libs": {
-      "evra": "1.8.11-8.fc42.x86_64",
-      "metadata": {
-        "sourcerpm": "iptables"
-      }
-    },
     "iptables-libs": {
-      "evra": "1.8.11-8.fc42.x86_64",
+      "evra": "1.8.11-11.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-nft": {
-      "evra": "1.8.11-8.fc42.x86_64",
+      "evra": "1.8.11-11.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-services": {
-      "evra": "1.8.11-8.fc42.noarch",
+      "evra": "1.8.11-11.fc43.noarch",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iptables-utils": {
-      "evra": "1.8.11-8.fc42.x86_64",
+      "evra": "1.8.11-11.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iptables"
       }
     },
     "iputils": {
-      "evra": "20250605-1.fc42.x86_64",
+      "evra": "20250605-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "iputils"
       }
     },
     "irqbalance": {
-      "evra": "2:1.9.4-6.fc42.x86_64",
+      "evra": "2:1.9.4-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "irqbalance"
       }
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.x86_64",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc42.x86_64",
+      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64",
       "metadata": {
         "sourcerpm": "iscsi-initiator-utils"
       }
     },
     "isns-utils-libs": {
-      "evra": "0.103-2.fc42.x86_64",
+      "evra": "0.103-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "isns-utils"
       }
     },
     "jansson": {
-      "evra": "2.14-2.fc42.x86_64",
+      "evra": "2.14-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "jansson"
       }
     },
     "jose": {
-      "evra": "14-4.fc42.x86_64",
+      "evra": "14-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "jq": {
-      "evra": "1.7.1-11.fc42.x86_64",
+      "evra": "1.7.1-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "jq"
       }
     },
     "json-c": {
-      "evra": "0.18-2.fc42.x86_64",
+      "evra": "0.18-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "json-c"
       }
     },
     "json-glib": {
-      "evra": "1.10.8-1.fc42.x86_64",
+      "evra": "1.10.8-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "json-glib"
       }
     },
     "kbd": {
-      "evra": "2.7.1-3.fc42.x86_64",
+      "evra": "2.8.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-legacy": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kbd-misc": {
-      "evra": "2.7.1-3.fc42.noarch",
+      "evra": "2.8.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "kbd"
       }
     },
     "kdump-utils": {
-      "evra": "1.0.56-1.fc42.x86_64",
+      "evra": "1.0.56-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kdump-utils"
       }
     },
     "kernel": {
-      "evra": "6.16.12-200.fc42.x86_64",
+      "evra": "6.17.1-300.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-core": {
-      "evra": "6.16.12-200.fc42.x86_64",
+      "evra": "6.17.1-300.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules": {
-      "evra": "6.16.12-200.fc42.x86_64",
+      "evra": "6.17.1-300.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kernel-modules-core": {
-      "evra": "6.16.12-200.fc42.x86_64",
+      "evra": "6.17.1-300.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kernel"
       }
     },
     "kexec-tools": {
-      "evra": "2.0.31-2.fc42.x86_64",
+      "evra": "2.0.31-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kexec-tools"
       }
     },
     "keyutils": {
-      "evra": "1.6.3-5.fc42.x86_64",
+      "evra": "1.6.3-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "keyutils-libs": {
-      "evra": "1.6.3-5.fc42.x86_64",
+      "evra": "1.6.3-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "keyutils"
       }
     },
     "kmod": {
-      "evra": "33-3.fc42.x86_64",
+      "evra": "34.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kmod-libs": {
-      "evra": "33-3.fc42.x86_64",
+      "evra": "34.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "kmod"
       }
     },
     "kpartx": {
-      "evra": "0.10.0-5.fc42.x86_64",
+      "evra": "0.11.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "device-mapper-multipath"
       }
     },
     "krb5-libs": {
-      "evra": "1.21.3-6.fc42.x86_64",
+      "evra": "1.21.3-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "krb5"
       }
     },
     "less": {
-      "evra": "679-1.fc42.x86_64",
+      "evra": "679-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "less"
       }
     },
     "libacl": {
-      "evra": "2.3.2-3.fc42.x86_64",
+      "evra": "2.3.2-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "acl"
       }
     },
     "libaio": {
-      "evra": "0.3.111-21.fc42.x86_64",
+      "evra": "0.3.111-22.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libaio"
       }
     },
     "libarchive": {
-      "evra": "3.8.1-1.fc42.x86_64",
+      "evra": "3.8.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libarchive"
       }
     },
     "libassuan": {
-      "evra": "2.5.7-3.fc42.x86_64",
+      "evra": "2.5.7-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libassuan"
       }
     },
     "libattr": {
-      "evra": "2.5.2-5.fc42.x86_64",
+      "evra": "2.5.2-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "attr"
       }
     },
     "libbasicobjects": {
-      "evra": "0.1.1-58.fc42.x86_64",
+      "evra": "0.1.1-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libblkid": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libbpf": {
-      "evra": "2:1.5.0-2.fc42.x86_64",
+      "evra": "2:1.6.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libbpf"
       }
     },
     "libbsd": {
-      "evra": "0.12.2-5.fc42.x86_64",
+      "evra": "0.12.2-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libbsd"
       }
     },
     "libcap": {
-      "evra": "2.73-2.fc42.x86_64",
+      "evra": "2.76-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libcap"
       }
     },
     "libcap-ng": {
-      "evra": "0.8.5-4.fc42.x86_64",
+      "evra": "0.8.5-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libcap-ng"
       }
     },
     "libcbor": {
-      "evra": "0.11.0-3.fc42.x86_64",
+      "evra": "0.12.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libcbor"
       }
     },
     "libcollection": {
-      "evra": "0.7.0-58.fc42.x86_64",
+      "evra": "0.7.0-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libcom_err": {
-      "evra": "1.47.2-3.fc42.x86_64",
+      "evra": "1.47.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libcurl-minimal": {
-      "evra": "8.11.1-6.fc42.x86_64",
+      "evra": "8.15.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "curl"
       }
     },
     "libdaemon": {
-      "evra": "0.14-31.fc42.x86_64",
+      "evra": "0.14-32.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libdaemon"
       }
     },
     "libdhash": {
-      "evra": "0.5.0-58.fc42.x86_64",
+      "evra": "0.5.0-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libdnf5": {
-      "evra": "5.2.16.0-1.fc42.x86_64",
+      "evra": "5.2.17.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdnf5-cli": {
-      "evra": "5.2.16.0-1.fc42.x86_64",
+      "evra": "5.2.17.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "dnf5"
       }
     },
     "libdrm": {
-      "evra": "2.4.126-1.fc42.x86_64",
+      "evra": "2.4.126-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libdrm"
       }
     },
     "libeconf": {
-      "evra": "0.7.6-2.fc42.x86_64",
+      "evra": "0.7.9-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libeconf"
       }
     },
     "libedit": {
-      "evra": "3.1-55.20250104cvs.fc42.x86_64",
+      "evra": "3.1-56.20250104cvs.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libedit"
       }
     },
     "libevent": {
-      "evra": "2.1.12-15.fc42.x86_64",
+      "evra": "2.1.12-16.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libevent"
       }
     },
     "libfdisk": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libffi": {
-      "evra": "3.4.6-5.fc42.x86_64",
+      "evra": "3.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libffi"
       }
     },
     "libfido2": {
-      "evra": "1.15.0-3.fc42.x86_64",
+      "evra": "1.16.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libfido2"
       }
     },
     "libgcc": {
-      "evra": "15.2.1-1.fc42.x86_64",
+      "evra": "15.2.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libgcrypt": {
-      "evra": "1.11.0-5.fc42.x86_64",
+      "evra": "1.11.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libgcrypt"
       }
     },
     "libgpg-error": {
-      "evra": "1.51-2.fc42.x86_64",
+      "evra": "1.55-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libgpg-error"
       }
     },
     "libibverbs": {
-      "evra": "55.0-1.fc42.x86_64",
+      "evra": "58.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rdma-core"
       }
     },
     "libicu": {
-      "evra": "76.1-4.fc42.x86_64",
+      "evra": "77.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "icu"
       }
     },
     "libidn2": {
-      "evra": "2.3.8-1.fc42.x86_64",
+      "evra": "2.3.8-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libidn2"
       }
     },
     "libini_config": {
-      "evra": "1.3.1-58.fc42.x86_64",
+      "evra": "1.3.1-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libipa_hbac": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libjcat": {
-      "evra": "0.2.5-1.fc42.x86_64",
+      "evra": "0.2.5-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libjcat"
       }
     },
     "libjose": {
-      "evra": "14-4.fc42.x86_64",
+      "evra": "14-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "jose"
       }
     },
     "libkcapi": {
-      "evra": "1.5.0-5.fc42.x86_64",
+      "evra": "1.5.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-5.fc42.x86_64",
+      "evra": "1.5.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-5.fc42.x86_64",
+      "evra": "1.5.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libkcapi"
       }
     },
     "libksba": {
-      "evra": "1.6.7-3.fc42.x86_64",
+      "evra": "1.6.7-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libksba"
       }
     },
+    "liblastlog2": {
+      "evra": "2.41.1-17.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "util-linux"
+      }
+    },
     "libldb": {
-      "evra": "2:4.22.4-1.fc42.x86_64",
+      "evra": "2:4.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libluksmeta": {
-      "evra": "9-24.fc42.x86_64",
+      "evra": "9-25.fc43.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "libmaxminddb": {
-      "evra": "1.12.2-3.fc42.x86_64",
+      "evra": "1.12.2-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libmaxminddb"
       }
     },
     "libmd": {
-      "evra": "1.1.0-7.fc42.x86_64",
+      "evra": "1.1.0-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libmd"
       }
     },
     "libmnl": {
-      "evra": "1.0.5-7.fc42.x86_64",
+      "evra": "1.0.5-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libmnl"
       }
     },
     "libmodulemd": {
-      "evra": "2.15.2-1.fc42.x86_64",
+      "evra": "2.15.2-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libmodulemd"
       }
     },
     "libmount": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libndp": {
-      "evra": "1.9-3.fc42.x86_64",
+      "evra": "1.9-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libndp"
       }
     },
     "libnet": {
-      "evra": "1.3-5.fc42.x86_64",
+      "evra": "1.3-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnet"
       }
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-8.fc42.x86_64",
+      "evra": "1.0.9-9.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnetfilter_conntrack"
       }
     },
     "libnfnetlink": {
-      "evra": "1.0.1-30.fc42.x86_64",
+      "evra": "1.0.1-31.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnfnetlink"
       }
     },
     "libnfsidmap": {
-      "evra": "1:2.8.4-0.fc42.x86_64",
+      "evra": "1:2.8.4-0.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "libnftnl": {
-      "evra": "1.2.8-4.fc42.x86_64",
+      "evra": "1.2.9-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnftnl"
       }
     },
     "libnghttp2": {
-      "evra": "1.64.0-3.fc42.x86_64",
+      "evra": "1.66.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nghttp2"
       }
     },
     "libnl3": {
-      "evra": "3.11.0-3.fc42.x86_64",
+      "evra": "3.11.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnl3-cli": {
-      "evra": "3.11.0-3.fc42.x86_64",
+      "evra": "3.11.0-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnl3"
       }
     },
     "libnsl2": {
-      "evra": "2.0.1-3.fc42.x86_64",
+      "evra": "2.0.1-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnsl2"
       }
     },
     "libnvme": {
-      "evra": "1.15-2.fc42.x86_64",
+      "evra": "1.15-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libnvme"
       }
     },
     "libpath_utils": {
-      "evra": "0.2.1-58.fc42.x86_64",
+      "evra": "0.2.1-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "libpcap": {
-      "evra": "14:1.10.5-2.fc42.x86_64",
+      "evra": "14:1.10.5-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libpcap"
       }
     },
     "libpciaccess": {
-      "evra": "0.16-15.fc42.x86_64",
+      "evra": "0.16-16.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libpciaccess"
       }
     },
     "libpkgconf": {
-      "evra": "2.3.0-2.fc42.x86_64",
+      "evra": "2.3.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "libpsl": {
-      "evra": "0.21.5-5.fc42.x86_64",
+      "evra": "0.21.5-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libpsl"
       }
     },
     "libpwquality": {
-      "evra": "1.4.5-12.fc42.x86_64",
+      "evra": "1.4.5-14.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libpwquality"
       }
     },
     "libref_array": {
-      "evra": "0.1.5-58.fc42.x86_64",
+      "evra": "0.1.5-59.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ding-libs"
       }
     },
     "librepo": {
-      "evra": "1.20.0-1.fc42.x86_64",
+      "evra": "1.20.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "librepo"
       }
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-5.fc42.noarch",
+      "evra": "2.17.15-9.fc43.noarch",
       "metadata": {
         "sourcerpm": "libreport"
       }
     },
     "libseccomp": {
-      "evra": "2.5.5-2.fc41.x86_64",
+      "evra": "2.6.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libseccomp"
       }
     },
     "libselinux": {
-      "evra": "3.8-3.fc42.x86_64",
+      "evra": "3.9-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libselinux-utils": {
-      "evra": "3.8-3.fc42.x86_64",
+      "evra": "3.9-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libselinux"
       }
     },
     "libsemanage": {
-      "evra": "3.8.1-2.fc42.x86_64",
+      "evra": "3.9-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libsemanage"
       }
     },
     "libsepol": {
-      "evra": "3.8-1.fc42.x86_64",
+      "evra": "3.9-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libsepol"
       }
     },
     "libslirp": {
-      "evra": "4.8.0-3.fc42.x86_64",
+      "evra": "4.9.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libslirp"
       }
     },
     "libsmartcols": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libsmbclient": {
-      "evra": "2:4.22.4-1.fc42.x86_64",
+      "evra": "2:4.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libsolv": {
-      "evra": "0.7.34-1.fc42.x86_64",
+      "evra": "0.7.34-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libsolv"
       }
     },
     "libss": {
-      "evra": "1.47.2-3.fc42.x86_64",
+      "evra": "1.47.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "e2fsprogs"
       }
     },
     "libsss_certmap": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_idmap": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_nss_idmap": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libsss_sudo": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "libstdc++": {
-      "evra": "15.2.1-1.fc42.x86_64",
+      "evra": "15.2.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gcc"
       }
     },
     "libtalloc": {
-      "evra": "2.4.3-2.fc42.x86_64",
+      "evra": "2.4.3-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtalloc"
       }
     },
     "libtasn1": {
-      "evra": "4.20.0-1.fc42.x86_64",
+      "evra": "4.20.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtasn1"
       }
     },
     "libtdb": {
-      "evra": "1.4.13-2.fc42.x86_64",
+      "evra": "1.4.14-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtdb"
       }
     },
     "libteam": {
-      "evra": "1.32-11.fc42.x86_64",
+      "evra": "1.32-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "libtevent": {
-      "evra": "0.16.2-2.fc42.x86_64",
+      "evra": "0.17.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtevent"
       }
     },
     "libtextstyle": {
-      "evra": "0.23.1-2.fc42.x86_64",
+      "evra": "0.25.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "gettext"
       }
     },
     "libtirpc": {
-      "evra": "1.3.7-0.fc42.x86_64",
+      "evra": "1.3.7-0.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtirpc"
       }
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-4.fc42.x86_64",
+      "evra": "2.5.4-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libtool"
       }
     },
     "libunistring": {
-      "evra": "1.1-9.fc42.x86_64",
+      "evra": "1.1-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libunistring"
       }
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc42.x86_64",
+      "evra": "1.0.29-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libusb1"
       }
     },
     "libuuid": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "libuv": {
-      "evra": "1:1.51.0-1.fc42.x86_64",
+      "evra": "1:1.51.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libuv"
       }
     },
     "libverto": {
-      "evra": "0.3.2-10.fc42.x86_64",
+      "evra": "0.3.2-11.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libverto"
       }
     },
     "libwbclient": {
-      "evra": "2:4.22.4-1.fc42.x86_64",
+      "evra": "2:4.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "libxcrypt": {
-      "evra": "4.4.38-7.fc42.x86_64",
+      "evra": "4.4.38-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libxcrypt"
       }
     },
     "libxml2": {
-      "evra": "2.12.10-1.fc42.x86_64",
+      "evra": "2.12.10-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libxml2"
       }
     },
     "libxmlb": {
-      "evra": "0.3.24-1.fc42.x86_64",
+      "evra": "0.3.24-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libxmlb"
       }
     },
     "libyaml": {
-      "evra": "0.2.5-16.fc42.x86_64",
+      "evra": "0.2.5-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libyaml"
       }
     },
     "libzstd": {
-      "evra": "1.5.7-1.fc42.x86_64",
+      "evra": "1.5.7-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     },
     "linux-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "linux-firmware-whence": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "lld18-libs": {
-      "evra": "18.1.8-6.fc42.x86_64",
+      "evra": "18.1.8-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lld18"
       }
@@ -1777,547 +1795,559 @@
       }
     },
     "lmdb-libs": {
-      "evra": "0.9.33-3.fc42.x86_64",
+      "evra": "0.9.33-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lmdb"
       }
     },
     "logrotate": {
-      "evra": "3.22.0-3.fc42.x86_64",
+      "evra": "3.22.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "logrotate"
       }
     },
     "lsof": {
-      "evra": "4.98.0-7.fc42.x86_64",
+      "evra": "4.98.0-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lsof"
       }
     },
     "lua-libs": {
-      "evra": "5.4.8-1.fc42.x86_64",
+      "evra": "5.4.8-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lua"
       }
     },
     "luksmeta": {
-      "evra": "9-24.fc42.x86_64",
+      "evra": "9-25.fc43.x86_64",
       "metadata": {
         "sourcerpm": "luksmeta"
       }
     },
     "lvm2": {
-      "evra": "2.03.30-3.fc42.x86_64",
+      "evra": "2.03.34-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lvm2-libs": {
-      "evra": "2.03.30-3.fc42.x86_64",
+      "evra": "2.03.34-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lvm2"
       }
     },
     "lz4-libs": {
-      "evra": "1.10.0-2.fc42.x86_64",
+      "evra": "1.10.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lz4"
       }
     },
     "lzo": {
-      "evra": "2.10-14.fc42.x86_64",
+      "evra": "2.10-15.fc43.x86_64",
       "metadata": {
         "sourcerpm": "lzo"
       }
     },
     "makedumpfile": {
-      "evra": "1.7.7-1.fc42.x86_64",
+      "evra": "1.7.7-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "makedumpfile"
       }
     },
     "mdadm": {
-      "evra": "4.3-8.fc42.x86_64",
+      "evra": "4.3-9.fc43.x86_64",
       "metadata": {
         "sourcerpm": "mdadm"
       }
     },
     "microcode_ctl": {
-      "evra": "2:2.1-70.fc42.x86_64",
+      "evra": "2:2.1-71.fc43.x86_64",
       "metadata": {
         "sourcerpm": "microcode_ctl"
       }
     },
     "moby-engine": {
-      "evra": "28.5.1-2.fc42.x86_64",
+      "evra": "28.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "moby-filesystem": {
-      "evra": "28.5.1-2.fc42.noarch",
+      "evra": "28.5.1-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "moby-engine"
       }
     },
     "mokutil": {
-      "evra": "2:0.7.1-5.fc42.x86_64",
+      "evra": "2:0.7.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "mokutil"
       }
     },
     "mpfr": {
-      "evra": "4.2.2-1.fc42.x86_64",
+      "evra": "4.2.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "mpfr"
       }
     },
     "nano": {
-      "evra": "8.3-3.fc42.x86_64",
+      "evra": "8.5-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "nano-default-editor": {
-      "evra": "8.3-3.fc42.noarch",
+      "evra": "8.5-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "nano"
       }
     },
     "ncurses": {
-      "evra": "6.5-5.20250125.fc42.x86_64",
+      "evra": "6.5-7.20250614.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-base": {
-      "evra": "6.5-5.20250125.fc42.noarch",
+      "evra": "6.5-7.20250614.fc43.noarch",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "ncurses-libs": {
-      "evra": "6.5-5.20250125.fc42.x86_64",
+      "evra": "6.5-7.20250614.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ncurses"
       }
     },
     "net-tools": {
-      "evra": "2.0-0.73.20160912git.fc42.x86_64",
+      "evra": "2.0-0.74.20160912git.fc43.x86_64",
       "metadata": {
         "sourcerpm": "net-tools"
       }
     },
     "netavark": {
-      "evra": "2:1.16.1-1.fc42.x86_64",
+      "evra": "2:1.16.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "netavark"
       }
     },
     "nettle": {
-      "evra": "3.10.1-1.fc42.x86_64",
+      "evra": "3.10.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nettle"
       }
     },
     "newt": {
-      "evra": "0.52.25-1.fc42.x86_64",
+      "evra": "0.52.25-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "newt"
       }
     },
     "nfs-utils-coreos": {
-      "evra": "1:2.8.4-0.fc42.x86_64",
+      "evra": "1:2.8.4-0.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nfs-utils"
       }
     },
     "nftables": {
-      "evra": "1:1.1.1-3.fc42.x86_64",
+      "evra": "1:1.1.3-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nftables"
       }
     },
+    "nftables-services": {
+      "evra": "1:1.1.3-5.fc43.noarch",
+      "metadata": {
+        "sourcerpm": "nftables"
+      }
+    },
+    "ngtcp2": {
+      "evra": "1.15.1-1.fc43.x86_64",
+      "metadata": {
+        "sourcerpm": "ngtcp2"
+      }
+    },
     "nmstate": {
-      "evra": "2.2.52-2.fc42.x86_64",
+      "evra": "2.2.52-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nmstate"
       }
     },
     "npth": {
-      "evra": "1.8-2.fc42.x86_64",
+      "evra": "1.8-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "npth"
       }
     },
     "nss-altfiles": {
-      "evra": "2.23.0-6.fc42.x86_64",
+      "evra": "2.23.0-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nss-altfiles"
       }
     },
     "numactl-libs": {
-      "evra": "2.0.19-2.fc42.x86_64",
+      "evra": "2.0.19-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "numactl"
       }
     },
     "nvidia-gpu-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "nvme-cli": {
-      "evra": "2.15-2.fc42.x86_64",
+      "evra": "2.15-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "nvme-cli"
       }
     },
     "oniguruma": {
-      "evra": "6.9.10-2.fc42.x86_64",
+      "evra": "6.9.10-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "oniguruma"
       }
     },
     "openldap": {
-      "evra": "2.6.10-1.fc42.x86_64",
+      "evra": "2.6.10-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openldap"
       }
     },
     "openssh": {
-      "evra": "9.9p1-11.fc42.x86_64",
+      "evra": "10.0p1-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-clients": {
-      "evra": "9.9p1-11.fc42.x86_64",
+      "evra": "10.0p1-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssh-server": {
-      "evra": "9.9p1-11.fc42.x86_64",
+      "evra": "10.0p1-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openssh"
       }
     },
     "openssl": {
-      "evra": "1:3.2.6-2.fc42.x86_64",
+      "evra": "1:3.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "openssl-libs": {
-      "evra": "1:3.2.6-2.fc42.x86_64",
+      "evra": "1:3.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "openssl"
       }
     },
     "os-prober": {
-      "evra": "1.81-9.fc42.x86_64",
+      "evra": "1.81-10.fc43.x86_64",
       "metadata": {
         "sourcerpm": "os-prober"
       }
     },
     "ostree": {
-      "evra": "2025.6-1.fc42.x86_64",
+      "evra": "2025.6-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "ostree-libs": {
-      "evra": "2025.6-1.fc42.x86_64",
+      "evra": "2025.6-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "ostree"
       }
     },
     "p11-kit": {
-      "evra": "0.25.8-1.fc42.x86_64",
+      "evra": "0.25.8-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "p11-kit-trust": {
-      "evra": "0.25.8-1.fc42.x86_64",
+      "evra": "0.25.8-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "p11-kit"
       }
     },
     "pam": {
-      "evra": "1.7.0-6.fc42.x86_64",
+      "evra": "1.7.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "pam-libs": {
-      "evra": "1.7.0-6.fc42.x86_64",
+      "evra": "1.7.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pam"
       }
     },
     "passim-libs": {
-      "evra": "0.1.10-1.fc42.x86_64",
+      "evra": "0.1.10-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "passim"
       }
     },
     "passt": {
-      "evra": "0^20250919.g623dbf6-1.fc42.x86_64",
+      "evra": "0^20250919.g623dbf6-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "passt-selinux": {
-      "evra": "0^20250919.g623dbf6-1.fc42.noarch",
+      "evra": "0^20250919.g623dbf6-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "passt"
       }
     },
     "pciutils": {
-      "evra": "3.14.0-1.fc42.x86_64",
+      "evra": "3.14.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pciutils-libs": {
-      "evra": "3.14.0-1.fc42.x86_64",
+      "evra": "3.14.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pciutils"
       }
     },
     "pcre2": {
-      "evra": "10.45-1.fc42.x86_64",
+      "evra": "10.46-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pcre2-syntax": {
-      "evra": "10.45-1.fc42.noarch",
+      "evra": "10.46-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "pcre2"
       }
     },
     "pigz": {
-      "evra": "2.8-6.fc42.x86_64",
+      "evra": "2.8-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pigz"
       }
     },
     "pkgconf": {
-      "evra": "2.3.0-2.fc42.x86_64",
+      "evra": "2.3.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-2.fc42.noarch",
+      "evra": "2.3.0-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-2.fc42.x86_64",
+      "evra": "2.3.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "pkgconf"
       }
     },
     "podman": {
-      "evra": "5:5.6.2-1.fc42.x86_64",
+      "evra": "5:5.6.2-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "podman"
       }
     },
     "policycoreutils": {
-      "evra": "3.8-1.fc42.x86_64",
+      "evra": "3.9-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "policycoreutils"
       }
     },
     "polkit": {
-      "evra": "126-3.fc42.1.x86_64",
+      "evra": "126-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "polkit-libs": {
-      "evra": "126-3.fc42.1.x86_64",
+      "evra": "126-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "polkit"
       }
     },
     "popt": {
-      "evra": "1.19-8.fc42.x86_64",
+      "evra": "1.19-9.fc43.x86_64",
       "metadata": {
         "sourcerpm": "popt"
       }
     },
     "procps-ng": {
-      "evra": "4.0.4-6.fc42.1.x86_64",
+      "evra": "4.0.4-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "procps-ng"
       }
     },
     "protobuf-c": {
-      "evra": "1.5.1-1.fc42.x86_64",
+      "evra": "1.5.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "protobuf-c"
       }
     },
     "psmisc": {
-      "evra": "23.7-5.fc42.x86_64",
+      "evra": "23.7-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "psmisc"
       }
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20250616-1.fc42.noarch",
+      "evra": "20250616-2.fc43.noarch",
       "metadata": {
         "sourcerpm": "publicsuffix-list"
       }
     },
     "qed-firmware": {
-      "evra": "20251011-1.fc42.noarch",
+      "evra": "20251021-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "linux-firmware"
       }
     },
     "readline": {
-      "evra": "8.2-13.fc42.x86_64",
+      "evra": "8.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "readline"
       }
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc42.x86_64",
+      "evra": "1.2.8-0.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpcbind"
       }
     },
     "rpm": {
-      "evra": "4.20.1-1.fc42.x86_64",
+      "evra": "6.0.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-libs": {
-      "evra": "4.20.1-1.fc42.x86_64",
+      "evra": "6.0.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-ostree": {
-      "evra": "2025.11-1.fc42.x86_64",
+      "evra": "2025.11-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-ostree-libs": {
-      "evra": "2025.11-1.fc42.x86_64",
+      "evra": "2025.11-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpm-ostree"
       }
     },
     "rpm-plugin-selinux": {
-      "evra": "4.20.1-1.fc42.x86_64",
+      "evra": "6.0.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rpm"
       }
     },
     "rpm-sequoia": {
-      "evra": "1.7.0-5.fc42.x86_64",
+      "evra": "1.9.0-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-rpm-sequoia"
       }
     },
     "rsync": {
-      "evra": "3.4.1-3.fc42.x86_64",
+      "evra": "3.4.1-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rsync"
       }
     },
     "runc": {
-      "evra": "2:1.3.2-1.fc42.x86_64",
+      "evra": "2:1.3.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "runc"
       }
     },
     "samba-client-libs": {
-      "evra": "2:4.22.4-1.fc42.x86_64",
+      "evra": "2:4.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common": {
-      "evra": "2:4.22.4-1.fc42.noarch",
+      "evra": "2:4.23.1-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "samba-common-libs": {
-      "evra": "2:4.22.4-1.fc42.x86_64",
+      "evra": "2:4.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "samba"
       }
     },
     "sdbus-cpp": {
-      "evra": "1.5.0-4.fc42.x86_64",
+      "evra": "2.1.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sdbus-cpp"
       }
     },
     "sed": {
-      "evra": "4.9-4.fc42.x86_64",
+      "evra": "4.9-5.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sed"
       }
     },
     "selinux-policy": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "selinux-policy-targeted": {
-      "evra": "42.13-1.fc42.noarch",
+      "evra": "42.13-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "selinux-policy"
       }
     },
     "setup": {
-      "evra": "2.15.0-13.fc42.noarch",
+      "evra": "2.15.0-26.fc43.noarch",
       "metadata": {
         "sourcerpm": "setup"
       }
     },
     "sg3_utils": {
-      "evra": "1.48-5.fc42.x86_64",
+      "evra": "1.48-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "sg3_utils-libs": {
-      "evra": "1.48-5.fc42.x86_64",
+      "evra": "1.48-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sg3_utils"
       }
     },
     "shadow-utils": {
-      "evra": "2:4.17.4-1.fc42.x86_64",
+      "evra": "2:4.18.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shadow-utils-subid": {
-      "evra": "2:4.17.4-1.fc42.x86_64",
+      "evra": "2:4.18.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "shadow-utils"
       }
     },
     "shared-mime-info": {
-      "evra": "2.3-7.fc42.x86_64",
+      "evra": "2.4-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "shared-mime-info"
       }
@@ -2329,341 +2359,344 @@
       }
     },
     "skopeo": {
-      "evra": "1:1.20.0-3.fc42.x86_64",
+      "evra": "1:1.20.0-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "skopeo"
       }
     },
     "slang": {
-      "evra": "2.3.3-7.fc42.x86_64",
+      "evra": "2.3.3-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "slang"
       }
     },
     "slirp4netns": {
-      "evra": "1.3.1-2.fc42.x86_64",
+      "evra": "1.3.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "slirp4netns"
       }
     },
     "snappy": {
-      "evra": "1.2.1-4.fc42.x86_64",
+      "evra": "1.2.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "snappy"
       }
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc42.x86_64",
+      "evra": "1.8.0.3-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "socat"
       }
     },
     "spdlog": {
-      "evra": "1.15.3-1.fc42.x86_64",
+      "evra": "1.15.3-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "spdlog"
       }
     },
     "sqlite-libs": {
-      "evra": "3.47.2-5.fc42.x86_64",
+      "evra": "3.50.2-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sqlite"
       }
     },
     "squashfs-tools": {
-      "evra": "4.6.1-6.fc42.x86_64",
+      "evra": "4.6.1-7.fc43.x86_64",
       "metadata": {
         "sourcerpm": "squashfs-tools"
       }
     },
     "ssh-key-dir": {
-      "evra": "0.1.5-2.fc42.x86_64",
+      "evra": "0.1.5-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-ssh-key-dir"
       }
     },
     "sssd-ad": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-client": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-common-pac": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ipa": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-krb5-common": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-ldap": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "sssd-nfs-idmap": {
-      "evra": "2.11.1-1.fc42.x86_64",
+      "evra": "2.11.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sssd"
       }
     },
     "stalld": {
-      "evra": "1.23.1-1.fc42.x86_64",
+      "evra": "1.23.1-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "stalld"
       }
     },
     "sudo": {
-      "evra": "1.9.17-2.p1.fc42.x86_64",
+      "evra": "1.9.17-5.p1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "sudo"
       }
     },
     "systemd": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-container": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-libs": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-pam": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-resolved": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-shared": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-sysusers": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "systemd-udev": {
-      "evra": "257.10-1.fc42.x86_64",
+      "evra": "258-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "systemd"
       }
     },
     "tar": {
-      "evra": "2:1.35-5.fc42.x86_64",
+      "evra": "2:1.35-6.fc43.x86_64",
       "metadata": {
         "sourcerpm": "tar"
       }
     },
     "teamd": {
-      "evra": "1.32-11.fc42.x86_64",
+      "evra": "1.32-12.fc43.x86_64",
       "metadata": {
         "sourcerpm": "libteam"
       }
     },
     "tini-static": {
-      "evra": "0.19.0-10.fc42.x86_64",
+      "evra": "0.19.0-11.fc43.x86_64",
       "metadata": {
         "sourcerpm": "tini"
       }
     },
     "toolbox": {
-      "evra": "0.3-1.fc42.x86_64",
+      "evra": "0.3-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "toolbox"
       }
     },
     "tpm2-tools": {
-      "evra": "5.7-3.fc42.x86_64",
+      "evra": "5.7-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tools"
       }
     },
     "tpm2-tss": {
-      "evra": "4.1.3-6.fc42.x86_64",
+      "evra": "4.1.3-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-6.fc42.x86_64",
+      "evra": "4.1.3-8.fc43.x86_64",
       "metadata": {
         "sourcerpm": "tpm2-tss"
       }
     },
     "tzdata": {
-      "evra": "2025b-1.fc42.noarch",
+      "evra": "2025b-3.fc43.noarch",
       "metadata": {
         "sourcerpm": "tzdata"
       }
     },
     "userspace-rcu": {
-      "evra": "0.15.0-1.fc42.x86_64",
+      "evra": "0.15.3-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "userspace-rcu"
       }
     },
     "util-linux": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "util-linux-core": {
-      "evra": "2.40.4-7.fc42.x86_64",
+      "evra": "2.41.1-17.fc43.x86_64",
       "metadata": {
         "sourcerpm": "util-linux"
       }
     },
     "vim-data": {
-      "evra": "2:9.1.1818-1.fc42.noarch",
+      "evra": "2:9.1.1818-1.fc43.noarch",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "vim-minimal": {
-      "evra": "2:9.1.1818-1.fc42.x86_64",
+      "evra": "2:9.1.1818-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "vim"
       }
     },
     "wasmedge-rt": {
-      "evra": "0.15.0-1.fc42.x86_64",
+      "evra": "0.15.0-1.fc43.x86_64",
       "metadata": {
         "sourcerpm": "wasmedge"
       }
     },
     "which": {
-      "evra": "2.23-2.fc42.x86_64",
+      "evra": "2.23-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "which"
       }
     },
     "wireguard-tools": {
-      "evra": "1.0.20210914-9.fc42.x86_64",
+      "evra": "1.0.20250521-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "wireguard-tools"
       }
     },
     "xfsprogs": {
-      "evra": "6.12.0-3.fc42.x86_64",
+      "evra": "6.15.0-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "xfsprogs"
       }
     },
     "xxhash-libs": {
-      "evra": "0.8.3-2.fc42.x86_64",
+      "evra": "0.8.3-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "xxhash"
       }
     },
     "xz": {
-      "evra": "1:5.8.1-2.fc42.x86_64",
+      "evra": "1:5.8.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "xz-libs": {
-      "evra": "1:5.8.1-2.fc42.x86_64",
+      "evra": "1:5.8.1-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "xz"
       }
     },
     "yajl": {
-      "evra": "2.1.0-25.fc42.x86_64",
+      "evra": "2.1.0-38.fc43.x86_64",
       "metadata": {
         "sourcerpm": "yajl"
       }
     },
     "zchunk-libs": {
-      "evra": "1.5.1-2.fc42.x86_64",
+      "evra": "1.5.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "zchunk"
       }
     },
     "zincati": {
-      "evra": "0.0.30-3.fc42.x86_64",
+      "evra": "0.0.30-4.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-zincati"
       }
     },
     "zlib-ng-compat": {
-      "evra": "2.2.5-2.fc42.x86_64",
+      "evra": "2.2.5-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "zlib-ng"
       }
     },
     "zram-generator": {
-      "evra": "1.2.1-2.fc42.x86_64",
+      "evra": "1.2.1-3.fc43.x86_64",
       "metadata": {
         "sourcerpm": "rust-zram-generator"
       }
     },
     "zstd": {
-      "evra": "1.5.7-1.fc42.x86_64",
+      "evra": "1.5.7-2.fc43.x86_64",
       "metadata": {
         "sourcerpm": "zstd"
       }
     }
   },
   "metadata": {
-    "generated": "2025-10-21T00:00:00Z",
+    "generated": "2025-10-24T00:00:00Z",
     "rpmmd_repos": {
-      "fedora": {
-        "generated": "2025-04-09T11:06:59Z"
+      "fedora-candidate-compose": {
+        "generated": "2025-10-23T03:37:20Z"
       },
       "fedora-coreos-pool": {
-        "generated": "2025-10-19T20:39:08Z"
+        "generated": "2025-10-23T12:37:24Z"
       },
-      "fedora-updates": {
-        "generated": "2025-10-21T00:56:46Z"
+      "fedora-next": {
+        "generated": "2025-10-23T07:45:46Z"
+      },
+      "fedora-next-updates": {
+        "generated": "2018-02-20T19:18:14Z"
       }
     }
   }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,11 @@ variables:
   stream: testing-devel
   prod: false
 
-releasever: 42
+metadata:
+  # tell `cosa build` to default to buildah path
+  build_with_buildah: true
+
+releasever: 43
 
 conditional-include:
   # TODO: There is no coreos-pool for RISCV yet


### PR DESCRIPTION
CI won't pass on this until F43 is officially released because the repos aren't populated yet. So this won't be able to merge until Tuesday.

See https://github.com/coreos/fedora-coreos-tracker/issues/1935
