### PR TITLE
build-rootfs: move buildroot-prep execution into build-rootfs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,9 +34,6 @@ COPY . /src
 # canonicalize permission bits, see also https://gitlab.com/fedora/bootc/base-images/-/merge_requests/274
 RUN chmod -R a=rX,u+w /src
 
-# this allows FCOS/SCOS/RHCOS to do specific things before going into the shared build-rootfs script
-RUN if test -x /src/buildroot-prep; then /src/buildroot-prep; fi
-
 # useful if you're hacking on rpm-ostree/bootc-base-imagectl
 # COPY rpm-ostree /usr/bin/
 # COPY bootc-base-imagectl /usr/libexec/

--- a/build-rootfs
+++ b/build-rootfs
@@ -112,6 +112,13 @@ def inject_yumrepos(srcdir):
             shutil.copy(repo, "/etc/yum.repos.d")
 
 
+def run_buildroot_prep():
+    # This allows FCOS/SCOS/RHCOS to do specific things before the main
+    # build process. Runs after inject_yumrepos() so repos are available.
+    buildroot_prep = os.path.join(SRCDIR, 'buildroot-prep')
+    if os.path.isfile(buildroot_prep):
+        subprocess.check_call([buildroot_prep])
+
 def build_rootfs(target_rootfs, srcdir, manifest_name,
                  image_config, osid, stream, version,
                  strict_mode, passwd_group_dir, mutate_os_release):

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -1,22 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script is called in the buildah path to modify the build environment
-# before entering the shared build-rootfs script. Example use cases are to
-# fast-track fixes or work around bugs.
+# This script is called very early in the buildah path from build-rootfs
+# after inject_yumrepos() to modify the build environment. Example use cases
+# are to fast-track fixes or work around bugs.
+# Note that any dowloaded packages here needs to be included in lockfiles (the main
+# or overrides one).
 
 arch=$(uname -m)
 . /etc/os-release
 
-# cachi2 is the repo Konflux injects when hermetic build is enabled and
-# is self-sufficient to pull all the required RPMs.
-if [ ! -f "/etc/yum.repos.d/cachi2.repo" ]; then
-    cp /src/fedora-coreos-continuous.repo /etc/yum.repos.d
-fi
-# NOTE: try to remove anything that queries repos here once it's no longer
-# needed so that we don't unnecessarily pay for repo metadata.
-
 # make sure we have https://github.com/coreos/rpm-ostree/pull/5454
 if ! rpm-ostree compose build-chunked-oci -h | grep -q -- --label; then
-    sudo dnf update rpm-ostree -y --repo fedora-coreos-continuous --releasever "$VERSION_ID"
+    sudo dnf update rpm-ostree -y
 fi


### PR DESCRIPTION
Move the buildroot-prep invocation from Containerfile into build-rootfs as a new run_buildroot_prep() function. This runs after inject_yumrepos() so that repos are available when buildroot-prep executes.

Also remove the cachi2 repo check from buildroot-prep since repo injection is now handled earlier in the build process by inject_yumrepos().

As a follow-up of #3723

Assisted-by: Claude (Opus 4)