### PR TITLE
Revert "manifests: drop systemd-auto-mount-removal"

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -155,3 +155,12 @@ postprocess:
         echo "${actuals}" 1>&2
         exit 1
     fi
+
+  # We don't want auto-generated mount units. See also
+  # https://github.com/systemd/systemd/issues/13099
+  - |
+    #!/usr/bin/env bash
+    set -x
+    # Find the .build-id file and remove it too so we don't have a broken symlink.
+    build_id_file=$(find -L /usr/lib/.build-id/ -samefile /usr/lib/systemd/system-generators/systemd-gpt-auto-generator)
+    rm -vf $build_id_file /usr/lib/systemd/system-generators/systemd-gpt-auto-generator


### PR DESCRIPTION
This reverts commit f12dc28e178b3798da6d32d92e107af4bbb96995.

We found issues with this and our luks* tests/configuration. See https://github.com/coreos/fedora-coreos-tracker/issues/2137