### PR TITLE
ci/overrides.py: update rpms lockfile when pinning

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -170,6 +170,8 @@ def do_pin(args):
     for lockfile_path in get_lockfiles():
         merge_overrides(lockfile_path, overrides)
 
+    konflux_rpm_lock(overrides)
+
 
 def do_srpms(args):
     printed = False


### PR DESCRIPTION
As a follow-up of [1], we also need to update the `rpms.lock.yaml` file when pinning NVR, otherwise hermetic build will diverge from the non-hermetic one.

[1] https://github.com/coreos/fedora-coreos-config/pull/3905