### PR TITLE
next-devel is now Fedora Linux 44

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -5,9 +5,9 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=next-devel
 DESCRIPTION=Fedora CoreOS next-devel
-VERSION=43
-MUTATE_OS_RELEASE=43
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:e5943df7d90e016a201b311001b4296e362b914d3077a704363d38eed40f421b
+VERSION=44
+MUTATE_OS_RELEASE=44
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:230a707fe23fc447c1658643ab043d3d989c278ded2d6b9668dad0ed41712120
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1348 +1,1369 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.55.91-3.fc44.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.55.91-3.fc44.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.55.91-3.fc44.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.55.91-3.fc44.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.55.91-3.fc44.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.15.0.1-1.fc43.noarch"
+      "evra": "2.15.0.1-3.fc44.noarch"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.0-1.fc43.x86_64"
+      "evra": "2:1.17.0-3.fc44.x86_64"
     },
     "acl": {
-      "evra": "2.3.2-4.fc43.x86_64"
+      "evra": "2.3.2-6.fc44.x86_64"
     },
     "adcli": {
-      "evra": "0.9.2-10.fc43.x86_64"
+      "evra": "0.9.3.1-5.fc44.x86_64"
+    },
+    "adcli-selinux": {
+      "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-3.fc43.x86_64"
+      "evra": "5.10.0-4.fc44.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-3.fc43.x86_64"
+      "evra": "5.10.0-4.fc44.x86_64"
     },
     "alternatives": {
-      "evra": "1.33-3.fc43.x86_64"
+      "evra": "1.33-5.fc44.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-6.fc43.x86_64"
+      "evra": "2.5.2-8.fc44.x86_64"
     },
     "audit": {
-      "evra": "4.1.3-1.fc43.x86_64"
+      "evra": "4.1.3-1.fc44.x86_64"
     },
     "audit-libs": {
-      "evra": "4.1.3-1.fc43.x86_64"
+      "evra": "4.1.3-1.fc44.x86_64"
     },
     "audit-rules": {
-      "evra": "4.1.3-1.fc43.x86_64"
+      "evra": "4.1.3-1.fc44.x86_64"
     },
     "authselect": {
-      "evra": "1.6.2-1.fc43.x86_64"
+      "evra": "1.7.1-1.fc44.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.6.2-1.fc43.x86_64"
-    },
-    "avahi-libs": {
-      "evra": "0.9~rc2-6.fc43.x86_64"
+      "evra": "1.7.1-1.fc44.x86_64"
     },
     "azure-vm-utils": {
-      "evra": "0.7.0-1.fc43.x86_64"
+      "evra": "0.7.0-3.fc44.x86_64"
     },
     "bash": {
-      "evra": "5.3.0-2.fc43.x86_64"
+      "evra": "5.3.9-3.fc44.x86_64"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-2.fc43.noarch"
+      "evra": "0.7.1-3.fc44.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.16-2.fc43.noarch"
+      "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.44-1.fc43.x86_64"
+      "evra": "32:9.18.44-2.fc44.x86_64"
     },
     "bind-utils": {
-      "evra": "32:9.18.44-1.fc43.x86_64"
+      "evra": "32:9.18.44-2.fc44.x86_64"
     },
     "bootc": {
-      "evra": "1.12.1-1.fc43.x86_64"
+      "evra": "1.12.1-1.fc44.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.32-2.fc43.x86_64"
+      "evra": "0.2.32-3.fc44.x86_64"
     },
     "bsdtar": {
-      "evra": "3.8.4-1.fc43.x86_64"
+      "evra": "3.8.4-2.fc44.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.17.1-1.fc43.x86_64"
+      "evra": "6.19-1.fc44.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.11.0-2.fc43.x86_64"
+      "evra": "0.11.0-4.fc44.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-21.fc43.x86_64"
+      "evra": "1.0.8-23.fc44.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-21.fc43.x86_64"
+      "evra": "1.0.8-23.fc44.x86_64"
     },
     "c-ares": {
-      "evra": "1.34.5-2.fc43.x86_64"
+      "evra": "1.34.6-3.fc44.x86_64"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.1.fc43.noarch"
+      "evra": "2025.2.80_v9.0.304-5.fc44.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-3.fc43.x86_64"
+      "evra": "0.2.1-5.fc44.x86_64"
     },
     "chrony": {
-      "evra": "4.8-3.fc43.x86_64"
+      "evra": "4.8-5.fc44.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.2-2.fc43.x86_64"
+      "evra": "7.4-3.fc44.x86_64"
     },
     "clevis": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-dracut": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-luks": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-10.fc43.x86_64"
+      "evra": "0.5.3-12.fc44.x86_64"
     },
     "clevis-systemd": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-11.fc43.noarch"
+      "evra": "0.33-13.fc44.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-3.fc43.x86_64"
+      "evra": "1.0.8-5.fc44.x86_64"
     },
     "composefs-libs": {
-      "evra": "1.0.8-3.fc43.x86_64"
+      "evra": "1.0.8-5.fc44.x86_64"
     },
     "conmon": {
-      "evra": "2:2.1.13-2.fc43.x86_64"
+      "evra": "2:2.2.0-3.fc44.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.245.0-1.fc43.noarch"
+      "evra": "4:2.245.0-3.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.1.6-1.fc43.x86_64"
+      "evra": "2.2.0-4.fc44.x86_64"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.25.0-5.fc43.x86_64"
+      "evra": "0.25.0-5.fc44.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-5.fc43.x86_64"
+      "evra": "0.25.0-5.fc44.x86_64"
     },
     "coreutils": {
-      "evra": "9.7-7.fc43.x86_64"
+      "evra": "9.9-4.fc44.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.7-7.fc43.x86_64"
+      "evra": "9.9-4.fc44.x86_64"
     },
     "cpio": {
-      "evra": "2.15-6.fc43.x86_64"
+      "evra": "2.15-9.fc44.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.11-8.fc43.x86_64"
+      "evra": "2.9.11-10.fc44.x86_64"
     },
     "criu": {
-      "evra": "4.2-11.fc43.x86_64"
+      "evra": "4.2-13.fc44.x86_64"
     },
     "criu-libs": {
-      "evra": "4.2-11.fc43.x86_64"
+      "evra": "4.2-13.fc44.x86_64"
     },
     "crun": {
-      "evra": "1.25.1-1.fc43.x86_64"
+      "evra": "1.26-3.fc44.x86_64"
     },
     "crun-wasm": {
-      "evra": "1.25.1-1.fc43.x86_64"
+      "evra": "1.26-3.fc44.x86_64"
     },
     "crypto-policies": {
-      "evra": "20251125-1.git63291f8.fc43.noarch"
+      "evra": "20251128-3.git19878fe.fc44.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc43.x86_64"
+      "evra": "2.8.4-1.fc44.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc43.x86_64"
+      "evra": "2.8.4-1.fc44.x86_64"
     },
     "curl": {
-      "evra": "8.15.0-5.fc43.x86_64"
+      "evra": "8.18.0-4.fc44.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-33.fc43.x86_64"
+      "evra": "2.1.28-35.fc44.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-33.fc43.x86_64"
+      "evra": "2.1.28-35.fc44.x86_64"
     },
     "dbus": {
-      "evra": "1:1.16.0-4.fc43.x86_64"
+      "evra": "1:1.16.0-8.fc44.x86_64"
     },
     "dbus-broker": {
-      "evra": "37-2.fc43.x86_64"
+      "evra": "37-8.fc44.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-4.fc43.noarch"
+      "evra": "1:1.16.0-8.fc44.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-4.fc43.x86_64"
+      "evra": "1:1.16.0-8.fc44.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-4.fc43.x86_64"
+      "evra": "1.3.1-3.fc44.x86_64"
     },
     "diffutils": {
-      "evra": "3.12-3.fc43.x86_64"
+      "evra": "3.12-5.fc44.x86_64"
     },
     "dnf5": {
-      "evra": "5.2.18.0-1.fc43.x86_64"
+      "evra": "5.3.0.0-7.fc44.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.92-1.fc43.x86_64"
+      "evra": "2.92-4.fc44.x86_64"
     },
     "docker-cli": {
-      "evra": "29.2.1-2.fc43.x86_64"
+      "evra": "29.2.1-2.fc44.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-16.fc43.x86_64"
+      "evra": "4.2-18.fc44.x86_64"
     },
     "dracut": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-5.fc44.x86_64"
     },
     "dracut-network": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-5.fc44.x86_64"
     },
     "dracut-squash": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-5.fc44.x86_64"
     },
     "duktape": {
-      "evra": "2.7.0-10.fc43.x86_64"
+      "evra": "2.7.0-11.fc44.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "efi-filesystem": {
-      "evra": "6-4.fc43.noarch"
+      "evra": "6-6.fc44.noarch"
     },
     "efibootmgr": {
-      "evra": "18-10.fc43.x86_64"
+      "evra": "18-11.fc44.x86_64"
     },
     "efivar-libs": {
-      "evra": "39-10.fc43.x86_64"
+      "evra": "39-12.fc44.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.194-1.fc43.noarch"
+      "evra": "0.194-3.fc44.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.194-1.fc43.x86_64"
+      "evra": "0.194-3.fc44.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.194-1.fc43.x86_64"
+      "evra": "0.194-3.fc44.x86_64"
     },
     "ethtool": {
-      "evra": "2:6.15-3.fc43.x86_64"
+      "evra": "2:6.15-4.fc44.x86_64"
     },
     "expat": {
-      "evra": "2.7.3-1.fc43.x86_64"
+      "evra": "2.7.3-2.fc44.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "43-1.noarch"
+      "evra": "44-0.3.noarch"
     },
     "fedora-release-common": {
-      "evra": "43-26.noarch"
+      "evra": "44-0.14.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "43-26.noarch"
+      "evra": "44-0.14.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "43-26.noarch"
+      "evra": "44-0.14.noarch"
     },
     "fedora-repos": {
-      "evra": "43-1.noarch"
+      "evra": "44-0.3.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "43-1.noarch"
-    },
-    "fedora-repos-ostree": {
-      "evra": "43-1.noarch"
+      "evra": "44-0.3.noarch"
     },
     "file": {
-      "evra": "5.46-8.fc43.x86_64"
+      "evra": "5.46-9.fc44.x86_64"
     },
     "file-libs": {
-      "evra": "5.46-8.fc43.x86_64"
+      "evra": "5.46-9.fc44.x86_64"
     },
     "filesystem": {
-      "evra": "3.18-50.fc43.x86_64"
+      "evra": "3.18-52.fc44.x86_64"
     },
     "findutils": {
-      "evra": "1:4.10.0-6.fc43.x86_64"
+      "evra": "1:4.10.0-7.fc44.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.16.3-1.fc43.x86_64"
+      "evra": "1.17.2-2.fc44.x86_64"
     },
     "fmt": {
-      "evra": "11.2.0-3.fc43.x86_64"
+      "evra": "11.2.0-4.fc44.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-13.fc43.x86_64"
+      "evra": "0.6.1-14.fc44.x86_64"
     },
     "fuse-common": {
-      "evra": "3.16.2-5.fc42.x86_64"
+      "evra": "3.18.1-2.fc44.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.13-4.fc43.x86_64"
+      "evra": "1.16-2.fc44.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-1.fc43.x86_64"
+      "evra": "3.7.5-3.fc44.x86_64"
     },
     "fuse3": {
-      "evra": "3.16.2-5.fc42.x86_64"
+      "evra": "3.18.1-2.fc44.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.16.2-5.fc42.x86_64"
+      "evra": "3.18.1-2.fc44.x86_64"
     },
     "fwupd": {
-      "evra": "2.0.20-1.fc43.x86_64"
+      "evra": "2.0.19-1.fc44.x86_64"
     },
     "gawk": {
-      "evra": "5.3.2-2.fc43.x86_64"
+      "evra": "5.3.2-3.fc44.x86_64"
     },
     "gdbm": {
-      "evra": "1:1.23-10.fc43.x86_64"
+      "evra": "1:1.23-11.fc44.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-10.fc43.x86_64"
+      "evra": "1:1.23-11.fc44.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.10-4.fc43.x86_64"
+      "evra": "1.0.10-5.fc44.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "git-core": {
-      "evra": "2.53.0-1.fc43.x86_64"
+      "evra": "2.53.0-1.fc44.x86_64"
     },
     "glib2": {
-      "evra": "2.86.4-1.fc43.x86_64"
+      "evra": "2.87.2-2.fc44.x86_64"
     },
     "glibc": {
-      "evra": "2.42-10.fc43.x86_64"
+      "evra": "2.43-1.fc44.x86_64"
     },
     "glibc-common": {
-      "evra": "2.42-10.fc43.x86_64"
+      "evra": "2.43-1.fc44.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.42-10.fc43.x86_64"
+      "evra": "2.43-1.fc44.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.42-10.fc43.x86_64"
+      "evra": "2.43-1.fc44.x86_64"
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc43.x86_64"
+      "evra": "1:6.3.0-5.fc44.x86_64"
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc43.noarch"
+      "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-5.fc44.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc43.x86_64"
+      "evra": "3.8.12-1.fc44.x86_64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-2.fc43.noarch"
+      "evra": "20250221.00-3.fc44.noarch"
     },
     "gpgme": {
-      "evra": "1.24.3-6.fc43.x86_64"
+      "evra": "2.0.1-3.fc44.x86_64"
     },
     "grep": {
-      "evra": "3.12-2.fc43.x86_64"
+      "evra": "3.12-3.fc44.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.12-40.fc43.noarch"
+      "evra": "1:2.12-53.fc44.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-40.fc43.x86_64"
+      "evra": "1:2.12-53.fc44.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.12-40.fc43.x86_64"
+      "evra": "1:2.12-53.fc44.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-40.fc43.noarch"
+      "evra": "1:2.12-53.fc44.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-40.fc43.x86_64"
+      "evra": "1:2.12-53.fc44.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-40.fc43.x86_64"
+      "evra": "1:2.12-53.fc44.x86_64"
+    },
+    "gssproxy": {
+      "evra": "0.9.2-10.fc44.x86_64"
     },
     "gzip": {
-      "evra": "1.13-4.fc43.x86_64"
+      "evra": "1.14-2.fc44.x86_64"
     },
     "hostname": {
-      "evra": "3.25-3.fc43.x86_64"
+      "evra": "3.25-4.fc44.x86_64"
     },
     "hwdata": {
-      "evra": "0.404-1.fc43.noarch"
+      "evra": "0.404-1.fc44.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-1.fc43.x86_64"
+      "evra": "2.26.0-2.fc44.x86_64"
     },
     "ignition-grub": {
-      "evra": "2.26.0-1.fc43.x86_64"
+      "evra": "2.26.0-2.fc44.x86_64"
     },
     "inih": {
-      "evra": "62-1.fc43.x86_64"
+      "evra": "62-2.fc44.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-12.fc43.x86_64"
+      "evra": "1.0.3-13.fc44.x86_64"
     },
     "iproute": {
-      "evra": "6.14.0-2.fc43.x86_64"
+      "evra": "6.17.0-2.fc44.x86_64"
     },
     "iproute-tc": {
-      "evra": "6.14.0-2.fc43.x86_64"
+      "evra": "6.17.0-2.fc44.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.11-12.fc43.noarch"
+      "evra": "1.8.11-13.fc44.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iputils": {
-      "evra": "20250605-1.fc43.x86_64"
+      "evra": "20250605-2.fc44.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.9.4-7.fc43.x86_64"
+      "evra": "2:1.9.5-2.fc44.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.103-3.fc43.x86_64"
+      "evra": "0.103-4.fc44.x86_64"
     },
     "jansson": {
-      "evra": "2.14-3.fc43.x86_64"
+      "evra": "2.14-4.fc44.x86_64"
     },
     "jose": {
-      "evra": "14-5.fc43.x86_64"
+      "evra": "14-6.fc44.x86_64"
     },
     "jq": {
-      "evra": "1.8.1-1.fc43.x86_64"
+      "evra": "1.8.1-2.fc44.x86_64"
     },
     "json-c": {
-      "evra": "0.18-7.fc43.x86_64"
+      "evra": "0.18-8.fc44.x86_64"
     },
     "json-glib": {
-      "evra": "1.10.8-4.fc43.x86_64"
+      "evra": "1.10.8-5.fc44.x86_64"
     },
     "kbd": {
-      "evra": "2.8.0-3.fc43.x86_64"
+      "evra": "2.9.0-2.fc44.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-2.fc44.noarch"
     },
     "kbd-misc": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-2.fc44.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.59-1.fc43.x86_64"
+      "evra": "1.0.59-2.fc44.x86_64"
     },
     "kernel": {
-      "evra": "6.18.13-200.fc43.x86_64"
+      "evra": "6.19.2-300.fc44.x86_64"
     },
     "kernel-core": {
-      "evra": "6.18.13-200.fc43.x86_64"
+      "evra": "6.19.2-300.fc44.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.18.13-200.fc43.x86_64"
+      "evra": "6.19.2-300.fc44.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.18.13-200.fc43.x86_64"
+      "evra": "6.19.2-300.fc44.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.32-1.fc43.x86_64"
+      "evra": "2.0.32-3.fc44.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.3-6.fc43.x86_64"
+      "evra": "1.6.3-7.fc44.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-6.fc43.x86_64"
+      "evra": "1.6.3-7.fc44.x86_64"
     },
     "kmod": {
-      "evra": "34.2-2.fc43.x86_64"
+      "evra": "34.2-4.fc44.x86_64"
     },
     "kmod-libs": {
-      "evra": "34.2-2.fc43.x86_64"
+      "evra": "34.2-4.fc44.x86_64"
     },
     "kpartx": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-2.fc43.x86_64"
+      "evra": "1.22.2-2.fc44.x86_64"
     },
     "less": {
-      "evra": "685-1.fc43.x86_64"
+      "evra": "691-2.fc44.x86_64"
     },
     "libacl": {
-      "evra": "2.3.2-4.fc43.x86_64"
+      "evra": "2.3.2-6.fc44.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-22.fc43.x86_64"
+      "evra": "0.3.111-23.fc44.x86_64"
     },
     "libarchive": {
-      "evra": "3.8.4-1.fc43.x86_64"
+      "evra": "3.8.4-2.fc44.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.7-4.fc43.x86_64"
+      "evra": "2.5.7-5.fc44.x86_64"
     },
     "libattr": {
-      "evra": "2.5.2-6.fc43.x86_64"
+      "evra": "2.5.2-8.fc44.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-59.fc43.x86_64"
+      "evra": "0.1.1-61.fc44.x86_64"
     },
     "libblkid": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libbpf": {
-      "evra": "2:1.6.1-3.fc43.x86_64"
+      "evra": "2:1.6.3-1.fc44.x86_64"
     },
     "libbsd": {
-      "evra": "0.12.2-6.fc43.x86_64"
+      "evra": "0.12.2-7.fc44.x86_64"
     },
     "libcap": {
-      "evra": "2.76-3.fc43.x86_64"
+      "evra": "2.77-2.fc44.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.9.1-1.fc43.x86_64"
+      "evra": "0.9-7.fc44.x86_64"
     },
     "libcbor": {
-      "evra": "0.12.0-6.fc43.x86_64"
+      "evra": "0.13.0-2.fc44.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-59.fc43.x86_64"
+      "evra": "0.7.0-61.fc44.x86_64"
     },
     "libcom_err": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "libcurl-minimal": {
-      "evra": "8.15.0-5.fc43.x86_64"
+      "evra": "8.18.0-4.fc44.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-32.fc43.x86_64"
+      "evra": "0.14-33.fc44.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-59.fc43.x86_64"
+      "evra": "0.5.0-61.fc44.x86_64"
     },
     "libdnf5": {
-      "evra": "5.2.18.0-1.fc43.x86_64"
+      "evra": "5.3.0.0-7.fc44.x86_64"
     },
     "libdnf5-cli": {
-      "evra": "5.2.18.0-1.fc43.x86_64"
+      "evra": "5.3.0.0-7.fc44.x86_64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc43.x86_64"
+      "evra": "2.4.131-1.fc44.x86_64"
     },
     "libeconf": {
-      "evra": "0.7.9-2.fc43.x86_64"
+      "evra": "0.7.9-3.fc44.x86_64"
     },
     "libedit": {
-      "evra": "3.1-57.20251016cvs.fc43.x86_64"
+      "evra": "3.1-58.20251016cvs.fc44.x86_64"
+    },
+    "libev": {
+      "evra": "4.33-15.fc44.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-16.fc43.x86_64"
+      "evra": "2.1.12-17.fc44.x86_64"
     },
     "libfdisk": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libffi": {
-      "evra": "3.5.2-1.fc43.x86_64"
+      "evra": "3.5.2-2.fc44.x86_64"
     },
     "libfido2": {
-      "evra": "1.16.0-3.fc43.x86_64"
+      "evra": "1.16.0-5.fc44.x86_64"
     },
     "libgcc": {
-      "evra": "15.2.1-7.fc43.x86_64"
+      "evra": "16.0.1-0.5.fc44.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.11.1-3.fc43.x86_64"
+      "evra": "1.11.2-1.fc44.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.55-2.fc43.x86_64"
+      "evra": "1.58-2.fc44.x86_64"
     },
     "libibverbs": {
-      "evra": "58.0-4.fc43.x86_64"
+      "evra": "61.0-2.fc44.x86_64"
     },
     "libicu": {
-      "evra": "77.1-1.fc43.x86_64"
+      "evra": "77.1-2.fc44.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.8-2.fc43.x86_64"
+      "evra": "2.3.8-3.fc44.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-59.fc43.x86_64"
+      "evra": "1.3.1-61.fc44.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "libjcat": {
-      "evra": "0.2.5-1.fc43.x86_64"
+      "evra": "0.2.5-2.fc44.x86_64"
     },
     "libjose": {
-      "evra": "14-5.fc43.x86_64"
+      "evra": "14-6.fc44.x86_64"
     },
     "libkcapi": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libksba": {
-      "evra": "1.6.7-4.fc43.x86_64"
+      "evra": "1.6.7-5.fc44.x86_64"
     },
     "liblastlog2": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libldb": {
-      "evra": "2:4.23.5-2.fc43.x86_64"
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
     },
     "libluksmeta": {
-      "evra": "10-1.fc43.x86_64"
+      "evra": "10-2.fc44.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.13.1-1.fc43.x86_64"
+      "evra": "1.12.2-5.fc44.x86_64"
     },
     "libmd": {
-      "evra": "1.1.0-8.fc43.x86_64"
+      "evra": "1.1.0-9.fc44.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.5-8.fc43.x86_64"
+      "evra": "1.0.5-9.fc44.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-4.fc43.x86_64"
+      "evra": "2.15.2-6.fc44.x86_64"
     },
     "libmount": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libndp": {
-      "evra": "1.9-4.fc43.x86_64"
+      "evra": "1.9-5.fc44.x86_64"
     },
     "libnet": {
-      "evra": "1.3-6.fc43.x86_64"
+      "evra": "1.3-7.fc44.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.1.1-1.fc43.x86_64"
+      "evra": "1.0.9-10.fc44.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-31.fc43.x86_64"
+      "evra": "1.0.1-32.fc44.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.5-0.fc43.x86_64"
+      "evra": "1:2.8.5-0.fc44.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.9-2.fc43.x86_64"
+      "evra": "1.3.1-2.fc44.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.66.0-2.fc43.x86_64"
+      "evra": "1.68.0-3.fc44.x86_64"
     },
     "libnl3": {
-      "evra": "3.12.0-2.fc43.x86_64"
+      "evra": "3.12.0-3.fc44.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-2.fc43.x86_64"
+      "evra": "3.12.0-3.fc44.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.1-4.fc43.x86_64"
+      "evra": "2.0.1-5.fc44.x86_64"
     },
     "libnvme": {
-      "evra": "1.16.1-1.fc43.x86_64"
+      "evra": "1.16.1-2.fc44.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-59.fc43.x86_64"
+      "evra": "0.2.1-61.fc44.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.6-1.fc43.x86_64"
+      "evra": "14:1.10.6-2.fc44.x86_64"
     },
     "libpciaccess": {
-      "evra": "0.16-16.fc43.x86_64"
+      "evra": "0.16-17.fc44.x86_64"
     },
     "libpkgconf": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.5-6.fc43.x86_64"
+      "evra": "0.21.5-7.fc44.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.5-14.fc43.x86_64"
+      "evra": "1.4.5-15.fc44.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-59.fc43.x86_64"
+      "evra": "0.1.5-61.fc44.x86_64"
     },
     "librepo": {
-      "evra": "1.20.0-4.fc43.x86_64"
+      "evra": "1.20.0-5.fc44.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-9.fc43.noarch"
+      "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-2.fc43.x86_64"
+      "evra": "2.6.0-3.fc44.x86_64"
     },
     "libselinux": {
-      "evra": "3.9-5.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.9-5.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libsemanage": {
-      "evra": "3.9-4.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libsepol": {
-      "evra": "3.9-2.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libslirp": {
-      "evra": "4.9.1-2.fc43.x86_64"
+      "evra": "4.9.1-3.fc44.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.23.5-2.fc43.x86_64"
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.35-3.fc43.x86_64"
+      "evra": "0.7.35-4.fc44.x86_64"
     },
     "libss": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "libstdc++": {
-      "evra": "15.2.1-7.fc43.x86_64"
+      "evra": "16.0.1-0.5.fc44.x86_64"
     },
     "libtalloc": {
-      "evra": "2.4.3-4.fc43.x86_64"
+      "evra": "2.4.4-1.fc44.x86_64"
     },
     "libtasn1": {
-      "evra": "4.20.0-2.fc43.x86_64"
+      "evra": "4.20.0-3.fc44.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.14-3.fc43.x86_64"
+      "evra": "1.4.15-1.fc44.x86_64"
     },
     "libteam": {
-      "evra": "1.32-12.fc43.x86_64"
+      "evra": "1.32-13.fc44.x86_64"
     },
     "libtevent": {
-      "evra": "0.17.1-3.fc43.x86_64"
+      "evra": "0.17.1-4.fc44.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.7-1.fc43.x86_64"
+      "evra": "1.3.7-2.fc44.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-8.fc43.x86_64"
+      "evra": "2.5.4-10.fc44.x86_64"
     },
     "libunistring": {
-      "evra": "1.1-10.fc43.x86_64"
+      "evra": "1.1-11.fc44.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc43.x86_64"
+      "evra": "1.0.29-5.fc44.x86_64"
     },
     "libuuid": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "libuv": {
-      "evra": "1:1.51.0-2.fc43.x86_64"
+      "evra": "1:1.51.0-3.fc44.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-11.fc43.x86_64"
+      "evra": "0.3.2-12.fc44.x86_64"
+    },
+    "libverto-libev": {
+      "evra": "0.3.2-12.fc44.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.23.5-2.fc43.x86_64"
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.5.2-1.fc43.x86_64"
+      "evra": "4.5.2-3.fc44.x86_64"
     },
     "libxml2": {
-      "evra": "2.12.10-5.fc43.x86_64"
+      "evra": "2.12.10-6.fc44.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.24-1.fc43.x86_64"
+      "evra": "0.3.25-1.fc44.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-17.fc43.x86_64"
+      "evra": "0.2.5-18.fc44.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.7-2.fc43.x86_64"
+      "evra": "1.5.7-5.fc44.x86_64"
     },
     "linux-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "lld18-libs": {
       "evra": "18.1.8-8.fc43.x86_64"
     },
     "llvm18-libs": {
-      "evra": "18.1.8-7.fc43.x86_64"
+      "evra": "18.1.8-8.fc44.x86_64"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-1.fc43.x86_64"
+      "evra": "0.9.34-2.fc44.x86_64"
     },
     "logrotate": {
-      "evra": "3.22.0-4.fc43.x86_64"
+      "evra": "3.22.0-5.fc44.x86_64"
     },
     "lsof": {
-      "evra": "4.98.0-8.fc43.x86_64"
+      "evra": "4.98.0-9.fc44.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.8-4.fc43.x86_64"
+      "evra": "5.4.8-5.fc44.x86_64"
     },
     "luksmeta": {
-      "evra": "10-1.fc43.x86_64"
+      "evra": "10-2.fc44.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.34-2.fc43.x86_64"
+      "evra": "2.03.38-2.fc44.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.34-2.fc43.x86_64"
+      "evra": "2.03.38-2.fc44.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.10.0-3.fc43.x86_64"
+      "evra": "1.10.0-4.fc44.x86_64"
     },
     "lzo": {
-      "evra": "2.10-15.fc43.x86_64"
+      "evra": "2.10-16.fc44.x86_64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-1.fc43.x86_64"
+      "evra": "1.7.8-2.fc44.x86_64"
     },
     "mdadm": {
-      "evra": "4.3-9.fc43.x86_64"
+      "evra": "4.3-9.fc44.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-71.1.fc43.x86_64"
+      "evra": "2:2.1-73.fc44.x86_64"
     },
     "moby-engine": {
-      "evra": "29.2.1-2.fc43.x86_64"
+      "evra": "29.2.1-2.fc44.x86_64"
     },
     "moby-filesystem": {
-      "evra": "29.2.1-2.fc43.noarch"
+      "evra": "29.2.1-2.fc44.noarch"
     },
     "mokutil": {
-      "evra": "2:0.7.2-2.fc43.x86_64"
+      "evra": "2:0.7.2-3.fc44.x86_64"
     },
     "mpfr": {
-      "evra": "4.2.2-2.fc43.x86_64"
+      "evra": "4.2.2-3.fc44.x86_64"
     },
     "nano": {
-      "evra": "8.5-2.fc43.x86_64"
+      "evra": "8.7.1-1.fc44.x86_64"
     },
     "nano-default-editor": {
-      "evra": "8.5-2.fc43.noarch"
+      "evra": "8.7.1-1.fc44.noarch"
     },
     "ncurses": {
-      "evra": "6.5-7.20250614.fc43.x86_64"
+      "evra": "6.6-1.fc44.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.5-7.20250614.fc43.noarch"
+      "evra": "6.6-1.fc44.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.5-7.20250614.fc43.x86_64"
+      "evra": "6.6-1.fc44.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.74.20160912git.fc43.x86_64"
+      "evra": "2.0-0.77.20160912git.fc44.x86_64"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc43.x86_64"
+      "evra": "2:1.17.2-1.fc44.x86_64"
     },
     "nettle": {
-      "evra": "3.10.1-2.fc43.x86_64"
+      "evra": "3.10.1-3.fc44.x86_64"
     },
     "newt": {
-      "evra": "0.52.25-5.fc43.x86_64"
+      "evra": "0.52.25-6.fc44.x86_64"
     },
-    "nfs-utils-coreos": {
-      "evra": "1:2.8.5-0.fc43.x86_64"
+    "nfs-client-utils": {
+      "evra": "1:2.8.5-0.fc44.x86_64"
+    },
+    "nfs-common-utils": {
+      "evra": "1:2.8.5-0.fc44.x86_64"
+    },
+    "nfsv3-client-utils": {
+      "evra": "1:2.8.5-0.fc44.x86_64"
+    },
+    "nfsv4-client-utils": {
+      "evra": "1:2.8.5-0.fc44.x86_64"
     },
     "nftables": {
-      "evra": "1:1.1.3-6.fc43.1.x86_64"
+      "evra": "1:1.1.6-2.fc44.x86_64"
     },
     "nftables-services": {
-      "evra": "1:1.1.3-6.fc43.1.noarch"
+      "evra": "1:1.1.6-2.fc44.noarch"
     },
     "ngtcp2": {
-      "evra": "1.19.0-1.fc43.x86_64"
+      "evra": "1.19.0-2.fc44.x86_64"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.19.0-1.fc43.x86_64"
+      "evra": "1.19.0-2.fc44.x86_64"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc43.x86_64"
+      "evra": "2.2.57-2.fc44.x86_64"
     },
     "npth": {
-      "evra": "1.8-3.fc43.x86_64"
+      "evra": "1.8-4.fc44.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-7.fc43.x86_64"
+      "evra": "2.23.0-8.fc44.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.19-3.fc43.x86_64"
+      "evra": "2.0.19-4.fc44.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-1.fc43.x86_64"
+      "evra": "2.16-2.fc44.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.10-3.fc43.x86_64"
+      "evra": "6.9.10-4.fc44.x86_64"
     },
     "openldap": {
-      "evra": "2.6.10-4.fc43.x86_64"
+      "evra": "2.6.10-7.fc44.x86_64"
     },
     "openssh": {
-      "evra": "10.0p1-6.fc43.x86_64"
+      "evra": "10.2p1-3.fc44.x86_64"
     },
     "openssh-clients": {
-      "evra": "10.0p1-6.fc43.x86_64"
+      "evra": "10.2p1-3.fc44.x86_64"
     },
     "openssh-server": {
-      "evra": "10.0p1-6.fc43.x86_64"
+      "evra": "10.2p1-3.fc44.x86_64"
     },
     "openssl": {
-      "evra": "1:3.5.4-2.fc43.x86_64"
+      "evra": "1:3.5.5-1.fc44.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.4-2.fc43.x86_64"
+      "evra": "1:3.5.5-1.fc44.x86_64"
     },
     "os-prober": {
-      "evra": "1.81-10.fc43.x86_64"
+      "evra": "1.81-11.fc44.x86_64"
     },
     "ostree": {
-      "evra": "2025.7-1.fc43.x86_64"
+      "evra": "2025.7-2.fc44.x86_64"
     },
     "ostree-libs": {
-      "evra": "2025.7-1.fc43.x86_64"
+      "evra": "2025.7-2.fc44.x86_64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc43.x86_64"
+      "evra": "0.26.2-1.fc44.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc43.x86_64"
+      "evra": "0.26.2-1.fc44.x86_64"
     },
     "pam": {
-      "evra": "1.7.1-4.fc43.x86_64"
+      "evra": "1.7.2-1.fc44.x86_64"
     },
     "pam-libs": {
-      "evra": "1.7.1-4.fc43.x86_64"
+      "evra": "1.7.2-1.fc44.x86_64"
     },
     "passim-libs": {
-      "evra": "0.1.10-2.fc43.x86_64"
+      "evra": "0.1.10-3.fc44.x86_64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc43.x86_64"
+      "evra": "0^20260120.g386b5f5-1.fc44.x86_64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc43.noarch"
+      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-2.fc43.x86_64"
+      "evra": "3.14.0-3.fc44.x86_64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-2.fc43.x86_64"
+      "evra": "3.14.0-3.fc44.x86_64"
     },
     "pcre2": {
-      "evra": "10.47-1.fc43.x86_64"
+      "evra": "10.47-1.fc44.1.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc43.noarch"
+      "evra": "10.47-1.fc44.1.noarch"
     },
     "pigz": {
-      "evra": "2.8-7.fc43.x86_64"
+      "evra": "2.8-8.fc44.x86_64"
     },
     "pkgconf": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-3.fc43.noarch"
+      "evra": "2.5.1-1.fc44.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "podman": {
-      "evra": "5:5.8.0-1.fc43.x86_64"
+      "evra": "5:5.8.0-1.fc44.x86_64"
     },
     "podman-sequoia": {
-      "evra": "0.2.0-3.fc43.x86_64"
+      "evra": "0.3.2-1.fc44.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.9-7.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "polkit": {
-      "evra": "126-6.fc43.x86_64"
+      "evra": "127-2.fc44.x86_64"
     },
     "polkit-libs": {
-      "evra": "126-6.fc43.x86_64"
+      "evra": "127-2.fc44.x86_64"
     },
     "popt": {
-      "evra": "1.19-9.fc43.x86_64"
+      "evra": "1.19-10.fc44.x86_64"
     },
     "procps-ng": {
-      "evra": "4.0.4-7.fc43.1.x86_64"
+      "evra": "4.0.6-1.fc44.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.5.2-1.fc43.x86_64"
+      "evra": "1.5.2-2.fc44.x86_64"
     },
     "psmisc": {
-      "evra": "23.7-6.fc43.x86_64"
+      "evra": "23.7-7.fc44.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc43.noarch"
+      "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260110-1.fc43.noarch"
+      "evra": "20260110-1.fc44.noarch"
+    },
+    "rdma-core-common": {
+      "evra": "61.0-2.fc44.noarch"
     },
     "readline": {
-      "evra": "8.3-2.fc43.x86_64"
+      "evra": "8.3-4.fc44.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc43.x86_64"
+      "evra": "1.2.8-1.fc44.x86_64"
     },
     "rpm": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-libs": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2025.12-1.fc43.x86_64"
+      "evra": "2026.1-1.fc44.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2025.12-1.fc43.x86_64"
+      "evra": "2026.1-1.fc44.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.1-1.fc43.x86_64"
+      "evra": "1.10.0-2.fc44.x86_64"
     },
     "rsync": {
-      "evra": "3.4.1-5.fc43.x86_64"
+      "evra": "3.4.1-6.fc44.x86_64"
     },
     "runc": {
-      "evra": "2:1.4.0-1.fc43.x86_64"
+      "evra": "2:1.4.0-3.fc44.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.23.5-2.fc43.x86_64"
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.23.5-2.fc43.noarch"
+      "evra": "2:4.24.0-0.5.rc3.fc44.noarch"
     },
-    "samba-common-libs": {
-      "evra": "2:4.23.5-2.fc43.x86_64"
+    "samba-core-libs": {
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+    },
+    "samba-ndr-libs": {
+      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
     },
     "sdbus-cpp": {
-      "evra": "2.1.0-3.fc43.x86_64"
+      "evra": "2.2.1-2.fc44.x86_64"
     },
     "sed": {
-      "evra": "4.9-5.fc43.x86_64"
+      "evra": "4.9-7.fc44.x86_64"
     },
     "selinux-policy": {
-      "evra": "42.24-1.fc43.noarch"
+      "evra": "42.23-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "42.24-1.fc43.noarch"
+      "evra": "42.23-1.fc44.noarch"
     },
     "setup": {
-      "evra": "2.15.0-26.fc43.noarch"
+      "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-6.fc43.x86_64"
+      "evra": "1.48-8.fc44.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-6.fc43.x86_64"
+      "evra": "1.48-8.fc44.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.18.0-3.fc43.x86_64"
+      "evra": "2:4.19.0-6.fc44.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.18.0-3.fc43.x86_64"
+      "evra": "2:4.19.0-6.fc44.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.4-2.fc43.x86_64"
+      "evra": "2.4-3.fc44.x86_64"
     },
     "shim-x64": {
-      "evra": "15.8-3.x86_64"
+      "evra": "16.1-5.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.22.0-2.fc43.x86_64"
+      "evra": "1:1.22.0-2.fc44.x86_64"
     },
     "slang": {
-      "evra": "2.3.3-8.fc43.x86_64"
+      "evra": "2.3.3-9.fc44.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.3.1-3.fc43.x86_64"
+      "evra": "1.3.1-4.fc44.x86_64"
     },
     "snappy": {
-      "evra": "1.2.2-2.fc43.x86_64"
+      "evra": "1.2.2-4.fc44.x86_64"
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc43.x86_64"
+      "evra": "1.8.1.0-2.fc44.x86_64"
     },
     "spdlog": {
-      "evra": "1.15.3-3.fc43.x86_64"
+      "evra": "1.15.3-4.fc44.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.50.2-2.fc43.x86_64"
+      "evra": "3.51.2-1.fc44.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-7.fc43.x86_64"
+      "evra": "4.6.1-8.fc44.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-client": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-common": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.12.0-3.fc44.x86_64"
     },
     "stalld": {
-      "evra": "1.26.3-1.fc43.x86_64"
+      "evra": "1.26.3-2.fc44.x86_64"
     },
     "sudo": {
-      "evra": "1.9.17-6.p2.fc43.x86_64"
+      "evra": "1.9.17-7.p2.fc44.x86_64"
     },
     "systemd": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-container": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-libs": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-pam": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-resolved": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-shared": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-sysusers": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "systemd-udev": {
-      "evra": "258.5-1.fc43.x86_64"
+      "evra": "259.1-1.fc44.x86_64"
     },
     "tar": {
-      "evra": "2:1.35-6.fc43.x86_64"
+      "evra": "2:1.35-8.fc44.x86_64"
     },
     "teamd": {
-      "evra": "1.32-12.fc43.x86_64"
+      "evra": "1.32-13.fc44.x86_64"
     },
     "tini-static": {
-      "evra": "0.19.0-11.fc43.x86_64"
+      "evra": "0.19.0-12.fc44.x86_64"
     },
     "toolbox": {
-      "evra": "0.3-1.fc43.x86_64"
+      "evra": "0.3-4.fc44.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.7-4.fc43.x86_64"
+      "evra": "5.7-5.fc44.x86_64"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-8.fc43.x86_64"
+      "evra": "4.1.3-9.fc44.x86_64"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-8.fc43.x86_64"
+      "evra": "4.1.3-9.fc44.x86_64"
     },
     "tzdata": {
-      "evra": "2025c-1.fc43.noarch"
+      "evra": "2025c-2.fc44.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.3-2.fc43.x86_64"
+      "evra": "0.15.6-1.fc44.x86_64"
     },
     "util-linux": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.41.3-7.fc43.x86_64"
+      "evra": "2.41.3-12.fc44.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.2.045-1.fc43.noarch"
+      "evra": "2:9.1.2146-2.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.045-1.fc43.x86_64"
+      "evra": "2:9.1.2146-2.fc44.x86_64"
     },
     "wasmedge-rt": {
-      "evra": "0.15.0-4.fc43.x86_64"
+      "evra": "0.16.1-1.fc44.x86_64"
     },
     "which": {
-      "evra": "2.23-3.fc43.x86_64"
+      "evra": "2.23-4.fc44.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-2.fc43.x86_64"
+      "evra": "1.0.20250521-3.fc44.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.15.0-3.fc43.x86_64"
+      "evra": "6.18.0-2.fc44.x86_64"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-3.fc43.x86_64"
+      "evra": "0.8.3-4.fc44.x86_64"
     },
     "xz": {
-      "evra": "1:5.8.1-4.fc43.x86_64"
+      "evra": "1:5.8.2-2.fc44.x86_64"
     },
     "xz-libs": {
-      "evra": "1:5.8.1-4.fc43.x86_64"
+      "evra": "1:5.8.2-2.fc44.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-38.fc43.x86_64"
+      "evra": "2.1.0-40.fc44.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-3.fc43.x86_64"
+      "evra": "1.5.1-4.fc44.x86_64"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc43.x86_64"
+      "evra": "0.0.32-1.fc44.x86_64"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-1.fc43.x86_64"
+      "evra": "2.3.3-2.fc44.x86_64"
     },
     "zram-generator": {
-      "evra": "1.2.1-3.fc43.x86_64"
+      "evra": "1.2.1-5.fc44.x86_64"
     },
     "zstd": {
-      "evra": "1.5.7-2.fc43.x86_64"
+      "evra": "1.5.7-5.fc44.x86_64"
     }
   },
   "metadata": {

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,9 +7,9 @@ repos:
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned. These repos are also used by the remove-graduated-overrides
   # GitHub Action.
-  - fedora
-  - fedora-updates
- #- fedora-next
- #- fedora-next-updates
- #- fedora-candidate-compose
+  # - fedora
+  # - fedora-updates
+  - fedora-next
+  - fedora-next-updates
+  - fedora-candidate-compose
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Fedora 44 beta is going to ship soon, so let's move next-devel over to Fedora 44 content so we can ship it in `next` alongside the beta.

See: https://github.com/coreos/fedora-coreos-tracker/issues/2055