### PR TITLE
manifest cleanups; add RHCOS support to versionary

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,11 +19,11 @@ ARG BUILDER_IMG=overridden
 FROM ${BUILDER_IMG} as builder
 
 ARG ID=overridden
-ARG BASE_VERSION=overridden
 ARG VERSION=overridden
+ARG STREAM=overridden
+ARG MUTATE_OS_RELEASE=overridden
 ARG MANIFEST=overridden
 ARG IMAGE_CONFIG=overridden
-ARG STREAM=overridden
 # XXX: see inject_passwd_group() in build-rootfs
 ARG PASSWD_GROUP_DIR
 ARG STRICT_MODE=0

--- a/Containerfile
+++ b/Containerfile
@@ -44,13 +44,7 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
-        /src/build-rootfs                      \
-            --manifest-name "${MANIFEST}"      \
-            --image-cfg-name "${IMAGE_CONFIG}" \
-            --stream "${STREAM}"               \
-            --base-version "${BASE_VERSION}"   \
-            --version "${VERSION}"             \
-            --target-rootfs /target-rootfs
+        /src/build-rootfs --target-rootfs /target-rootfs
 RUN --mount=type=bind,target=/run/src,rw \
       rpm-ostree experimental compose build-chunked-oci \
         --bootc --format-version=1 --rootfs /target-rootfs \

--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,7 @@ ARG BUILDER_IMG=overridden
 
 FROM ${BUILDER_IMG} as builder
 
+ARG ID=overridden
 ARG BASE_VERSION=overridden
 ARG VERSION=overridden
 ARG MANIFEST=overridden

--- a/build-args.conf
+++ b/build-args.conf
@@ -1,6 +1,12 @@
 # Stream-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
-#
+
+# A few basics. ID (man os-release), NAME/DESCRIPTION of what we're building
+# and the name of the STREAM.
+ID=fedora
+NAME=fedora-coreos
+STREAM=testing-devel
+DESCRIPTION=Fedora CoreOS testing-devel
 # This is the base version. This value will get used as a starting point for
 # determining what the actual version should be. It's also the value that gets found
 # and replaced in /usr/lib/os-release.
@@ -12,7 +18,4 @@ BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:84542b433065993f
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
-NAME=fedora-coreos
-STREAM=testing-devel
-DESCRIPTION=Fedora CoreOS testing-devel
 IMAGE_CONFIG=image.yaml

--- a/build-args.conf
+++ b/build-args.conf
@@ -1,19 +1,12 @@
 # Stream-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
 
-# A few basics. ID (man os-release), NAME/DESCRIPTION of what we're building
-# and the name of the STREAM.
 ID=fedora
 NAME=fedora-coreos
 STREAM=testing-devel
 DESCRIPTION=Fedora CoreOS testing-devel
-# This is the base version. This value will get used as a starting point for
-# determining what the actual version should be. It's also the value that gets found
-# and replaced in /usr/lib/os-release.
-BASE_VERSION=43
-# This is the developer default version. In COSA builds or pipeline runs, this will get
-# overridden by versionary.
-VERSION=43.dev
+VERSION=43
+MUTATE_OS_RELEASE=43
 BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:84542b433065993f7fdea344ea117a37638ed9345b990de80d5daf164edb9399
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs

--- a/build-rootfs
+++ b/build-rootfs
@@ -28,16 +28,15 @@ IS_HERMETIC = os.path.exists(HERMETIC_REPO)
 
 def main():
     parser = argparse.ArgumentParser(description='Build an FCOS rootfs.')
-    parser.add_argument('--manifest-name', required=True, help='Name of the manifest file.')
-    parser.add_argument('--image-cfg-name', required=True, help='Name of the image config file.')
-    parser.add_argument('--stream', required=True, help='The CoreOS stream name.')
-    parser.add_argument('--base-version', required=True, help='Base version string.')
-    parser.add_argument('--version', required=True, help='Full version string.')
     parser.add_argument('--target-rootfs', required=True, help='Path to the target rootfs.')
     args = parser.parse_args()
 
-    manifest_path = os.path.join(SRCDIR, args.manifest_name)
-    image_cfg_path = os.path.join(SRCDIR, args.image_cfg_name)
+    manifest_path = os.path.join(SRCDIR, os.getenv('MANIFEST'))
+    image_cfg_path = os.path.join(SRCDIR, os.getenv('IMAGE_CONFIG'))
+    base_version = os.getenv('BASE_VERSION')
+    version = os.getenv('VERSION')
+    stream = os.getenv('STREAM')
+
     manifest = get_treefile(manifest_path)
 
     packages = list(manifest['packages'])
@@ -77,11 +76,11 @@ def main():
     )
 
     inject_live(args.target_rootfs)
-    inject_image_json(args.target_rootfs, image_cfg_path, args.stream)
+    inject_image_json(args.target_rootfs, image_cfg_path, stream)
     inject_platforms_json(args.target_rootfs)
     inject_content_manifest(args.target_rootfs, manifest)
 
-    inject_version_info(args.target_rootfs, args.base_version, args.version)
+    inject_version_info(args.target_rootfs, base_version, version)
 
     strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':

--- a/build-rootfs
+++ b/build-rootfs
@@ -36,9 +36,14 @@ def main():
     base_version = os.getenv('BASE_VERSION')
     version = os.getenv('VERSION')
     stream = os.getenv('STREAM')
+    id = os.getenv('ID')
 
-    manifest = get_treefile(manifest_path)
-
+    manifest = get_treefile(
+        manifest=manifest_path,
+        id=id,
+        stream=stream,
+        base_version=base_version
+    )
     packages = list(manifest['packages'])
 
     repos = manifest.get('repos', [])
@@ -92,16 +97,17 @@ def main():
     calculate_inputhash(args.target_rootfs, overlays, manifest)
 
 
-def get_treefile(manifest_path):
+def get_treefile(manifest, id, stream, base_version):
     with tempfile.NamedTemporaryFile(suffix='.json', mode='w') as tmp_manifest:
-        # This ensures that the treefile represents only the CoreOS bits and
-        # doesn't recurse into fedora-bootc. We can drop this once we've fully
-        # cut over to derivation.
+        # Substitute in a few values from build-args into the treefile.
         json.dump({
             "variables": {
-                "deriving": True
+                "deriving": True,
+                "id": id,
+                "stream": stream,
+                "osversion": f"{id}-{base_version}"
             },
-            "include": manifest_path
+            "include": manifest
         }, tmp_manifest)
         tmp_manifest.flush()
         data = subprocess.check_output(['rpm-ostree', 'compose', 'tree',

--- a/build-rootfs
+++ b/build-rootfs
@@ -113,6 +113,7 @@ def get_treefile(manifest, id, stream, version):
                 "stream": stream,
                 "osversion": f"{id}-{major_version}"
             },
+            "releasever": int(major_version),  # Only needed/used by Fedora
             "include": manifest
         }, tmp_manifest)
         tmp_manifest.flush()

--- a/build-rootfs
+++ b/build-rootfs
@@ -33,16 +33,16 @@ def main():
 
     manifest_path = os.path.join(SRCDIR, os.getenv('MANIFEST'))
     image_cfg_path = os.path.join(SRCDIR, os.getenv('IMAGE_CONFIG'))
-    base_version = os.getenv('BASE_VERSION')
     version = os.getenv('VERSION')
     stream = os.getenv('STREAM')
     id = os.getenv('ID')
+    mutate_os_release = os.getenv('MUTATE_OS_RELEASE')
 
     manifest = get_treefile(
         manifest=manifest_path,
         id=id,
         stream=stream,
-        base_version=base_version
+        version=version
     )
     packages = list(manifest['packages'])
 
@@ -85,7 +85,11 @@ def main():
     inject_platforms_json(args.target_rootfs)
     inject_content_manifest(args.target_rootfs, manifest)
 
-    inject_version_info(args.target_rootfs, base_version, version)
+    inject_version_info(
+        rootfs=args.target_rootfs,
+        replace_version=mutate_os_release,
+        version=version
+    )
 
     strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':
@@ -97,15 +101,16 @@ def main():
     calculate_inputhash(args.target_rootfs, overlays, manifest)
 
 
-def get_treefile(manifest, id, stream, base_version):
+def get_treefile(manifest, id, stream, version):
     with tempfile.NamedTemporaryFile(suffix='.json', mode='w') as tmp_manifest:
         # Substitute in a few values from build-args into the treefile.
+        major_version = version.split('.')[0]
         json.dump({
             "variables": {
                 "deriving": True,
                 "id": id,
                 "stream": stream,
-                "osversion": f"{id}-{base_version}"
+                "osversion": f"{id}-{major_version}"
             },
             "include": manifest
         }, tmp_manifest)
@@ -362,7 +367,7 @@ def modify_pool_repo(locked_nevras):
 # and only rely on org.opencontainers.image.version as argued in:
 # https://gitlab.com/fedora/bootc/base-images/-/issues/40
 # https://gitlab.com/fedora/bootc/base-images/-/issues/46
-def inject_version_info(rootfs, base_version, version):
+def inject_version_info(rootfs, replace_version, version):
     os_release_path = os.path.join(rootfs, 'usr/lib/os-release')
     with open(os_release_path) as f:
         from collections import OrderedDict
@@ -375,7 +380,7 @@ def inject_version_info(rootfs, base_version, version):
             os_release[k] = v
 
     for key in ['VERSION', 'PRETTY_NAME']:
-        os_release[key] = os_release[key].replace(base_version, version)
+        os_release[key] = os_release[key].replace(replace_version, version)
     os_release['OSTREE_VERSION'] = f"'{version}'"
     os_release['IMAGE_VERSION'] = f"'{version}'"
 

--- a/build-rootfs
+++ b/build-rootfs
@@ -37,6 +37,8 @@ def main():
     stream = os.getenv('STREAM')
     id = os.getenv('ID')
     mutate_os_release = os.getenv('MUTATE_OS_RELEASE')
+    strict_mode = os.getenv('STRICT_MODE')
+    passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
 
     manifest = get_treefile(
         manifest=manifest_path,
@@ -77,7 +79,7 @@ def main():
 
     build_rootfs(
         args.target_rootfs, manifest_path, packages, locked_nevras,
-        overlays, repos, nodocs, recommends, no_initramfs
+        overlays, repos, nodocs, recommends, no_initramfs, passwd_group_dir
     )
 
     inject_live(args.target_rootfs)
@@ -91,7 +93,6 @@ def main():
         version=version
     )
 
-    strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':
         verify_strict_mode(args.target_rootfs, locked_nevras)
     run_postprocess_scripts(args.target_rootfs, manifest)
@@ -138,9 +139,9 @@ def inject_yumrepos():
 
 def build_rootfs(
     target_rootfs, manifest_path, packages, locked_nevras,
-    overlays, repos, nodocs, recommends, no_initramfs
+    overlays, repos, nodocs, recommends, no_initramfs,
+    passwd_group_dir
 ):
-    passwd_group_dir = os.getenv('PASSWD_GROUP_DIR')
     if passwd_group_dir is not None:
         inject_passwd_group(os.path.join(SRCDIR, passwd_group_dir))
     with tempfile.NamedTemporaryFile(mode='w') as argsfile:

--- a/build-rootfs
+++ b/build-rootfs
@@ -81,8 +81,7 @@ def main():
     inject_platforms_json(args.target_rootfs)
     inject_content_manifest(args.target_rootfs, manifest)
 
-    if args.version != "":
-        inject_version_info(args.target_rootfs, args.base_version, args.version)
+    inject_version_info(args.target_rootfs, args.base_version, args.version)
 
     strict_mode = os.getenv('STRICT_MODE')
     if strict_mode == '1':

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,5 @@
 variables:
   stream: testing-devel
-  prod: false
 
 metadata:
   # tell `cosa build` to default to buildah path

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,8 +2,6 @@ metadata:
   # tell `cosa build` to default to buildah path
   build_with_buildah: true
 
-releasever: 43
-
 conditional-include:
   # TODO: There is no coreos-pool for RISCV yet
   #       https://github.com/coreos/fedora-coreos-tracker/issues/1931

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,3 @@
-variables:
-  stream: testing-devel
-
 metadata:
   # tell `cosa build` to default to buildah path
   build_with_buildah: true

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -2,14 +2,6 @@
 # Add things in this file which are somewhat "opinionated", not necessarily
 # core functionality.
 
-variables:
-  id: "fedora"
-  # osversion is unused in Fedora for now, but it's needed because we
-  # do some conditional_includes: which do leverage the osversion
-  # defined in rhcos/scos. When https://github.com/coreos/rpm-ostree/pull/5392
-  # merges we can define this with values from other vars: osversion: "${id}-${releasever}"
-  osversion: "unused"
-
 include:
   - system-configuration.yaml
   - ignition-and-ostree.yaml

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -6,8 +6,11 @@ include: fedora-coreos-base.yaml
 conditional-include:
   - if: releasever >= 41
     include: selinux-workaround.yaml
-  # If not production then disable Zincati
-  - if: prod == false
+  # If not on a production stream then disable Zincati
+  - if:
+      - stream != "stable"
+      - stream != "testing"
+      - stream != "next"
     include:
       postprocess:
         - |

--- a/versionary
+++ b/versionary
@@ -44,7 +44,7 @@ def main():
     assert os.path.isdir('builds'), 'Missing builds/ dir'
 
     config = dotenv.dotenv_values('src/config/build-args.conf')
-    x, z = (get_x(config), get_z(config, args.dev))
+    x, z = (get_x(config), get_z(config))
     dt = get_timestamp()  # A datetime object
     # Convert to a YYYYMMDD formatted string for y.
     y = int(dt.strftime('%Y%m%d'))
@@ -54,7 +54,9 @@ def main():
         n = get_next_iteration_from_builds(x, y, z)
     else:
         n = get_next_iteration_from_git(str(dt))
-    new_version = f'{x}.{y}.{z}.{n}'
+
+    dev = 'dev' if args.dev else ''
+    new_version = f'{x}.{y}.{z}.{dev}{n}'
 
     # sanity check the new version by trying to re-parse it
     assert parse_version(new_version) is not None
@@ -110,13 +112,10 @@ def get_timestamp():
     return dt
 
 
-def get_z(config, dev):
+def get_z(config):
     """
         Z is the stream indicator.
     """
-    if dev:
-        eprint("z: dev (overridden)")
-        return 'dev'
     stream = config['STREAM']
     assert stream in STREAM_TO_NUM, f"Unknown stream: {stream}"
     mapped = STREAM_TO_NUM[stream]
@@ -181,7 +180,9 @@ def get_next_iteration_from_git(timestamp):
 
 
 def parse_version(version):
-    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+|dev)\.([0-9]+)$', version)
+    # Note that (?:pattern) os a non-matching group in python regex so
+    # it won't show up in the matched m.groups()
+    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+)\.(?:dev)?([0-9]+)$', version)
     if m is None:
         return None
     # sanity-check date
@@ -189,7 +190,7 @@ def parse_version(version):
         time.strptime(m.group(2), '%Y%m%d')
     except ValueError:
         return None
-    return tuple(map(lambda x: 'dev' if x == 'dev' else int(x), m.groups()))
+    return tuple(map(int, m.groups()))
 
 
 def eprint(*args):

--- a/versionary
+++ b/versionary
@@ -45,12 +45,15 @@ def main():
 
     config = dotenv.dotenv_values('src/config/build-args.conf')
     x, z = (get_x(config), get_z(config, args.dev))
-    y, y_as_timestamp = get_y()
+    dt = get_timestamp()  # A datetime object
+    # Convert to a YYYYMMDD formatted string for y.
+    y = int(dt.strftime('%Y%m%d'))
+
     # Default behavior generates the iteration from Git (dev mode uses builds)
     if args.dev:
         n = get_next_iteration_from_builds(x, y, z)
     else:
-        n = get_next_iteration_from_git(y_as_timestamp)
+        n = get_next_iteration_from_git(str(dt))
     new_version = f'{x}.{y}.{z}.{n}'
 
     # sanity check the new version by trying to re-parse it
@@ -76,10 +79,10 @@ def get_x(config):
     return int(base_version)
 
 
-def get_y():
+def get_timestamp():
     """
-        Y is the base snapshot date in YYYYMMDD format of Fedora. We derive
-        this using the timestamp in the base lockfile.
+        Get the timestamp from either the lockfiles, or use the
+        current time if no lockfiles exist.
     """
 
     # XXX: should sanity check that the lockfiles for all the basearches have
@@ -103,9 +106,8 @@ def get_y():
         msg_src = "from datetime.now()"
         dt = datetime.now()
 
-    ymd = dt.strftime('%Y%m%d')
-    eprint(f"y: {ymd} ({msg_src})")
-    return int(ymd), str(dt)
+    eprint(f"timestamp: {dt.strftime('%Y%m%d')} ({msg_src})")
+    return dt
 
 
 def get_z(config, dev):
@@ -148,7 +150,7 @@ def get_next_iteration_from_builds(x, y, z):
     return n
 
 
-def get_next_iteration_from_git(y_as_timestamp):
+def get_next_iteration_from_git(timestamp):
     """
     Compute the next iteration number based on git commit history.
 
@@ -162,7 +164,7 @@ def get_next_iteration_from_git(y_as_timestamp):
     try:
         # Count commits after that point
         commit_count_since_change = subprocess.check_output(
-            ['git', 'rev-list', '--count', '--after', y_as_timestamp, 'HEAD'],
+            ['git', 'rev-list', '--count', '--after', timestamp, 'HEAD'],
             cwd="src/config", text=True
         ).strip()
         eprint(

--- a/versionary
+++ b/versionary
@@ -8,6 +8,8 @@
     Implements the Fedora CoreOS versioning scheme as per:
         https://github.com/coreos/fedora-coreos-tracker/issues/81
         https://github.com/coreos/fedora-coreos-tracker/issues/211
+    And also the RHCOS/SCOS versioning scheme such as:
+        9.8.20260125-0
 '''
 
 import argparse
@@ -24,7 +26,7 @@ import yaml
 from datetime import datetime
 
 # https://github.com/coreos/fedora-coreos-tracker/issues/211#issuecomment-543547587
-STREAM_TO_NUM = {
+FCOS_STREAM_TO_NUM = {
     'next': 1,
     'testing': 2,
     'stable': 3,
@@ -43,20 +45,47 @@ def main():
         os.chdir(args.workdir)
     assert os.path.isdir('builds'), 'Missing builds/ dir'
 
-    config = dotenv.dotenv_values('src/config/build-args.conf')
-    x, z = (get_x(config), get_z(config))
-    dt = get_timestamp()  # A datetime object
-    # Convert to a YYYYMMDD formatted string for y.
-    y = int(dt.strftime('%Y%m%d'))
+    # Initialize all the components of our versions
+    x, y, z, n = (0, 0, 0, 0)
 
-    # Default behavior generates the iteration from Git (dev mode uses builds)
-    if args.dev:
+    # Pick up values from our build-args.
+    config = dotenv.dotenv_values('src/config/build-args.conf')
+
+    # Grab the current datetime object representing the timestamp
+    # for the timestamp component of our version.
+    dt = get_timestamp()
+
+    # The base version in FCOS is a single number (i.e. 43) while
+    # in RHCOS/SCOS it's two numbers separated by . (i.e. 9.8 or 10.0)
+    x, y = split_base_version(config['VERSION'])
+
+    # The y component in FCOS is the timestamp, while in RHCOS/SCOS
+    # it's the z component. We'll convert to a YYYYMMDD formatted string.
+    if not y:
+        y = int(dt.strftime('%Y%m%d'))
+    else:
+        z = int(dt.strftime('%Y%m%d'))
+
+    # At this point if z isn't defined then we're FCOS
+    if not z:
+        z = FCOS_STREAM_TO_NUM[config['STREAM']]
+
+    # For !FCOS and in dev mode we'll default to getting the build ID
+    # n component by incrementing on top of the last build. For FCOS
+    # not in dev mode we'll calculate the n by looking at git history.
+    if args.dev or config['ID'] != 'fedora':
         n = get_next_iteration_from_builds(x, y, z)
     else:
         n = get_next_iteration_from_git(str(dt))
 
+    # On !FCOS the delimeter for the `n` component is a -
+    n_delimiter = '.' if config['ID'] == 'fedora' else '-'
+
+    # Now we can compute the final version. Note we prepend the
+    # `dev` string for the n component if --dev was passed.
     dev = 'dev' if args.dev else ''
-    new_version = f'{x}.{y}.{z}.{dev}{n}'
+    new_version = f'{x}.{y}.{z}{n_delimiter}{dev}{n}'
+    eprint(f'VERSIONARY: selected new version for build: {new_version}')
 
     # sanity check the new version by trying to re-parse it
     assert parse_version(new_version) is not None
@@ -70,15 +99,6 @@ def parse_args():
         "--dev", action="store_true", help="generate a developer version"
     )
     return parser.parse_args()
-
-
-def get_x(config):
-    """
-        X is the base release version on which we're based.
-    """
-    base_version = config['VERSION']
-    eprint(f"x: {base_version} (from config)")
-    return int(base_version)
 
 
 def get_timestamp():
@@ -112,15 +132,12 @@ def get_timestamp():
     return dt
 
 
-def get_z(config):
-    """
-        Z is the stream indicator.
-    """
-    stream = config['STREAM']
-    assert stream in STREAM_TO_NUM, f"Unknown stream: {stream}"
-    mapped = STREAM_TO_NUM[stream]
-    eprint(f"z: {mapped} (mapped from stream {stream})")
-    return mapped
+def split_base_version(base_version):
+    components = base_version.split('.')
+    if len(components) == 1:
+        return int(components[0]), 0
+    else:
+        return int(components[0]), int(components[1])
 
 
 def get_next_iteration_from_builds(x, y, z):
@@ -182,12 +199,16 @@ def get_next_iteration_from_git(timestamp):
 def parse_version(version):
     # Note that (?:pattern) os a non-matching group in python regex so
     # it won't show up in the matched m.groups()
-    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+)\.(?:dev)?([0-9]+)$', version)
+    m = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)(?:\.|-)(?:dev)?([0-9]+)$', version)
     if m is None:
         return None
-    # sanity-check date
+    # sanity-check date. The time could be in the y component or z component
+    # so we have to look for it in either.
+    timegroup = 2
+    if len(m.group(3)) == 8:
+        timegroup = 3
     try:
-        time.strptime(m.group(2), '%Y%m%d')
+        time.strptime(m.group(timegroup), '%Y%m%d')
     except ValueError:
         return None
     return tuple(map(int, m.groups()))

--- a/versionary
+++ b/versionary
@@ -189,7 +189,7 @@ def get_next_iteration_from_git(timestamp):
             f"n: {commit_count_since_change} "
             "(calculated using git commit history)"
         )
-        return commit_count_since_change
+        return int(commit_count_since_change)
     except subprocess.CalledProcessError as err:
         msg = (
             "Git command failed: unable to determine the next "

--- a/versionary
+++ b/versionary
@@ -49,7 +49,7 @@ def main():
     x, y, z, n = (0, 0, 0, 0)
 
     # Pick up values from our build-args.
-    config = dotenv.dotenv_values('src/config/build-args.conf')
+    config = dotenv.dotenv_values(args.build_args)
 
     # Grab the current datetime object representing the timestamp
     # for the timestamp component of our version.
@@ -94,6 +94,8 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--build-args', help="path to build-args.conf",
+                        default='src/config/build-args.conf')
     parser.add_argument('--workdir', help="path to cosa workdir")
     parser.add_argument(
         "--dev", action="store_true", help="generate a developer version"

--- a/versionary
+++ b/versionary
@@ -135,16 +135,16 @@ def get_next_iteration_from_builds(x, y, z):
         return 0
 
     last_buildid = builds['builds'][0]['id']
-    last_version = parse_version(last_buildid)
-    if not last_version:
+    last_version_tuple = parse_version(last_buildid)
+    if not last_version_tuple:
         eprint(f"n: 0 (previous version {last_buildid} does not match scheme)")
         return 0
 
-    if (x, y, z) != last_version[:3]:
+    if (x, y, z) != last_version_tuple[:3]:
         eprint(f"n: 0 (previous version {last_buildid} x.y.z does not match)")
         return 0
 
-    n = last_version[3] + 1
+    n = last_version_tuple[3] + 1
     eprint(f"n: {n} (incremented from previous version {last_buildid})")
     return n
 

--- a/versionary
+++ b/versionary
@@ -77,7 +77,7 @@ def get_x(config):
     """
         X is the base release version on which we're based.
     """
-    base_version = config['BASE_VERSION']
+    base_version = config['VERSION']
     eprint(f"x: {base_version} (from config)")
     return int(base_version)
 

--- a/versionary
+++ b/versionary
@@ -23,12 +23,6 @@ import yaml
 
 from datetime import datetime
 
-# streams which don't use lockfiles
-UNLOCKED_STREAMS = [
-    'bodhi-updates-testing',
-    'bodhi-updates',
-]
-
 # https://github.com/coreos/fedora-coreos-tracker/issues/211#issuecomment-543547587
 STREAM_TO_NUM = {
     'next': 1,
@@ -51,7 +45,7 @@ def main():
 
     config = dotenv.dotenv_values('src/config/build-args.conf')
     x, z = (get_x(config), get_z(config, args.dev))
-    y, y_as_timestamp = get_y(config)
+    y, y_as_timestamp = get_y()
     # Default behavior generates the iteration from Git (dev mode uses builds)
     if args.dev:
         n = get_next_iteration_from_builds(x, y, z)
@@ -82,13 +76,11 @@ def get_x(config):
     return int(base_version)
 
 
-def get_y(config):
+def get_y():
     """
         Y is the base snapshot date in YYYYMMDD format of Fedora. We derive
         this using the timestamp in the base lockfile.
     """
-
-    stream = config['STREAM']
 
     # XXX: should sanity check that the lockfiles for all the basearches have
     # matching timestamps
@@ -103,15 +95,12 @@ def get_y(config):
                     raise Exception("Missing 'metadata.generated' key "
                                     f"from {lockfile}")
                 dt = datetime.strptime(generated, '%Y-%m-%dT%H:%M:%SZ')
-                assert stream not in UNLOCKED_STREAMS
                 msg_src = "from lockfile"
                 break
         except FileNotFoundError:
             continue
     else:
-        # must be an unlocked stream
-        assert stream in UNLOCKED_STREAMS
-        msg_src = "unlocked stream"
+        msg_src = "from datetime.now()"
         dt = datetime.now()
 
     ymd = dt.strftime('%Y%m%d')


### PR DESCRIPTION
We now drain even more out of the manifests and into build-args. Also adding support for RHCOS/SCOS versioning to versionary so we can drop the donstream version of the code that exists today in https://github.com/coreos/rhel-coreos-config/blob/3dd484ecda8f8d81514e5f2e2fd3746e6aa3efcb/versionary

See individual commit messages.