### PR TITLE
tests/kola: switch container helpers to Fedora 43

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -24,13 +24,13 @@ get_ipv4_for_nic() {
 
 get_fedora_container_ref() {
     local repo='quay.io/fedora/fedora'
-    local tag='42'
+    local tag='43'
     echo "${repo}:${tag}"
 }
 
 get_fedora_minimal_container_ref() {
     local repo='quay.io/fedora/fedora-minimal'
-    local tag='42'
+    local tag='43'
     echo "${repo}:${tag}"
 }
 


### PR DESCRIPTION
This should have been part of https://github.com/coreos/fedora-coreos-config/commit/51a217a1a22276091a3dfc27a3d4f45b293d7e74 but there was a failure observed in the `ext.config.podman.rootless-systemd` test that wasn't seen using the Fedora 42 container images. There must have been some update with either systemd, selinux-policy, coreos-assembler, or elsewhere that allows httpd to start in a rootless-systemd environment again becasue the test is now passing.