### PR TITLE
overrides: fast-track ignition-2.26.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,6 +19,16 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c9a2529ed0
       type: fast-track
+  ignition:
+    evr: 2.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      type: fast-track
+  ignition-grub:
+    evr: 2.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      type: fast-track
   podman:
     evr: 5:5.7.1-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).