### PR TITLE
numad/test.sh: Increase timeout from 25s to 45s

### DIFF
--- a/tests/kola/numad/test.sh
+++ b/tests/kola/numad/test.sh
@@ -33,7 +33,7 @@ fi
 podman run --privileged --name stress-ng --pid=host                      \
     --volume=root:/root/:nocopy --volume=vartmp:/var/tmp/:nocopy         \
     --workdir /root --rootfs /var/cosaroot                               \
-    stress-ng --temp-path /var/tmp --vm 1 --vm-bytes 1024M --timeout 25s
+    stress-ng --temp-path /var/tmp --vm 1 --vm-bytes 1024M --timeout 45s
 
 logfile="/var/log/numad.log"
 for node in 0 1; do


### PR DESCRIPTION
This test can be flaky, potentially due to numad not having enough time to log information about the stress-ng process.