### PR TITLE
Drop fedora-repos-ostree in F44

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -39,6 +39,11 @@ conditional-include:
     include:
       ostree-layers:
         - overlay/50alternatives
+  # Drop fedora-repos-ostree in F44
+  - if: releasever < 44
+    include:
+      packages:
+        - fedora-repos-ostree
 
 ostree-layers:
   - overlay/15fcos
@@ -47,7 +52,6 @@ ostree-layers:
 
 packages:
   - fedora-release-coreos
-  - fedora-repos-ostree
   # CL ships this.
   - moby-engine
   # Already pulled in by moby-engine, but let's be explicit. Typhoon uses it.


### PR DESCRIPTION
This may have other implications. Let's see what CI says.