### PR TITLE
[rawhide] overrides: fast-track glibc-2.43.9000-10.fc45

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -10,22 +10,26 @@
 
 packages:
   glibc:
-    evr: 2.43.9000-4.fc45
+    evr: 2.43.9000-10.fc45
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-16d5de8bc9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133#issuecomment-4241138887
+      type: fast-track
   glibc-common:
-    evr: 2.43.9000-4.fc45
+    evr: 2.43.9000-10.fc45
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-16d5de8bc9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133#issuecomment-4241138887
+      type: fast-track
   glibc-gconv-extra:
-    evr: 2.43.9000-4.fc45
+    evr: 2.43.9000-10.fc45
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-16d5de8bc9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133#issuecomment-4241138887
+      type: fast-track
   glibc-minimal-langpack:
-    evr: 2.43.9000-4.fc45
+    evr: 2.43.9000-10.fc45
     metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133
-      type: pin
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-16d5de8bc9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2133#issuecomment-4241138887
+      type: fast-track


### PR DESCRIPTION
This newer version of glibc seems to resolve the recent failures seen in rawhide.

See: https://github.com/coreos/fedora-coreos-tracker/issues/2133