### PR TITLE
tests/kola: Increase crashkernel size to fix kdump kola crash test on PowerPC

### DIFF
--- a/tests/kola/kdump/crash/config.bu
+++ b/tests/kola/kdump/crash/config.bu
@@ -6,8 +6,8 @@ kernel_arguments:
     # and RHCOS here. Currently the worst case output of `kdumpctl estimate`
     # is aarch64 RHCOS where the it says "Recommended crashkernel: 448M".
     # Though for some reason when we set crashkernel=448M ppc64le complains
-    # and wants 512M so let's set it to 512M here.
-    - crashkernel=512M
+    # and wants 528M so let's set it to 528M here.
+    - crashkernel=528M
 systemd:
   units:
     - name: kdump.service


### PR DESCRIPTION
Adjust crashkernel size in kdump test as the ext.config.shared.kdump.crash test failing with below error.

```
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Recommended crashkernel: 528M
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Kernel image size:   0M
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Kernel modules size: 19M
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Initramfs size:      45M
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Runtime reservation: 16M
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: Large modules:
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]:     xfs: 3014656
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]:     ext4: 1245184
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: WARNING: Current crashkernel size is lower than recommended size 528M.'
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: + grep -q 'WARNING: Current crashkernel size is lower than recommended size'
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: + fatal 'The reserved crashkernel size is lower than recommended.'
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: + echo 'The reserved crashkernel size is lower than recommended.'
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: The reserved crashkernel size is lower than recommended.
Jan 06 09:44:51 qemu0 kola-runext-test.sh[19639]: + exit 1
Jan 06 09:44:51 qemu0 systemd[1]: kola-runext.service: Main process exited, code=exited, status=1/FAILURE
Jan 06 09:44:51 qemu0 systemd[1]: kola-runext.service: Failed with result 'exit-code'.
Jan 06 09:44:51 qemu0 systemd[1]: kola-runext.service: Consumed 10.831s CPU time, 38M memory peak.
```
Updated crashkernel size to aligns with upstream CPU-based calculation for PowerPC ref: https://gitlab.com/redhat/centos-stream/rpms/kdump-utils/-/commit/0241584fd0ad40f51f4ec8740ceba02aabd752b8
cc: @jbtrystram @dustymabe @joelcapitao 