### PR TITLE
[next-devel] update build-args for latest `testing-devel` branch changes

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -1,7 +1,12 @@
 # Stream-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
-
-# This is the developer default version. In pipelines, this is driven by versionary.
+#
+# This is the base version. This value will get used as a starting point for
+# determining what the actual version should be. It's also the value that gets found
+# and replaced in /usr/lib/os-release.
+BASE_VERSION=43
+# This is the developer default version. In COSA builds or pipeline runs, this will get
+# overridden by versionary.
 VERSION=43.dev
 BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:b7ad5bc503ead71c091f41e0c4faf2d3726563a6aa61fb50875e15ab900ae5f4
 MANIFEST=manifest.yaml
@@ -10,3 +15,4 @@ PASSWD_GROUP_DIR=manifests
 NAME=fedora-coreos
 STREAM=next-devel
 DESCRIPTION=Fedora CoreOS next-devel
+IMAGE_CONFIG=image.yaml


### PR DESCRIPTION
This includes adding BASE_VERSION [1] and IMAGE_CONFIG [2].

[1] https://github.com/coreos/fedora-coreos-config/pull/3921
[2] https://github.com/coreos/fedora-coreos-config/pull/3922