### PR TITLE
overlay/container-signing: add F42, drop F45 key

### DIFF
--- a/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
+++ b/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
@@ -44,9 +44,9 @@
           "type": "signedBy",
           "keyType": "GPGKeys",
           "keyPaths": [
-            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-42-primary",
             "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-43-primary",
-            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-primary"
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-primary",
+            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-45-primary"
           ]
         }
       ]


### PR DESCRIPTION
Rawhide is now F45 so we need to add that key to the policy. We can drop the F42 key since we are no longer building for F42.