### PR TITLE
overlays: create 10bootc

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -15,6 +15,7 @@ ostree-layers:
   - overlay/05core
   - overlay/08nouveau
   - overlay/09misc
+  - overlay/10bootc
   - overlay/20platform-chrony
   - overlay/30lvmdevices
 

--- a/overlay.d/10bootc/usr/lib/bootc/install/10-grub-bls-append.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/10-grub-bls-append.toml
@@ -1,0 +1,2 @@
+[install.ostree]
+bls-append-except-default = 'grub_users=""'

--- a/overlay.d/10bootc/usr/lib/bootc/install/10-ostree-signed-remote.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/10-ostree-signed-remote.toml
@@ -1,0 +1,2 @@
+[install]
+enforce-container-sigpolicy = "true"

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -24,6 +24,12 @@ https://bugzilla.redhat.com/show_bug.cgi?id=1700056
 
 Warning about `/etc/sysconfig`.
 
+10bootc
+-------
+
+Configuration files for bootc and image-builder. These are used when building
+our disk images.
+
 15fcos
 ------
 


### PR DESCRIPTION
Introduce a new overlay to ship configuration files for bootc and image-builder. These file are sourced from the container during `bootc install to-filesystem`.
We can also use this later to ship other bits as we make the container more and more the source of truth, e.g. the partition table definition.

This is prep work for [1]

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1827 

See also https://github.com/coreos/coreos-assembler/pull/4224