### PR TITLE
denylist: extend kdump.crash denials to include kdump.crash.nfs

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,15 +8,7 @@
 ##  arches:
 ##    - aarch64
 
-- pattern: kdump.crash.ssh
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
-  snooze: 2026-02-28
-  arches:
-    - s390x
-  streams:
-    - rawhide
-
-- pattern: ext.config.kdump.crash
+- pattern: '*kdump.crash*'
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
   snooze: 2026-02-28
   arches:


### PR DESCRIPTION
This test is also failing on s390x along with the others.

https://github.com/coreos/fedora-coreos-tracker/issues/2100