### PR TITLE
[testing] overlay.d/05core: disable systemd-oomd.socket too

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -1,8 +1,9 @@
 # This file contains overrides for systemd services that are
 # enabled by default, but conflict with things we ship.
 
-# We don't have swap by default, and systemd-oomd hard requires it.
+# We don't have swap by default, and systemd-oomd strongly recommends it.
 disable systemd-oomd.service
+disable systemd-oomd.socket
 
 # Disable systemd-firstboot because it conflicts with Ignition.
 # In most cases this is handled via the remove-from-packages


### PR DESCRIPTION
At some point the socket started getting enabled by default [1], which means systemd-oomd.service was running. Let's disable the socket too.

[1] https://src.fedoraproject.org/rpms/redhat-systemd-presets/blob/b056f04a013590fa58d765807c7d1e210608690c/f/90-default.preset#_15

(cherry picked from commit 34d14ce20c75b487ab4e94e46300c8882da8287c)