### PR TITLE
[next-devel] overrides: fast track downgraded packages 2026-03-30

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -46,21 +46,27 @@ packages:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
   ignition:
-    evr: 2.26.0-2.fc44
+    evr: 2.26.0-4.fc44
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-477703d3e9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
   ignition-grub:
-    evr: 2.26.0-2.fc44
+    evr: 2.26.0-4.fc44
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da57357ea0
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-477703d3e9
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
   libcap-ng:
     evr: 0.9.2-1.fc44
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e42eb4fe32
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
+      type: fast-track
+  libtasn1:
+    evr: 4.21.0-1.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-48a302496d
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2055#issuecomment-4013167589
       type: fast-track
   ngtcp2:


### PR DESCRIPTION
libtasn1 is showing as downgraded in F44 because the latest bodhi
update went stable within the last day and wasn't picked up by the
bump-lockfile job.

Ignition is showing as downgraded because the F44 update was never
created for the associated F43 version. A new F44 update has been
posted, so let's consume it here in next-devel.