### PR TITLE
tests/alternatives: enable using fedora-coreos-pool for overlaying RPM

### DIFF
--- a/tests/kola/files/alternatives/data/commonlib.sh
+++ b/tests/kola/files/alternatives/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/files/alternatives/data/fedora-coreos-pool.repo
+++ b/tests/kola/files/alternatives/data/fedora-coreos-pool.repo
@@ -1,0 +1,1 @@
+../../../../../fedora-coreos-pool.repo

--- a/tests/kola/files/alternatives/test.sh
+++ b/tests/kola/files/alternatives/test.sh
@@ -32,7 +32,9 @@ fi
 # To test the migration we will re-create the setup from an older FCOS node
 
 # We need to overlay iptables-legacy as it is not included in the base image
-# since 43.
+# since 43. To make sure we can always get the same version of iptables-legacy
+# as the iptables version in FCOS let's include the fedora-coreos-pool.repo.
+cp "${KOLA_EXT_DATA}/fedora-coreos-pool.repo" /etc/yum.repos.d/
 rpm-ostree install --apply-live iptables-legacy
 
 # First, reset iptables to the legacy backend


### PR DESCRIPTION
We occasionally hit an issue where rawhide becomes out of date for a few days (CI failures, etc) and the alternatives test will start failing if there is a new iptables package that shipped in the meantime.

Let's convert this test to be able to grab the right version of iptables from the coreos-pool, since that repo definitely has the all the subpackages of the iptables that was baked into the last `rawhide` build.