### PR TITLE
denylist: deny kdump.crash.ssh && ext.config.kdump.crash on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,3 +7,15 @@
 ##  warn: true
 ##  arches:
 ##    - aarch64
+
+- pattern: kdump.crash.ssh
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
+  snooze: 2026-02-28
+  arches:
+    - s390x
+
+- pattern: ext.config.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
+  snooze: 2026-02-28
+  arches:
+    - s390x


### PR DESCRIPTION
see : https://github.com/coreos/fedora-coreos-tracker/issues/2100