### PR TITLE
Pin glibc-2.43.9000-4.fc45

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,24 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  glibc:
+    evr: 2.43.9000-4.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
+      type: pin
+  glibc-common:
+    evr: 2.43.9000-4.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
+      type: pin
+  glibc-gconv-extra:
+    evr: 2.43.9000-4.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
+      type: pin
+  glibc-minimal-langpack:
+    evr: 2.43.9000-4.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
+      type: pin


### PR DESCRIPTION
Pin glibc-2.43.9000-4.fc45

The latest rawhide update broke aarch64. Pinning to unlock the
bump-lockfile as the lockfiles became stale.
See https://github.com/coreos/fedora-coreos-tracker/issues/2133
