### PR TITLE
overrides: fast-track ignition-2.26.0-3.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,12 +10,12 @@
 
 packages:
   ignition:
-    evr: 2.26.0-1.fc43
+    evr: 2.26.0-3.fc43
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a31c42dada
       type: fast-track
   ignition-grub:
-    evr: 2.26.0-1.fc43
+    evr: 2.26.0-3.fc43
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a9467ef8
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a31c42dada
       type: fast-track


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).