### PR TITLE
manifests: updates for azure packages 

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -119,7 +119,6 @@ packages:
   - wireguard-tools
   # Storage
   - btrfs-progs
-  - WALinuxAgent-udev
   # Allow communication between sudo and SSSD
   # for caching sudo rules by SSSD.
   # https://github.com/coreos/fedora-coreos-tracker/issues/445

--- a/manifests/shared-el.yaml
+++ b/manifests/shared-el.yaml
@@ -6,6 +6,7 @@ conditional-include:
     include: shared-el9.yaml
   - if: osversion == "centos-9"
     include: shared-el9.yaml
+
   # Include shared-el10 workarounds on Fedora and EL10
   - if: id == "fedora"
     include: shared-el10.yaml
@@ -14,8 +15,14 @@ conditional-include:
   - if: osversion == "centos-10"
     include: shared-el10.yaml
 
-packages:
-  # Include udev rules for NVMe backed Azure Instances [1]
-  # and unmanaged SRIOV network devices.
-  # [1] https://issues.redhat.com/browse/COS-3124
-  - azure-vm-utils
+  # Include Azure specific packages for x86_64 and aarch64
+  - if:
+      - basearch != "ppc64le"
+      - basearch != "riscv64"
+      - basearch != "s390x"
+    include:
+      packages:
+        # Include udev rules for NVMe backed Azure Instances [1]
+        # and unmanaged SRIOV network devices.
+        # [1] https://issues.redhat.com/browse/COS-3124
+        - azure-vm-utils

--- a/manifests/shared-el.yaml
+++ b/manifests/shared-el.yaml
@@ -26,3 +26,5 @@ conditional-include:
         # and unmanaged SRIOV network devices.
         # [1] https://issues.redhat.com/browse/COS-3124
         - azure-vm-utils
+        # Include udev rules azure storage and productid
+        - WALinuxAgent-udev

--- a/tests/kola/files/initrd/expected-contents
+++ b/tests/kola/files/initrd/expected-contents
@@ -17,9 +17,12 @@ set -xeuo pipefail
 . "$KOLA_EXT_DATA/commonlib.sh"
 
 required_initrd_files=(
-    # Files from the 25azure-udev-rules overlay
+    # Files from the WALinuxAgent-udev package
     "/usr/lib/udev/rules.d/66-azure-storage.rules"
     "/usr/lib/udev/rules.d/99-azure-product-uuid.rules"
+    # Files from the azure-vm-utils package
+    "/usr/lib/udev/rules.d/80-azure-disk.rules"
+    "/usr/lib/udev/rules.d/10-azure-unmanaged-sriov.rules"
     # Files from the google-compute-engine-guest-configs-udev RPM (FCOS)
     # or 30gcp-udev-rules overlay (RHCOS). We can probably remove these
     # checks once RHCOS is using the RPM too.


### PR DESCRIPTION
commit fbcfba1916336d798749546580e1890ffa5d8383
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Dec 18 08:21:44 2025 -0500

    manifests: move WALinuxAgent-udev to shared el manifest
    
    We use this downstream too. Let's put it in a shared manifest. At the
    same time limit to x86_64 and aarch64 since those are the only two
    architectures Azure supports.

commit 0420b0ff5aa12adbaa2f930a03b53bb159afe659
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Dec 18 08:10:29 2025 -0500

    manifests/shared-el: limit architectures for azure-vm-utils
    
    Azure only supports x86_64 and aarch64 and downstream the package
    isn't built for s390x and ppc64le. Let's make inclusion conditional
    on the architecture.
