### PR TITLE
[next-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,18 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  afterburn:
-    evr: 5.10.0-4.fc44
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
-      reason: https://github.com/coreos/fedora-coreos-config/pull/3885#issuecomment-4013155688
-      type: fast-track
-  afterburn-dracut:
-    evr: 5.10.0-4.fc44
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
-      reason: https://github.com/coreos/fedora-coreos-config/pull/3885#issuecomment-4013155688
-      type: fast-track
   coreos-installer:
     evr: 0.26.0-1.fc44
     metadata:
@@ -39,40 +27,10 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-ac444ae4ce
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
-  ignition:
-    evr: 2.26.0-2.fc44
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
-      reason: https://github.com/coreos/fedora-coreos-config/pull/3885#issuecomment-4013155688
-      type: fast-track
-  ignition-grub:
-    evr: 2.26.0-2.fc44
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
-      reason: https://github.com/coreos/fedora-coreos-config/pull/3885#issuecomment-4013155688
-      type: fast-track
   libcap-ng:
     evr: 0.9.1-1.fc44
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-8770342aca
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
-      type: fast-track
-  rpm-sequoia:
-    evr: 1.10.1-1.fc44
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-6905b76fd1
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
-      type: fast-track
-  selinux-policy:
-    evra: 42.24-1.fc44.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-d791eea3b2
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
-      type: fast-track
-  selinux-policy-targeted:
-    evra: 42.24-1.fc44.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-d791eea3b2
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
   vim-data:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).