### PR TITLE
kola: bump minimum memory for alternatives test

### DIFF
--- a/tests/kola/files/alternatives/test.sh
+++ b/tests/kola/files/alternatives/test.sh
@@ -4,6 +4,8 @@
 ##   tags: "platform-independent needs-internet"
 ##   description: Verify that the alternatives config is properly migrated and test the migration
 ##   distros: fcos
+##   ## package layering needs more memory
+##   minMemory: 1536
 # See
 # - https://github.com/coreos/fedora-coreos-tracker/issues/1818
 


### PR DESCRIPTION
The alternatives test is now failing because rpm-ostree gets OOM killed because we're now including the coreos-pool repo when layering iptables-legacy [1]. Let's just bump the minimum required memory for now.

[1] https://github.com/coreos/fedora-coreos-config/pull/4038