### PR TITLE
build-args: Add stable STREAM to build-args.conf

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -10,4 +10,5 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
+STREAM=stable
 DESCRIPTION=Fedora CoreOS stable


### PR DESCRIPTION
The STREAM build argument is used to populate the `com.coreos.stream` label. This update adds the stable stream to build-args.conf.

See: https://github.com/coreos/fedora-coreos-config/pull/3867