### PR TITLE
Add STREAM build arg and generic com.coreos.stream label for image builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,7 +48,7 @@ RUN --mount=type=bind,target=/run/src,rw \
         --bootc --format-version=1 --rootfs /target-rootfs \
         --output oci-archive:/run/src/out.ociarchive \
         --label com.coreos.inputhash=$(cat /run/inputhash) \
-        --label fedora-coreos.stream=$STREAM
+        --label com.coreos.stream=$STREAM
 
 FROM oci-archive:./out.ociarchive
 ARG VERSION

--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,7 @@ FROM ${BUILDER_IMG} as builder
 
 ARG VERSION=overridden
 ARG MANIFEST=overridden
+ARG STREAM=overridden
 # XXX: see inject_passwd_group() in build-rootfs
 ARG PASSWD_GROUP_DIR
 ARG STRICT_MODE=0
@@ -46,7 +47,8 @@ RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \
         --output oci-archive:/run/src/out.ociarchive \
-        --label com.coreos.inputhash=$(cat /run/inputhash)
+        --label com.coreos.inputhash=$(cat /run/inputhash) \
+        --label fedora-coreos.stream=$STREAM
 
 FROM oci-archive:./out.ociarchive
 ARG VERSION

--- a/build-args.conf
+++ b/build-args.conf
@@ -8,4 +8,5 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
+STREAM=testing-devel
 DESCRIPTION=Fedora CoreOS testing-devel


### PR DESCRIPTION
This PR adds support for labeling CoreOS-derived images with their stream during build time. 

Introduces a new `STREAM` arg in the `Containerfile` and `build-args.conf` so the image can be labeled with `fedora-coreos.stream=$STREAM` directly during the build. This removes the temporary labeling hack used in `cmd-build-with-buildah`. 
See: [coreos-assembler#4337](https://github.com/coreos/coreos-assembler/issues/4337)

Also adds a generic com.coreos.stream label for both FCOS and RHCOS images. This helps Jenkins jobs importing Konflux-built OCI images via cosa import determine the stream.
See: [COS-3604](https://issues.redhat.com/browse/COS-3604)