### PR TITLE
overlay/coreos-boot-mount-generator: Be compatible with `bcvk ephemeral`

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
+++ b/overlay.d/05core/usr/lib/systemd/system-generators/coreos-boot-mount-generator
@@ -24,6 +24,13 @@ if [ -f /run/ostree-live ]; then
     exit 0
 fi
 
+# Don't create mount units for /boot in bcvk ephemeral environments
+# where there are no block devices by default.
+rootfstype=$(karg rootfstype)
+if [ "${rootfstype}" = "virtiofs" ]; then
+    exit 0
+fi
+
 add_wants() {
     local name="$1"; shift
     local wants_dir="${UNIT_DIR}/local-fs.target.wants"


### PR DESCRIPTION
See https://github.com/bootc-dev/bcvk/pull/101

This also is needed to eventually make FCOS work with `bcvk to-disk`.