### PR TITLE
[rawhide] overrides: pin on adcli-0.9.2-10.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  adcli:
+    evr: 0.9.2-10.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2082
+      type: pin


### PR DESCRIPTION
The new adcli-0.9.3.1-1.fc44 pulls in python [1].

[1] https://github.com/coreos/fedora-coreos-tracker/issues/2082