### PR TITLE
image-base: use -Efragments for erofs creation

### DIFF
--- a/image-base.yaml
+++ b/image-base.yaml
@@ -39,6 +39,6 @@ container-imgref: "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{st
 
 # Enable 'erofs' by default for the rootfs in the Live ISO/PXE artifacts
 live-rootfs-fstype: "erofs"
-live-rootfs-fsoptions: "-zlzma,level=6 -Eall-fragments,fragdedupe=inode -C1048576 --quiet"
+live-rootfs-fsoptions: "-zlzma,level=6 -Efragments -C1048576 --quiet"
 
 include: image-default.yaml


### PR DESCRIPTION
As suggested by the maintainer we'll change this option from `-Eall-fragments,fragdedupe=inode` to -Efragments.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1991