### PR TITLE
denylist: skip blocking tests on rawhide/s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -34,3 +34,37 @@
     - ppc64le
   streams:
     - rawhide
+
+# Waiting a bootc release to fix s390x with `bootc install`
+# Right now bootc is not setting `sysroot.bootloader` to `zipl`
+# On s390x causing the bootloader to not be updated.
+- pattern: ostree.hotfix
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide
+- pattern: rpmostree.upgrade-rollback
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide
+- pattern: rpmostree.install-uninstall
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide
+- pattern: multipath.day2
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide
+- pattern: ext.config.systemd.condition-needs-update
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-config/commit/10f346e464dd56d69a02b56460e2d9aaca8da226 we switched rawhide to use `bootc install to-filesystem` to create our disk images.

This was reverted in https://github.com/coreos/fedora-coreos-config/commit/90a6d6e9f2e18e2348b1071d12ebe3d724c7d43b a PR with the fix is now opened in bootc : https://github.com/bootc-dev/bootc/pull/2152 so let's denylist those tests so we can re-enable `bootc install` for rawhide.