### PR TITLE
denylist: snooze *kdump.crash* in next-devel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,6 +8,14 @@
 ##  arches:
 ##    - aarch64
 
+- pattern: '*kdump.crash*'
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
+  snooze: 2026-03-31
+  arches:
+    - s390x
+  streams:
+    - next-devel
+
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
   snooze: 2026-03-10


### PR DESCRIPTION
These tests were snoozed in rawhide but somehow they were not running in next-devel either. The tests have been failing for, probably, the same reason as https://github.com/coreos/fedora-coreos-tracker/issues/2100. Let's re-snooze them in next-devel while we investigate.