### PR TITLE
versionary: print n origin details to sterr

### DIFF
--- a/versionary
+++ b/versionary
@@ -176,7 +176,7 @@ def get_next_iteration_from_git(y_as_timestamp):
             ['git', 'rev-list', '--count', '--after', y_as_timestamp, 'HEAD'],
             cwd="src/config", text=True
         ).strip()
-        print(
+        eprint(
             f"n: {commit_count_since_change} "
             "(calculated using git commit history)"
         )


### PR DESCRIPTION
The pipeline take the `stdout` of this script as the build ID, so we need to print any log messages to stderr to avoid parsing errors.