### PR TITLE
denylist: add kernel-replace for s390x/rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -68,3 +68,9 @@
      - s390x
   streams:
     - rawhide
+- pattern: ext.config.rpm-ostree.kernel-replace
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  arches:
+     - s390x
+  streams:
+    - rawhide


### PR DESCRIPTION
In d1f479328f6e755943ed092a3ee28f4e95c7e264 I added a few tests that are not passing due to a bug in bootc that have been fixed upstream already.

I missed this one, but it's failing for the same reason so let's deny- list it as well.

We're just denylisting the tests to unstuck rawhide and make progress towards the `bootc install to-filesystem` migration.