### PR TITLE
overrides: unpin less rpm

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  less:
-    evr: 685-1.fc44
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2059
-      type: pin
+packages: {}


### PR DESCRIPTION
We can now unpin this less rpm as there is a bodhi update available
- https://bodhi.fedoraproject.org/updates/FEDORA-2025-412e51ae6a,

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/2059