### PR TITLE
COS-4032: Add numad and numactl packages

### DIFF
--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -987,8 +987,14 @@
     "nss-altfiles": {
       "evra": "2.23.0-7.fc43.aarch64"
     },
+    "numactl": {
+      "evra": "2.0.19-3.fc43.aarch64"
+    },
     "numactl-libs": {
       "evra": "2.0.19-3.fc43.aarch64"
+    },
+    "numad": {
+      "evra": "0.5-47.20150602git.fc43.aarch64"
     },
     "nvidia-gpu-firmware": {
       "evra": "20260221-1.fc43.noarch"

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -969,8 +969,14 @@
     "nss-altfiles": {
       "evra": "2.23.0-7.fc43.ppc64le"
     },
+    "numactl": {
+      "evra": "2.0.19-3.fc43.ppc64le"
+    },
     "numactl-libs": {
       "evra": "2.0.19-3.fc43.ppc64le"
+    },
+    "numad": {
+      "evra": "0.5-47.20150602git.fc43.ppc64le"
     },
     "nvidia-gpu-firmware": {
       "evra": "20260221-1.fc43.noarch"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -996,8 +996,14 @@
     "nss-altfiles": {
       "evra": "2.23.0-7.fc43.x86_64"
     },
+    "numactl": {
+      "evra": "2.0.19-3.fc43.x86_64"
+    },
     "numactl-libs": {
       "evra": "2.0.19-3.fc43.x86_64"
+    },
+    "numad": {
+      "evra": "0.5-47.20150602git.fc43.x86_64"
     },
     "nvidia-gpu-firmware": {
       "evra": "20260221-1.fc43.noarch"

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -34,6 +34,17 @@ packages:
   # https://github.com/coreos/fedora-coreos-tracker/issues/753
   - stalld
 
+conditional-include:
+  # numad is not available for s390x
+  - if: basearch != "s390x"
+    include:
+      packages:
+        # https://github.com/coreos/fedora-coreos-tracker/issues/2096
+        # numad: Daemon that provides placement advice for efficient use of CPUs and memory on systems with NUMA topology.
+        # numactl: Control NUMA policy for processes or shared memory
+        - numad
+        - numactl
+
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first
   # boot and does not use systemd-repart currently. See also

--- a/tests/kola/numad/config.bu
+++ b/tests/kola/numad/config.bu
@@ -1,0 +1,6 @@
+variant: fcos
+version: 1.6.0
+systemd:
+  units:
+    - name: numad.service
+      enabled: true

--- a/tests/kola/numad/data/commonlib.sh
+++ b/tests/kola/numad/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../data/commonlib.sh

--- a/tests/kola/numad/test.sh
+++ b/tests/kola/numad/test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+## kola:
+##   platforms: qemu
+##   numaNodes: true
+##   minMemory: 2048
+##   architectures: "!s390x"
+##   description: Verify that numad detects nodes and tracks set -euo pipefail
+##   bindMountHostRO: ["/,/var/cosaroot"]
+##   creationDate: 2026-04-09
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if [[ $(systemctl show numad -p ActiveState) != "ActiveState=active" ]]; then
+    fatal "numad did not activate"
+fi
+
+# Call numad to change the already running daemon's settings for -l and -i
+# `-l 7` adds extra information to the logs
+# `-i 5` changes interval from every 15s to every 5s
+numad -l7 -i5
+
+if ! lscpu | grep -Eq "NUMA node\(s\):\s*2"; then
+    fatal "expected to find exactly 2 numa nodes"
+fi
+
+# As part of the test we want to run a somewhat intensive process, so that
+# we can verify that numad is successfully tracking processes. Here we
+# use the same pattern of using a mounted in COSA as the container root as:
+# https://github.com/coreos/coreos-assembler/blob/8dbfe3ea8b8f571e732e8cc0ab307e983a0be1f3/mantle/cmd/kola/resources/iscsi_butane_setup.yaml#L102-L113
+podman run --privileged --name stress-ng --pid=host                      \
+    --volume=root:/root/:nocopy --volume=vartmp:/var/tmp/:nocopy         \
+    --workdir /root --rootfs /var/cosaroot                               \
+    stress-ng --temp-path /var/tmp --vm 1 --vm-bytes 1024M --timeout 25s
+
+logfile="/var/log/numad.log"
+for node in 0 1; do
+	# Different versions of numad have a slightly different format for the log file,
+	# e.g. MBs_total vs MBs_tot. This pattern should match both versions.
+	if ! grep -Eq "Node.${node}.*MBs_tot(al)?.*CPUs_tot(al)?" "$logfile"; then
+		fatal "Numad didn't detect Node ${node}"
+	fi
+done
+
+# Check that the stress test was being monitored by numad
+if ! grep -q "stress-ng-vm" "$logfile"; then
+    fatal "Numad is not monitoring the stress test"
+fi
+
+ok "Numad working as expected"


### PR DESCRIPTION
Add `numad` and `numactl` to `x86_64`, `aarch64`, and `ppc64le`. `numad` is not available for `s390x`, so we will not install the packages in that architecture.