### PR TITLE
tests/toolbox: adjust to be runnable on RHCOS

### DIFF
--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -1,52 +1,114 @@
 #!/bin/bash
 ## kola:
 ##   tags: "platform-independent needs-internet"
-##   # This test only runs on FCOS because RHCOS is missing the `machinectl` command.
-##   # Additionally, there are some distro specific choices made for this test that
-##   # should/could be adapted for RHCOS.
-##   # TODO-RHCOS: adapt test for RHCOS specifics or create separate RHCOS toolbox test
-##   distros: fcos
 ##   # Toolbox container is currently available only for x86_64 and aarch64 in Fedora
 ##   architectures: x86_64 aarch64
 ##   description: Make sure that basic toolbox functionality works (creating,
 ##     running commands, and removing).
-
-# Important note: Commands are run indirectly via calls to `machinectl shell`
-# to re-create the user environment needed for unprivileged podman
-# functionality. However, machinectl shell does not propagate the exit
-# code/status of the invoked shell process thus we need additionnal checks to
-# ensure that previous commands were successful.
+##   creationDate: 2026-05-05
 
 set -xeuo pipefail
 
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
+# IMPORTANT: Commands are run indirectly via `su - core` to re-create the
+# user environment needed for unprivileged podman functionality.
+run_as_core() {
+    su - core -c "$(printf '%q ' "$@")"
+}
+
+# Functions for testing basic functionality - overridden depending on toolbox being used
+toolbox_create() {
+    run_as_core /bin/toolbox create --assumeyes 1> /dev/null
+}
+
+toolbox_run_basic() {
+    run_as_core /bin/toolbox run touch ok_toolbox
+}
+
+toolbox_list() {
+    run_as_core /bin/toolbox list --containers
+}
+
+toolbox_count() {
+    toolbox_list | grep --count -E "(fedora|rhel)-toolbox-" || true
+}
+
+toolbox_rm() {
+    toolbox="$(toolbox_list | awk '/(fedora|rhel)-toolbox-/ {print $2}')"
+    run_as_core /bin/toolbox rm -f "${toolbox}"
+}
+
+# Older variants (e.g. RHEL-9.8) use https://github.com/coreos/toolbox
+# NOTE: script uses privileged podman
+if file /bin/toolbox | grep -q "shell script"; then
+    echo "Using toolbox script <https://github.com/coreos/toolbox>"
+
+    # Create configuration for coreos/toolbox
+    rhel_major_version=$(get_rhel_maj_ver)
+    cat << EOF > /var/home/core/.toolboxrc
+REGISTRY=registry.access.redhat.com
+IMAGE=ubi${rhel_major_version}/toolbox:latest
+TOOLBOX_NAME=rhel-toolbox-latest
+AUTHFILE=/var/home/core/config.json
+EOF
+    # Toolbox fails if the AUTHFILE does not exist, but we don't actually need credentials
+    echo '{}' > /var/home/core/config.json
+
+    toolbox_create() {
+        # Container created on first run of any command
+        run_as_core /bin/toolbox true
+    }
+
+    toolbox_run_basic() {
+        run_as_core /bin/toolbox touch /host/home/core/ok_toolbox
+    }
+
+    toolbox_list() {
+        /bin/podman ps -a
+    }
+
+    toolbox_rm() {
+        toolbox="$(toolbox_list | awk '/(fedora|rhel)-toolbox-/ {print $1}')"
+        /bin/podman rm -f "${toolbox}"
+    }
+elif is_rhcos; then
+    # When using an image that's not yet released (e.g.
+    # 10.2 as of writing this) the image won't exist in the
+    # registry. Let's just use the `:latest` tag so we don't
+    # hit that problem.
+    rhel_major_version=$(get_rhel_maj_ver)
+    cat << EOF > /etc/containers/toolbox.conf
+[general]
+image = "registry.access.redhat.com/ubi${rhel_major_version}/toolbox:latest"
+EOF
+fi
+
 # Try five times to create the toolbox to avoid container registry infra flakes
 for i in {1..5}; do
-    machinectl -q shell core@ /bin/toolbox create --assumeyes 1>/dev/null
-    if [[ $(machinectl -qE TERM=dumb shell core@ /bin/toolbox list --containers | grep --count fedora-toolbox-) -ne 1 ]]; then
-        echo "Could not create toolbox on try: $i"
-        sleep 10
-    else
+    toolbox_create || true
+    if [[ $(toolbox_count) -eq 1 ]]; then
         break
     fi
+
+    if [[ $i -eq 5 ]]; then
+        fatal "Could not create toolbox after 5 attempts"
+    fi
+
+    echo "Could not create toolbox on try: $i"
+    sleep 10
 done
-if [[ $(machinectl -qE TERM=dumb shell core@ /bin/toolbox list --containers | grep --count fedora-toolbox-) -ne 1 ]]; then
-    fatal "Could not create toolbox"
-fi
 ok toolbox create
 
-machinectl -q shell core@ /bin/toolbox run touch ok_toolbox
+toolbox_run_basic
 if [[ ! -f '/home/core/ok_toolbox' ]]; then
     fatal "Could not run a simple command inside a toolbox"
 fi
 ok toolbox run
 
-toolbox="$(machinectl -qE TERM=dumb shell core@ /bin/toolbox list --containers | awk '/fedora-toolbox-/ {print $2}')"
-machinectl -q shell core@ /bin/podman stop "${toolbox}"
-machinectl -q shell core@ /bin/toolbox rm "${toolbox}"
-if [[ -n "$(machinectl -qE TERM=dumb shell core@ /bin/toolbox list --containers)" ]]; then
+toolbox_rm
+if [[ $(toolbox_count) -ne 0 ]]; then
     fatal "Could not remove the toolbox container"
 fi
 ok toolbox rm


### PR DESCRIPTION
Closes openshift/os#1035

This will should enable running the basic toolbox test for RHCOS.

To explain a couple of the reasons it would not work in its current state in RHCOS, and the changes this PR makes to get around them:

1. No `machinectl` command on RHCOS. I've instead used `su - core` to run commands as the core user. Also has the minor benefit of propagating error codes, though I opted to keep the explicit checks anyway.
2. Grep and awk calls were looking only for `fedora-toolbox-`. I simply expanded the search to also accept `rhel-toolbox-`.
3. The rhel-9.8 variant is using [this toolbox](https://github.com/coreos/toolbox) - this is the one that adds the most complexity to this script. Commands for this one are completely different, the script uses root podman and requires extra configuration. I have a butane config to setup the tool as required, and I've defined and overridden functions to test the same functionality across this script and the modern toolbox binary.

I would love feedback, as I'm not sure all the decisions I made were the best ones. For example, I could see a case for keeping the `machinectl` path for systems which have it available, as it actually simulates an interactive login. Also, do we even need to test that older toolbox script? Either way, I'm happy to make any changes.