### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,16 +21,6 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c623038804
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
       type: fast-track
-  coreos-installer:
-    evr: 0.25.0-5.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c9a2529ed0
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.25.0-5.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c9a2529ed0
-      type: fast-track
   podman:
     evr: 5:5.8.0-1.fc43
     metadata:
@@ -42,9 +32,4 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c623038804
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
-      type: fast-track
-  zincati:
-    evr: 0.0.32-1.fc43
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-7fbf04756e
       type: fast-track


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).