### PR TITLE
build-rootfs: pass in stream to build-rootfs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,6 +47,7 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
         /src/build-rootfs                      \
             --manifest-name "${MANIFEST}"      \
             --image-cfg-name "${IMAGE_CONFIG}" \
+            --stream "${STREAM}"               \
             --base-version "${BASE_VERSION}"   \
             --version "${VERSION}"             \
             --target-rootfs /target-rootfs

--- a/Containerfile
+++ b/Containerfile
@@ -44,7 +44,12 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
-        /src/build-rootfs "${MANIFEST}" "${IMAGE_CONFIG}" "${BASE_VERSION}" "${VERSION}" /target-rootfs
+        /src/build-rootfs                      \
+            --manifest-name "${MANIFEST}"      \
+            --image-cfg-name "${IMAGE_CONFIG}" \
+            --base-version "${BASE_VERSION}"   \
+            --version "${VERSION}"             \
+            --target-rootfs /target-rootfs
 RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \

--- a/build-rootfs
+++ b/build-rootfs
@@ -30,6 +30,7 @@ def main():
     parser = argparse.ArgumentParser(description='Build an FCOS rootfs.')
     parser.add_argument('--manifest-name', required=True, help='Name of the manifest file.')
     parser.add_argument('--image-cfg-name', required=True, help='Name of the image config file.')
+    parser.add_argument('--stream', required=True, help='The CoreOS stream name.')
     parser.add_argument('--base-version', required=True, help='Base version string.')
     parser.add_argument('--version', required=True, help='Full version string.')
     parser.add_argument('--target-rootfs', required=True, help='Path to the target rootfs.')
@@ -76,7 +77,7 @@ def main():
     )
 
     inject_live(args.target_rootfs)
-    inject_image_json(args.target_rootfs, image_cfg_path, manifest_path)
+    inject_image_json(args.target_rootfs, image_cfg_path, args.stream)
     inject_platforms_json(args.target_rootfs)
     inject_content_manifest(args.target_rootfs, manifest)
 
@@ -400,9 +401,8 @@ def inject_live(rootfs):
     shutil.copytree(os.path.join(SRCDIR, "live"), target_path)
 
 
-def inject_image_json(rootfs, image_cfg_path, manifest_path):
-    manifest_vars = yaml.safe_load(open(manifest_path))['variables']
-    image = flatten_image_yaml(image_cfg_path, format_args=manifest_vars)
+def inject_image_json(rootfs, image_cfg_path, stream):
+    image = flatten_image_yaml(image_cfg_path, format_args={'stream': stream})
     fn = os.path.join(rootfs, 'usr/share/coreos-assembler/image.json')
     with open(fn, 'w') as f:
         json.dump(image, f, sort_keys=True)

--- a/build-rootfs
+++ b/build-rootfs
@@ -7,6 +7,7 @@
 # 4. It injects various metadata (e.g. image.json, live/ bits, and platforms.json).
 # 5. It runs the postprocess scripts defined in the manifest.
 
+import argparse
 import glob
 import hashlib
 import json
@@ -26,14 +27,16 @@ IS_HERMETIC = os.path.exists(HERMETIC_REPO)
 
 
 def main():
-    manifest_name = sys.argv[1]
-    image_cfg_name = sys.argv[2]
-    base_version = sys.argv[3]
-    version = sys.argv[4]
-    target_rootfs = sys.argv[5]
+    parser = argparse.ArgumentParser(description='Build an FCOS rootfs.')
+    parser.add_argument('--manifest-name', required=True, help='Name of the manifest file.')
+    parser.add_argument('--image-cfg-name', required=True, help='Name of the image config file.')
+    parser.add_argument('--base-version', required=True, help='Base version string.')
+    parser.add_argument('--version', required=True, help='Full version string.')
+    parser.add_argument('--target-rootfs', required=True, help='Path to the target rootfs.')
+    args = parser.parse_args()
 
-    manifest_path = os.path.join(SRCDIR, manifest_name)
-    image_cfg_path = os.path.join(SRCDIR, image_cfg_name)
+    manifest_path = os.path.join(SRCDIR, args.manifest_name)
+    image_cfg_path = os.path.join(SRCDIR, args.image_cfg_name)
     manifest = get_treefile(manifest_path)
 
     packages = list(manifest['packages'])
@@ -43,7 +46,7 @@ def main():
     if repos or lockfile_repos:
         inject_yumrepos()
 
-    local_overrides = prepare_local_rpm_overrides(target_rootfs)
+    local_overrides = prepare_local_rpm_overrides(args.target_rootfs)
     if local_overrides:
         repos += ['overrides']
 
@@ -68,26 +71,26 @@ def main():
     no_initramfs = True if no_initramfs_arg_supported() else False
 
     build_rootfs(
-        target_rootfs, manifest_path, packages, locked_nevras,
+        args.target_rootfs, manifest_path, packages, locked_nevras,
         overlays, repos, nodocs, recommends, no_initramfs
     )
 
-    inject_live(target_rootfs)
-    inject_image_json(target_rootfs, image_cfg_path, manifest_path)
-    inject_platforms_json(target_rootfs)
-    inject_content_manifest(target_rootfs, manifest)
+    inject_live(args.target_rootfs)
+    inject_image_json(args.target_rootfs, image_cfg_path, manifest_path)
+    inject_platforms_json(args.target_rootfs)
+    inject_content_manifest(args.target_rootfs, manifest)
 
-    if version != "":
-        inject_version_info(target_rootfs, base_version, version)
+    if args.version != "":
+        inject_version_info(args.target_rootfs, args.base_version, args.version)
 
     strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':
-        verify_strict_mode(target_rootfs, locked_nevras)
-    run_postprocess_scripts(target_rootfs, manifest)
-    run_dracut(target_rootfs)
-    cleanup_extraneous_files(target_rootfs)
+        verify_strict_mode(args.target_rootfs, locked_nevras)
+    run_postprocess_scripts(args.target_rootfs, manifest)
+    run_dracut(args.target_rootfs)
+    cleanup_extraneous_files(args.target_rootfs)
 
-    calculate_inputhash(target_rootfs, overlays, manifest)
+    calculate_inputhash(args.target_rootfs, overlays, manifest)
 
 
 def get_treefile(manifest_path):


### PR DESCRIPTION
..and use it for variable replacement in the image.yaml files rather
than the manifest since stream is the only var we are formatting/replacing
right now.

This further removes our dependence on the manifest.