### PR TITLE
versionary: remove mechanical streams from unlocked streams

### DIFF
--- a/versionary
+++ b/versionary
@@ -23,8 +23,6 @@ from datetime import datetime
 
 # streams which don't use lockfiles
 UNLOCKED_STREAMS = [
-    'rawhide',
-    'branched',
     'bodhi-updates-testing',
     'bodhi-updates',
 ]


### PR DESCRIPTION
In the process of using konflux to build rawhide, we enabled lockfiles
for mechanial streams in [1].
Reflect that change in versionary since rawhide and branched need to be
locked streams. bodhi-updates* should technically also be locked but these
haven't been built in years so i won't touch them for now as they require
are more thorough cleanup. [3]

See [2] for more details.

[1] coreos/fedora-coreos-pipeline#1256
[2] coreos/fedora-coreos-tracker#2038 (comment)
[3] coreos/fedora-coreos-tracker#1734