### PR TITLE
[rawhide] overrides: pin less-685-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  less:
+    evr: 685-1.fc44
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2059
+      type: pin


### PR DESCRIPTION
Requested by @joelcapitao via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).