### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,19 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  bootupd:
-    evr: 0.2.32-2.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-76d42868a5
-      type: fast-track
-  ignition:
-    evr: 2.25.0-1.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-9d88f033c1
-      type: fast-track
-  ignition-grub:
-    evr: 2.25.0-1.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2025-9d88f033c1
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).