### PR TITLE
overlay.d/05core: Remove obsolete 'bootupd.socket' preset

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos.preset
@@ -23,8 +23,6 @@ enable afterburn-sshkeys.target
 enable zincati.service
 # Testing aid
 enable coreos-liveiso-success.service
-# See bootupd.yaml
-enable bootupd.socket
 # Enable rtas_errd for ppc64le to discover dynamically attached pci devices - https://bugzilla.redhat.com/show_bug.cgi?id=1811537
 # The event for the attached device comes as a diag event.
 # Ideally it should have been added as part of base Fedora - but since it was arch specific, it was not added: https://bugzilla.redhat.com/show_bug.cgi?id=1433859


### PR DESCRIPTION
bootup is now using a transient systemd service and no longer use the socket unit.

The actual service unit trigerring the updates is enabled in the Fedora bootc image.

See: https://github.com/coreos/bootupd/issues/551