### PR TITLE
[rawhide]: Move more things into build-args.conf

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -1,18 +1,14 @@
 # Stream-specific build arguments.
 # Pass to buildah/podman using `--build-arg-file`.
-#
-# This is the base version. This value will get used as a starting point for
-# determining what the actual version should be. It's also the value that gets found
-# and replaced in /usr/lib/os-release.
-BASE_VERSION=44
-# This is the developer default version. In COSA builds or pipeline runs, this will get
-# overridden by versionary.
-VERSION=44.dev
+
+ID=fedora
+NAME=fedora-coreos
+STREAM=rawhide
+DESCRIPTION=Fedora CoreOS rawhide
+VERSION=44
+MUTATE_OS_RELEASE=44
 BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:99622cfadfc5691a0c628a9499f608aa003d1aaf7fd9a90dd26c6aac09365222
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
-NAME=fedora-coreos
-STREAM=rawhide
-DESCRIPTION=Fedora CoreOS rawhide
 IMAGE_CONFIG=image.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,12 +1,6 @@
-variables:
-  stream: rawhide
-  prod: false
-
 metadata:
   # tell `cosa build` to default to buildah path
   build_with_buildah: true
-
-releasever: 44
 
 repos:
   - fedora-rawhide

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -12,3 +12,13 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
+
+conditional-include:
+  # Temporary hack to include systemd-pam. This is fixed in bootc base
+  # images [1], but they are having trouble building rawhide right now [2].
+  # [1] https://gitlab.com/fedora/bootc/base-images/-/merge_requests/350
+  # [2] https://gitlab.com/fedora/bootc/tracker/-/issues/84
+  - if: releasever == 44
+    include:
+      packages:
+        - systemd-pam


### PR DESCRIPTION
and also name systemd-pam in our packages list as a temporary workaround/hack.

See individual commit messages.