### PR TITLE
tests: enable cgroups-v2 test downstream

### DIFF
--- a/tests/kola/containers/cgroups-v2
+++ b/tests/kola/containers/cgroups-v2
@@ -1,11 +1,12 @@
 #!/bin/bash
 ## kola:
-##   # This test only runs on FCOS because RHCOS does not currently
-##   # support cgroupsv2 by default.
-##   # TODO-RHCOS: drop "fcos" tag when cgroupsv2 lands in RHCOS
-##   distros: fcos
+##   # Check to make sure we are running cgroups v2
 ##   exclusive: false
-##   description: Verify the system supports cgroupsv2 on FCOS.
+##   description: Verify the system supports cgroupsv2.
+##   # Abuse creationDate here since we are introducing
+##   # the test running on RHCOS and don't want hard failures
+##   # there if the test needs to be adjusted.
+##   creationDate: 2026-04-16
 
 set -xeuo pipefail
 


### PR DESCRIPTION
cgroups has been enabled in RHCOS/OpenShift for a while now and is the only option in 4.19+.