### PR TITLE
test/kdump.crash: add sleep before crash

### DIFF
--- a/tests/kola/kdump/crash/test.sh
+++ b/tests/kola/kdump/crash/test.sh
@@ -51,6 +51,10 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       /tmp/autopkgtest-reboot-prepare aftercrash
       echo "Triggering sysrq"
       sync
+      # Give I/O a moment to settle after sync before crashing.
+      # We've seen this test hang forever in prow without this.
+      # https://github.com/coreos/rhel-coreos-config/issues/132
+      sleep 1
       echo 1 > /proc/sys/kernel/sysrq
       # This one will trigger kdump, which will write the kernel core, then reboot.
       echo c > /proc/sysrq-trigger


### PR DESCRIPTION
See https://github.com/coreos/rhel-coreos-config/issues/132

(cherry picked from commit 36274c49b9f46b013e4cc73e5e22737df86b04e3)