### PR TITLE
overlay.d/05core: disable bootloader-update.service on live ISO

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/bootloader-update.service.d/coreos-live-disable.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/bootloader-update.service.d/coreos-live-disable.conf
@@ -1,0 +1,8 @@
+# bootupd is enabled by default in CoreOS (F43+ / CentOS9+).
+# On live ISOs, it fails to read metadata from
+# "sysroot/.coreos-aleph-version.json" because the filesystem
+# does not support statx.stx_btime.
+# https://github.com/coreos/fedora-coreos-tracker/issues/2136
+
+[Service]
+ExecCondition=/bin/bash -c '[[ ! $(findmnt -n -o FSTYPE /sysroot) =~ ^(erofs|squashfs)$ ]]'


### PR DESCRIPTION
When running from live-iso `bootupctl` fails with:
```
    error: Querying adoptable state: creation time is not available for the filesystem
```
That happens because filesystem (erofs|suqashfs) doesn't support `statx.stc_btime` field:
```
    $ stat /sysroot/.coreos-aleph-version.json
    Access: 2022-08-01 23:42:11.000000000 +0000
    Modify: 2022-08-01 23:42:11.000000000 +0000
    Change: 2022-08-01 23:42:11.000000000 +0000
     Birth: -
```
https://github.com/coreos/fedora-coreos-tracker/issues/2136