### PR TITLE
Revert "overrides: drop podman pin"

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,3 +29,8 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
       type: fast-track
+  podman:
+    evr: 5:5.7.1-1.fc43
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2110
+      type: pin


### PR DESCRIPTION
This reverts commit 31a82c04fc64bc510308e9c0079bca059f9bdf07.

There's a report of some bugs so we'll re-add the pin for now.

https://github.com/coreos/fedora-coreos-tracker/issues/2110#issuecomment-4017324689