### PR TITLE
Update bootc image with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,33 @@
       "rebaseWhen": "behind-base-branch"
     },
     {
+      "matchPackageNames": [
+        "/^quay.io/bootc-devel/fedora-bootc*/"
+      ],
+      "matchBaseBranches": [
+        "rawhide"
+      ],
+      "schedule": ["before 5am"],
+      "enabled": true,
+      "automerge": true,
+      "automergeType": "branch",
+      "groupName": "bootc base image",
+      "branchPrefix": "renovate/bump-bootc-base-image/",
+      "group": {
+        "branchTopic": "{{{baseBranch}}}",
+        "commitMessageTopic": "{{{groupName}}}"
+      },
+      "commitMessageTopic": "bootc base image",
+      "prBodyColumns": [
+        "Package",
+        "Change",
+        "Notes"
+      ],
+      "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+      "recreateWhen": "always",
+      "rebaseWhen": "behind-base-branch"
+    },
+    {
       "matchDatasources": [
         "docker"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,8 @@
         "testing-devel"
       ],
       "enabled": true,
+      "automerge": true,
+      "automergeType": "branch",
       "groupName": "Konflux references",
       "branchPrefix": "renovate/konflux/references/",
       "group": {


### PR DESCRIPTION
Konflux is designed to be event-driven, more precisely commit-driven
only, whereas Jenkins offers more flexible triggering i.e: time-driven
or event-driven.
For clarification, that's only for the builds. For the test and release
Konflux pipelines, they can be triggered with CronJobs by taking the
latest completed build.
The underlying reason is to make reproducible builds possible, all the
information should be self-contained in the repo. By reproducible I
mean having the same build result everywhere e.g: CI or locally, at
any give time (within a defined time window) from the same commit.
But this is an issue when the software depends on external dependencies
like RPM repos. RPM lockfiles fixes this, ensuring we have the updated
package periodically committed in the repo, thus triggering a new build.

However, we don't enable rpm-ostree lockfiles for rawhide, thus we
cannot generate Konflux lockfiles by derivation as we do for development
streams e.g: testing-devel. For clarification, Konflux RPM lockfiles is
only required for hermetic build purpose, and we don't want to enable
it for rawhide for now. In another words, having rpm-ostree lockfiles
would be enough.

This patch is taking another path, which is to bump the digest of the
bootc base image with Renovate. This is a cheap way to have periodic
build for rawhide. This does not solve the reproducibility, which
can be fixed by pulling RPMs from the compose repos instead of the
mirrors.