### PR TITLE
[branched] overrides: fast-track ignition-2.26.0-2.fc44, rust-afterburn-5.10.0-4.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  afterburn:
+    evr: 5.10.0-4.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      type: fast-track
+  afterburn-dracut:
+    evr: 5.10.0-4.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      type: fast-track
+  ignition:
+    evr: 2.26.0-2.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      type: fast-track
+  ignition-grub:
+    evr: 2.26.0-2.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      type: fast-track


### PR DESCRIPTION
Requested by @joelcapitao via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).