### PR TITLE
build-rootfs: Don't follow symlinks in the overlay

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -467,12 +467,17 @@ def calculate_inputhash(rootfs, overlays, manifest):
                 all_files.append(os.path.join(root, file))
         all_files = sorted(all_files)
         for file in all_files:
-            with open(file, 'rb') as f:
-                # When python3.11+ is the minimal version we can use hashlib.file_digest
-                # h.update(hashlib.file_digest(f, 'sha256').digest())
-                h.update(hashlib.sha256(f.read()).digest())
-                has_x_bit = os.stat(f.fileno()).st_mode & 0o111 != 0
-                h.update(bytes([has_x_bit]))
+            if os.path.islink(file):
+                # For symlinks, hash the link target instead of following it
+                link_target = os.readlink(file)
+                h.update(link_target.encode('utf-8'))
+            else:
+                with open(file, 'rb') as f:
+                    # When python3.11+ is the minimal version we can use hashlib.file_digest
+                    # h.update(hashlib.file_digest(f, 'sha256').digest())
+                    h.update(hashlib.sha256(f.read()).digest())
+                    has_x_bit = os.stat(f.fileno()).st_mode & 0o111 != 0
+                    h.update(bytes([has_x_bit]))
 
     # postprocess
     for script in manifest.get('postprocess', []):


### PR DESCRIPTION
Add the link target to the hash instead.

This broke the ostree builds with
`[2025-11-11T03:36:28.572Z] FileNotFoundError: [Errno 2] No such file or directory: '/src/overrides/rootfs/etc/grub.d/15_ostree'`