### PR TITLE
overrides: drop podman pin

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -19,8 +19,3 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
       type: fast-track
-  podman:
-    evr: 5:5.7.1-1.fc43
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
-      type: pin


### PR DESCRIPTION
The experiment in `next` hasn't had any reports of failures so I'd say we can drop the pin here and when the package reaches bodhi stable it will flow into CoreOS.