### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,22 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  audit:
-    evr: 4.1.2-2.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
-      type: fast-track
-  audit-libs:
-    evr: 4.1.2-2.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
-      type: fast-track
-  audit-rules:
-    evr: 4.1.2-2.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-1a9b66e130
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1935#issuecomment-3298693537
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).