### PR TITLE
[next-devel] overrides: fast-track rust-coreos-installer-0.26.0-1.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -21,6 +21,16 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-c623038804
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
       type: fast-track
+  coreos-installer:
+    evr: 0.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-4c93ab89d9
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.26.0-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-4c93ab89d9
+      type: fast-track
   ignition:
     evr: 2.26.0-1.fc43
     metadata:


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).