### PR TITLE
manifests: drop systemd-auto-mount-removal

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -155,12 +155,3 @@ postprocess:
         echo "${actuals}" 1>&2
         exit 1
     fi
-
-  # We don't want auto-generated mount units. See also
-  # https://github.com/systemd/systemd/issues/13099
-  - |
-    #!/usr/bin/env bash
-    set -x
-    # Find the .build-id file and remove it too so we don't have a broken symlink.
-    build_id_file=$(find -L /usr/lib/.build-id/ -samefile /usr/lib/systemd/system-generators/systemd-gpt-auto-generator)
-    rm -vf $build_id_file /usr/lib/systemd/system-generators/systemd-gpt-auto-generator


### PR DESCRIPTION
It appears to not interfere anymore with our boot.mount unit:

```
[core@cosa-devsh ~]$ sudo findmnt  | grep boot
├─/boot      /dev/vda3     ext4       ro,nosuid,nodev,relatime,seclabel
```

I do still see the automount listed when I run `list-automounts --all`:

```
[core@cosa-devsh ~]$ sudo systemctl list-automounts --all
WHAT        WHERE                    MOUNTED IDLE TIMEOUT UNIT
composefs                            yes     -            boot.automount
binfmt_misc /proc/sys/fs/binfmt_misc no      -            proc-sys-fs-binfmt_misc.automount
```

but if you query systemctl directly about it it says it couldn't be found:

```
[core@cosa-devsh ~]$ systemctl status boot.automount
Unit boot.automount could not be found.
```

So it's there, but inactive.

This is all with:

```
[core@cosa-devsh ~]$ rpm -q systemd
systemd-258.7-1.fc43.x86_64
```