### PR TITLE
Extend rpm-ostree.kernel-replace test snooze date

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,7 +10,7 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-04-01
+  snooze: 2026-04-13
   warn: true
   arches:
     - ppc64le
@@ -19,7 +19,7 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2124
-  snooze: 2026-04-01
+  snooze: 2026-04-13
   warn: true
   arches:
     - aarch64


### PR DESCRIPTION
Extending the ext.config.rpm-ostree.kernel-replace test snooze date as the issue is not fixed yet.