### PR TITLE
overrides: fast-track rust-bootupd-0.2.32-2.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,9 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  bootupd:
+    evr: 0.2.32-2.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-76d42868a5
+      type: fast-track

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -56,7 +56,7 @@ arches:
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/b/bootc-1.10.0-2.fc43.aarch64.rpm
   - repoid: fedora-updates
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/b/bootupd-0.2.31-1.fc43.aarch64.rpm
+    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/aarch64/Packages/b/bootupd-0.2.32-2.fc43.aarch64.rpm
   - repoid: fedora
     url: https://dl.fedoraproject.org/pub/fedora/linux/updates/43/Everything/aarch64/Packages/b/bsdtar-3.8.4-1.fc43.aarch64.rpm
   - repoid: fedora-updates
@@ -954,7 +954,7 @@ arches:
   - repoid: fedora-updates
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/b/bootc-1.10.0-2.fc43.ppc64le.rpm
   - repoid: fedora
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/b/bootupd-0.2.31-1.fc43.ppc64le.rpm
+    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/ppc64le/Packages/b/bootupd-0.2.32-2.fc43.ppc64le.rpm
   - repoid: fedora-updates
     url: https://dl.fedoraproject.org/pub/fedora/linux/updates/43/Everything/ppc64le/Packages/b/bsdtar-3.8.4-1.fc43.ppc64le.rpm
   - repoid: fedora
@@ -1840,7 +1840,7 @@ arches:
   - repoid: fedora
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/b/bootc-1.10.0-2.fc43.s390x.rpm
   - repoid: fedora-updates
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/b/bootupd-0.2.31-1.fc43.s390x.rpm
+    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/s390x/Packages/b/bootupd-0.2.32-2.fc43.s390x.rpm
   - repoid: fedora
     url: https://dl.fedoraproject.org/pub/fedora/linux/updates/43/Everything/s390x/Packages/b/bsdtar-3.8.4-1.fc43.s390x.rpm
   - repoid: fedora-updates
@@ -2694,7 +2694,7 @@ arches:
   - repoid: fedora-updates
     url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/b/bootc-1.10.0-2.fc43.x86_64.rpm
   - repoid: fedora
-    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/b/bootupd-0.2.31-1.fc43.x86_64.rpm
+    url: https://kojipkgs.fedoraproject.org/repos-dist/coreos-pool/latest/x86_64/Packages/b/bootupd-0.2.32-2.fc43.x86_64.rpm
   - repoid: fedora-updates
     url: https://dl.fedoraproject.org/pub/fedora/linux/updates/43/Everything/x86_64/Packages/b/bsdtar-3.8.4-1.fc43.x86_64.rpm
   - repoid: fedora


### PR DESCRIPTION
Requested by @HuijingHei via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).