### PR TITLE
Revert "manifest: temporarily name systemd-pam in our packages"

### DIFF
--- a/.tekton/trigger
+++ b/.tekton/trigger
@@ -6,4 +6,4 @@
 # on the pipeline.
 # See https://github.com/coreos/fedora-coreos-tracker/issues/2038#issuecomment-3498258143
 # The format is YYYYMMDD
-20260130
+20260129

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,13 +6,3 @@ repos:
   - fedora-rawhide
 
 include: manifests/fedora-coreos.yaml
-
-conditional-include:
-  # Temporary hack to include systemd-pam. This is fixed in bootc base
-  # images [1], but they are having trouble building rawhide right now [2].
-  # [1] https://gitlab.com/fedora/bootc/base-images/-/merge_requests/350
-  # [2] https://gitlab.com/fedora/bootc/tracker/-/issues/84
-  - if: releasever == 44
-    include:
-      packages:
-        - systemd-pam


### PR DESCRIPTION
This reverts commit b64c6b9b822b135108e67bc28a859fecef20941c. 
We inherit the change from bootc since 5e6a796
Also, we edit the trigger file to make Konflux start a new build.