### PR TITLE
build-args: Add next-devel STREAM to build-args.conf

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -8,4 +8,5 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
+STREAM=next-devel
 DESCRIPTION=Fedora CoreOS next-devel


### PR DESCRIPTION
The STREAM build argument is used to populate the `com.coreos.stream` label. This update adds the stable stream to build-args.conf.