### PR TITLE
.tekton: increase clone depth

### DIFF
--- a/.tekton/base/base/fedora-coreos.yaml
+++ b/.tekton/base/base/fedora-coreos.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
+++ b/.tekton/base/on-pull-request/fedora-coreos-on-pull-request.yaml
@@ -39,12 +39,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/base/on-push/fedora-coreos-on-push.yaml
+++ b/.tekton/base/on-push/fedora-coreos-on-push.yaml
@@ -38,10 +38,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
+++ b/.tekton/next-devel/on-pull-request/fedora-coreos-next-devel-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
+++ b/.tekton/next-devel/on-push/fedora-coreos-next-devel-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
+++ b/.tekton/next/on-pull-request/fedora-coreos-next-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
+++ b/.tekton/next/on-push/fedora-coreos-next-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
+++ b/.tekton/rawhide/on-pull-request/fedora-coreos-rawhide-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
+++ b/.tekton/rawhide/on-push/fedora-coreos-rawhide-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
+++ b/.tekton/stable/on-pull-request/fedora-coreos-stable-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
+++ b/.tekton/stable/on-push/fedora-coreos-stable-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
+++ b/.tekton/testing-devel/on-pull-request/fedora-coreos-testing-devel-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
+++ b/.tekton/testing-devel/on-push/fedora-coreos-testing-devel-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
+++ b/.tekton/testing/on-pull-request/fedora-coreos-testing-on-pull-request.yaml
@@ -40,12 +40,14 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   - name: image-expires-after
     value: 5d
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind

--- a/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
+++ b/.tekton/testing/on-push/fedora-coreos-testing-on-push.yaml
@@ -39,10 +39,12 @@ spec:
     - linux/arm64
     - linux/s390x
     - linux/ppc64le
+  - name: clone-depth
+    value: 50
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:d29a4d1bc4f331a327e23d96ba48e4cdd2d8e732078faf6970dd9657e9b817e6
+      value: quay.io/bootc-devel/tekton-catalog/pipeline-buildah-build-bootc-multi-platform-oci-ta@sha256:b16aa8d0330ebe9161b2671976893fc9cf9ae128ade608d60fb80e75c400620d
     - name: name
       value: buildah-build-bootc-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
Since 5c83258, we need to have a git tree containing more commits than just 1 (the default), because the python script versionary calculates the `n` value based on the number of commits. This patch increases the number of commits to clone up to 50. We expect not having more than 50 commits since the last manifest lockfile update.