### PR TITLE
build-args: pin on a specific bootc builder image

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -3,9 +3,7 @@
 
 # This is the developer default version. In pipelines, this is driven by versionary.
 VERSION=44.dev
-# XXX: This should be a digested pull that gets bumped.
-# https://gitlab.com/fedora/bootc/tracker/-/issues/34
-BUILDER_IMG=quay.io/fedora/fedora-bootc:44
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:2cb44d3a05e58816bdf10faa8eedfe398b95e2ca87a209b190d62ae21fdb22d3
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests


### PR DESCRIPTION
We are about to enable bump-lockfile job for `rawhide` branch which bumps bootc builder image as well.
The job expects the image format to be defined by digest.