### PR TITLE
.tekton: disable hermetic for branched stream

### DIFF
--- a/.tekton/branched/on-pull-request-overrides/fedora-coreos-branched-on-pull-request-overrides.yaml
+++ b/.tekton/branched/on-pull-request-overrides/fedora-coreos-branched-on-pull-request-overrides.yaml
@@ -43,7 +43,7 @@ spec:
   - name: clone-depth
     value: 50
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: '[{"type": "rpm", "path": "."}]'
   - name: image-expires-after

--- a/.tekton/branched/on-pull-request-overrides/kustomization.yaml
+++ b/.tekton/branched/on-pull-request-overrides/kustomization.yaml
@@ -33,3 +33,6 @@ patches:
       - op: replace
         path: /metadata/name
         value: 'fedora-coreos-branched-on-pull-request-overrides'
+      - op: replace
+        path: /spec/params/10/value
+        value: false

--- a/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
+++ b/.tekton/branched/on-pull-request/fedora-coreos-branched-on-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
   - name: clone-depth
     value: 50
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: '[{"type": "rpm", "path": "."}]'
   - name: image-expires-after

--- a/.tekton/branched/on-pull-request/kustomization.yaml
+++ b/.tekton/branched/on-pull-request/kustomization.yaml
@@ -33,3 +33,6 @@ patches:
       - op: replace
         path: /metadata/name
         value: 'fedora-coreos-branched-on-pull-request'
+      - op: replace
+        path: /spec/params/10/value
+        value: false

--- a/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
+++ b/.tekton/branched/on-push/fedora-coreos-branched-on-push.yaml
@@ -42,7 +42,7 @@ spec:
   - name: clone-depth
     value: 50
   - name: hermetic
-    value: true
+    value: false
   - name: prefetch-input
     value: '[{"type": "rpm", "path": "."}]'
   pipelineRef:

--- a/.tekton/branched/on-push/kustomization.yaml
+++ b/.tekton/branched/on-push/kustomization.yaml
@@ -33,3 +33,6 @@ patches:
       - op: replace
         path: /metadata/name
         value: 'fedora-coreos-branched-on-push'
+      - op: replace
+        path: /spec/params/10/value
+        value: false


### PR DESCRIPTION
branched stream does not use manifest lockfiles, so building it hermetically is not possible as we derived from the manifest lockfiles to generate the Konflux ones.