### PR TITLE
platforms/hetzner: Console configuration for aarch64 systems

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -25,6 +25,10 @@ conditional-include:
       # All Fedora CoreOS streams share the same pool for locked files.
       lockfile-repos:
         - fedora-coreos-pool
+  - if: basearch == "aarch64"
+    include:
+      ostree-layers:
+        - overlay/10aarch64
   # In F43 and older pull in the nfs-utils-coreos package
   - if: releasever <= 43
     include:

--- a/overlay.d/10aarch64/usr/lib/dracut/dracut.conf.d/50-virtio-gpu.conf
+++ b/overlay.d/10aarch64/usr/lib/dracut/dracut.conf.d/50-virtio-gpu.conf
@@ -1,0 +1,7 @@
+# On aarch64 virtio platforms (e.g. Hetzner Cloud), the virtio-gpu
+# kernel module is required in the initramfs for console output
+# during early boot. We need to manually enable this since we can't
+# rely on hostonly=yes.
+# FCOS issue: https://github.com/coreos/fedora-coreos-tracker/issues/1959
+# Upstream issue: https://github.com/dracut-ng/dracut-ng/issues/2362
+force_drivers+=" virtio-gpu "

--- a/platforms.yaml
+++ b/platforms.yaml
@@ -42,6 +42,15 @@ aarch64:
     kernel_arguments:
       - console=tty0
       - console=ttyAMA0,115200n8
+  hetzner:
+    # Related issue: https://github.com/coreos/fedora-coreos-tracker/issues/1959
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8
   openstack:
     # Graphical console primary, serial console available for logging
     # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html


### PR DESCRIPTION
Opening this PR to hopefully lead to further discussions on how to proceed with coreos/fedora-coreos-tracker#1959

As described there, it seems there is room to improve the solution, but I'm not sure how.