### PR TITLE
[rhcos-4.18] Fix multipath.custom-partition test fcos version

### DIFF
--- a/tests/kola/multipath/custom-partition/config.bu
+++ b/tests/kola/multipath/custom-partition/config.bu
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.6.0
+version: 1.5.0
 storage:
   disks:
   - device: /dev/disk/by-id/coreos-boot-disk


### PR DESCRIPTION
Set the fcos version to 1.5.0 to be able to run the test on a older version of FCOS/RHCOS like rhcos-4.18.


(cherry picked from commit 992011b9823bc74dbfcd08d7d7379a8dec7b97ea)