### PR TITLE
build-rootfs: fix typo in rpm query format

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -432,7 +432,7 @@ def inject_content_manifest(target_rootfs, manifest):
 
 
 def verify_strict_mode(rootfs, locked_nevras):
-    cmd = ['rpm', '-qa', '--qf', '${EPOCH}\t%{NVRA}\t%{NVR}\t%{NEVRA}\t%{NEVR}\n']
+    cmd = ['rpm', '-qa', '--qf', '%{EPOCH}\t%{NVRA}\t%{NVR}\t%{NEVRA}\t%{NEVR}\n']
     rpms = bwrap(rootfs, cmd, capture=True)
     for rpm in rpms.splitlines():
         epoch, nvra, nvr, nevra, nevr = rpm.split()


### PR DESCRIPTION
This should have been a % instead of a $. I think I somehow copy pasted it wrong.

Fixes 67cc34a