### PR TITLE
[rawhide] Reapply "manifest.yaml: use bootc install in osbuild"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,12 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Use bootc install to-filesystem to build the disk image
+# Only for this stream for now
+# See https://github.com/coreos/fedora-coreos-tracker/issues/1827
+bootc-install-to-fs: true
+
+# Bootc will inject the ostree prefix when doing the ostree
+# deployment so we need only the OCI imgref here
+container-imgref: "quay.io/fedora/fedora-coreos:{stream}"


### PR DESCRIPTION
 This reverts commit 90a6d6e9f2e18e2348b1071d12ebe3d724c7d43b.
    
 In 10f346e we switched rawhide to use `bootc install to-filesystem`
 to create our disk images.
    
 This was reverted in 90a6d6e because of s390x issues.
 A PR with the fix is now opened in bootc : bootc-dev/bootc#2152 and
 the tests denylisted in https://github.com/coreos/fedora-coreos-config/pull/4117
 so let's revert the revert to enable this again.

