### PR TITLE
Fix sfdisk path on coreos-disk-contains-partition-name.sh

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-partition-name.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-disk-contains-partition-name.sh
@@ -25,7 +25,7 @@ if  [[ -n ${multipath} ]]; then
     fi
 fi
 
-if sfdisk "/dev/${disk}" --json | jq -e '.partitiontable.partitions | any(.name == "'"${label}"'")'; then
+if /usr/sbin/sfdisk "/dev/${disk}" --json | jq -e '.partitiontable.partitions | any(.name == "'"${label}"'")'; then
     exit 0
 fi
 


### PR DESCRIPTION
Use sfdisk full path as /usr/sbin is not part of the default path on older releases

fixes https://github.com/coreos/fedora-coreos-config/issues/3790