### PR TITLE
35coreos-ignition: find sfdisk path

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-partition-name.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-partition-name.sh
@@ -25,9 +25,23 @@ if  [[ -n ${multipath} ]]; then
     fi
 fi
 
-if sfdisk "/dev/${disk}" --json | jq -e '.partitiontable.partitions | any(.name == "'"${label}"'")'; then
+# On Fedora (with /bin_/sbin merge), sfdisk is located at /usr/bin/sfdisk,
+# so udev helper scripts find it automatically via PATH. On RHEL/RHCOS 9.6,
+# sfdisk resides in /usr/sbin, but udev worker processes reset PATH to a
+# minimal environment (/usr/local/bin:/usr/bin), causing scripts that call
+# 'sfdisk' without the full path to fail. So we need this to find the full
+# sfdisk path.
+# See https://github.com/coreos/fedora-coreos-config/pull/3862#issuecomment-3467947591
+sfdisk_cmd=''
+for f in /usr/bin/sfdisk /usr/sbin/sfdisk; do
+    if [ -x "${f}" ]; then
+        sfdisk_cmd="${f}"
+        break
+    fi
+done
+
+if [ -n "${sfdisk_cmd}" ] && ${sfdisk_cmd} "/dev/${disk}" --json | jq -e '.partitiontable.partitions | any(.name == "'"${label}"'")'; then
     exit 0
 fi
 
 exit 1
-


### PR DESCRIPTION
Thank you Dusty for pointing out the root cause in
https://github.com/coreos/fedora-coreos-config/pull/3862#issuecomment-3467947591

For centos stream and rhcos, the tests that want to use
"/dev/disk/by-id/coreos-boot-disk" failed with
```
ignition[728]: disks: createPartitions: op(1): [failed]   waiting
for devices [/dev/disk/by-id/coreos-boot-disk]: device unit
dev-disk-by\x2did-coreos\x2dboot\x2ddisk.device timeout
```
e.g. `ext.config.shared.ignition.stable-boot`

Detail logs:
`/usr/lib/udev/coreos-disk-contains-partition-name: line 28: sfdisk: command not found`