### PR TITLE
overlay.d/05core: adjust systemd presets

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -1,8 +1,9 @@
 # This file contains overrides for systemd services that are
 # enabled by default, but conflict with things we ship.
 
-# We don't have swap by default, and systemd-oomd hard requires it.
+# We don't have swap by default, and systemd-oomd strongly recommends it.
 disable systemd-oomd.service
+disable systemd-oomd.socket
 
 # Disable systemd-firstboot because it conflicts with Ignition.
 # In most cases this is handled via the remove-from-packages

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -9,8 +9,3 @@ disable systemd-oomd.service
 # bits in the manifest (ignition-and-ostree.yaml), but
 # we want to support overlaying builds of systemd from git.
 disable systemd-firstboot.service
-
-# This hasn't been tested with ostree/rpm-ostree and heavily overlaps
-# with the latter.  Preemptively disable the service; it will hopefully
-# be subpackaged though for Fedora.
-disable systemd-sysext.service

--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -4,9 +4,3 @@
 # We don't have swap by default, and systemd-oomd strongly recommends it.
 disable systemd-oomd.service
 disable systemd-oomd.socket
-
-# Disable systemd-firstboot because it conflicts with Ignition.
-# In most cases this is handled via the remove-from-packages
-# bits in the manifest (ignition-and-ostree.yaml), but
-# we want to support overlaying builds of systemd from git.
-disable systemd-firstboot.service

--- a/overlay.d/05core/usr/lib/systemd/system/systemd-backlight@.service.d/45-after-ostree-remount.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/systemd-backlight@.service.d/45-after-ostree-remount.conf
@@ -1,4 +1,0 @@
-# Temporary fix for https://github.com/coreos/fedora-coreos-tracker/issues/975
-# until https://github.com/ostreedev/ostree/issues/2115 is fixed.
-[Unit]
-After=ostree-remount.service

--- a/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/systemd-firstboot.service.d/fcos-disable.conf
@@ -1,5 +1,0 @@
-# See the comment in 40-coreos-systemd.preset; we're
-# keeping this even stronger disable override for now,
-# but it may not really be necessary.
-[Unit]
-ConditionPathExists=/run/nosuchfile


### PR DESCRIPTION
commit e66ced5c81c81ed2f96fa09b80a708f7bfeab3c7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 16:38:54 2026 -0400

    overlay.d/05core: drop systemd-firstboot.service disablement
    
    The systemd-firstboot.service is a static unit (no [Install] section)
    which means you can't just enable or disable it as one would typically
    do so IIUC the preset disablement does nothing anyway.

    The systemd-firstboot.service.d/fcos-disable.conf override also seems to
    be unneeded because the only thing trying to pull it in is disabled at
    the bootc level anyway [1].
    
    Maybe let's just remove these workarounds because it seems like they
    aren't needed.
    
    [1] https://gitlab.com/fedora/bootc/base-images/-/blob/9f9824c9a4ec87062509fe2f9f56382088aebaba/minimal/manifest.yaml#L18

commit db268d55ba3b7b0317e88c8a62d04289afef7fc3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 15:30:23 2026 -0400

    overlay.d/05core: disable systemd-oomd.socket too
    
    At some point the socket started getting enabled by default [1], which means
    systemd-oomd.service was running. Let's disable the socket too.
    
    [1] https://src.fedoraproject.org/rpms/redhat-systemd-presets/blob/b056f04a013590fa58d765807c7d1e210608690c/f/90-default.preset#_15

commit c906f48de7ccb1bd8013c1eea98bf5fdcd3cc551
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 15:26:54 2026 -0400

    overlay.d/05core: drop systemd-backlight.service override
    
    The linked issue here [1] has long since been fixed.
    
    [1] https://github.com/ostreedev/ostree/issues/2115

commit 24777725fb8429834c9b41eaf95937d5aeac916c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 15:22:15 2026 -0400

    overlay.d/05core: drop systemd-sysext.service disablement
    
    We been progressively exploring sysexts more [1] and the service today
    won't actually run uness /etc/extensions, /run/extensions, or /var/lib/extensions
    has files.
    
    ```
    [core@cosa-devsh ~]$ systemctl status systemd-sysext.service
    ○ systemd-sysext.service - Merge System Extension Images into /usr/ and /opt/
         Loaded: loaded (/usr/lib/systemd/system/systemd-sysext.service; enabled; preset: enabled)
        Drop-In: /usr/lib/systemd/system/service.d
                 └─10-timeout-abort.conf
         Active: inactive (dead)
      Condition: start condition unmet at Mon 2026-04-20 19:23:40 UTC; 17s ago
                 ├─ ConditionDirectoryNotEmpty=|/etc/extensions was not met
                 ├─ ConditionDirectoryNotEmpty=|/run/extensions was not met
                 └─ ConditionDirectoryNotEmpty=|/var/lib/extensions was not met
           Docs: man:systemd-sysext.service(8)
    
    ```
    
    Let's remove the preset disablement here.
    
    [1] https://fedora-sysexts.github.io/fedora/
