### PR TITLE
ci/workflow: fix the syntax error

### DIFF
--- a/.github/workflows/bump-rhcos-submodule.yml
+++ b/.github/workflows/bump-rhcos-submodule.yml
@@ -68,6 +68,7 @@ jobs:
                 echo "TARGET_BRANCH=${SOURCE_BRANCH}" >> $GITHUB_ENV
                 echo "BRANCH_NAME=fcc-sync-${SOURCE_BRANCH}" >> $GITHUB_ENV
                 echo "TITLE_PREFIX=[${SOURCE_BRANCH}] " >> $GITHUB_ENV
+                ;;
               *)
                 echo "SOURCE_BRANCH=$SOURCE_BRANCH is invalid" >&2
                 exit 1


### PR DESCRIPTION
Fix syntax error for https://github.com/coreos/fedora-coreos-config/pull/3954