### PR TITLE
tests/sysexts: Run on streams based on stable Fedora releases

### DIFF
--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -34,8 +34,11 @@ get_fedora_minimal_container_ref() {
     echo "${repo}:${tag}"
 }
 
+# Look for the "fedora-coreos.stream" annotation from the container image
 get_fcos_stream() {
-    rpm-ostree status -b --json | jq -r '.deployments[0]["base-commit-meta"]["fedora-coreos.stream"]'
+    rpm-ostree status -b --json \
+        | jq -r '.deployments[0]."base-commit-meta"."ostree.manifest"' \
+        | jq -r '.annotations."fedora-coreos.stream"'
 }
 
 is_fcos() {

--- a/tests/kola/systemd/sysexts
+++ b/tests/kola/systemd/sysexts
@@ -18,6 +18,14 @@ set -xeuo pipefail
 # available in Fedora.
 SYSEXTS_BASE_URL="https://extensions.fcos.fr/fedora"
 
+# Those extensions are only built for stable Fedora releases for now so skip it
+# everywhere else.
+stream="$(get_fcos_stream)"
+case "${stream}" in
+    "stable"|"testing"|"testing-devel") echo "Running test on ${stream}" ;;
+    *) ok "Skipping test on ${stream}" ; exit 0 ;;
+esac
+
 install -d -m 0755 -o 0 -g 0 /var/lib/extensions /var/lib/extensions.d
 restorecon -RFv /var/lib/extensions /var/lib/extensions.d
 systemctl enable --now systemd-sysext.service


### PR DESCRIPTION
tests/kola/commonlib: Fix get_fcos_stream for container case

Get the stream from the fedora-coreos.stream annotation from the
container image.

---

tests/sysexts: Run only on streams based on stable Fedora releases

The sysexts used for this test are only built for stable Fedora releases
for now so skip it everywhere else.