### PR TITLE
Specify the image yaml file name in build-args.conf

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,7 @@ FROM ${BUILDER_IMG} as builder
 ARG BASE_VERSION=overridden
 ARG VERSION=overridden
 ARG MANIFEST=overridden
+ARG IMAGE_CONFIG=overridden
 ARG STREAM=overridden
 # XXX: see inject_passwd_group() in build-rootfs
 ARG PASSWD_GROUP_DIR
@@ -43,7 +44,7 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
-        /src/build-rootfs "${MANIFEST}" "${BASE_VERSION}" "${VERSION}" /target-rootfs
+        /src/build-rootfs "${MANIFEST}" "${IMAGE_CONFIG}" "${BASE_VERSION}" "${VERSION}" /target-rootfs
 RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \

--- a/build-args.conf
+++ b/build-args.conf
@@ -15,3 +15,4 @@ PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
 STREAM=testing-devel
 DESCRIPTION=Fedora CoreOS testing-devel
+IMAGE_CONFIG=image.yaml

--- a/build-rootfs
+++ b/build-rootfs
@@ -25,11 +25,13 @@ INPUTHASH = '/run/inputhash'
 
 def main():
     manifest_name = sys.argv[1]
-    base_version = sys.argv[2]
-    version = sys.argv[3]
-    target_rootfs = sys.argv[4]
+    image_cfg_name = sys.argv[2]
+    base_version = sys.argv[3]
+    version = sys.argv[4]
+    target_rootfs = sys.argv[5]
 
     manifest_path = os.path.join(SRCDIR, manifest_name)
+    image_cfg_path = os.path.join(SRCDIR, image_cfg_name)
     manifest = get_treefile(manifest_path)
 
     packages = list(manifest['packages'])
@@ -68,7 +70,7 @@ def main():
     )
 
     inject_live(target_rootfs)
-    inject_image_json(target_rootfs, manifest_path)
+    inject_image_json(target_rootfs, image_cfg_path, manifest_path)
     inject_platforms_json(target_rootfs)
     inject_content_manifest(target_rootfs, manifest)
 
@@ -389,10 +391,9 @@ def inject_live(rootfs):
     shutil.copytree(os.path.join(SRCDIR, "live"), target_path)
 
 
-def inject_image_json(rootfs, manifest_path):
+def inject_image_json(rootfs, image_cfg_path, manifest_path):
     manifest_vars = yaml.safe_load(open(manifest_path))['variables']
-    image = flatten_image_yaml(os.path.join(SRCDIR, 'image.yaml'),
-                               format_args=manifest_vars)
+    image = flatten_image_yaml(image_cfg_path, format_args=manifest_vars)
     fn = os.path.join(rootfs, 'usr/share/coreos-assembler/image.json')
     with open(fn, 'w') as f:
         json.dump(image, f, sort_keys=True)


### PR DESCRIPTION
This will make it easier to support downstream rhel-coreos-config where we support building more than one variant from the main branch and the image.yaml files are named per variant.