### PR TITLE
tests: add `raid1-boot` config with `layout`

### DIFF
--- a/tests/kola/boot/raid1-boot/config.bu
+++ b/tests/kola/boot/raid1-boot/config.bu
@@ -1,6 +1,8 @@
 variant: fcos
 version: 1.5.0
 boot_device:
+  # This will be replaced by https://github.com/coreos/coreos-assembler/pull/4525
+  layout: {{LAYOUT}}
   mirror:
     devices:
       - /dev/vda

--- a/tests/kola/boot/raid1-boot/test.sh
+++ b/tests/kola/boot/raid1-boot/test.sh
@@ -20,6 +20,35 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
+check_bootupctl_components() {
+    local arch_type="$1"
+    local components=()
+    local output_file="out.txt"
+
+    # Define components based on the passed architecture
+    case "${arch_type}" in
+        x86_64)  components=("BIOS" "EFI") ;;
+        aarch64) components=("EFI") ;;
+        ppc64le) components=("BIOS") ;;
+        *)
+            echo "Skipped checking for arch: ${arch_type}"
+            return 0
+            ;;
+    esac
+
+    # 1. Test adopt-and-update
+    bootupctl adopt-and-update | tee "${output_file}"
+    for comp in "${components[@]}"; do
+        assert_file_has_content "${output_file}" "Adopted and updated: ${comp}: .*"
+    done
+
+    # 2. Test status
+    bootupctl status | tee "${output_file}"
+    for comp in "${components[@]}"; do
+        assert_file_has_content_literal "${output_file}" "Component ${comp}"
+    done
+}
+
 tmpdir=$(mktemp -d)
 cd "${tmpdir}"
 
@@ -36,11 +65,6 @@ ok "source is XFS on RAID1 device"
 mount -o remount,rw /boot
 rm -f -v /boot/bootupd-state.json
 
-bootupctl adopt-and-update | tee out.txt
-assert_file_has_content out.txt "Adopted and updated: BIOS: .*"
-assert_file_has_content out.txt "Adopted and updated: EFI: .*"
+check_bootupctl_components "$(arch)"
 
-bootupctl status | tee out.txt
-assert_file_has_content_literal out.txt 'Component BIOS'
-assert_file_has_content_literal out.txt 'Component EFI'
-ok "bootupctl adopt-and-update supports multiple EFIs on RAID1"
+ok "bootupctl adopt-and-update supports RAID1 boot"


### PR DESCRIPTION
The test failed on aarch64 / ppc64le because of missing `layout`.

Requires https://github.com/coreos/coreos-assembler/pull/4525