### PR TITLE
overlay/ignition: delete pre-existing bootuuid.cfg

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.service
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.service
@@ -28,3 +28,6 @@ OnFailureJobMode=isolate
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/coreos-gpt-setup /dev/disk/by-label/boot
+# MountFlags=slave is so the umount of /boot is guaranteed to happen.
+# /boot will only be mounted for the lifetime of the unit.
+MountFlags=slave

--- a/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
+++ b/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.sh
@@ -26,6 +26,19 @@ if [ "${PTUUID:-}" != "$UNINITIALIZED_GUID" ]; then
     exit 0
 fi
 
+
+# Mount /boot. Note that we mount /boot but we don't unmount it because we
+# are run in a systemd unit with MountFlags=slave so it is unmounted for us.
+bootmnt=/mnt/boot_partition/
+bootdev=/dev/disk/by-label/boot
+mount -o rw ${bootdev} ${bootmnt}
+# Make sure we delete any pre-existing bootuuid.cfg
+# bootc install stamps it during the disk image creation
+# since we are changing the uuid here we want to remove this file
+# otherwise it will prevent a reboot
+rm -f ${bootmnt}/grub2/bootuuid.cfg
+
+
 echo "Randomizing disk GUID"
 sgdisk --disk-guid=R --move-second-header "$PKNAME"
 udevadm settle || :


### PR DESCRIPTION
In our disk images, bootupd inject a grub script that looks for a `/boot/grub2/bootuuid.cfg` to find the boot partition. If the file is not present, the label `boot` is used to find the partition. See [1] for more.

During the first boot, the hard-coded uuid of the boot partition is replaced with a random one [2].
However this happen in two phases:
First `coreos-gpt-setup.service` assigns a new UUID to the partition, Then `coreos-boot-edit.service` writes that new uuid to `/boot/grub2/bootuuid.cfg`.
However, when ignition needs to reboot (e.g. for applying a karg), the reboot happens between the two.

In `bootc install to-disk` the UUID of the boot partition is written to `/boot/grub2/bootuuid.cfg`, so it will be present at first boot. But if we restamp the parition then reboot, the original `bootuuid.cfg` is still there, preventing the reboot.

So let's delete this file just before the restamp, so we don't end up in this inconsistent state.
This allows us to use `bootc install to-disk` to build our disk images. See [3][4].

[1] https://github.com/coreos/bootupd/blob/1768f31c85b5d8cd72f4339ab669b703d7071b51/src/grub2/grub-static-pre.cfg
[2] https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core/usr/lib/dracut/modules.d/35coreos-ignition/coreos-gpt-setup.service
[3] https://issues.redhat.com/browse/COS-3374
[4] https://github.com/coreos/coreos-assembler/pull/4224