### PR TITLE
[next-devel] overrides: fast-track ignition-2.26.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,6 +21,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c623038804
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
       type: fast-track
+  ignition:
+    evr: 2.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      type: fast-track
+  ignition-grub:
+    evr: 2.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      type: fast-track
   podman:
     evr: 5:5.8.0-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).