### PR TITLE
versionary: pull Y from the arch-matching lockfile

### DIFF
--- a/versionary
+++ b/versionary
@@ -13,6 +13,7 @@
 import argparse
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -84,9 +85,10 @@ def get_y(manifest):
     # XXX: should sanity check that the lockfiles for all the basearches have
     # matching timestamps
     exts = ['json', 'yaml']
+    basearch = platform.machine()
     for ext in exts:
         try:
-            with open(f"src/config/manifest-lock.x86_64.{ext}") as f:
+            with open(f"src/config/manifest-lock.{basearch}.{ext}") as f:
                 lockfile = yaml.safe_load(f)
                 generated = lockfile.get('metadata', {}).get('generated')
                 if not generated:


### PR DESCRIPTION
Versionary pull the Y component of the version ID from the lockfile timestamp (if it exists).
Instead of always pulling from the x86 manifest, open the one lockfile matching the machine architecture.
This will fix a corner case of the `bump-lockfile` job failing when creating the lockfile for the first time: on the remote multi-arch builders, the x86 lockfile does not exist yet
(it will be there in the next commit.)