### PR TITLE
[next-devel] overrides: fast track libnetfilter_conntrack to avoid downgrade

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -51,6 +51,13 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-8770342aca
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
+  # Using F43 version of the package because no F44 version has been built yet.
+  libnetfilter_conntrack:
+    evr: 1.1.1-1.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-5373cb4438
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
+      type: fast-track
   libnfsidmap:
     evr: 1:2.8.7-0.fc44
     metadata:


### PR DESCRIPTION
For libnetfilter_conntrack we are using the F43 version of the package because it was never built for F44 yet. Probably an oversight by the maintainer.