### PR TITLE
extend denial of kdump.crash tests on s390x rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,7 +10,7 @@
 
 - pattern: '*kdump.crash*'
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
-  snooze: 2026-02-28
+  snooze: 2026-03-31
   arches:
     - s390x
   streams:


### PR DESCRIPTION
RCs of kernel 6.20.0 have an issue where, after the kernel dump, qemu-system-s390x either hangs or terminates.

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/2100