### PR TITLE
rawhide: Revert "manifest.yaml: use bootc install in osbuild"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,12 +2,3 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
-
-# Use bootc install to-filesystem to build the disk image
-# Only for this stream for now
-# See https://github.com/coreos/fedora-coreos-tracker/issues/1827
-bootc-install-to-fs: true
-
-# Bootc will inject the ostree prefix when doing the ostree
-# deployement so we need only the OCI imgref here
-container-imgref: "quay.io/fedora/fedora-coreos:{stream}"


### PR DESCRIPTION
This reverts commit 10f346e464dd56d69a02b56460e2d9aaca8da226.

This works well on x86_64, aarch64, and ppc64le, but on s390x there are a group of tests that are failing:

- ostree.hotfix
- rpmostree.upgrade-rollback
- rpmostree.install-uninstall
- multipath.day2
- ext.config.systemd.condition-needs-update

Let's revert this and re-implement the change once we get those tests succeeding.