### PR TITLE
tests/validate-symlinks: add exception for libmtcr_ul.a

### DIFF
--- a/tests/kola/files/validate-symlinks
+++ b/tests/kola/files/validate-symlinks
@@ -48,6 +48,7 @@ if is_scos || is_rhcos; then
         '/etc/pki/tls/'
         '/etc/rhsm-host'
         '/etc/sysconfig/grub'
+        '/usr/lib64/libmtcr_ul.a'
     )
     list_broken_symlinks_skip+=("${rhcos_list[@]}")
 fi


### PR DESCRIPTION
Recently mstflint.rpm was added for el9 and el10, so this test now fails on broken /usr/lib64/libmtcr_ul.a:
```
Error: /usr/lib64/libmtcr_ul.a symlink to /usr/lib64/mstflint/libmtcr_ul.a which does not exist
```