### PR TITLE
denylist: unblock *kdump* tests on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,14 +8,6 @@
 ##  arches:
 ##    - aarch64
 
-- pattern: '*kdump.crash*'
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
-  snooze: 2026-03-31
-  arches:
-    - s390x
-  streams:
-    - rawhide
-
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
   snooze: 2026-03-10


### PR DESCRIPTION
`rawhide` now comes with `kernel-7.0.0-0.rc2`, which has the [fix](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1623a554c68f352c17d0a358bc62580dc187f06b).

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/2100