### PR TITLE
ci: Workaround for base-files dpkg error when adding 'testing' repo

### DIFF
--- a/.github/workflows/container-native.yml
+++ b/.github/workflows/container-native.yml
@@ -20,7 +20,15 @@ jobs:
         run: |
           set -xeuo pipefail
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6ED0E7B82643E131 78DBA3BC47EF2265
           sudo apt update
+          DIVERSION_PATHS="lib32 libo32 lib64"
+          for PATH_NAME in $DIVERSION_PATHS; do
+            sudo dpkg-divert --remove --package base-files --divert /$PATH_NAME.usr-is-merged /$PATH_NAME || true
+            sudo dpkg-divert --remove --package base-files --divert /.$PATH_NAME.usr-is-merged /$PATH_NAME || true
+          done
+          sudo dpkg --configure -a
+          sudo apt --fix-broken install
           sudo apt install -y crun/testing podman/testing skopeo/testing
           # Something is confused in latest GHA here
           sudo rm /var/lib/containers -rf


### PR DESCRIPTION
Refer to https://github.com/coreos/bootupd/pull/1029