### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,28 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  kernel:
-    evr: 6.18.5-200.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1118e5854e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2087
-      type: fast-track
-  kernel-core:
-    evr: 6.18.5-200.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1118e5854e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2087
-      type: fast-track
-  kernel-modules:
-    evr: 6.18.5-200.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1118e5854e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2087
-      type: fast-track
-  kernel-modules-core:
-    evr: 6.18.5-200.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1118e5854e
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2087
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).