### PR TITLE
Skip acquiring the repo lock file

### DIFF
--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -80,7 +80,8 @@ build_derived_ociarchive() {
         c9s_mirror="https://mirror.stream.centos.org/9-stream/BaseOS/${arch}/os"
         # we're probably already on CentOS and running the latest kernel. so
         # here we need to instead pick whatever the latest that's *not* the same
-        dnf_opts="--repofrompath=tmp,"${c9s_mirror}" --disablerepo=* --enablerepo tmp"
+        printf "[main]\nskip_system_repo_lock=true" > dnf_config
+        dnf_opts="--config=dnf_config --repofrompath=tmp,"${c9s_mirror}" --disablerepo=* --enablerepo tmp"
         kver=$(dnf repoquery $dnf_opts kernel --qf '%{EVR}' | \
                   grep -v "$(rpm -q kernel --qf '%{EVR}')" | tail -n1)
         dnf download $dnf_opts --resolve kernel-{,core-,modules-,modules-core-,modules-extra-}$kver

--- a/tests/kola/systemd/sysexts
+++ b/tests/kola/systemd/sysexts
@@ -33,7 +33,9 @@ build_sysext(){
   # - Resolve dependency relative to the current root
   # - Only get packages for the current arch and arch independent ones
   # - Disable the OpenH264 repo as it's a frequent source of flakes
+  printf "[main]\nskip_system_repo_lock=true" > dnf_config
   dnf download \
+      --config=dnf_config \
       --resolve \
       --arch="noarch" \
       --arch="$(arch)" \


### PR DESCRIPTION
Since [1], libdnf stores a repo lock file in
`/usr/lib/sysimage/libdnf5/system-repo.lock` but as /usr is read-only, it fails.
We skip this operation in all the impacted dnf calls.

I'm editing the general dnf config instead of directly specifying the
`--skip-file-locks` option in order to keep backward compatibilty
with streams and downstream that do not have the new flag option.

Closes [2].

[1] https://github.com/rpm-software-management/dnf5/pull/2519
[2] https://github.com/coreos/fedora-coreos-tracker/issues/2113