### PR TITLE
overrides: unpin adcli rpm

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,9 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  adcli:
-    evr: 0.9.2-10.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2082
-      type: pin
+packages: {}


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/2082

There is a new pkg `adcli-0.9.3.1-3.fc44` available that would fix this issue.