### PR TITLE
Revert "tests/kdump.crash: add in sleep to workaround XFS race

### DIFF
--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -49,10 +49,6 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       fi
 
       /tmp/autopkgtest-reboot-prepare aftercrash
-      # Add in a sleep to workaround race condition where XFS/kernel errors happen
-      # during crash kernel boot.
-      # https://github.com/coreos/fedora-coreos-tracker/issues/1195
-      sleep 5
       echo "Triggering sysrq"
       sync
       echo 1 > /proc/sys/kernel/sysrq


### PR DESCRIPTION
This reverts commit 738540302951582e75a42f0e847d0f44b4601823.

The bug seems to not happen any longer.
https://github.com/coreos/fedora-coreos-tracker/issues/1195#issuecomment-3519608669