### PR TITLE
[rawhide] Rawhide is now Fedora Linux 45

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -5,9 +5,9 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=rawhide
 DESCRIPTION=Fedora CoreOS rawhide
-VERSION=44
-MUTATE_OS_RELEASE=44
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:bd28a2cb7ef091476de4ffd7b99bea9b15632ff172c46299689672e2303db3f4
+VERSION=45
+MUTATE_OS_RELEASE=45
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:d5bfad158b3a58f1c94164faef765ad7dbb05af2efc3e62d7eee1a0044b695b7
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests


### PR DESCRIPTION
Branching for F44 has happened so we need to switch rawhide to be based on F45.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/2055