### PR TITLE
manifests: Replace ssh-key-dir by openssh config

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1203,9 +1203,6 @@
     "squashfs-tools": {
       "evra": "4.6.1-7.fc43.aarch64"
     },
-    "ssh-key-dir": {
-      "evra": "0.1.5-3.fc43.aarch64"
-    },
     "sssd-ad": {
       "evra": "2.11.1-4.fc43.aarch64"
     },

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1194,9 +1194,6 @@
     "squashfs-tools": {
       "evra": "4.6.1-7.fc43.ppc64le"
     },
-    "ssh-key-dir": {
-      "evra": "0.1.5-3.fc43.ppc64le"
-    },
     "sssd-ad": {
       "evra": "2.11.1-4.fc43.ppc64le"
     },

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1137,9 +1137,6 @@
     "squashfs-tools": {
       "evra": "4.6.1-7.fc43.s390x"
     },
-    "ssh-key-dir": {
-      "evra": "0.1.5-3.fc43.s390x"
-    },
     "sssd-ad": {
       "evra": "2.11.1-4.fc43.s390x"
     },

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1209,9 +1209,6 @@
     "squashfs-tools": {
       "evra": "4.6.1-7.fc43.x86_64"
     },
-    "ssh-key-dir": {
-      "evra": "0.1.5-3.fc43.x86_64"
-    },
     "sssd-ad": {
       "evra": "2.11.1-4.fc43.x86_64"
     },

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -43,6 +43,7 @@ conditional-include:
 ostree-layers:
   - overlay/15fcos
   - overlay/17fcos-container-signing
+  - overlay/18sshd-authorized-keys-file
 
 packages:
   - fedora-release-coreos

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -33,8 +33,6 @@ packages:
   # Boost starving threads
   # https://github.com/coreos/fedora-coreos-tracker/issues/753
   - stalld
-  # Ignition aware SSH key management
-  - ssh-key-dir
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first

--- a/overlay.d/18sshd-authorized-keys-file/etc/ssh/sshd_config.d/40-authorized-keys-file.conf
+++ b/overlay.d/18sshd-authorized-keys-file/etc/ssh/sshd_config.d/40-authorized-keys-file.conf
@@ -1,0 +1,2 @@
+# Also accept keys configured by Ignition and Afterburn
+AuthorizedKeysFile=.ssh/authorized_keys .ssh/authorized_keys.d/*

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -46,6 +46,14 @@ here in a separate overlay to make it easy to include on specific
 streams for the time being. Eventually can probably put this in
 15fcos.
 
+18sshd-authorized-keys-file
+---------------------------
+
+Configuration to have OpenSSH read authorized keys from files in
+`~/.ssh/authorized_keys.d/*` in addition to `~/.ssh/authorized_keys` (default).
+We can drop this overlay once we have moved this configuration file to be
+installed alongside the Afterburn and Ignition packages.
+
 20platform-chrony
 -----------------
 

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -803,8 +803,6 @@ arches:
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/s/sqlite-libs-3.50.2-2.fc43.aarch64.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/s/squashfs-tools-4.6.1-7.fc43.aarch64.rpm
-  - repoid: fedora-updates
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/s/ssh-key-dir-0.1.5-3.fc43.aarch64.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/s/sssd-ad-2.11.1-4.fc43.aarch64.rpm
   - repoid: fedora-updates
@@ -1693,8 +1691,6 @@ arches:
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/s/sqlite-libs-3.50.2-2.fc43.ppc64le.rpm
   - repoid: fedora-updates
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/s/squashfs-tools-4.6.1-7.fc43.ppc64le.rpm
-  - repoid: fedora
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/s/ssh-key-dir-0.1.5-3.fc43.ppc64le.rpm
   - repoid: fedora-updates
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/s/sssd-ad-2.11.1-4.fc43.ppc64le.rpm
   - repoid: fedora
@@ -2543,8 +2539,6 @@ arches:
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/s/sqlite-libs-3.50.2-2.fc43.s390x.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/s/squashfs-tools-4.6.1-7.fc43.s390x.rpm
-  - repoid: fedora-updates
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/s/ssh-key-dir-0.1.5-3.fc43.s390x.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/s/sssd-ad-2.11.1-4.fc43.s390x.rpm
   - repoid: fedora-updates
@@ -3443,8 +3437,6 @@ arches:
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/s/sqlite-libs-3.50.2-2.fc43.x86_64.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/s/squashfs-tools-4.6.1-7.fc43.x86_64.rpm
-  - repoid: fedora-updates
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/s/ssh-key-dir-0.1.5-3.fc43.x86_64.rpm
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/s/sssd-ad-2.11.1-4.fc43.x86_64.rpm
   - repoid: fedora-updates


### PR DESCRIPTION
We can now use the extended support for globs in `AuthorizedKeysFile` to tell sshd to look at the files written by Ignition and Afterburn for ssh key to accept.

See: https://github.com/coreos/ssh-key-dir/issues/188
See: https://man.openbsd.org/sshd_config#AuthorizedKeysFile