### PR TITLE
kola-denylist: Append aarch64 to entry for ext.config.rpm-ostree.kernel-replace

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,7 +10,7 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-03-10
+  snooze: 2026-04-01
   warn: true
   arches:
     - ppc64le

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,3 +16,12 @@
     - ppc64le
   streams:
     - rawhide
+
+- pattern: ext.config.rpm-ostree.kernel-replace
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2124
+  snooze: 2026-04-01
+  warn: true
+  arches:
+    - aarch64
+  streams:
+    - rawhide


### PR DESCRIPTION
Currently, this test is also being very flaky and causing failures on aarch64, while continuing to fail on ppc6le. Let's reset the snooze for 2 more weeks on this entry and add aarch64 to the list of arches.

Previously I made these changes to the rawhide branch in #4053 so that got overwritten. Issue tracked in coreos/fedora-coreos-tracker#2115