### PR TITLE
Revert "denylist: snooze *kdump.crash* in next-devel"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -8,14 +8,6 @@
 ##  arches:
 ##    - aarch64
 
-- pattern: '*kdump.crash*'
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2100
-  snooze: 2026-03-31
-  arches:
-    - s390x
-  streams:
-    - next-devel
-
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
   snooze: 2026-03-10


### PR DESCRIPTION
The tests are now passing after a new kernel was included in the most recent bump-lockfile job. The commit to snooze the tests in next-devel was never synced to the branch so the tests wound up running and passing in builds of next-devel. Seems the most recent kernel included the fix for the regression.

See https://github.com/coreos/fedora-coreos-tracker/issues/2100

This reverts commit 6149523050863cfcb5fdaea47d9a5cb39ce3a0fb.