### PR TITLE
versionary: reduce temporary the constraint

### DIFF
--- a/versionary
+++ b/versionary
@@ -102,7 +102,7 @@ def get_y(manifest):
             continue
     else:
         # must be an unlocked stream
-        assert stream in UNLOCKED_STREAMS
+        #assert stream in UNLOCKED_STREAMS
         msg_src = "unlocked stream"
         dt = datetime.now()
 


### PR DESCRIPTION
We are in the middle of moving the rawhide stream to be a locked one. We need to loose temporary the configuration in order to unblock the migration.
We'll then revert this commit once done.