### PR TITLE
overlay.d/05core: drop obsolete or redundant dracut configuration

### DIFF
--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/60-coreos-nohostonly.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/60-coreos-nohostonly.conf
@@ -1,2 +1,0 @@
-# Default rpm-ostree model is server-side generated initramfs
-hostonly=no

--- a/overlay.d/05core/usr/lib/dracut/dracut.conf.d/60-coreos-nostrip.conf
+++ b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/60-coreos-nostrip.conf
@@ -1,3 +1,0 @@
-# We don't ship `strip` or `eu-strip` today, and even if we did, it doesn't
-# save much space. So let's disable it to avoid the error-looking message.
-do_strip=no


### PR DESCRIPTION
commit 287dabab9d4bd043179085a7b3dfd454328598d8
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 17:03:38 2026 -0400

    overlay.d/05core: drop hostonly=no dracut config
    
    This is defined in the bootc base images [1] so we don't need to
    additionally define it here.
    
    [1] https://gitlab.com/fedora/bootc/base-images/-/blob/9f9824c9a4ec87062509fe2f9f56382088aebaba/minimal/initramfs.yaml#L9

commit 4a89ee6c0e9baee06d84524eef26fcf4c89924d2
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Apr 20 17:00:45 2026 -0400

    overlay.d/05core: drop dracut conf disabling strip
    
    Since we don't ship it anyway this will have no effect other than
    preventing a harmess warning message:
    
    ```
    dracut[I]: Could not find 'strip'. Not stripping the initramfs.
    ```
    
    I think keeping this config and spending cycles in the future to figure
    out if it is still useful is more harmful than it's worth.
    
    As a side note the bootc base images don't have this config. If we did
    decide it was important enough in the future to re-add this I would argue
    the config should get added there, rather than re-added here.
