### PR TITLE
[rawhide] overrides: fast-track grub2-2.12-50.fc44

### DIFF
--- a/manifest-lock.overrides.aarch64.yaml
+++ b/manifest-lock.overrides.aarch64.yaml
@@ -1,0 +1,31 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-50.fc44.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-50.fc44.aarch64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-50.fc44.aarch64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-efi-aa64:
+    evra: 1:2.12-50.fc44.aarch64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,36 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-50.fc44.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-50.fc44.ppc64le
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-50.fc44.ppc64le
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-ppc64le:
+    evra: 1:2.12-50.fc44.ppc64le
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-ppc64le-modules:
+    evra: 1:2.12-50.fc44.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track

--- a/manifest-lock.overrides.x86_64.yaml
+++ b/manifest-lock.overrides.x86_64.yaml
@@ -1,0 +1,41 @@
+# This lockfile should be used to pin to a package version (`type: pin`) or to
+# fast-track packages ahead of Bodhi (`type: fast-track`). Fast-tracked
+# packages will automatically be removed once they are in the stable repos.
+#
+# IMPORTANT: YAML comments *will not* be preserved. All `pin` overrides *must*
+# include a URL in the `metadata.reason` key. Overrides of type `fast-track`
+# *should* include a Bodhi update URL in the `metadata.bodhi` key and a URL
+# in the `metadata.reason` key, though it's acceptable to omit a `reason`
+# for FCOS-specific packages (ignition, afterburn, etc.).
+
+packages:
+  grub2-common:
+    evra: 1:2.12-50.fc44.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools:
+    evra: 1:2.12-50.fc44.x86_64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-tools-minimal:
+    evra: 1:2.12-50.fc44.x86_64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-pc-modules:
+    evra: 1:2.12-50.fc44.noarch
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-efi-x64:
+    evra: 1:2.12-50.fc44.x86_64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track
+  grub2-pc:
+    evra: 1:2.12-50.fc44.x86_64
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2420430
+      type: fast-track


### PR DESCRIPTION
This will allow our ppc64le builds to work again see:

- https://github.com/osbuild/osbuild/pull/2274#event-21442279344
- https://bugzilla.redhat.com/show_bug.cgi?id=2420430