### PR TITLE
[rawhide] kola-denylist: Append aarch64 to entry for ext.config.rpm-ostree.kernel-replace

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,9 +10,10 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-03-10
+  snooze: 2026-03-25
   warn: true
   arches:
     - ppc64le
+    - aarch64
   streams:
     - rawhide


### PR DESCRIPTION
Currently, this test is also being very flaky and causing failures on aarch64, while continuing to fail on ppc6le. Let's reset the snooze for 2 more weeks on this entry and add aarch64 to the list of arches.

See https://github.com/coreos/fedora-coreos-tracker/issues/2115#issuecomment-4040330913