### PR TITLE
[testing-devel] Move to Fedora 44

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -5,9 +5,9 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=testing-devel
 DESCRIPTION=Fedora CoreOS testing-devel
-VERSION=43
-MUTATE_OS_RELEASE=43
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-43-standard@sha256:46d31a2d9d13b09fd8e437dd4e375eda99df21d20550ec899ca3a7a6aab39275
+VERSION=44
+MUTATE_OS_RELEASE=44
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:1093a468e82abb1f410e362ee5e8cb3d938ebe6e92bdc6e87f876fcce44b810a
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/ci/buildroot/Dockerfile
+++ b/ci/buildroot/Dockerfile
@@ -5,7 +5,7 @@
 #
 # This image is used by CoreOS CI to build software like
 # Ignition, rpm-ostree, ostree, coreos-installer, etc...
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 # Work around for https://bugzilla.redhat.com/show_bug.cgi?id=2278652
 ENV container=oci
 COPY . /src

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,1348 +1,1366 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.54.3-2.fc43.aarch64"
+      "evra": "1:1.56.0-1.fc44.aarch64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.54.3-2.fc43.aarch64"
+      "evra": "1:1.56.0-1.fc44.aarch64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.54.3-2.fc43.aarch64"
+      "evra": "1:1.56.0-1.fc44.aarch64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.54.3-2.fc43.aarch64"
+      "evra": "1:1.56.0-1.fc44.aarch64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.54.3-2.fc43.aarch64"
+      "evra": "1:1.56.0-1.fc44.aarch64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.15.0.1-1.fc43.noarch"
+      "evra": "2.15.0.1-3.fc44.noarch"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.1-1.fc43.aarch64"
+      "evra": "2:1.17.1-1.fc44.aarch64"
     },
     "acl": {
-      "evra": "2.3.2-4.fc43.aarch64"
+      "evra": "2.3.2-6.fc44.aarch64"
     },
     "adcli": {
-      "evra": "0.9.2-10.fc43.aarch64"
+      "evra": "0.9.3.1-5.fc44.aarch64"
+    },
+    "adcli-selinux": {
+      "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc43.aarch64"
+      "evra": "5.10.0-6.fc44.aarch64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc43.aarch64"
+      "evra": "5.10.0-6.fc44.aarch64"
     },
     "alternatives": {
-      "evra": "1.33-3.fc43.aarch64"
+      "evra": "1.33-5.fc44.aarch64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-6.fc43.aarch64"
+      "evra": "2.5.2-8.fc44.aarch64"
     },
     "audit": {
-      "evra": "4.1.4-1.fc43.aarch64"
+      "evra": "4.1.4-1.fc44.aarch64"
     },
     "audit-libs": {
-      "evra": "4.1.4-1.fc43.aarch64"
+      "evra": "4.1.4-1.fc44.aarch64"
     },
     "audit-rules": {
-      "evra": "4.1.4-1.fc43.aarch64"
+      "evra": "4.1.4-1.fc44.aarch64"
     },
     "authselect": {
-      "evra": "1.6.2-1.fc43.aarch64"
+      "evra": "1.7.1-1.fc44.aarch64"
     },
     "authselect-libs": {
-      "evra": "1.6.2-1.fc43.aarch64"
-    },
-    "avahi-libs": {
-      "evra": "0.9~rc2-6.fc43.aarch64"
+      "evra": "1.7.1-1.fc44.aarch64"
     },
     "azure-vm-utils": {
-      "evra": "0.7.0-1.fc43.aarch64"
+      "evra": "0.7.0-3.fc44.aarch64"
     },
     "bash": {
-      "evra": "5.3.0-2.fc43.aarch64"
+      "evra": "5.3.9-3.fc44.aarch64"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-2.fc43.noarch"
+      "evra": "0.7.1-3.fc44.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.16-2.fc43.noarch"
+      "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc43.aarch64"
+      "evra": "32:9.18.48-1.fc44.aarch64"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc43.aarch64"
+      "evra": "32:9.18.48-1.fc44.aarch64"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc43.aarch64"
+      "evra": "1.15.1-1.fc44.aarch64"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc43.aarch64"
+      "evra": "0.2.33-1.fc44.aarch64"
     },
     "bsdtar": {
-      "evra": "3.8.4-1.fc43.aarch64"
+      "evra": "3.8.7-1.fc44.aarch64"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc43.aarch64"
+      "evra": "6.19.1-1.fc44.aarch64"
     },
     "bubblewrap": {
-      "evra": "0.11.0-2.fc43.aarch64"
+      "evra": "0.11.0-4.fc44.aarch64"
     },
     "bzip2": {
-      "evra": "1.0.8-21.fc43.aarch64"
+      "evra": "1.0.8-23.fc44.aarch64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-21.fc43.aarch64"
+      "evra": "1.0.8-23.fc44.aarch64"
     },
     "c-ares": {
-      "evra": "1.34.5-2.fc43.aarch64"
+      "evra": "1.34.6-3.fc44.aarch64"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.2.fc43.noarch"
+      "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-3.fc43.aarch64"
+      "evra": "0.2.1-5.fc44.aarch64"
     },
     "chrony": {
-      "evra": "4.8-3.fc43.aarch64"
+      "evra": "4.8-5.fc44.aarch64"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc43.aarch64"
+      "evra": "7.5-1.fc44.aarch64"
     },
     "clevis": {
-      "evra": "21-12.fc43.aarch64"
+      "evra": "21-14.fc44.aarch64"
     },
     "clevis-dracut": {
-      "evra": "21-12.fc43.aarch64"
+      "evra": "21-14.fc44.aarch64"
     },
     "clevis-luks": {
-      "evra": "21-12.fc43.aarch64"
+      "evra": "21-14.fc44.aarch64"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-10.fc43.aarch64"
+      "evra": "0.5.4-1.fc44.aarch64"
     },
     "clevis-systemd": {
-      "evra": "21-12.fc43.aarch64"
+      "evra": "21-14.fc44.aarch64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-11.fc43.noarch"
+      "evra": "0.33-13.fc44.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-3.fc43.aarch64"
+      "evra": "1.0.8-5.fc44.aarch64"
     },
     "composefs-libs": {
-      "evra": "1.0.8-3.fc43.aarch64"
+      "evra": "1.0.8-5.fc44.aarch64"
     },
     "conmon": {
-      "evra": "2:2.2.1-2.fc43.aarch64"
+      "evra": "2:2.2.1-2.fc44.aarch64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc43.noarch"
+      "evra": "4:2.247.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.1.7-1.fc43.aarch64"
+      "evra": "2.2.3-1.fc44.aarch64"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc43.aarch64"
+      "evra": "0.26.0-1.fc44.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc43.aarch64"
+      "evra": "0.26.0-1.fc44.aarch64"
     },
     "coreutils": {
-      "evra": "9.7-8.fc43.aarch64"
+      "evra": "9.10-3.fc44.aarch64"
     },
     "coreutils-common": {
-      "evra": "9.7-8.fc43.aarch64"
+      "evra": "9.10-3.fc44.aarch64"
     },
     "cpio": {
-      "evra": "2.15-6.fc43.aarch64"
+      "evra": "2.15-9.fc44.aarch64"
     },
     "cracklib": {
-      "evra": "2.9.11-8.fc43.aarch64"
+      "evra": "2.9.11-10.fc44.aarch64"
     },
     "criu": {
-      "evra": "4.2-11.fc43.aarch64"
+      "evra": "4.2-13.fc44.aarch64"
     },
     "criu-libs": {
-      "evra": "4.2-11.fc43.aarch64"
+      "evra": "4.2-13.fc44.aarch64"
     },
     "crun": {
-      "evra": "1.27.1-1.fc43.aarch64"
+      "evra": "1.27.1-1.fc44.aarch64"
     },
     "crun-wasm": {
-      "evra": "1.27.1-1.fc43.aarch64"
+      "evra": "1.27.1-1.fc44.aarch64"
     },
     "crypto-policies": {
-      "evra": "20251125-1.git63291f8.fc43.noarch"
+      "evra": "20251128-3.git19878fe.fc44.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc43.aarch64"
+      "evra": "2.8.4-1.fc44.aarch64"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc43.aarch64"
+      "evra": "2.8.4-1.fc44.aarch64"
     },
     "curl": {
-      "evra": "8.15.0-6.fc43.aarch64"
+      "evra": "8.18.0-6.fc44.aarch64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-33.fc43.aarch64"
+      "evra": "2.1.28-35.fc44.aarch64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-33.fc43.aarch64"
+      "evra": "2.1.28-35.fc44.aarch64"
     },
     "dbus": {
-      "evra": "1:1.16.0-4.fc43.aarch64"
+      "evra": "1:1.16.2-1.fc44.aarch64"
     },
     "dbus-broker": {
-      "evra": "37-2.fc43.aarch64"
+      "evra": "37-8.fc44.aarch64"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-4.fc43.noarch"
+      "evra": "1:1.16.2-1.fc44.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-4.fc43.aarch64"
+      "evra": "1:1.16.2-1.fc44.aarch64"
     },
     "device-mapper": {
-      "evra": "1.02.208-2.fc43.aarch64"
+      "evra": "1.02.212-2.fc44.aarch64"
     },
     "device-mapper-event": {
-      "evra": "1.02.208-2.fc43.aarch64"
+      "evra": "1.02.212-2.fc44.aarch64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.208-2.fc43.aarch64"
+      "evra": "1.02.212-2.fc44.aarch64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.208-2.fc43.aarch64"
+      "evra": "1.02.212-2.fc44.aarch64"
     },
     "device-mapper-multipath": {
-      "evra": "0.11.1-2.fc43.aarch64"
+      "evra": "0.13.1-1.fc44.aarch64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.11.1-2.fc43.aarch64"
+      "evra": "0.13.1-1.fc44.aarch64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-4.fc43.aarch64"
+      "evra": "1.3.1-3.fc44.aarch64"
     },
     "diffutils": {
-      "evra": "3.12-3.fc43.aarch64"
+      "evra": "3.12-5.fc44.aarch64"
     },
     "dnf5": {
-      "evra": "5.2.18.0-3.fc43.aarch64"
+      "evra": "5.4.2.0-1.fc44.aarch64"
     },
     "dnsmasq": {
-      "evra": "2.92-1.fc43.aarch64"
+      "evra": "2.92-4.fc44.aarch64"
     },
     "docker-cli": {
-      "evra": "29.4.0-1.fc43.aarch64"
+      "evra": "29.4.1-1.fc44.aarch64"
     },
     "dosfstools": {
-      "evra": "4.2-16.fc43.aarch64"
+      "evra": "4.2-18.fc44.aarch64"
     },
     "dracut": {
-      "evra": "107-8.fc43.aarch64"
+      "evra": "108-6.fc44.aarch64"
     },
     "dracut-network": {
-      "evra": "107-8.fc43.aarch64"
+      "evra": "108-6.fc44.aarch64"
     },
     "dracut-squash": {
-      "evra": "107-8.fc43.aarch64"
+      "evra": "108-6.fc44.aarch64"
     },
     "duktape": {
-      "evra": "2.7.0-10.fc43.aarch64"
+      "evra": "2.7.0-11.fc44.aarch64"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-2.fc43.aarch64"
+      "evra": "1.47.3-4.fc44.aarch64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-2.fc43.aarch64"
+      "evra": "1.47.3-4.fc44.aarch64"
     },
     "efi-filesystem": {
-      "evra": "6-4.fc43.noarch"
+      "evra": "6-6.fc44.noarch"
     },
     "efibootmgr": {
-      "evra": "18-10.fc43.aarch64"
+      "evra": "18-11.fc44.aarch64"
     },
     "efivar-libs": {
-      "evra": "39-10.fc43.aarch64"
+      "evra": "39-12.fc44.aarch64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.195-1.fc43.noarch"
+      "evra": "0.195-1.fc44.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.195-1.fc43.aarch64"
+      "evra": "0.195-1.fc44.aarch64"
     },
     "elfutils-libs": {
-      "evra": "0.195-1.fc43.aarch64"
+      "evra": "0.195-1.fc44.aarch64"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc43.aarch64"
+      "evra": "2:7.0-1.fc44.aarch64"
     },
     "expat": {
-      "evra": "2.7.3-1.fc43.aarch64"
+      "evra": "2.7.3-2.fc44.aarch64"
     },
     "fedora-gpg-keys": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-repos": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "43-1.noarch"
-    },
-    "fedora-repos-ostree": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "file": {
-      "evra": "5.46-9.fc43.aarch64"
+      "evra": "5.46-10.fc44.aarch64"
     },
     "file-libs": {
-      "evra": "5.46-9.fc43.aarch64"
+      "evra": "5.46-10.fc44.aarch64"
     },
     "filesystem": {
-      "evra": "3.18-50.fc43.aarch64"
+      "evra": "3.18-52.fc44.aarch64"
     },
     "findutils": {
-      "evra": "1:4.10.0-6.fc43.aarch64"
+      "evra": "1:4.10.0-7.fc44.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.16.6-1.fc43.aarch64"
+      "evra": "1.17.6-1.fc44.aarch64"
     },
     "fmt": {
-      "evra": "11.2.0-3.fc43.aarch64"
+      "evra": "11.2.0-4.fc44.aarch64"
     },
     "fstrm": {
-      "evra": "0.6.1-13.fc43.aarch64"
+      "evra": "0.6.1-14.fc44.aarch64"
     },
     "fuse-common": {
-      "evra": "3.16.2-6.fc43.aarch64"
+      "evra": "3.18.2-1.fc44.aarch64"
     },
     "fuse-overlayfs": {
-      "evra": "1.13-4.fc43.aarch64"
+      "evra": "1.16-2.fc44.aarch64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-1.fc43.aarch64"
+      "evra": "3.7.5-3.fc44.aarch64"
     },
     "fuse3": {
-      "evra": "3.16.2-6.fc43.aarch64"
+      "evra": "3.18.2-1.fc44.aarch64"
     },
     "fuse3-libs": {
-      "evra": "3.16.2-6.fc43.aarch64"
+      "evra": "3.18.2-1.fc44.aarch64"
     },
     "fwupd": {
-      "evra": "2.0.20-1.fc43.aarch64"
+      "evra": "2.1.1-1.fc44.aarch64"
     },
     "gawk": {
-      "evra": "5.3.2-2.fc43.aarch64"
+      "evra": "5.3.2-3.fc44.aarch64"
     },
     "gdbm": {
-      "evra": "1:1.23-10.fc43.aarch64"
+      "evra": "1:1.23-11.fc44.aarch64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-10.fc43.aarch64"
+      "evra": "1:1.23-11.fc44.aarch64"
     },
     "gdisk": {
-      "evra": "1.0.10-4.fc43.aarch64"
+      "evra": "1.0.10-5.fc44.aarch64"
     },
     "gettext-envsubst": {
-      "evra": "0.25.1-2.fc43.aarch64"
+      "evra": "0.26-4.fc44.aarch64"
     },
     "gettext-libs": {
-      "evra": "0.25.1-2.fc43.aarch64"
+      "evra": "0.26-4.fc44.aarch64"
     },
     "gettext-runtime": {
-      "evra": "0.25.1-2.fc43.aarch64"
+      "evra": "0.26-4.fc44.aarch64"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc43.aarch64"
+      "evra": "2.54.0-1.fc44.aarch64"
     },
     "glib2": {
-      "evra": "2.86.5-1.fc43.aarch64"
+      "evra": "2.88.0-1.fc44.aarch64"
     },
     "glibc": {
-      "evra": "2.42-11.fc43.aarch64"
+      "evra": "2.43-3.fc44.aarch64"
     },
     "glibc-common": {
-      "evra": "2.42-11.fc43.aarch64"
+      "evra": "2.43-3.fc44.aarch64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.42-11.fc43.aarch64"
+      "evra": "2.43-3.fc44.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.42-11.fc43.aarch64"
+      "evra": "2.43-3.fc44.aarch64"
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc43.aarch64"
+      "evra": "1:6.3.0-5.fc44.aarch64"
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc43.noarch"
+      "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc43.aarch64"
+      "evra": "2.4.9-7.fc44.aarch64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc43.aarch64"
+      "evra": "3.8.12-1.fc44.aarch64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-2.fc43.noarch"
+      "evra": "20250221.00-3.fc44.noarch"
     },
     "gpgme": {
-      "evra": "1.24.3-6.fc43.aarch64"
+      "evra": "2.0.1-3.fc44.aarch64"
     },
     "grep": {
-      "evra": "3.12-2.fc43.aarch64"
+      "evra": "3.12-3.fc44.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.12-43.fc43.noarch"
+      "evra": "1:2.12-56.fc44.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.12-43.fc43.aarch64"
+      "evra": "1:2.12-56.fc44.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.12-43.fc43.aarch64"
+      "evra": "1:2.12-56.fc44.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-43.fc43.aarch64"
+      "evra": "1:2.12-56.fc44.aarch64"
+    },
+    "gssproxy": {
+      "evra": "0.9.2-10.fc44.aarch64"
     },
     "gzip": {
-      "evra": "1.13-4.fc43.aarch64"
+      "evra": "1.14-2.fc44.aarch64"
     },
     "hostname": {
-      "evra": "3.25-3.fc43.aarch64"
+      "evra": "3.25-4.fc44.aarch64"
     },
     "hwdata": {
-      "evra": "0.406-1.fc43.noarch"
+      "evra": "0.406-1.fc44.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-4.fc43.aarch64"
+      "evra": "2.26.0-4.fc44.aarch64"
     },
     "ignition-grub": {
-      "evra": "2.26.0-4.fc43.aarch64"
+      "evra": "2.26.0-4.fc44.aarch64"
     },
     "inih": {
-      "evra": "62-1.fc43.aarch64"
+      "evra": "62-2.fc44.aarch64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-12.fc43.aarch64"
+      "evra": "1.0.3-13.fc44.aarch64"
     },
     "iproute": {
-      "evra": "6.14.0-2.fc43.aarch64"
+      "evra": "6.17.0-2.fc44.aarch64"
     },
     "iproute-tc": {
-      "evra": "6.14.0-2.fc43.aarch64"
+      "evra": "6.17.0-2.fc44.aarch64"
     },
     "iptables-libs": {
-      "evra": "1.8.11-12.fc43.aarch64"
+      "evra": "1.8.11-13.fc44.aarch64"
     },
     "iptables-nft": {
-      "evra": "1.8.11-12.fc43.aarch64"
+      "evra": "1.8.11-13.fc44.aarch64"
     },
     "iptables-services": {
-      "evra": "1.8.11-12.fc43.noarch"
+      "evra": "1.8.11-13.fc44.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-12.fc43.aarch64"
+      "evra": "1.8.11-13.fc44.aarch64"
     },
     "iputils": {
-      "evra": "20250605-1.fc43.aarch64"
+      "evra": "20250605-2.fc44.aarch64"
     },
     "irqbalance": {
-      "evra": "2:1.9.4-7.fc43.aarch64"
+      "evra": "2:1.9.5-2.fc44.aarch64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.aarch64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.aarch64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.aarch64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.aarch64"
     },
     "isns-utils-libs": {
-      "evra": "0.103-3.fc43.aarch64"
+      "evra": "0.103-4.fc44.aarch64"
     },
     "jansson": {
-      "evra": "2.14-3.fc43.aarch64"
+      "evra": "2.14-4.fc44.aarch64"
     },
     "jose": {
-      "evra": "14-5.fc43.aarch64"
+      "evra": "14-6.fc44.aarch64"
     },
     "jq": {
-      "evra": "1.8.1-3.fc43.aarch64"
+      "evra": "1.8.1-3.fc44.aarch64"
     },
     "json-c": {
-      "evra": "0.18-7.fc43.aarch64"
+      "evra": "0.18-8.fc44.aarch64"
     },
     "json-glib": {
-      "evra": "1.10.8-4.fc43.aarch64"
+      "evra": "1.10.8-5.fc44.aarch64"
     },
     "kbd": {
-      "evra": "2.8.0-3.fc43.aarch64"
+      "evra": "2.9.0-3.fc44.aarch64"
     },
     "kbd-legacy": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kbd-misc": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.61-1.fc43.aarch64"
+      "evra": "1.0.61-1.fc44.aarch64"
     },
     "kernel": {
-      "evra": "6.19.14-200.fc43.aarch64"
+      "evra": "6.19.14-300.fc44.aarch64"
     },
     "kernel-core": {
-      "evra": "6.19.14-200.fc43.aarch64"
+      "evra": "6.19.14-300.fc44.aarch64"
     },
     "kernel-modules": {
-      "evra": "6.19.14-200.fc43.aarch64"
+      "evra": "6.19.14-300.fc44.aarch64"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-200.fc43.aarch64"
+      "evra": "6.19.14-300.fc44.aarch64"
     },
     "kexec-tools": {
-      "evra": "2.0.32-1.fc43.aarch64"
+      "evra": "2.0.32-3.fc44.aarch64"
     },
     "keyutils": {
-      "evra": "1.6.3-6.fc43.aarch64"
+      "evra": "1.6.3-7.fc44.aarch64"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-6.fc43.aarch64"
+      "evra": "1.6.3-7.fc44.aarch64"
     },
     "kmod": {
-      "evra": "34.2-2.fc43.aarch64"
+      "evra": "34.2-4.fc44.aarch64"
     },
     "kmod-libs": {
-      "evra": "34.2-2.fc43.aarch64"
+      "evra": "34.2-4.fc44.aarch64"
     },
     "kpartx": {
-      "evra": "0.11.1-2.fc43.aarch64"
+      "evra": "0.13.1-1.fc44.aarch64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc43.aarch64"
+      "evra": "1.22.2-3.fc44.aarch64"
     },
     "less": {
-      "evra": "692-5.fc43.aarch64"
+      "evra": "692-5.fc44.aarch64"
     },
     "libacl": {
-      "evra": "2.3.2-4.fc43.aarch64"
+      "evra": "2.3.2-6.fc44.aarch64"
     },
     "libaio": {
-      "evra": "0.3.111-22.fc43.aarch64"
+      "evra": "0.3.111-23.fc44.aarch64"
     },
     "libarchive": {
-      "evra": "3.8.4-1.fc43.aarch64"
+      "evra": "3.8.7-1.fc44.aarch64"
     },
     "libassuan": {
-      "evra": "2.5.7-4.fc43.aarch64"
-    },
-    "libatomic": {
-      "evra": "15.2.1-7.fc43.aarch64"
+      "evra": "2.5.7-5.fc44.aarch64"
     },
     "libattr": {
-      "evra": "2.5.2-6.fc43.aarch64"
+      "evra": "2.5.2-8.fc44.aarch64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-59.fc43.aarch64"
+      "evra": "0.1.1-61.fc44.aarch64"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libbpf": {
-      "evra": "2:1.6.1-3.fc43.aarch64"
+      "evra": "2:1.6.3-1.fc44.aarch64"
     },
     "libbsd": {
-      "evra": "0.12.2-6.fc43.aarch64"
+      "evra": "0.12.2-7.fc44.aarch64"
     },
     "libcap": {
-      "evra": "2.76-4.fc43.aarch64"
+      "evra": "2.78-1.fc44.aarch64"
     },
     "libcap-ng": {
-      "evra": "0.9.3-1.fc43.aarch64"
+      "evra": "0.9.3-1.fc44.aarch64"
     },
     "libcbor": {
-      "evra": "0.12.0-6.fc43.aarch64"
+      "evra": "0.13.0-2.fc44.aarch64"
     },
     "libcollection": {
-      "evra": "0.7.0-59.fc43.aarch64"
+      "evra": "0.7.0-61.fc44.aarch64"
     },
     "libcom_err": {
-      "evra": "1.47.3-2.fc43.aarch64"
+      "evra": "1.47.3-4.fc44.aarch64"
     },
     "libcurl-minimal": {
-      "evra": "8.15.0-6.fc43.aarch64"
+      "evra": "8.18.0-6.fc44.aarch64"
     },
     "libdaemon": {
-      "evra": "0.14-32.fc43.aarch64"
+      "evra": "0.14-33.fc44.aarch64"
     },
     "libdhash": {
-      "evra": "0.5.0-59.fc43.aarch64"
+      "evra": "0.5.0-61.fc44.aarch64"
     },
     "libdnf5": {
-      "evra": "5.2.18.0-3.fc43.aarch64"
+      "evra": "5.4.2.0-1.fc44.aarch64"
     },
     "libdnf5-cli": {
-      "evra": "5.2.18.0-3.fc43.aarch64"
+      "evra": "5.4.2.0-1.fc44.aarch64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc43.aarch64"
+      "evra": "2.4.131-1.fc44.aarch64"
     },
     "libeconf": {
-      "evra": "0.7.9-2.fc43.aarch64"
+      "evra": "0.7.9-3.fc44.aarch64"
     },
     "libedit": {
-      "evra": "3.1-57.20251016cvs.fc43.aarch64"
+      "evra": "3.1-58.20251016cvs.fc44.aarch64"
+    },
+    "libev": {
+      "evra": "4.33-15.fc44.aarch64"
     },
     "libevent": {
-      "evra": "2.1.12-16.fc43.aarch64"
+      "evra": "2.1.12-17.fc44.aarch64"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libffi": {
-      "evra": "3.5.2-1.fc43.aarch64"
+      "evra": "3.5.2-2.fc44.aarch64"
     },
     "libfido2": {
-      "evra": "1.16.0-3.fc43.aarch64"
+      "evra": "1.16.0-5.fc44.aarch64"
     },
     "libgcc": {
-      "evra": "15.2.1-7.fc43.aarch64"
+      "evra": "16.0.1-0.10.fc44.aarch64"
     },
     "libgcrypt": {
-      "evra": "1.11.1-4.fc43.aarch64"
+      "evra": "1.12.2-1.fc44.aarch64"
     },
     "libgpg-error": {
-      "evra": "1.55-2.fc43.aarch64"
+      "evra": "1.58-2.fc44.aarch64"
     },
     "libibverbs": {
-      "evra": "58.0-4.fc43.aarch64"
+      "evra": "61.0-2.fc44.aarch64"
     },
     "libicu": {
-      "evra": "77.1-1.fc43.aarch64"
+      "evra": "77.1-2.fc44.aarch64"
     },
     "libidn2": {
-      "evra": "2.3.8-2.fc43.aarch64"
+      "evra": "2.3.8-3.fc44.aarch64"
     },
     "libini_config": {
-      "evra": "1.3.1-59.fc43.aarch64"
+      "evra": "1.3.1-61.fc44.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "libjcat": {
-      "evra": "0.2.6-1.fc43.aarch64"
+      "evra": "0.2.6-1.fc44.aarch64"
     },
     "libjose": {
-      "evra": "14-5.fc43.aarch64"
+      "evra": "14-6.fc44.aarch64"
     },
     "libkcapi": {
-      "evra": "1.5.0-6.fc43.aarch64"
+      "evra": "1.5.0-7.fc44.aarch64"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-6.fc43.aarch64"
+      "evra": "1.5.0-7.fc44.aarch64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-6.fc43.aarch64"
+      "evra": "1.5.0-7.fc44.aarch64"
     },
     "libksba": {
-      "evra": "1.6.7-4.fc43.aarch64"
+      "evra": "1.6.7-5.fc44.aarch64"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libldb": {
-      "evra": "2:4.23.7-2.fc43.aarch64"
+      "evra": "2:4.24.1-1.fc44.aarch64"
     },
     "libluksmeta": {
-      "evra": "10-1.fc43.aarch64"
+      "evra": "10-2.fc44.aarch64"
     },
     "libmaxminddb": {
-      "evra": "1.13.3-1.fc43.aarch64"
+      "evra": "1.13.3-1.fc44.aarch64"
     },
     "libmd": {
-      "evra": "1.1.0-8.fc43.aarch64"
+      "evra": "1.1.0-9.fc44.aarch64"
     },
     "libmnl": {
-      "evra": "1.0.5-8.fc43.aarch64"
+      "evra": "1.0.5-9.fc44.aarch64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-4.fc43.aarch64"
+      "evra": "2.15.2-7.fc44.aarch64"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libndp": {
-      "evra": "1.9-4.fc43.aarch64"
+      "evra": "1.9-5.fc44.aarch64"
     },
     "libnet": {
-      "evra": "1.3-6.fc43.aarch64"
+      "evra": "1.3-7.fc44.aarch64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.1.1-1.fc43.aarch64"
+      "evra": "1.1.1-1.fc44.aarch64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-31.fc43.aarch64"
+      "evra": "1.0.1-32.fc44.aarch64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc43.aarch64"
+      "evra": "1:2.8.7-1.fc44.aarch64"
     },
     "libnftnl": {
-      "evra": "1.2.9-2.fc43.aarch64"
+      "evra": "1.3.1-2.fc44.aarch64"
     },
     "libnghttp2": {
-      "evra": "1.66.0-2.fc43.aarch64"
+      "evra": "1.68.0-3.fc44.aarch64"
     },
     "libnl3": {
-      "evra": "3.12.0-2.fc43.aarch64"
+      "evra": "3.12.0-3.fc44.aarch64"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-2.fc43.aarch64"
+      "evra": "3.12.0-3.fc44.aarch64"
     },
     "libnsl2": {
-      "evra": "2.0.1-4.fc43.aarch64"
+      "evra": "2.0.1-5.fc44.aarch64"
     },
     "libnvme": {
-      "evra": "1.16.1-1.fc43.aarch64"
+      "evra": "1.16.1-2.fc44.aarch64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-59.fc43.aarch64"
+      "evra": "0.2.1-61.fc44.aarch64"
     },
     "libpcap": {
-      "evra": "14:1.10.6-1.fc43.aarch64"
+      "evra": "14:1.10.6-2.fc44.aarch64"
     },
     "libpciaccess": {
-      "evra": "0.16-16.fc43.aarch64"
+      "evra": "0.16-17.fc44.aarch64"
     },
     "libpkgconf": {
-      "evra": "2.3.0-3.fc43.aarch64"
+      "evra": "2.5.1-1.fc44.aarch64"
     },
     "libpsl": {
-      "evra": "0.21.5-6.fc43.aarch64"
+      "evra": "0.21.5-7.fc44.aarch64"
     },
     "libpwquality": {
-      "evra": "1.4.5-14.fc43.aarch64"
+      "evra": "1.4.5-15.fc44.aarch64"
     },
     "libref_array": {
-      "evra": "0.1.5-59.fc43.aarch64"
+      "evra": "0.1.5-61.fc44.aarch64"
     },
     "librepo": {
-      "evra": "1.20.0-4.fc43.aarch64"
+      "evra": "1.20.0-5.fc44.aarch64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-9.fc43.noarch"
+      "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-2.fc43.aarch64"
+      "evra": "2.6.0-3.fc44.aarch64"
     },
     "libselinux": {
-      "evra": "3.9-5.fc43.aarch64"
+      "evra": "3.10-1.fc44.aarch64"
     },
     "libselinux-utils": {
-      "evra": "3.9-5.fc43.aarch64"
+      "evra": "3.10-1.fc44.aarch64"
     },
     "libsemanage": {
-      "evra": "3.9-4.fc43.aarch64"
+      "evra": "3.10-1.fc44.aarch64"
     },
     "libsepol": {
-      "evra": "3.9-2.fc43.aarch64"
+      "evra": "3.10-1.fc44.aarch64"
     },
     "libslirp": {
-      "evra": "4.9.1-2.fc43.aarch64"
+      "evra": "4.9.1-3.fc44.aarch64"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.23.7-2.fc43.aarch64"
+      "evra": "2:4.24.1-1.fc44.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.36-3.fc43.aarch64"
+      "evra": "0.7.37-2.fc44.aarch64"
     },
     "libss": {
-      "evra": "1.47.3-2.fc43.aarch64"
+      "evra": "1.47.3-4.fc44.aarch64"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "libstdc++": {
-      "evra": "15.2.1-7.fc43.aarch64"
+      "evra": "16.0.1-0.10.fc44.aarch64"
     },
     "libtalloc": {
-      "evra": "2.4.3-4.fc43.aarch64"
+      "evra": "2.4.4-1.fc44.aarch64"
     },
     "libtasn1": {
-      "evra": "4.21.0-1.fc43.aarch64"
+      "evra": "4.21.0-1.fc44.aarch64"
     },
     "libtdb": {
-      "evra": "1.4.14-3.fc43.aarch64"
+      "evra": "1.4.15-1.fc44.aarch64"
     },
     "libteam": {
-      "evra": "1.32-12.fc43.aarch64"
+      "evra": "1.32-13.fc44.aarch64"
     },
     "libtevent": {
-      "evra": "0.17.1-3.fc43.aarch64"
+      "evra": "0.17.1-4.fc44.aarch64"
     },
     "libtextstyle": {
-      "evra": "0.25.1-2.fc43.aarch64"
+      "evra": "0.26-4.fc44.aarch64"
     },
     "libtirpc": {
-      "evra": "1.3.7-1.fc43.aarch64"
+      "evra": "1.3.7-2.fc44.aarch64"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-8.fc43.aarch64"
+      "evra": "2.5.4-10.fc44.aarch64"
     },
     "libunistring": {
-      "evra": "1.1-10.fc43.aarch64"
+      "evra": "1.1-11.fc44.aarch64"
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc43.aarch64"
+      "evra": "1.0.29-5.fc44.aarch64"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "libuv": {
-      "evra": "1:1.51.0-2.fc43.aarch64"
+      "evra": "1:1.51.0-3.fc44.aarch64"
     },
     "libverto": {
-      "evra": "0.3.2-11.fc43.aarch64"
+      "evra": "0.3.2-12.fc44.aarch64"
+    },
+    "libverto-libev": {
+      "evra": "0.3.2-12.fc44.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.23.7-2.fc43.aarch64"
+      "evra": "2:4.24.1-1.fc44.aarch64"
     },
     "libxcrypt": {
-      "evra": "4.5.2-1.fc43.aarch64"
+      "evra": "4.5.2-3.fc44.aarch64"
     },
     "libxml2": {
-      "evra": "2.12.10-5.fc43.aarch64"
+      "evra": "2.12.10-6.fc44.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc43.aarch64"
+      "evra": "0.3.26-1.fc44.aarch64"
     },
     "libyaml": {
-      "evra": "0.2.5-17.fc43.aarch64"
+      "evra": "0.2.5-18.fc44.aarch64"
     },
     "libzstd": {
-      "evra": "1.5.7-2.fc43.aarch64"
+      "evra": "1.5.7-5.fc44.aarch64"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "lld18-libs": {
       "evra": "18.1.8-8.fc43.aarch64"
     },
     "llvm18-libs": {
-      "evra": "18.1.8-7.fc43.aarch64"
+      "evra": "18.1.8-8.fc44.aarch64"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-1.fc43.aarch64"
+      "evra": "0.9.34-2.fc44.aarch64"
     },
     "logrotate": {
-      "evra": "3.22.0-4.fc43.aarch64"
+      "evra": "3.22.0-5.fc44.aarch64"
     },
     "lsof": {
-      "evra": "4.98.0-8.fc43.aarch64"
+      "evra": "4.98.0-9.fc44.aarch64"
     },
     "lua-libs": {
-      "evra": "5.4.8-4.fc43.aarch64"
+      "evra": "5.4.8-5.fc44.aarch64"
     },
     "luksmeta": {
-      "evra": "10-1.fc43.aarch64"
+      "evra": "10-2.fc44.aarch64"
     },
     "lvm2": {
-      "evra": "2.03.34-2.fc43.aarch64"
+      "evra": "2.03.38-2.fc44.aarch64"
     },
     "lvm2-libs": {
-      "evra": "2.03.34-2.fc43.aarch64"
+      "evra": "2.03.38-2.fc44.aarch64"
     },
     "lz4-libs": {
-      "evra": "1.10.0-3.fc43.aarch64"
+      "evra": "1.10.0-4.fc44.aarch64"
     },
     "lzo": {
-      "evra": "2.10-15.fc43.aarch64"
+      "evra": "2.10-16.fc44.aarch64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-1.fc43.aarch64"
+      "evra": "1.7.8-2.fc44.aarch64"
     },
     "mdadm": {
-      "evra": "4.3-9.fc43.aarch64"
+      "evra": "4.3-11.fc44.aarch64"
     },
     "moby-engine": {
-      "evra": "29.4.0-1.fc43.aarch64"
+      "evra": "29.4.1-1.fc44.aarch64"
     },
     "moby-filesystem": {
-      "evra": "29.4.0-1.fc43.noarch"
+      "evra": "29.4.1-1.fc44.noarch"
     },
     "mokutil": {
-      "evra": "2:0.7.2-2.fc43.aarch64"
+      "evra": "2:0.7.2-3.fc44.aarch64"
     },
     "mpfr": {
-      "evra": "4.2.2-2.fc43.aarch64"
+      "evra": "4.2.2-3.fc44.aarch64"
     },
     "nano": {
-      "evra": "8.5-2.fc43.aarch64"
+      "evra": "8.7.1-1.fc44.aarch64"
     },
     "nano-default-editor": {
-      "evra": "8.5-2.fc43.noarch"
+      "evra": "8.7.1-1.fc44.noarch"
     },
     "ncurses": {
-      "evra": "6.5-7.20250614.fc43.aarch64"
+      "evra": "6.6-1.fc44.aarch64"
     },
     "ncurses-base": {
-      "evra": "6.5-7.20250614.fc43.noarch"
+      "evra": "6.6-1.fc44.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.5-7.20250614.fc43.aarch64"
+      "evra": "6.6-1.fc44.aarch64"
     },
     "net-tools": {
-      "evra": "2.0-0.74.20160912git.fc43.aarch64"
+      "evra": "2.0-0.77.20160912git.fc44.aarch64"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc43.aarch64"
+      "evra": "2:1.17.2-1.fc44.aarch64"
     },
     "nettle": {
-      "evra": "3.10.1-2.fc43.aarch64"
+      "evra": "3.10.1-3.fc44.aarch64"
     },
     "newt": {
-      "evra": "0.52.25-5.fc43.aarch64"
+      "evra": "0.52.25-6.fc44.aarch64"
     },
-    "nfs-utils-coreos": {
-      "evra": "1:2.8.7-1.fc43.aarch64"
+    "nfs-client-utils": {
+      "evra": "1:2.8.7-1.fc44.aarch64"
+    },
+    "nfs-common-utils": {
+      "evra": "1:2.8.7-1.fc44.aarch64"
+    },
+    "nfsv3-client-utils": {
+      "evra": "1:2.8.7-1.fc44.aarch64"
+    },
+    "nfsv4-client-utils": {
+      "evra": "1:2.8.7-1.fc44.aarch64"
     },
     "nftables": {
-      "evra": "1:1.1.3-6.fc43.1.aarch64"
+      "evra": "1:1.1.6-2.fc44.aarch64"
     },
     "nftables-services": {
-      "evra": "1:1.1.3-6.fc43.1.noarch"
+      "evra": "1:1.1.6-2.fc44.noarch"
     },
     "ngtcp2": {
-      "evra": "1.22.1-1.fc43.aarch64"
+      "evra": "1.22.1-1.fc44.aarch64"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.22.1-1.fc43.aarch64"
+      "evra": "1.22.1-1.fc44.aarch64"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc43.aarch64"
+      "evra": "2.2.57-2.fc44.aarch64"
     },
     "npth": {
-      "evra": "1.8-3.fc43.aarch64"
+      "evra": "1.8-4.fc44.aarch64"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-7.fc43.aarch64"
+      "evra": "2.23.0-9.fc44.aarch64"
     },
     "numactl": {
-      "evra": "2.0.19-3.fc43.aarch64"
+      "evra": "2.0.19-4.fc44.aarch64"
     },
     "numactl-libs": {
-      "evra": "2.0.19-3.fc43.aarch64"
+      "evra": "2.0.19-4.fc44.aarch64"
     },
     "numad": {
-      "evra": "0.5-47.20150602git.fc43.aarch64"
+      "evra": "0.5-50.20251104git.fc44.aarch64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-1.fc43.aarch64"
+      "evra": "2.16-2.fc44.aarch64"
     },
     "oniguruma": {
-      "evra": "6.9.10-3.fc43.aarch64"
+      "evra": "6.9.10-4.fc44.aarch64"
     },
     "openldap": {
-      "evra": "2.6.13-1.fc43.aarch64"
+      "evra": "2.6.13-1.fc44.aarch64"
     },
     "openssh": {
-      "evra": "10.0p1-9.fc43.aarch64"
+      "evra": "10.2p1-9.fc44.aarch64"
     },
     "openssh-clients": {
-      "evra": "10.0p1-9.fc43.aarch64"
+      "evra": "10.2p1-9.fc44.aarch64"
     },
     "openssh-server": {
-      "evra": "10.0p1-9.fc43.aarch64"
+      "evra": "10.2p1-9.fc44.aarch64"
     },
     "openssl": {
-      "evra": "1:3.5.4-3.fc43.aarch64"
+      "evra": "1:3.5.5-2.fc44.aarch64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.4-3.fc43.aarch64"
+      "evra": "1:3.5.5-2.fc44.aarch64"
     },
     "os-prober": {
-      "evra": "1.81-10.fc43.aarch64"
+      "evra": "1.81-11.fc44.aarch64"
     },
     "ostree": {
-      "evra": "2026.1-1.fc43.aarch64"
+      "evra": "2026.1-1.fc44.aarch64"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc43.aarch64"
+      "evra": "2026.1-1.fc44.aarch64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc43.aarch64"
+      "evra": "0.26.2-1.fc44.aarch64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc43.aarch64"
+      "evra": "0.26.2-1.fc44.aarch64"
     },
     "pam": {
-      "evra": "1.7.1-4.fc43.aarch64"
+      "evra": "1.7.2-1.fc44.aarch64"
     },
     "pam-libs": {
-      "evra": "1.7.1-4.fc43.aarch64"
+      "evra": "1.7.2-1.fc44.aarch64"
     },
     "passim-libs": {
-      "evra": "0.1.11-1.fc43.aarch64"
+      "evra": "0.1.11-1.fc44.aarch64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc43.aarch64"
+      "evra": "0^20260120.g386b5f5-1.fc44.aarch64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc43.noarch"
+      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-2.fc43.aarch64"
+      "evra": "3.14.0-3.fc44.aarch64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-2.fc43.aarch64"
+      "evra": "3.14.0-3.fc44.aarch64"
     },
     "pcre2": {
-      "evra": "10.47-1.fc43.aarch64"
+      "evra": "10.47-1.fc44.1.aarch64"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc43.noarch"
+      "evra": "10.47-1.fc44.1.noarch"
     },
     "pigz": {
-      "evra": "2.8-7.fc43.aarch64"
+      "evra": "2.8-8.fc44.aarch64"
     },
     "pkgconf": {
-      "evra": "2.3.0-3.fc43.aarch64"
+      "evra": "2.5.1-1.fc44.aarch64"
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-3.fc43.noarch"
+      "evra": "2.5.1-1.fc44.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-3.fc43.aarch64"
+      "evra": "2.5.1-1.fc44.aarch64"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc43.aarch64"
+      "evra": "5:5.8.2-1.fc44.aarch64"
     },
     "podman-sequoia": {
-      "evra": "0.2.0-3.fc43.aarch64"
+      "evra": "0.3.2-1.fc44.aarch64"
     },
     "policycoreutils": {
-      "evra": "3.9-7.fc43.aarch64"
+      "evra": "3.10-1.fc44.aarch64"
     },
     "polkit": {
-      "evra": "126-6.fc43.2.aarch64"
+      "evra": "127-2.fc44.2.aarch64"
     },
     "polkit-libs": {
-      "evra": "126-6.fc43.2.aarch64"
+      "evra": "127-2.fc44.2.aarch64"
     },
     "popt": {
-      "evra": "1.19-9.fc43.aarch64"
+      "evra": "1.19-10.fc44.aarch64"
     },
     "procps-ng": {
-      "evra": "4.0.4-7.fc43.1.aarch64"
+      "evra": "4.0.6-1.fc44.aarch64"
     },
     "protobuf-c": {
-      "evra": "1.5.2-1.fc43.aarch64"
+      "evra": "1.5.2-2.fc44.aarch64"
     },
     "psmisc": {
-      "evra": "23.7-6.fc43.aarch64"
+      "evra": "23.7-7.fc44.aarch64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc43.noarch"
+      "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:10.1.5-1.fc43.aarch64"
+      "evra": "2:10.2.2-1.fc44.aarch64"
+    },
+    "rdma-core-common": {
+      "evra": "61.0-2.fc44.noarch"
     },
     "readline": {
-      "evra": "8.3-2.fc43.aarch64"
+      "evra": "8.3-4.fc44.aarch64"
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc43.aarch64"
+      "evra": "1.2.8-1.fc44.aarch64"
     },
     "rpm": {
-      "evra": "6.0.1-1.fc43.aarch64"
+      "evra": "6.0.1-2.fc44.aarch64"
     },
     "rpm-libs": {
-      "evra": "6.0.1-1.fc43.aarch64"
+      "evra": "6.0.1-2.fc44.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc43.aarch64"
+      "evra": "2026.1-3.fc44.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc43.aarch64"
+      "evra": "2026.1-3.fc44.aarch64"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-1.fc43.aarch64"
+      "evra": "6.0.1-2.fc44.aarch64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc43.aarch64"
+      "evra": "1.10.2-1.fc44.aarch64"
     },
     "rsync": {
-      "evra": "3.4.1-5.fc43.aarch64"
+      "evra": "3.4.1-6.fc44.aarch64"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc43.aarch64"
+      "evra": "2:1.4.2-1.fc44.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.23.7-2.fc43.aarch64"
+      "evra": "2:4.24.1-1.fc44.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.23.7-2.fc43.noarch"
+      "evra": "2:4.24.1-1.fc44.noarch"
     },
-    "samba-common-libs": {
-      "evra": "2:4.23.7-2.fc43.aarch64"
+    "samba-core-libs": {
+      "evra": "2:4.24.1-1.fc44.aarch64"
+    },
+    "samba-ndr-libs": {
+      "evra": "2:4.24.1-1.fc44.aarch64"
     },
     "sdbus-cpp": {
-      "evra": "2.1.0-3.fc43.aarch64"
+      "evra": "2.2.1-2.fc44.aarch64"
     },
     "sed": {
-      "evra": "4.9-5.fc43.aarch64"
+      "evra": "4.9-7.fc44.aarch64"
     },
     "selinux-policy": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "setup": {
-      "evra": "2.15.0-26.fc43.noarch"
+      "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-6.fc43.aarch64"
+      "evra": "1.48-8.fc44.aarch64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-6.fc43.aarch64"
+      "evra": "1.48-8.fc44.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.18.0-3.fc43.aarch64"
+      "evra": "2:4.19.0-6.fc44.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.18.0-3.fc43.aarch64"
+      "evra": "2:4.19.0-6.fc44.aarch64"
     },
     "shared-mime-info": {
-      "evra": "2.4-2.fc43.aarch64"
+      "evra": "2.4-3.fc44.aarch64"
     },
     "shim-aa64": {
-      "evra": "15.8-3.aarch64"
+      "evra": "16.1-5.aarch64"
     },
     "skopeo": {
-      "evra": "1:1.22.2-1.fc43.aarch64"
+      "evra": "1:1.22.2-1.fc44.aarch64"
     },
     "slang": {
-      "evra": "2.3.3-8.fc43.aarch64"
+      "evra": "2.3.3-9.fc44.aarch64"
     },
     "slirp4netns": {
-      "evra": "1.3.1-3.fc43.aarch64"
+      "evra": "1.3.1-4.fc44.aarch64"
     },
     "snappy": {
-      "evra": "1.2.2-2.fc43.aarch64"
+      "evra": "1.2.2-4.fc44.aarch64"
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc43.aarch64"
+      "evra": "1.8.1.0-2.fc44.aarch64"
     },
     "spdlog": {
-      "evra": "1.15.3-3.fc43.aarch64"
+      "evra": "1.15.3-4.fc44.aarch64"
     },
     "sqlite-libs": {
-      "evra": "3.50.2-2.fc43.aarch64"
+      "evra": "3.51.2-1.fc44.aarch64"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-7.fc43.aarch64"
+      "evra": "4.6.1-8.fc44.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-client": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-common": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-1.fc43.aarch64"
+      "evra": "2.13.0-1.fc44.aarch64"
     },
     "stalld": {
-      "evra": "1.26.3-1.fc43.aarch64"
+      "evra": "1.26.3-2.fc44.aarch64"
     },
     "sudo": {
-      "evra": "1.9.17-7.p2.fc43.aarch64"
+      "evra": "1.9.17-8.p2.fc44.aarch64"
     },
     "systemd": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-container": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-libs": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-pam": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-resolved": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-shared": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-sysusers": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "systemd-udev": {
-      "evra": "258.7-1.fc43.aarch64"
+      "evra": "259.5-1.fc44.aarch64"
     },
     "tar": {
-      "evra": "2:1.35-6.fc43.aarch64"
+      "evra": "2:1.35-8.fc44.aarch64"
     },
     "teamd": {
-      "evra": "1.32-12.fc43.aarch64"
+      "evra": "1.32-13.fc44.aarch64"
     },
     "tini-static": {
-      "evra": "0.19.0-11.fc43.aarch64"
+      "evra": "0.19.0-12.fc44.aarch64"
     },
     "toolbox": {
-      "evra": "0.3-1.fc43.aarch64"
+      "evra": "0.3-4.fc44.aarch64"
     },
     "tpm2-tools": {
-      "evra": "5.7-4.fc43.aarch64"
+      "evra": "5.7-5.fc44.aarch64"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-8.fc43.aarch64"
+      "evra": "4.1.3-9.fc44.aarch64"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-8.fc43.aarch64"
+      "evra": "4.1.3-9.fc44.aarch64"
     },
     "tzdata": {
-      "evra": "2026a-1.fc43.noarch"
+      "evra": "2026a-1.fc44.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.3-2.fc43.aarch64"
+      "evra": "0.15.6-1.fc44.aarch64"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc43.aarch64"
+      "evra": "2.41.4-7.fc44.aarch64"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc43.noarch"
+      "evra": "2:9.2.390-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc43.aarch64"
+      "evra": "2:9.2.390-1.fc44.aarch64"
     },
     "wasmedge-rt": {
-      "evra": "0.15.0-4.fc43.aarch64"
+      "evra": "0.16.1-1.fc44.aarch64"
     },
     "which": {
-      "evra": "2.23-3.fc43.aarch64"
+      "evra": "2.23-4.fc44.aarch64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-2.fc43.aarch64"
+      "evra": "1.0.20250521-3.fc44.aarch64"
     },
     "xfsprogs": {
-      "evra": "6.15.0-3.fc43.aarch64"
+      "evra": "6.18.0-2.fc44.aarch64"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-3.fc43.aarch64"
+      "evra": "0.8.3-4.fc44.aarch64"
     },
     "xz": {
-      "evra": "1:5.8.1-4.fc43.aarch64"
+      "evra": "1:5.8.2-2.fc44.aarch64"
     },
     "xz-libs": {
-      "evra": "1:5.8.1-4.fc43.aarch64"
+      "evra": "1:5.8.2-2.fc44.aarch64"
     },
     "yajl": {
-      "evra": "2.1.0-38.fc43.aarch64"
+      "evra": "2.1.0-40.fc44.aarch64"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-3.fc43.aarch64"
+      "evra": "1.5.1-4.fc44.aarch64"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc43.aarch64"
+      "evra": "0.0.32-1.fc44.aarch64"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-2.fc43.aarch64"
+      "evra": "2.3.3-3.fc44.aarch64"
     },
     "zram-generator": {
-      "evra": "1.2.1-3.fc43.aarch64"
+      "evra": "1.2.1-5.fc44.aarch64"
     },
     "zstd": {
-      "evra": "1.5.7-2.fc43.aarch64"
+      "evra": "1.5.7-5.fc44.aarch64"
     }
   },
   "metadata": {

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,1333 +1,1351 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.54.3-2.fc43.ppc64le"
+      "evra": "1:1.56.0-1.fc44.ppc64le"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.54.3-2.fc43.ppc64le"
+      "evra": "1:1.56.0-1.fc44.ppc64le"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.54.3-2.fc43.ppc64le"
+      "evra": "1:1.56.0-1.fc44.ppc64le"
     },
     "NetworkManager-team": {
-      "evra": "1:1.54.3-2.fc43.ppc64le"
+      "evra": "1:1.56.0-1.fc44.ppc64le"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.54.3-2.fc43.ppc64le"
+      "evra": "1:1.56.0-1.fc44.ppc64le"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.1-1.fc43.ppc64le"
+      "evra": "2:1.17.1-1.fc44.ppc64le"
     },
     "acl": {
-      "evra": "2.3.2-4.fc43.ppc64le"
+      "evra": "2.3.2-6.fc44.ppc64le"
     },
     "adcli": {
-      "evra": "0.9.2-10.fc43.ppc64le"
+      "evra": "0.9.3.1-5.fc44.ppc64le"
+    },
+    "adcli-selinux": {
+      "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc43.ppc64le"
+      "evra": "5.10.0-6.fc44.ppc64le"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc43.ppc64le"
+      "evra": "5.10.0-6.fc44.ppc64le"
     },
     "alternatives": {
-      "evra": "1.33-3.fc43.ppc64le"
+      "evra": "1.33-5.fc44.ppc64le"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-6.fc43.ppc64le"
+      "evra": "2.5.2-8.fc44.ppc64le"
     },
     "audit": {
-      "evra": "4.1.4-1.fc43.ppc64le"
+      "evra": "4.1.4-1.fc44.ppc64le"
     },
     "audit-libs": {
-      "evra": "4.1.4-1.fc43.ppc64le"
+      "evra": "4.1.4-1.fc44.ppc64le"
     },
     "audit-rules": {
-      "evra": "4.1.4-1.fc43.ppc64le"
+      "evra": "4.1.4-1.fc44.ppc64le"
     },
     "authselect": {
-      "evra": "1.6.2-1.fc43.ppc64le"
+      "evra": "1.7.1-1.fc44.ppc64le"
     },
     "authselect-libs": {
-      "evra": "1.6.2-1.fc43.ppc64le"
-    },
-    "avahi-libs": {
-      "evra": "0.9~rc2-6.fc43.ppc64le"
+      "evra": "1.7.1-1.fc44.ppc64le"
     },
     "bash": {
-      "evra": "5.3.0-2.fc43.ppc64le"
+      "evra": "5.3.9-3.fc44.ppc64le"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-2.fc43.noarch"
+      "evra": "0.7.1-3.fc44.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.16-2.fc43.noarch"
+      "evra": "1:2.17-2.fc44.noarch"
     },
     "bc": {
-      "evra": "1.08.2-2.fc43.ppc64le"
+      "evra": "1.08.2-4.fc44.ppc64le"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc43.ppc64le"
+      "evra": "32:9.18.48-1.fc44.ppc64le"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc43.ppc64le"
+      "evra": "32:9.18.48-1.fc44.ppc64le"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc43.ppc64le"
+      "evra": "1.15.1-1.fc44.ppc64le"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc43.ppc64le"
+      "evra": "0.2.33-1.fc44.ppc64le"
     },
     "bsdtar": {
-      "evra": "3.8.4-1.fc43.ppc64le"
+      "evra": "3.8.7-1.fc44.ppc64le"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc43.ppc64le"
+      "evra": "6.19.1-1.fc44.ppc64le"
     },
     "bubblewrap": {
-      "evra": "0.11.0-2.fc43.ppc64le"
+      "evra": "0.11.0-4.fc44.ppc64le"
     },
     "bzip2": {
-      "evra": "1.0.8-21.fc43.ppc64le"
+      "evra": "1.0.8-23.fc44.ppc64le"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-21.fc43.ppc64le"
+      "evra": "1.0.8-23.fc44.ppc64le"
     },
     "c-ares": {
-      "evra": "1.34.5-2.fc43.ppc64le"
+      "evra": "1.34.6-3.fc44.ppc64le"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.2.fc43.noarch"
+      "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-3.fc43.ppc64le"
+      "evra": "0.2.1-5.fc44.ppc64le"
     },
     "chrony": {
-      "evra": "4.8-3.fc43.ppc64le"
+      "evra": "4.8-5.fc44.ppc64le"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc43.ppc64le"
+      "evra": "7.5-1.fc44.ppc64le"
     },
     "clevis": {
-      "evra": "21-12.fc43.ppc64le"
+      "evra": "21-14.fc44.ppc64le"
     },
     "clevis-dracut": {
-      "evra": "21-12.fc43.ppc64le"
+      "evra": "21-14.fc44.ppc64le"
     },
     "clevis-luks": {
-      "evra": "21-12.fc43.ppc64le"
+      "evra": "21-14.fc44.ppc64le"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-10.fc43.ppc64le"
+      "evra": "0.5.4-1.fc44.ppc64le"
     },
     "clevis-systemd": {
-      "evra": "21-12.fc43.ppc64le"
+      "evra": "21-14.fc44.ppc64le"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-11.fc43.noarch"
+      "evra": "0.33-13.fc44.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-3.fc43.ppc64le"
+      "evra": "1.0.8-5.fc44.ppc64le"
     },
     "composefs-libs": {
-      "evra": "1.0.8-3.fc43.ppc64le"
+      "evra": "1.0.8-5.fc44.ppc64le"
     },
     "conmon": {
-      "evra": "2:2.2.1-2.fc43.ppc64le"
+      "evra": "2:2.2.1-2.fc44.ppc64le"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc43.noarch"
+      "evra": "4:2.247.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.1.7-1.fc43.ppc64le"
+      "evra": "2.2.3-1.fc44.ppc64le"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc43.ppc64le"
+      "evra": "0.26.0-1.fc44.ppc64le"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc43.ppc64le"
+      "evra": "0.26.0-1.fc44.ppc64le"
     },
     "coreutils": {
-      "evra": "9.7-8.fc43.ppc64le"
+      "evra": "9.10-3.fc44.ppc64le"
     },
     "coreutils-common": {
-      "evra": "9.7-8.fc43.ppc64le"
+      "evra": "9.10-3.fc44.ppc64le"
     },
     "cpio": {
-      "evra": "2.15-6.fc43.ppc64le"
+      "evra": "2.15-9.fc44.ppc64le"
     },
     "cracklib": {
-      "evra": "2.9.11-8.fc43.ppc64le"
+      "evra": "2.9.11-10.fc44.ppc64le"
     },
     "criu": {
-      "evra": "4.2-11.fc43.ppc64le"
+      "evra": "4.2-13.fc44.ppc64le"
     },
     "criu-libs": {
-      "evra": "4.2-11.fc43.ppc64le"
+      "evra": "4.2-13.fc44.ppc64le"
     },
     "crun": {
-      "evra": "1.27.1-1.fc43.ppc64le"
+      "evra": "1.27.1-1.fc44.ppc64le"
     },
     "crypto-policies": {
-      "evra": "20251125-1.git63291f8.fc43.noarch"
+      "evra": "20251128-3.git19878fe.fc44.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc43.ppc64le"
+      "evra": "2.8.4-1.fc44.ppc64le"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc43.ppc64le"
+      "evra": "2.8.4-1.fc44.ppc64le"
     },
     "curl": {
-      "evra": "8.15.0-6.fc43.ppc64le"
+      "evra": "8.18.0-6.fc44.ppc64le"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-33.fc43.ppc64le"
+      "evra": "2.1.28-35.fc44.ppc64le"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-33.fc43.ppc64le"
+      "evra": "2.1.28-35.fc44.ppc64le"
     },
     "dbus": {
-      "evra": "1:1.16.0-4.fc43.ppc64le"
+      "evra": "1:1.16.2-1.fc44.ppc64le"
     },
     "dbus-broker": {
-      "evra": "37-2.fc43.ppc64le"
+      "evra": "37-8.fc44.ppc64le"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-4.fc43.noarch"
+      "evra": "1:1.16.2-1.fc44.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-4.fc43.ppc64le"
+      "evra": "1:1.16.2-1.fc44.ppc64le"
     },
     "device-mapper": {
-      "evra": "1.02.208-2.fc43.ppc64le"
+      "evra": "1.02.212-2.fc44.ppc64le"
     },
     "device-mapper-event": {
-      "evra": "1.02.208-2.fc43.ppc64le"
+      "evra": "1.02.212-2.fc44.ppc64le"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.208-2.fc43.ppc64le"
+      "evra": "1.02.212-2.fc44.ppc64le"
     },
     "device-mapper-libs": {
-      "evra": "1.02.208-2.fc43.ppc64le"
+      "evra": "1.02.212-2.fc44.ppc64le"
     },
     "device-mapper-multipath": {
-      "evra": "0.11.1-2.fc43.ppc64le"
+      "evra": "0.13.1-1.fc44.ppc64le"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.11.1-2.fc43.ppc64le"
+      "evra": "0.13.1-1.fc44.ppc64le"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-4.fc43.ppc64le"
+      "evra": "1.3.1-3.fc44.ppc64le"
     },
     "diffutils": {
-      "evra": "3.12-3.fc43.ppc64le"
+      "evra": "3.12-5.fc44.ppc64le"
     },
     "dnf5": {
-      "evra": "5.2.18.0-3.fc43.ppc64le"
+      "evra": "5.4.2.0-1.fc44.ppc64le"
     },
     "dnsmasq": {
-      "evra": "2.92-1.fc43.ppc64le"
+      "evra": "2.92-4.fc44.ppc64le"
     },
     "docker-cli": {
-      "evra": "29.4.0-1.fc43.ppc64le"
+      "evra": "29.4.1-1.fc44.ppc64le"
     },
     "dosfstools": {
-      "evra": "4.2-16.fc43.ppc64le"
+      "evra": "4.2-18.fc44.ppc64le"
     },
     "dracut": {
-      "evra": "107-8.fc43.ppc64le"
+      "evra": "108-6.fc44.ppc64le"
     },
     "dracut-network": {
-      "evra": "107-8.fc43.ppc64le"
+      "evra": "108-6.fc44.ppc64le"
     },
     "dracut-squash": {
-      "evra": "107-8.fc43.ppc64le"
+      "evra": "108-6.fc44.ppc64le"
     },
     "duktape": {
-      "evra": "2.7.0-10.fc43.ppc64le"
+      "evra": "2.7.0-11.fc44.ppc64le"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-2.fc43.ppc64le"
+      "evra": "1.47.3-4.fc44.ppc64le"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-2.fc43.ppc64le"
+      "evra": "1.47.3-4.fc44.ppc64le"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.195-1.fc43.noarch"
+      "evra": "0.195-1.fc44.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.195-1.fc43.ppc64le"
+      "evra": "0.195-1.fc44.ppc64le"
     },
     "elfutils-libs": {
-      "evra": "0.195-1.fc43.ppc64le"
+      "evra": "0.195-1.fc44.ppc64le"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc43.ppc64le"
+      "evra": "2:7.0-1.fc44.ppc64le"
     },
     "expat": {
-      "evra": "2.7.3-1.fc43.ppc64le"
+      "evra": "2.7.3-2.fc44.ppc64le"
     },
     "fedora-gpg-keys": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-repos": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "43-1.noarch"
-    },
-    "fedora-repos-ostree": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "file": {
-      "evra": "5.46-9.fc43.ppc64le"
+      "evra": "5.46-10.fc44.ppc64le"
     },
     "file-libs": {
-      "evra": "5.46-9.fc43.ppc64le"
+      "evra": "5.46-10.fc44.ppc64le"
     },
     "filesystem": {
-      "evra": "3.18-50.fc43.ppc64le"
+      "evra": "3.18-52.fc44.ppc64le"
     },
     "findutils": {
-      "evra": "1:4.10.0-6.fc43.ppc64le"
+      "evra": "1:4.10.0-7.fc44.ppc64le"
     },
     "flatpak-session-helper": {
-      "evra": "1.16.6-1.fc43.ppc64le"
+      "evra": "1.17.6-1.fc44.ppc64le"
     },
     "fmt": {
-      "evra": "11.2.0-3.fc43.ppc64le"
+      "evra": "11.2.0-4.fc44.ppc64le"
     },
     "fstrm": {
-      "evra": "0.6.1-13.fc43.ppc64le"
+      "evra": "0.6.1-14.fc44.ppc64le"
     },
     "fuse-common": {
-      "evra": "3.16.2-6.fc43.ppc64le"
+      "evra": "3.18.2-1.fc44.ppc64le"
     },
     "fuse-overlayfs": {
-      "evra": "1.13-4.fc43.ppc64le"
+      "evra": "1.16-2.fc44.ppc64le"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-1.fc43.ppc64le"
+      "evra": "3.7.5-3.fc44.ppc64le"
     },
     "fuse3": {
-      "evra": "3.16.2-6.fc43.ppc64le"
+      "evra": "3.18.2-1.fc44.ppc64le"
     },
     "fuse3-libs": {
-      "evra": "3.16.2-6.fc43.ppc64le"
+      "evra": "3.18.2-1.fc44.ppc64le"
     },
     "fwupd": {
-      "evra": "2.0.20-1.fc43.ppc64le"
+      "evra": "2.1.1-1.fc44.ppc64le"
     },
     "gawk": {
-      "evra": "5.3.2-2.fc43.ppc64le"
+      "evra": "5.3.2-3.fc44.ppc64le"
     },
     "gdbm": {
-      "evra": "1:1.23-10.fc43.ppc64le"
+      "evra": "1:1.23-11.fc44.ppc64le"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-10.fc43.ppc64le"
+      "evra": "1:1.23-11.fc44.ppc64le"
     },
     "gdisk": {
-      "evra": "1.0.10-4.fc43.ppc64le"
+      "evra": "1.0.10-5.fc44.ppc64le"
     },
     "gettext-envsubst": {
-      "evra": "0.25.1-2.fc43.ppc64le"
+      "evra": "0.26-4.fc44.ppc64le"
     },
     "gettext-libs": {
-      "evra": "0.25.1-2.fc43.ppc64le"
+      "evra": "0.26-4.fc44.ppc64le"
     },
     "gettext-runtime": {
-      "evra": "0.25.1-2.fc43.ppc64le"
+      "evra": "0.26-4.fc44.ppc64le"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc43.ppc64le"
+      "evra": "2.54.0-1.fc44.ppc64le"
     },
     "glib2": {
-      "evra": "2.86.5-1.fc43.ppc64le"
+      "evra": "2.88.0-1.fc44.ppc64le"
     },
     "glibc": {
-      "evra": "2.42-11.fc43.ppc64le"
+      "evra": "2.43-3.fc44.ppc64le"
     },
     "glibc-common": {
-      "evra": "2.42-11.fc43.ppc64le"
+      "evra": "2.43-3.fc44.ppc64le"
     },
     "glibc-gconv-extra": {
-      "evra": "2.42-11.fc43.ppc64le"
+      "evra": "2.43-3.fc44.ppc64le"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.42-11.fc43.ppc64le"
+      "evra": "2.43-3.fc44.ppc64le"
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc43.ppc64le"
+      "evra": "1:6.3.0-5.fc44.ppc64le"
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc43.noarch"
+      "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc43.ppc64le"
+      "evra": "2.4.9-7.fc44.ppc64le"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc43.ppc64le"
+      "evra": "3.8.12-1.fc44.ppc64le"
     },
     "gpgme": {
-      "evra": "1.24.3-6.fc43.ppc64le"
+      "evra": "2.0.1-3.fc44.ppc64le"
     },
     "grep": {
-      "evra": "3.12-2.fc43.ppc64le"
+      "evra": "3.12-3.fc44.ppc64le"
     },
     "grub2-common": {
-      "evra": "1:2.12-43.fc43.noarch"
+      "evra": "1:2.12-56.fc44.noarch"
     },
     "grub2-ppc64le": {
-      "evra": "1:2.12-43.fc43.ppc64le"
+      "evra": "1:2.12-56.fc44.ppc64le"
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.12-43.fc43.noarch"
+      "evra": "1:2.12-56.fc44.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-43.fc43.ppc64le"
+      "evra": "1:2.12-56.fc44.ppc64le"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-43.fc43.ppc64le"
+      "evra": "1:2.12-56.fc44.ppc64le"
+    },
+    "gssproxy": {
+      "evra": "0.9.2-10.fc44.ppc64le"
     },
     "gzip": {
-      "evra": "1.13-4.fc43.ppc64le"
+      "evra": "1.14-2.fc44.ppc64le"
     },
     "hostname": {
-      "evra": "3.25-3.fc43.ppc64le"
+      "evra": "3.25-4.fc44.ppc64le"
     },
     "hwdata": {
-      "evra": "0.406-1.fc43.noarch"
+      "evra": "0.406-1.fc44.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-4.fc43.ppc64le"
+      "evra": "2.26.0-4.fc44.ppc64le"
     },
     "ignition-grub": {
-      "evra": "2.26.0-4.fc43.ppc64le"
+      "evra": "2.26.0-4.fc44.ppc64le"
     },
     "inih": {
-      "evra": "62-1.fc43.ppc64le"
+      "evra": "62-2.fc44.ppc64le"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-12.fc43.ppc64le"
+      "evra": "1.0.3-13.fc44.ppc64le"
     },
     "iproute": {
-      "evra": "6.14.0-2.fc43.ppc64le"
+      "evra": "6.17.0-2.fc44.ppc64le"
     },
     "iproute-tc": {
-      "evra": "6.14.0-2.fc43.ppc64le"
+      "evra": "6.17.0-2.fc44.ppc64le"
     },
     "iptables-libs": {
-      "evra": "1.8.11-12.fc43.ppc64le"
+      "evra": "1.8.11-13.fc44.ppc64le"
     },
     "iptables-nft": {
-      "evra": "1.8.11-12.fc43.ppc64le"
+      "evra": "1.8.11-13.fc44.ppc64le"
     },
     "iptables-services": {
-      "evra": "1.8.11-12.fc43.noarch"
+      "evra": "1.8.11-13.fc44.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-12.fc43.ppc64le"
+      "evra": "1.8.11-13.fc44.ppc64le"
     },
     "iputils": {
-      "evra": "20250605-1.fc43.ppc64le"
+      "evra": "20250605-2.fc44.ppc64le"
     },
     "irqbalance": {
-      "evra": "2:1.9.4-7.fc43.ppc64le"
+      "evra": "2:1.9.5-2.fc44.ppc64le"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.ppc64le"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.ppc64le"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.ppc64le"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.ppc64le"
     },
     "isns-utils-libs": {
-      "evra": "0.103-3.fc43.ppc64le"
+      "evra": "0.103-4.fc44.ppc64le"
     },
     "jansson": {
-      "evra": "2.14-3.fc43.ppc64le"
+      "evra": "2.14-4.fc44.ppc64le"
     },
     "jose": {
-      "evra": "14-5.fc43.ppc64le"
+      "evra": "14-6.fc44.ppc64le"
     },
     "jq": {
-      "evra": "1.8.1-3.fc43.ppc64le"
+      "evra": "1.8.1-3.fc44.ppc64le"
     },
     "json-c": {
-      "evra": "0.18-7.fc43.ppc64le"
+      "evra": "0.18-8.fc44.ppc64le"
     },
     "json-glib": {
-      "evra": "1.10.8-4.fc43.ppc64le"
+      "evra": "1.10.8-5.fc44.ppc64le"
     },
     "kbd": {
-      "evra": "2.8.0-3.fc43.ppc64le"
+      "evra": "2.9.0-3.fc44.ppc64le"
     },
     "kbd-legacy": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kbd-misc": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.61-1.fc43.ppc64le"
+      "evra": "1.0.61-1.fc44.ppc64le"
     },
     "kernel": {
-      "evra": "6.19.14-200.fc43.ppc64le"
+      "evra": "6.19.14-300.fc44.ppc64le"
     },
     "kernel-core": {
-      "evra": "6.19.14-200.fc43.ppc64le"
+      "evra": "6.19.14-300.fc44.ppc64le"
     },
     "kernel-modules": {
-      "evra": "6.19.14-200.fc43.ppc64le"
+      "evra": "6.19.14-300.fc44.ppc64le"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-200.fc43.ppc64le"
+      "evra": "6.19.14-300.fc44.ppc64le"
     },
     "kexec-tools": {
-      "evra": "2.0.32-1.fc43.ppc64le"
+      "evra": "2.0.32-3.fc44.ppc64le"
     },
     "keyutils": {
-      "evra": "1.6.3-6.fc43.ppc64le"
+      "evra": "1.6.3-7.fc44.ppc64le"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-6.fc43.ppc64le"
+      "evra": "1.6.3-7.fc44.ppc64le"
     },
     "kmod": {
-      "evra": "34.2-2.fc43.ppc64le"
+      "evra": "34.2-4.fc44.ppc64le"
     },
     "kmod-libs": {
-      "evra": "34.2-2.fc43.ppc64le"
+      "evra": "34.2-4.fc44.ppc64le"
     },
     "kpartx": {
-      "evra": "0.11.1-2.fc43.ppc64le"
+      "evra": "0.13.1-1.fc44.ppc64le"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc43.ppc64le"
+      "evra": "1.22.2-3.fc44.ppc64le"
     },
     "less": {
-      "evra": "692-5.fc43.ppc64le"
+      "evra": "692-5.fc44.ppc64le"
     },
     "libacl": {
-      "evra": "2.3.2-4.fc43.ppc64le"
+      "evra": "2.3.2-6.fc44.ppc64le"
     },
     "libaio": {
-      "evra": "0.3.111-22.fc43.ppc64le"
+      "evra": "0.3.111-23.fc44.ppc64le"
     },
     "libarchive": {
-      "evra": "3.8.4-1.fc43.ppc64le"
+      "evra": "3.8.7-1.fc44.ppc64le"
     },
     "libassuan": {
-      "evra": "2.5.7-4.fc43.ppc64le"
-    },
-    "libatomic": {
-      "evra": "15.2.1-7.fc43.ppc64le"
+      "evra": "2.5.7-5.fc44.ppc64le"
     },
     "libattr": {
-      "evra": "2.5.2-6.fc43.ppc64le"
+      "evra": "2.5.2-8.fc44.ppc64le"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-59.fc43.ppc64le"
+      "evra": "0.1.1-61.fc44.ppc64le"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libbpf": {
-      "evra": "2:1.6.1-3.fc43.ppc64le"
+      "evra": "2:1.6.3-1.fc44.ppc64le"
     },
     "libbsd": {
-      "evra": "0.12.2-6.fc43.ppc64le"
+      "evra": "0.12.2-7.fc44.ppc64le"
     },
     "libcap": {
-      "evra": "2.76-4.fc43.ppc64le"
+      "evra": "2.78-1.fc44.ppc64le"
     },
     "libcap-ng": {
-      "evra": "0.9.3-1.fc43.ppc64le"
+      "evra": "0.9.3-1.fc44.ppc64le"
     },
     "libcbor": {
-      "evra": "0.12.0-6.fc43.ppc64le"
+      "evra": "0.13.0-2.fc44.ppc64le"
     },
     "libcollection": {
-      "evra": "0.7.0-59.fc43.ppc64le"
+      "evra": "0.7.0-61.fc44.ppc64le"
     },
     "libcom_err": {
-      "evra": "1.47.3-2.fc43.ppc64le"
+      "evra": "1.47.3-4.fc44.ppc64le"
     },
     "libcurl-minimal": {
-      "evra": "8.15.0-6.fc43.ppc64le"
+      "evra": "8.18.0-6.fc44.ppc64le"
     },
     "libdaemon": {
-      "evra": "0.14-32.fc43.ppc64le"
+      "evra": "0.14-33.fc44.ppc64le"
     },
     "libdhash": {
-      "evra": "0.5.0-59.fc43.ppc64le"
+      "evra": "0.5.0-61.fc44.ppc64le"
     },
     "libdnf5": {
-      "evra": "5.2.18.0-3.fc43.ppc64le"
+      "evra": "5.4.2.0-1.fc44.ppc64le"
     },
     "libdnf5-cli": {
-      "evra": "5.2.18.0-3.fc43.ppc64le"
+      "evra": "5.4.2.0-1.fc44.ppc64le"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc43.ppc64le"
+      "evra": "2.4.131-1.fc44.ppc64le"
     },
     "libeconf": {
-      "evra": "0.7.9-2.fc43.ppc64le"
+      "evra": "0.7.9-3.fc44.ppc64le"
     },
     "libedit": {
-      "evra": "3.1-57.20251016cvs.fc43.ppc64le"
+      "evra": "3.1-58.20251016cvs.fc44.ppc64le"
+    },
+    "libev": {
+      "evra": "4.33-15.fc44.ppc64le"
     },
     "libevent": {
-      "evra": "2.1.12-16.fc43.ppc64le"
+      "evra": "2.1.12-17.fc44.ppc64le"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libffi": {
-      "evra": "3.5.2-1.fc43.ppc64le"
+      "evra": "3.5.2-2.fc44.ppc64le"
     },
     "libfido2": {
-      "evra": "1.16.0-3.fc43.ppc64le"
+      "evra": "1.16.0-5.fc44.ppc64le"
     },
     "libgcc": {
-      "evra": "15.2.1-7.fc43.ppc64le"
+      "evra": "16.0.1-0.10.fc44.ppc64le"
     },
     "libgcrypt": {
-      "evra": "1.11.1-4.fc43.ppc64le"
+      "evra": "1.12.2-1.fc44.ppc64le"
     },
     "libgpg-error": {
-      "evra": "1.55-2.fc43.ppc64le"
+      "evra": "1.58-2.fc44.ppc64le"
     },
     "libibverbs": {
-      "evra": "58.0-4.fc43.ppc64le"
+      "evra": "61.0-2.fc44.ppc64le"
     },
     "libicu": {
-      "evra": "77.1-1.fc43.ppc64le"
+      "evra": "77.1-2.fc44.ppc64le"
     },
     "libidn2": {
-      "evra": "2.3.8-2.fc43.ppc64le"
+      "evra": "2.3.8-3.fc44.ppc64le"
     },
     "libini_config": {
-      "evra": "1.3.1-59.fc43.ppc64le"
+      "evra": "1.3.1-61.fc44.ppc64le"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "libjcat": {
-      "evra": "0.2.6-1.fc43.ppc64le"
+      "evra": "0.2.6-1.fc44.ppc64le"
     },
     "libjose": {
-      "evra": "14-5.fc43.ppc64le"
+      "evra": "14-6.fc44.ppc64le"
     },
     "libkcapi": {
-      "evra": "1.5.0-6.fc43.ppc64le"
+      "evra": "1.5.0-7.fc44.ppc64le"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-6.fc43.ppc64le"
+      "evra": "1.5.0-7.fc44.ppc64le"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-6.fc43.ppc64le"
+      "evra": "1.5.0-7.fc44.ppc64le"
     },
     "libksba": {
-      "evra": "1.6.7-4.fc43.ppc64le"
+      "evra": "1.6.7-5.fc44.ppc64le"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libldb": {
-      "evra": "2:4.23.7-2.fc43.ppc64le"
+      "evra": "2:4.24.1-1.fc44.ppc64le"
     },
     "libluksmeta": {
-      "evra": "10-1.fc43.ppc64le"
+      "evra": "10-2.fc44.ppc64le"
     },
     "libmaxminddb": {
-      "evra": "1.13.3-1.fc43.ppc64le"
+      "evra": "1.13.3-1.fc44.ppc64le"
     },
     "libmd": {
-      "evra": "1.1.0-8.fc43.ppc64le"
+      "evra": "1.1.0-9.fc44.ppc64le"
     },
     "libmnl": {
-      "evra": "1.0.5-8.fc43.ppc64le"
+      "evra": "1.0.5-9.fc44.ppc64le"
     },
     "libmodulemd": {
-      "evra": "2.15.2-4.fc43.ppc64le"
+      "evra": "2.15.2-7.fc44.ppc64le"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libndp": {
-      "evra": "1.9-4.fc43.ppc64le"
+      "evra": "1.9-5.fc44.ppc64le"
     },
     "libnet": {
-      "evra": "1.3-6.fc43.ppc64le"
+      "evra": "1.3-7.fc44.ppc64le"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.1.1-1.fc43.ppc64le"
+      "evra": "1.1.1-1.fc44.ppc64le"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-31.fc43.ppc64le"
+      "evra": "1.0.1-32.fc44.ppc64le"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc43.ppc64le"
+      "evra": "1:2.8.7-1.fc44.ppc64le"
     },
     "libnftnl": {
-      "evra": "1.2.9-2.fc43.ppc64le"
+      "evra": "1.3.1-2.fc44.ppc64le"
     },
     "libnghttp2": {
-      "evra": "1.66.0-2.fc43.ppc64le"
+      "evra": "1.68.0-3.fc44.ppc64le"
     },
     "libnl3": {
-      "evra": "3.12.0-2.fc43.ppc64le"
+      "evra": "3.12.0-3.fc44.ppc64le"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-2.fc43.ppc64le"
+      "evra": "3.12.0-3.fc44.ppc64le"
     },
     "libnsl2": {
-      "evra": "2.0.1-4.fc43.ppc64le"
+      "evra": "2.0.1-5.fc44.ppc64le"
     },
     "libnvme": {
-      "evra": "1.16.1-1.fc43.ppc64le"
+      "evra": "1.16.1-2.fc44.ppc64le"
     },
     "libpath_utils": {
-      "evra": "0.2.1-59.fc43.ppc64le"
+      "evra": "0.2.1-61.fc44.ppc64le"
     },
     "libpcap": {
-      "evra": "14:1.10.6-1.fc43.ppc64le"
+      "evra": "14:1.10.6-2.fc44.ppc64le"
     },
     "libpciaccess": {
-      "evra": "0.16-16.fc43.ppc64le"
+      "evra": "0.16-17.fc44.ppc64le"
     },
     "libpkgconf": {
-      "evra": "2.3.0-3.fc43.ppc64le"
+      "evra": "2.5.1-1.fc44.ppc64le"
     },
     "libpsl": {
-      "evra": "0.21.5-6.fc43.ppc64le"
+      "evra": "0.21.5-7.fc44.ppc64le"
     },
     "libpwquality": {
-      "evra": "1.4.5-14.fc43.ppc64le"
+      "evra": "1.4.5-15.fc44.ppc64le"
     },
     "libref_array": {
-      "evra": "0.1.5-59.fc43.ppc64le"
+      "evra": "0.1.5-61.fc44.ppc64le"
     },
     "librepo": {
-      "evra": "1.20.0-4.fc43.ppc64le"
+      "evra": "1.20.0-5.fc44.ppc64le"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-9.fc43.noarch"
+      "evra": "2.17.15-10.fc44.noarch"
     },
     "librtas": {
-      "evra": "2.0.6-4.fc43.ppc64le"
+      "evra": "2.0.6-6.fc44.ppc64le"
     },
     "libseccomp": {
-      "evra": "2.6.0-2.fc43.ppc64le"
+      "evra": "2.6.0-3.fc44.ppc64le"
     },
     "libselinux": {
-      "evra": "3.9-5.fc43.ppc64le"
+      "evra": "3.10-1.fc44.ppc64le"
     },
     "libselinux-utils": {
-      "evra": "3.9-5.fc43.ppc64le"
+      "evra": "3.10-1.fc44.ppc64le"
     },
     "libsemanage": {
-      "evra": "3.9-4.fc43.ppc64le"
+      "evra": "3.10-1.fc44.ppc64le"
     },
     "libsepol": {
-      "evra": "3.9-2.fc43.ppc64le"
+      "evra": "3.10-1.fc44.ppc64le"
     },
     "libservicelog": {
-      "evra": "1.1.19-16.fc43.ppc64le"
+      "evra": "1.1.19-17.fc44.ppc64le"
     },
     "libslirp": {
-      "evra": "4.9.1-2.fc43.ppc64le"
+      "evra": "4.9.1-3.fc44.ppc64le"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libsmbclient": {
-      "evra": "2:4.23.7-2.fc43.ppc64le"
+      "evra": "2:4.24.1-1.fc44.ppc64le"
     },
     "libsolv": {
-      "evra": "0.7.36-3.fc43.ppc64le"
+      "evra": "0.7.37-2.fc44.ppc64le"
     },
     "libss": {
-      "evra": "1.47.3-2.fc43.ppc64le"
+      "evra": "1.47.3-4.fc44.ppc64le"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "libstdc++": {
-      "evra": "15.2.1-7.fc43.ppc64le"
+      "evra": "16.0.1-0.10.fc44.ppc64le"
     },
     "libtalloc": {
-      "evra": "2.4.3-4.fc43.ppc64le"
+      "evra": "2.4.4-1.fc44.ppc64le"
     },
     "libtasn1": {
-      "evra": "4.21.0-1.fc43.ppc64le"
+      "evra": "4.21.0-1.fc44.ppc64le"
     },
     "libtdb": {
-      "evra": "1.4.14-3.fc43.ppc64le"
+      "evra": "1.4.15-1.fc44.ppc64le"
     },
     "libteam": {
-      "evra": "1.32-12.fc43.ppc64le"
+      "evra": "1.32-13.fc44.ppc64le"
     },
     "libtevent": {
-      "evra": "0.17.1-3.fc43.ppc64le"
+      "evra": "0.17.1-4.fc44.ppc64le"
     },
     "libtextstyle": {
-      "evra": "0.25.1-2.fc43.ppc64le"
+      "evra": "0.26-4.fc44.ppc64le"
     },
     "libtirpc": {
-      "evra": "1.3.7-1.fc43.ppc64le"
+      "evra": "1.3.7-2.fc44.ppc64le"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-8.fc43.ppc64le"
+      "evra": "2.5.4-10.fc44.ppc64le"
     },
     "libunistring": {
-      "evra": "1.1-10.fc43.ppc64le"
+      "evra": "1.1-11.fc44.ppc64le"
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc43.ppc64le"
+      "evra": "1.0.29-5.fc44.ppc64le"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "libuv": {
-      "evra": "1:1.51.0-2.fc43.ppc64le"
+      "evra": "1:1.51.0-3.fc44.ppc64le"
     },
     "libverto": {
-      "evra": "0.3.2-11.fc43.ppc64le"
+      "evra": "0.3.2-12.fc44.ppc64le"
+    },
+    "libverto-libev": {
+      "evra": "0.3.2-12.fc44.ppc64le"
     },
     "libwbclient": {
-      "evra": "2:4.23.7-2.fc43.ppc64le"
+      "evra": "2:4.24.1-1.fc44.ppc64le"
     },
     "libxcrypt": {
-      "evra": "4.5.2-1.fc43.ppc64le"
+      "evra": "4.5.2-3.fc44.ppc64le"
     },
     "libxml2": {
-      "evra": "2.12.10-5.fc43.ppc64le"
+      "evra": "2.12.10-6.fc44.ppc64le"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc43.ppc64le"
+      "evra": "0.3.26-1.fc44.ppc64le"
     },
     "libyaml": {
-      "evra": "0.2.5-17.fc43.ppc64le"
+      "evra": "0.2.5-18.fc44.ppc64le"
     },
     "libzstd": {
-      "evra": "1.5.7-2.fc43.ppc64le"
+      "evra": "1.5.7-5.fc44.ppc64le"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-1.fc43.ppc64le"
+      "evra": "0.9.34-2.fc44.ppc64le"
     },
     "logrotate": {
-      "evra": "3.22.0-4.fc43.ppc64le"
+      "evra": "3.22.0-5.fc44.ppc64le"
     },
     "lsof": {
-      "evra": "4.98.0-8.fc43.ppc64le"
+      "evra": "4.98.0-9.fc44.ppc64le"
     },
     "lua-libs": {
-      "evra": "5.4.8-4.fc43.ppc64le"
+      "evra": "5.4.8-5.fc44.ppc64le"
     },
     "luksmeta": {
-      "evra": "10-1.fc43.ppc64le"
+      "evra": "10-2.fc44.ppc64le"
     },
     "lvm2": {
-      "evra": "2.03.34-2.fc43.ppc64le"
+      "evra": "2.03.38-2.fc44.ppc64le"
     },
     "lvm2-libs": {
-      "evra": "2.03.34-2.fc43.ppc64le"
+      "evra": "2.03.38-2.fc44.ppc64le"
     },
     "lz4-libs": {
-      "evra": "1.10.0-3.fc43.ppc64le"
+      "evra": "1.10.0-4.fc44.ppc64le"
     },
     "lzo": {
-      "evra": "2.10-15.fc43.ppc64le"
+      "evra": "2.10-16.fc44.ppc64le"
     },
     "makedumpfile": {
-      "evra": "1.7.8-1.fc43.ppc64le"
+      "evra": "1.7.8-2.fc44.ppc64le"
     },
     "mdadm": {
-      "evra": "4.3-9.fc43.ppc64le"
+      "evra": "4.3-11.fc44.ppc64le"
     },
     "moby-engine": {
-      "evra": "29.4.0-1.fc43.ppc64le"
+      "evra": "29.4.1-1.fc44.ppc64le"
     },
     "moby-filesystem": {
-      "evra": "29.4.0-1.fc43.noarch"
+      "evra": "29.4.1-1.fc44.noarch"
     },
     "mpfr": {
-      "evra": "4.2.2-2.fc43.ppc64le"
+      "evra": "4.2.2-3.fc44.ppc64le"
     },
     "nano": {
-      "evra": "8.5-2.fc43.ppc64le"
+      "evra": "8.7.1-1.fc44.ppc64le"
     },
     "nano-default-editor": {
-      "evra": "8.5-2.fc43.noarch"
+      "evra": "8.7.1-1.fc44.noarch"
     },
     "ncurses": {
-      "evra": "6.5-7.20250614.fc43.ppc64le"
+      "evra": "6.6-1.fc44.ppc64le"
     },
     "ncurses-base": {
-      "evra": "6.5-7.20250614.fc43.noarch"
+      "evra": "6.6-1.fc44.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.5-7.20250614.fc43.ppc64le"
+      "evra": "6.6-1.fc44.ppc64le"
     },
     "net-tools": {
-      "evra": "2.0-0.74.20160912git.fc43.ppc64le"
+      "evra": "2.0-0.77.20160912git.fc44.ppc64le"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc43.ppc64le"
+      "evra": "2:1.17.2-1.fc44.ppc64le"
     },
     "nettle": {
-      "evra": "3.10.1-2.fc43.ppc64le"
+      "evra": "3.10.1-3.fc44.ppc64le"
     },
     "newt": {
-      "evra": "0.52.25-5.fc43.ppc64le"
+      "evra": "0.52.25-6.fc44.ppc64le"
     },
-    "nfs-utils-coreos": {
-      "evra": "1:2.8.7-1.fc43.ppc64le"
+    "nfs-client-utils": {
+      "evra": "1:2.8.7-1.fc44.ppc64le"
+    },
+    "nfs-common-utils": {
+      "evra": "1:2.8.7-1.fc44.ppc64le"
+    },
+    "nfsv3-client-utils": {
+      "evra": "1:2.8.7-1.fc44.ppc64le"
+    },
+    "nfsv4-client-utils": {
+      "evra": "1:2.8.7-1.fc44.ppc64le"
     },
     "nftables": {
-      "evra": "1:1.1.3-6.fc43.1.ppc64le"
+      "evra": "1:1.1.6-2.fc44.ppc64le"
     },
     "nftables-services": {
-      "evra": "1:1.1.3-6.fc43.1.noarch"
+      "evra": "1:1.1.6-2.fc44.noarch"
     },
     "ngtcp2": {
-      "evra": "1.22.1-1.fc43.ppc64le"
+      "evra": "1.22.1-1.fc44.ppc64le"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.22.1-1.fc43.ppc64le"
+      "evra": "1.22.1-1.fc44.ppc64le"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc43.ppc64le"
+      "evra": "2.2.57-2.fc44.ppc64le"
     },
     "npth": {
-      "evra": "1.8-3.fc43.ppc64le"
+      "evra": "1.8-4.fc44.ppc64le"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-7.fc43.ppc64le"
+      "evra": "2.23.0-9.fc44.ppc64le"
     },
     "numactl": {
-      "evra": "2.0.19-3.fc43.ppc64le"
+      "evra": "2.0.19-4.fc44.ppc64le"
     },
     "numactl-libs": {
-      "evra": "2.0.19-3.fc43.ppc64le"
+      "evra": "2.0.19-4.fc44.ppc64le"
     },
     "numad": {
-      "evra": "0.5-47.20150602git.fc43.ppc64le"
+      "evra": "0.5-50.20251104git.fc44.ppc64le"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-1.fc43.ppc64le"
+      "evra": "2.16-2.fc44.ppc64le"
     },
     "oniguruma": {
-      "evra": "6.9.10-3.fc43.ppc64le"
+      "evra": "6.9.10-4.fc44.ppc64le"
     },
     "openldap": {
-      "evra": "2.6.13-1.fc43.ppc64le"
+      "evra": "2.6.13-1.fc44.ppc64le"
     },
     "openssh": {
-      "evra": "10.0p1-9.fc43.ppc64le"
+      "evra": "10.2p1-9.fc44.ppc64le"
     },
     "openssh-clients": {
-      "evra": "10.0p1-9.fc43.ppc64le"
+      "evra": "10.2p1-9.fc44.ppc64le"
     },
     "openssh-server": {
-      "evra": "10.0p1-9.fc43.ppc64le"
+      "evra": "10.2p1-9.fc44.ppc64le"
     },
     "openssl": {
-      "evra": "1:3.5.4-3.fc43.ppc64le"
+      "evra": "1:3.5.5-2.fc44.ppc64le"
     },
     "openssl-libs": {
-      "evra": "1:3.5.4-3.fc43.ppc64le"
+      "evra": "1:3.5.5-2.fc44.ppc64le"
     },
     "os-prober": {
-      "evra": "1.81-10.fc43.ppc64le"
+      "evra": "1.81-11.fc44.ppc64le"
     },
     "ostree": {
-      "evra": "2026.1-1.fc43.ppc64le"
+      "evra": "2026.1-1.fc44.ppc64le"
     },
     "ostree-grub2": {
-      "evra": "2026.1-1.fc43.ppc64le"
+      "evra": "2026.1-1.fc44.ppc64le"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc43.ppc64le"
+      "evra": "2026.1-1.fc44.ppc64le"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc43.ppc64le"
+      "evra": "0.26.2-1.fc44.ppc64le"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc43.ppc64le"
+      "evra": "0.26.2-1.fc44.ppc64le"
     },
     "pam": {
-      "evra": "1.7.1-4.fc43.ppc64le"
+      "evra": "1.7.2-1.fc44.ppc64le"
     },
     "pam-libs": {
-      "evra": "1.7.1-4.fc43.ppc64le"
+      "evra": "1.7.2-1.fc44.ppc64le"
     },
     "passim-libs": {
-      "evra": "0.1.11-1.fc43.ppc64le"
+      "evra": "0.1.11-1.fc44.ppc64le"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc43.ppc64le"
+      "evra": "0^20260120.g386b5f5-1.fc44.ppc64le"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc43.noarch"
+      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-2.fc43.ppc64le"
+      "evra": "3.14.0-3.fc44.ppc64le"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-2.fc43.ppc64le"
+      "evra": "3.14.0-3.fc44.ppc64le"
     },
     "pcre2": {
-      "evra": "10.47-1.fc43.ppc64le"
+      "evra": "10.47-1.fc44.1.ppc64le"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc43.noarch"
+      "evra": "10.47-1.fc44.1.noarch"
     },
     "pigz": {
-      "evra": "2.8-7.fc43.ppc64le"
+      "evra": "2.8-8.fc44.ppc64le"
     },
     "pkgconf": {
-      "evra": "2.3.0-3.fc43.ppc64le"
+      "evra": "2.5.1-1.fc44.ppc64le"
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-3.fc43.noarch"
+      "evra": "2.5.1-1.fc44.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-3.fc43.ppc64le"
+      "evra": "2.5.1-1.fc44.ppc64le"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc43.ppc64le"
+      "evra": "5:5.8.2-1.fc44.ppc64le"
     },
     "podman-sequoia": {
-      "evra": "0.2.0-3.fc43.ppc64le"
+      "evra": "0.3.2-1.fc44.ppc64le"
     },
     "policycoreutils": {
-      "evra": "3.9-7.fc43.ppc64le"
+      "evra": "3.10-1.fc44.ppc64le"
     },
     "polkit": {
-      "evra": "126-6.fc43.2.ppc64le"
+      "evra": "127-2.fc44.2.ppc64le"
     },
     "polkit-libs": {
-      "evra": "126-6.fc43.2.ppc64le"
+      "evra": "127-2.fc44.2.ppc64le"
     },
     "popt": {
-      "evra": "1.19-9.fc43.ppc64le"
+      "evra": "1.19-10.fc44.ppc64le"
     },
     "powerpc-utils-core": {
-      "evra": "1.3.13-4.fc43.ppc64le"
+      "evra": "1.3.13-5.fc44.ppc64le"
     },
     "ppc64-diag-rtas": {
-      "evra": "2.7.10-6.fc43.ppc64le"
+      "evra": "2.7.11-1.fc44.ppc64le"
     },
     "procps-ng": {
-      "evra": "4.0.4-7.fc43.1.ppc64le"
+      "evra": "4.0.6-1.fc44.ppc64le"
     },
     "protobuf-c": {
-      "evra": "1.5.2-1.fc43.ppc64le"
+      "evra": "1.5.2-2.fc44.ppc64le"
     },
     "psmisc": {
-      "evra": "23.7-6.fc43.ppc64le"
+      "evra": "23.7-7.fc44.ppc64le"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc43.noarch"
+      "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:10.1.5-1.fc43.ppc64le"
+      "evra": "2:10.2.2-1.fc44.ppc64le"
+    },
+    "rdma-core-common": {
+      "evra": "61.0-2.fc44.noarch"
     },
     "readline": {
-      "evra": "8.3-2.fc43.ppc64le"
+      "evra": "8.3-4.fc44.ppc64le"
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc43.ppc64le"
+      "evra": "1.2.8-1.fc44.ppc64le"
     },
     "rpm": {
-      "evra": "6.0.1-1.fc43.ppc64le"
+      "evra": "6.0.1-2.fc44.ppc64le"
     },
     "rpm-libs": {
-      "evra": "6.0.1-1.fc43.ppc64le"
+      "evra": "6.0.1-2.fc44.ppc64le"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc43.ppc64le"
+      "evra": "2026.1-3.fc44.ppc64le"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc43.ppc64le"
+      "evra": "2026.1-3.fc44.ppc64le"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-1.fc43.ppc64le"
+      "evra": "6.0.1-2.fc44.ppc64le"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc43.ppc64le"
+      "evra": "1.10.2-1.fc44.ppc64le"
     },
     "rsync": {
-      "evra": "3.4.1-5.fc43.ppc64le"
+      "evra": "3.4.1-6.fc44.ppc64le"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc43.ppc64le"
+      "evra": "2:1.4.2-1.fc44.ppc64le"
     },
     "samba-client-libs": {
-      "evra": "2:4.23.7-2.fc43.ppc64le"
+      "evra": "2:4.24.1-1.fc44.ppc64le"
     },
     "samba-common": {
-      "evra": "2:4.23.7-2.fc43.noarch"
+      "evra": "2:4.24.1-1.fc44.noarch"
     },
-    "samba-common-libs": {
-      "evra": "2:4.23.7-2.fc43.ppc64le"
+    "samba-core-libs": {
+      "evra": "2:4.24.1-1.fc44.ppc64le"
+    },
+    "samba-ndr-libs": {
+      "evra": "2:4.24.1-1.fc44.ppc64le"
     },
     "sdbus-cpp": {
-      "evra": "2.1.0-3.fc43.ppc64le"
+      "evra": "2.2.1-2.fc44.ppc64le"
     },
     "sed": {
-      "evra": "4.9-5.fc43.ppc64le"
+      "evra": "4.9-7.fc44.ppc64le"
     },
     "selinux-policy": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "servicelog": {
-      "evra": "1.1.16-9.fc43.ppc64le"
+      "evra": "1.1.16-10.fc44.ppc64le"
     },
     "setup": {
-      "evra": "2.15.0-26.fc43.noarch"
+      "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-6.fc43.ppc64le"
+      "evra": "1.48-8.fc44.ppc64le"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-6.fc43.ppc64le"
+      "evra": "1.48-8.fc44.ppc64le"
     },
     "shadow-utils": {
-      "evra": "2:4.18.0-3.fc43.ppc64le"
+      "evra": "2:4.19.0-6.fc44.ppc64le"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.18.0-3.fc43.ppc64le"
+      "evra": "2:4.19.0-6.fc44.ppc64le"
     },
     "shared-mime-info": {
-      "evra": "2.4-2.fc43.ppc64le"
+      "evra": "2.4-3.fc44.ppc64le"
     },
     "skopeo": {
-      "evra": "1:1.22.2-1.fc43.ppc64le"
+      "evra": "1:1.22.2-1.fc44.ppc64le"
     },
     "slang": {
-      "evra": "2.3.3-8.fc43.ppc64le"
+      "evra": "2.3.3-9.fc44.ppc64le"
     },
     "slirp4netns": {
-      "evra": "1.3.1-3.fc43.ppc64le"
+      "evra": "1.3.1-4.fc44.ppc64le"
     },
     "snappy": {
-      "evra": "1.2.2-2.fc43.ppc64le"
+      "evra": "1.2.2-4.fc44.ppc64le"
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc43.ppc64le"
+      "evra": "1.8.1.0-2.fc44.ppc64le"
     },
     "sqlite-libs": {
-      "evra": "3.50.2-2.fc43.ppc64le"
+      "evra": "3.51.2-1.fc44.ppc64le"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-7.fc43.ppc64le"
+      "evra": "4.6.1-8.fc44.ppc64le"
     },
     "sssd-ad": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-client": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-common": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-1.fc43.ppc64le"
+      "evra": "2.13.0-1.fc44.ppc64le"
     },
     "stalld": {
-      "evra": "1.26.3-1.fc43.ppc64le"
+      "evra": "1.26.3-2.fc44.ppc64le"
     },
     "sudo": {
-      "evra": "1.9.17-7.p2.fc43.ppc64le"
+      "evra": "1.9.17-8.p2.fc44.ppc64le"
     },
     "systemd": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-container": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-libs": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-pam": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-resolved": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-shared": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-sysusers": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "systemd-udev": {
-      "evra": "258.7-1.fc43.ppc64le"
+      "evra": "259.5-1.fc44.ppc64le"
     },
     "tar": {
-      "evra": "2:1.35-6.fc43.ppc64le"
+      "evra": "2:1.35-8.fc44.ppc64le"
     },
     "teamd": {
-      "evra": "1.32-12.fc43.ppc64le"
+      "evra": "1.32-13.fc44.ppc64le"
     },
     "tini-static": {
-      "evra": "0.19.0-11.fc43.ppc64le"
+      "evra": "0.19.0-12.fc44.ppc64le"
     },
     "toolbox": {
-      "evra": "0.3-1.fc43.ppc64le"
+      "evra": "0.3-4.fc44.ppc64le"
     },
     "tpm2-tools": {
-      "evra": "5.7-4.fc43.ppc64le"
+      "evra": "5.7-5.fc44.ppc64le"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-8.fc43.ppc64le"
+      "evra": "4.1.3-9.fc44.ppc64le"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-8.fc43.ppc64le"
+      "evra": "4.1.3-9.fc44.ppc64le"
     },
     "tzdata": {
-      "evra": "2026a-1.fc43.noarch"
+      "evra": "2026a-1.fc44.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.3-2.fc43.ppc64le"
+      "evra": "0.15.6-1.fc44.ppc64le"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc43.ppc64le"
+      "evra": "2.41.4-7.fc44.ppc64le"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc43.noarch"
+      "evra": "2:9.2.390-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc43.ppc64le"
+      "evra": "2:9.2.390-1.fc44.ppc64le"
     },
     "which": {
-      "evra": "2.23-3.fc43.ppc64le"
+      "evra": "2.23-4.fc44.ppc64le"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-2.fc43.ppc64le"
+      "evra": "1.0.20250521-3.fc44.ppc64le"
     },
     "xfsprogs": {
-      "evra": "6.15.0-3.fc43.ppc64le"
+      "evra": "6.18.0-2.fc44.ppc64le"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-3.fc43.ppc64le"
+      "evra": "0.8.3-4.fc44.ppc64le"
     },
     "xz": {
-      "evra": "1:5.8.1-4.fc43.ppc64le"
+      "evra": "1:5.8.2-2.fc44.ppc64le"
     },
     "xz-libs": {
-      "evra": "1:5.8.1-4.fc43.ppc64le"
+      "evra": "1:5.8.2-2.fc44.ppc64le"
     },
     "yajl": {
-      "evra": "2.1.0-38.fc43.ppc64le"
+      "evra": "2.1.0-40.fc44.ppc64le"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-3.fc43.ppc64le"
+      "evra": "1.5.1-4.fc44.ppc64le"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc43.ppc64le"
+      "evra": "0.0.32-1.fc44.ppc64le"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-2.fc43.ppc64le"
+      "evra": "2.3.3-3.fc44.ppc64le"
     },
     "zram-generator": {
-      "evra": "1.2.1-3.fc43.ppc64le"
+      "evra": "1.2.1-5.fc44.ppc64le"
     },
     "zstd": {
-      "evra": "1.5.7-2.fc43.ppc64le"
+      "evra": "1.5.7-5.fc44.ppc64le"
     }
   },
   "metadata": {

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,1273 +1,1294 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.54.3-2.fc43.s390x"
+      "evra": "1:1.56.0-1.fc44.s390x"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.54.3-2.fc43.s390x"
+      "evra": "1:1.56.0-1.fc44.s390x"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.54.3-2.fc43.s390x"
+      "evra": "1:1.56.0-1.fc44.s390x"
     },
     "NetworkManager-team": {
-      "evra": "1:1.54.3-2.fc43.s390x"
+      "evra": "1:1.56.0-1.fc44.s390x"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.54.3-2.fc43.s390x"
+      "evra": "1:1.56.0-1.fc44.s390x"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.1-1.fc43.s390x"
+      "evra": "2:1.17.1-1.fc44.s390x"
     },
     "acl": {
-      "evra": "2.3.2-4.fc43.s390x"
+      "evra": "2.3.2-6.fc44.s390x"
     },
     "adcli": {
-      "evra": "0.9.2-10.fc43.s390x"
+      "evra": "0.9.3.1-5.fc44.s390x"
+    },
+    "adcli-selinux": {
+      "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc43.s390x"
+      "evra": "5.10.0-6.fc44.s390x"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc43.s390x"
+      "evra": "5.10.0-6.fc44.s390x"
     },
     "alternatives": {
-      "evra": "1.33-3.fc43.s390x"
+      "evra": "1.33-5.fc44.s390x"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-6.fc43.s390x"
+      "evra": "2.5.2-8.fc44.s390x"
     },
     "audit": {
-      "evra": "4.1.4-1.fc43.s390x"
+      "evra": "4.1.4-1.fc44.s390x"
     },
     "audit-libs": {
-      "evra": "4.1.4-1.fc43.s390x"
+      "evra": "4.1.4-1.fc44.s390x"
     },
     "audit-rules": {
-      "evra": "4.1.4-1.fc43.s390x"
+      "evra": "4.1.4-1.fc44.s390x"
     },
     "authselect": {
-      "evra": "1.6.2-1.fc43.s390x"
+      "evra": "1.7.1-1.fc44.s390x"
     },
     "authselect-libs": {
-      "evra": "1.6.2-1.fc43.s390x"
-    },
-    "avahi-libs": {
-      "evra": "0.9~rc2-6.fc43.s390x"
+      "evra": "1.7.1-1.fc44.s390x"
     },
     "bash": {
-      "evra": "5.3.0-2.fc43.s390x"
+      "evra": "5.3.9-3.fc44.s390x"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-2.fc43.noarch"
+      "evra": "0.7.1-3.fc44.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.16-2.fc43.noarch"
+      "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc43.s390x"
+      "evra": "32:9.18.48-1.fc44.s390x"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc43.s390x"
+      "evra": "32:9.18.48-1.fc44.s390x"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc43.s390x"
+      "evra": "1.15.1-1.fc44.s390x"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc43.s390x"
+      "evra": "0.2.33-1.fc44.s390x"
     },
     "bsdtar": {
-      "evra": "3.8.4-1.fc43.s390x"
+      "evra": "3.8.7-1.fc44.s390x"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc43.s390x"
+      "evra": "6.19.1-1.fc44.s390x"
     },
     "bubblewrap": {
-      "evra": "0.11.0-2.fc43.s390x"
+      "evra": "0.11.0-4.fc44.s390x"
     },
     "bzip2": {
-      "evra": "1.0.8-21.fc43.s390x"
+      "evra": "1.0.8-23.fc44.s390x"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-21.fc43.s390x"
+      "evra": "1.0.8-23.fc44.s390x"
     },
     "c-ares": {
-      "evra": "1.34.5-2.fc43.s390x"
+      "evra": "1.34.6-3.fc44.s390x"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.2.fc43.noarch"
+      "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-3.fc43.s390x"
+      "evra": "0.2.1-5.fc44.s390x"
     },
     "chrony": {
-      "evra": "4.8-3.fc43.s390x"
+      "evra": "4.8-5.fc44.s390x"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc43.s390x"
+      "evra": "7.5-1.fc44.s390x"
     },
     "clevis": {
-      "evra": "21-12.fc43.s390x"
+      "evra": "21-14.fc44.s390x"
     },
     "clevis-dracut": {
-      "evra": "21-12.fc43.s390x"
+      "evra": "21-14.fc44.s390x"
     },
     "clevis-luks": {
-      "evra": "21-12.fc43.s390x"
+      "evra": "21-14.fc44.s390x"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-10.fc43.s390x"
+      "evra": "0.5.4-1.fc44.s390x"
     },
     "clevis-systemd": {
-      "evra": "21-12.fc43.s390x"
+      "evra": "21-14.fc44.s390x"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-11.fc43.noarch"
+      "evra": "0.33-13.fc44.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-3.fc43.s390x"
+      "evra": "1.0.8-5.fc44.s390x"
     },
     "composefs-libs": {
-      "evra": "1.0.8-3.fc43.s390x"
+      "evra": "1.0.8-5.fc44.s390x"
     },
     "conmon": {
-      "evra": "2:2.2.1-2.fc43.s390x"
+      "evra": "2:2.2.1-2.fc44.s390x"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc43.noarch"
+      "evra": "4:2.247.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.1.7-1.fc43.s390x"
+      "evra": "2.2.3-1.fc44.s390x"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc43.s390x"
+      "evra": "0.26.0-1.fc44.s390x"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc43.s390x"
+      "evra": "0.26.0-1.fc44.s390x"
     },
     "coreutils": {
-      "evra": "9.7-8.fc43.s390x"
+      "evra": "9.10-3.fc44.s390x"
     },
     "coreutils-common": {
-      "evra": "9.7-8.fc43.s390x"
+      "evra": "9.10-3.fc44.s390x"
     },
     "cpio": {
-      "evra": "2.15-6.fc43.s390x"
+      "evra": "2.15-9.fc44.s390x"
     },
     "cracklib": {
-      "evra": "2.9.11-8.fc43.s390x"
+      "evra": "2.9.11-10.fc44.s390x"
     },
     "criu": {
-      "evra": "4.2-11.fc43.s390x"
+      "evra": "4.2-13.fc44.s390x"
     },
     "criu-libs": {
-      "evra": "4.2-11.fc43.s390x"
+      "evra": "4.2-13.fc44.s390x"
     },
     "crun": {
-      "evra": "1.27.1-1.fc43.s390x"
+      "evra": "1.27.1-1.fc44.s390x"
     },
     "crypto-policies": {
-      "evra": "20251125-1.git63291f8.fc43.noarch"
+      "evra": "20251128-3.git19878fe.fc44.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc43.s390x"
+      "evra": "2.8.4-1.fc44.s390x"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc43.s390x"
+      "evra": "2.8.4-1.fc44.s390x"
     },
     "curl": {
-      "evra": "8.15.0-6.fc43.s390x"
+      "evra": "8.18.0-6.fc44.s390x"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-33.fc43.s390x"
+      "evra": "2.1.28-35.fc44.s390x"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-33.fc43.s390x"
+      "evra": "2.1.28-35.fc44.s390x"
     },
     "dbus": {
-      "evra": "1:1.16.0-4.fc43.s390x"
+      "evra": "1:1.16.2-1.fc44.s390x"
     },
     "dbus-broker": {
-      "evra": "37-2.fc43.s390x"
+      "evra": "37-8.fc44.s390x"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-4.fc43.noarch"
+      "evra": "1:1.16.2-1.fc44.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-4.fc43.s390x"
+      "evra": "1:1.16.2-1.fc44.s390x"
     },
     "device-mapper": {
-      "evra": "1.02.208-2.fc43.s390x"
+      "evra": "1.02.212-2.fc44.s390x"
     },
     "device-mapper-event": {
-      "evra": "1.02.208-2.fc43.s390x"
+      "evra": "1.02.212-2.fc44.s390x"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.208-2.fc43.s390x"
+      "evra": "1.02.212-2.fc44.s390x"
     },
     "device-mapper-libs": {
-      "evra": "1.02.208-2.fc43.s390x"
+      "evra": "1.02.212-2.fc44.s390x"
     },
     "device-mapper-multipath": {
-      "evra": "0.11.1-2.fc43.s390x"
+      "evra": "0.13.1-1.fc44.s390x"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.11.1-2.fc43.s390x"
+      "evra": "0.13.1-1.fc44.s390x"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-4.fc43.s390x"
+      "evra": "1.3.1-3.fc44.s390x"
     },
     "diffutils": {
-      "evra": "3.12-3.fc43.s390x"
+      "evra": "3.12-5.fc44.s390x"
     },
     "dnf5": {
-      "evra": "5.2.18.0-3.fc43.s390x"
+      "evra": "5.4.2.0-1.fc44.s390x"
     },
     "dnsmasq": {
-      "evra": "2.92-1.fc43.s390x"
+      "evra": "2.92-4.fc44.s390x"
     },
     "docker-cli": {
-      "evra": "29.4.0-1.fc43.s390x"
+      "evra": "29.4.1-1.fc44.s390x"
     },
     "dosfstools": {
-      "evra": "4.2-16.fc43.s390x"
+      "evra": "4.2-18.fc44.s390x"
     },
     "dracut": {
-      "evra": "107-8.fc43.s390x"
+      "evra": "108-6.fc44.s390x"
     },
     "dracut-network": {
-      "evra": "107-8.fc43.s390x"
+      "evra": "108-6.fc44.s390x"
     },
     "dracut-squash": {
-      "evra": "107-8.fc43.s390x"
+      "evra": "108-6.fc44.s390x"
     },
     "duktape": {
-      "evra": "2.7.0-10.fc43.s390x"
+      "evra": "2.7.0-11.fc44.s390x"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-2.fc43.s390x"
+      "evra": "1.47.3-4.fc44.s390x"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-2.fc43.s390x"
+      "evra": "1.47.3-4.fc44.s390x"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.195-1.fc43.noarch"
+      "evra": "0.195-1.fc44.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.195-1.fc43.s390x"
+      "evra": "0.195-1.fc44.s390x"
     },
     "elfutils-libs": {
-      "evra": "0.195-1.fc43.s390x"
+      "evra": "0.195-1.fc44.s390x"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc43.s390x"
+      "evra": "2:7.0-1.fc44.s390x"
     },
     "expat": {
-      "evra": "2.7.3-1.fc43.s390x"
+      "evra": "2.7.3-2.fc44.s390x"
     },
     "fedora-gpg-keys": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-repos": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "43-1.noarch"
-    },
-    "fedora-repos-ostree": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "file": {
-      "evra": "5.46-9.fc43.s390x"
+      "evra": "5.46-10.fc44.s390x"
     },
     "file-libs": {
-      "evra": "5.46-9.fc43.s390x"
+      "evra": "5.46-10.fc44.s390x"
     },
     "filesystem": {
-      "evra": "3.18-50.fc43.s390x"
+      "evra": "3.18-52.fc44.s390x"
     },
     "findutils": {
-      "evra": "1:4.10.0-6.fc43.s390x"
+      "evra": "1:4.10.0-7.fc44.s390x"
     },
     "flatpak-session-helper": {
-      "evra": "1.16.6-1.fc43.s390x"
+      "evra": "1.17.6-1.fc44.s390x"
     },
     "fmt": {
-      "evra": "11.2.0-3.fc43.s390x"
+      "evra": "11.2.0-4.fc44.s390x"
     },
     "fstrm": {
-      "evra": "0.6.1-13.fc43.s390x"
+      "evra": "0.6.1-14.fc44.s390x"
     },
     "fuse-common": {
-      "evra": "3.16.2-6.fc43.s390x"
+      "evra": "3.18.2-1.fc44.s390x"
     },
     "fuse-overlayfs": {
-      "evra": "1.13-4.fc43.s390x"
+      "evra": "1.16-2.fc44.s390x"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-1.fc43.s390x"
+      "evra": "3.7.5-3.fc44.s390x"
     },
     "fuse3": {
-      "evra": "3.16.2-6.fc43.s390x"
+      "evra": "3.18.2-1.fc44.s390x"
     },
     "fuse3-libs": {
-      "evra": "3.16.2-6.fc43.s390x"
+      "evra": "3.18.2-1.fc44.s390x"
     },
     "fwupd": {
-      "evra": "2.0.20-1.fc43.s390x"
+      "evra": "2.1.1-1.fc44.s390x"
     },
     "gawk": {
-      "evra": "5.3.2-2.fc43.s390x"
+      "evra": "5.3.2-3.fc44.s390x"
     },
     "gdbm": {
-      "evra": "1:1.23-10.fc43.s390x"
+      "evra": "1:1.23-11.fc44.s390x"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-10.fc43.s390x"
+      "evra": "1:1.23-11.fc44.s390x"
     },
     "gdisk": {
-      "evra": "1.0.10-4.fc43.s390x"
+      "evra": "1.0.10-5.fc44.s390x"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc43.s390x"
+      "evra": "2.54.0-1.fc44.s390x"
     },
     "glib2": {
-      "evra": "2.86.5-1.fc43.s390x"
+      "evra": "2.88.0-1.fc44.s390x"
     },
     "glibc": {
-      "evra": "2.42-11.fc43.s390x"
+      "evra": "2.43-3.fc44.s390x"
     },
     "glibc-common": {
-      "evra": "2.42-11.fc43.s390x"
+      "evra": "2.43-3.fc44.s390x"
     },
     "glibc-gconv-extra": {
-      "evra": "2.42-11.fc43.s390x"
+      "evra": "2.43-3.fc44.s390x"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.42-11.fc43.s390x"
+      "evra": "2.43-3.fc44.s390x"
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc43.s390x"
+      "evra": "1:6.3.0-5.fc44.s390x"
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc43.noarch"
+      "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc43.s390x"
+      "evra": "2.4.9-7.fc44.s390x"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc43.s390x"
+      "evra": "3.8.12-1.fc44.s390x"
     },
     "gpgme": {
-      "evra": "1.24.3-6.fc43.s390x"
+      "evra": "2.0.1-3.fc44.s390x"
     },
     "grep": {
-      "evra": "3.12-2.fc43.s390x"
+      "evra": "3.12-3.fc44.s390x"
+    },
+    "gssproxy": {
+      "evra": "0.9.2-10.fc44.s390x"
     },
     "gzip": {
-      "evra": "1.13-4.fc43.s390x"
+      "evra": "1.14-2.fc44.s390x"
     },
     "hostname": {
-      "evra": "3.25-3.fc43.s390x"
+      "evra": "3.25-4.fc44.s390x"
     },
     "hwdata": {
-      "evra": "0.406-1.fc43.noarch"
+      "evra": "0.406-1.fc44.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-4.fc43.s390x"
+      "evra": "2.26.0-4.fc44.s390x"
     },
     "ignition-grub": {
-      "evra": "2.26.0-4.fc43.s390x"
+      "evra": "2.26.0-4.fc44.s390x"
     },
     "inih": {
-      "evra": "62-1.fc43.s390x"
+      "evra": "62-2.fc44.s390x"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-12.fc43.s390x"
+      "evra": "1.0.3-13.fc44.s390x"
     },
     "iproute": {
-      "evra": "6.14.0-2.fc43.s390x"
+      "evra": "6.17.0-2.fc44.s390x"
     },
     "iproute-tc": {
-      "evra": "6.14.0-2.fc43.s390x"
+      "evra": "6.17.0-2.fc44.s390x"
     },
     "iptables-libs": {
-      "evra": "1.8.11-12.fc43.s390x"
+      "evra": "1.8.11-13.fc44.s390x"
     },
     "iptables-nft": {
-      "evra": "1.8.11-12.fc43.s390x"
+      "evra": "1.8.11-13.fc44.s390x"
     },
     "iptables-services": {
-      "evra": "1.8.11-12.fc43.noarch"
+      "evra": "1.8.11-13.fc44.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-12.fc43.s390x"
+      "evra": "1.8.11-13.fc44.s390x"
     },
     "iputils": {
-      "evra": "20250605-1.fc43.s390x"
+      "evra": "20250605-2.fc44.s390x"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.s390x"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.s390x"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.s390x"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.s390x"
     },
     "isns-utils-libs": {
-      "evra": "0.103-3.fc43.s390x"
+      "evra": "0.103-4.fc44.s390x"
     },
     "jansson": {
-      "evra": "2.14-3.fc43.s390x"
+      "evra": "2.14-4.fc44.s390x"
     },
     "jose": {
-      "evra": "14-5.fc43.s390x"
+      "evra": "14-6.fc44.s390x"
     },
     "jq": {
-      "evra": "1.8.1-3.fc43.s390x"
+      "evra": "1.8.1-3.fc44.s390x"
     },
     "json-c": {
-      "evra": "0.18-7.fc43.s390x"
+      "evra": "0.18-8.fc44.s390x"
     },
     "json-glib": {
-      "evra": "1.10.8-4.fc43.s390x"
+      "evra": "1.10.8-5.fc44.s390x"
     },
     "kbd": {
-      "evra": "2.8.0-3.fc43.s390x"
+      "evra": "2.9.0-3.fc44.s390x"
     },
     "kbd-legacy": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kbd-misc": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.61-1.fc43.s390x"
+      "evra": "1.0.61-1.fc44.s390x"
     },
     "kernel": {
-      "evra": "6.19.14-200.fc43.s390x"
+      "evra": "6.19.14-300.fc44.s390x"
     },
     "kernel-core": {
-      "evra": "6.19.14-200.fc43.s390x"
+      "evra": "6.19.14-300.fc44.s390x"
     },
     "kernel-modules": {
-      "evra": "6.19.14-200.fc43.s390x"
+      "evra": "6.19.14-300.fc44.s390x"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-200.fc43.s390x"
+      "evra": "6.19.14-300.fc44.s390x"
     },
     "kexec-tools": {
-      "evra": "2.0.32-1.fc43.s390x"
+      "evra": "2.0.32-3.fc44.s390x"
     },
     "keyutils": {
-      "evra": "1.6.3-6.fc43.s390x"
+      "evra": "1.6.3-7.fc44.s390x"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-6.fc43.s390x"
+      "evra": "1.6.3-7.fc44.s390x"
     },
     "kmod": {
-      "evra": "34.2-2.fc43.s390x"
+      "evra": "34.2-4.fc44.s390x"
     },
     "kmod-libs": {
-      "evra": "34.2-2.fc43.s390x"
+      "evra": "34.2-4.fc44.s390x"
     },
     "kpartx": {
-      "evra": "0.11.1-2.fc43.s390x"
+      "evra": "0.13.1-1.fc44.s390x"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc43.s390x"
+      "evra": "1.22.2-3.fc44.s390x"
     },
     "less": {
-      "evra": "692-5.fc43.s390x"
+      "evra": "692-5.fc44.s390x"
     },
     "libacl": {
-      "evra": "2.3.2-4.fc43.s390x"
+      "evra": "2.3.2-6.fc44.s390x"
     },
     "libaio": {
-      "evra": "0.3.111-22.fc43.s390x"
+      "evra": "0.3.111-23.fc44.s390x"
     },
     "libarchive": {
-      "evra": "3.8.4-1.fc43.s390x"
+      "evra": "3.8.7-1.fc44.s390x"
     },
     "libassuan": {
-      "evra": "2.5.7-4.fc43.s390x"
+      "evra": "2.5.7-5.fc44.s390x"
     },
     "libattr": {
-      "evra": "2.5.2-6.fc43.s390x"
+      "evra": "2.5.2-8.fc44.s390x"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-59.fc43.s390x"
+      "evra": "0.1.1-61.fc44.s390x"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libbpf": {
-      "evra": "2:1.6.1-3.fc43.s390x"
+      "evra": "2:1.6.3-1.fc44.s390x"
     },
     "libbsd": {
-      "evra": "0.12.2-6.fc43.s390x"
+      "evra": "0.12.2-7.fc44.s390x"
     },
     "libcap": {
-      "evra": "2.76-4.fc43.s390x"
+      "evra": "2.78-1.fc44.s390x"
     },
     "libcap-ng": {
-      "evra": "0.9.3-1.fc43.s390x"
+      "evra": "0.9.3-1.fc44.s390x"
     },
     "libcbor": {
-      "evra": "0.12.0-6.fc43.s390x"
+      "evra": "0.13.0-2.fc44.s390x"
     },
     "libcollection": {
-      "evra": "0.7.0-59.fc43.s390x"
+      "evra": "0.7.0-61.fc44.s390x"
     },
     "libcom_err": {
-      "evra": "1.47.3-2.fc43.s390x"
+      "evra": "1.47.3-4.fc44.s390x"
     },
     "libcurl-minimal": {
-      "evra": "8.15.0-6.fc43.s390x"
+      "evra": "8.18.0-6.fc44.s390x"
     },
     "libdaemon": {
-      "evra": "0.14-32.fc43.s390x"
+      "evra": "0.14-33.fc44.s390x"
     },
     "libdhash": {
-      "evra": "0.5.0-59.fc43.s390x"
+      "evra": "0.5.0-61.fc44.s390x"
     },
     "libdnf5": {
-      "evra": "5.2.18.0-3.fc43.s390x"
+      "evra": "5.4.2.0-1.fc44.s390x"
     },
     "libdnf5-cli": {
-      "evra": "5.2.18.0-3.fc43.s390x"
+      "evra": "5.4.2.0-1.fc44.s390x"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc43.s390x"
+      "evra": "2.4.131-1.fc44.s390x"
     },
     "libeconf": {
-      "evra": "0.7.9-2.fc43.s390x"
+      "evra": "0.7.9-3.fc44.s390x"
     },
     "libedit": {
-      "evra": "3.1-57.20251016cvs.fc43.s390x"
+      "evra": "3.1-58.20251016cvs.fc44.s390x"
+    },
+    "libev": {
+      "evra": "4.33-15.fc44.s390x"
     },
     "libevent": {
-      "evra": "2.1.12-16.fc43.s390x"
+      "evra": "2.1.12-17.fc44.s390x"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libffi": {
-      "evra": "3.5.2-1.fc43.s390x"
+      "evra": "3.5.2-2.fc44.s390x"
     },
     "libfido2": {
-      "evra": "1.16.0-3.fc43.s390x"
+      "evra": "1.16.0-5.fc44.s390x"
     },
     "libgcc": {
-      "evra": "15.2.1-7.fc43.s390x"
+      "evra": "16.0.1-0.10.fc44.s390x"
     },
     "libgcrypt": {
-      "evra": "1.11.1-4.fc43.s390x"
+      "evra": "1.12.2-1.fc44.s390x"
     },
     "libgpg-error": {
-      "evra": "1.55-2.fc43.s390x"
+      "evra": "1.58-2.fc44.s390x"
     },
     "libibverbs": {
-      "evra": "58.0-4.fc43.s390x"
+      "evra": "61.0-2.fc44.s390x"
     },
     "libicu": {
-      "evra": "77.1-1.fc43.s390x"
+      "evra": "77.1-2.fc44.s390x"
     },
     "libidn2": {
-      "evra": "2.3.8-2.fc43.s390x"
+      "evra": "2.3.8-3.fc44.s390x"
     },
     "libini_config": {
-      "evra": "1.3.1-59.fc43.s390x"
+      "evra": "1.3.1-61.fc44.s390x"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "libjcat": {
-      "evra": "0.2.6-1.fc43.s390x"
+      "evra": "0.2.6-1.fc44.s390x"
     },
     "libjose": {
-      "evra": "14-5.fc43.s390x"
+      "evra": "14-6.fc44.s390x"
     },
     "libkcapi": {
-      "evra": "1.5.0-6.fc43.s390x"
+      "evra": "1.5.0-7.fc44.s390x"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-6.fc43.s390x"
+      "evra": "1.5.0-7.fc44.s390x"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-6.fc43.s390x"
+      "evra": "1.5.0-7.fc44.s390x"
     },
     "libksba": {
-      "evra": "1.6.7-4.fc43.s390x"
+      "evra": "1.6.7-5.fc44.s390x"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libldb": {
-      "evra": "2:4.23.7-2.fc43.s390x"
+      "evra": "2:4.24.1-1.fc44.s390x"
     },
     "libluksmeta": {
-      "evra": "10-1.fc43.s390x"
+      "evra": "10-2.fc44.s390x"
     },
     "libmaxminddb": {
-      "evra": "1.13.3-1.fc43.s390x"
+      "evra": "1.13.3-1.fc44.s390x"
     },
     "libmd": {
-      "evra": "1.1.0-8.fc43.s390x"
+      "evra": "1.1.0-9.fc44.s390x"
     },
     "libmnl": {
-      "evra": "1.0.5-8.fc43.s390x"
+      "evra": "1.0.5-9.fc44.s390x"
     },
     "libmodulemd": {
-      "evra": "2.15.2-4.fc43.s390x"
+      "evra": "2.15.2-7.fc44.s390x"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libndp": {
-      "evra": "1.9-4.fc43.s390x"
+      "evra": "1.9-5.fc44.s390x"
     },
     "libnet": {
-      "evra": "1.3-6.fc43.s390x"
+      "evra": "1.3-7.fc44.s390x"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.1.1-1.fc43.s390x"
+      "evra": "1.1.1-1.fc44.s390x"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-31.fc43.s390x"
+      "evra": "1.0.1-32.fc44.s390x"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc43.s390x"
+      "evra": "1:2.8.7-1.fc44.s390x"
     },
     "libnftnl": {
-      "evra": "1.2.9-2.fc43.s390x"
+      "evra": "1.3.1-2.fc44.s390x"
     },
     "libnghttp2": {
-      "evra": "1.66.0-2.fc43.s390x"
+      "evra": "1.68.0-3.fc44.s390x"
     },
     "libnl3": {
-      "evra": "3.12.0-2.fc43.s390x"
+      "evra": "3.12.0-3.fc44.s390x"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-2.fc43.s390x"
+      "evra": "3.12.0-3.fc44.s390x"
     },
     "libnsl2": {
-      "evra": "2.0.1-4.fc43.s390x"
+      "evra": "2.0.1-5.fc44.s390x"
     },
     "libnvme": {
-      "evra": "1.16.1-1.fc43.s390x"
+      "evra": "1.16.1-2.fc44.s390x"
     },
     "libpath_utils": {
-      "evra": "0.2.1-59.fc43.s390x"
+      "evra": "0.2.1-61.fc44.s390x"
     },
     "libpcap": {
-      "evra": "14:1.10.6-1.fc43.s390x"
+      "evra": "14:1.10.6-2.fc44.s390x"
     },
     "libpciaccess": {
-      "evra": "0.16-16.fc43.s390x"
+      "evra": "0.16-17.fc44.s390x"
     },
     "libpkgconf": {
-      "evra": "2.3.0-3.fc43.s390x"
+      "evra": "2.5.1-1.fc44.s390x"
     },
     "libpsl": {
-      "evra": "0.21.5-6.fc43.s390x"
+      "evra": "0.21.5-7.fc44.s390x"
     },
     "libpwquality": {
-      "evra": "1.4.5-14.fc43.s390x"
+      "evra": "1.4.5-15.fc44.s390x"
     },
     "libref_array": {
-      "evra": "0.1.5-59.fc43.s390x"
+      "evra": "0.1.5-61.fc44.s390x"
     },
     "librepo": {
-      "evra": "1.20.0-4.fc43.s390x"
+      "evra": "1.20.0-5.fc44.s390x"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-9.fc43.noarch"
+      "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-2.fc43.s390x"
+      "evra": "2.6.0-3.fc44.s390x"
     },
     "libselinux": {
-      "evra": "3.9-5.fc43.s390x"
+      "evra": "3.10-1.fc44.s390x"
     },
     "libselinux-utils": {
-      "evra": "3.9-5.fc43.s390x"
+      "evra": "3.10-1.fc44.s390x"
     },
     "libsemanage": {
-      "evra": "3.9-4.fc43.s390x"
+      "evra": "3.10-1.fc44.s390x"
     },
     "libsepol": {
-      "evra": "3.9-2.fc43.s390x"
+      "evra": "3.10-1.fc44.s390x"
     },
     "libslirp": {
-      "evra": "4.9.1-2.fc43.s390x"
+      "evra": "4.9.1-3.fc44.s390x"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libsmbclient": {
-      "evra": "2:4.23.7-2.fc43.s390x"
+      "evra": "2:4.24.1-1.fc44.s390x"
     },
     "libsolv": {
-      "evra": "0.7.36-3.fc43.s390x"
+      "evra": "0.7.37-2.fc44.s390x"
     },
     "libss": {
-      "evra": "1.47.3-2.fc43.s390x"
+      "evra": "1.47.3-4.fc44.s390x"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "libstdc++": {
-      "evra": "15.2.1-7.fc43.s390x"
+      "evra": "16.0.1-0.10.fc44.s390x"
     },
     "libtalloc": {
-      "evra": "2.4.3-4.fc43.s390x"
+      "evra": "2.4.4-1.fc44.s390x"
     },
     "libtasn1": {
-      "evra": "4.21.0-1.fc43.s390x"
+      "evra": "4.21.0-1.fc44.s390x"
     },
     "libtdb": {
-      "evra": "1.4.14-3.fc43.s390x"
+      "evra": "1.4.15-1.fc44.s390x"
     },
     "libteam": {
-      "evra": "1.32-12.fc43.s390x"
+      "evra": "1.32-13.fc44.s390x"
     },
     "libtevent": {
-      "evra": "0.17.1-3.fc43.s390x"
+      "evra": "0.17.1-4.fc44.s390x"
     },
     "libtirpc": {
-      "evra": "1.3.7-1.fc43.s390x"
+      "evra": "1.3.7-2.fc44.s390x"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-8.fc43.s390x"
+      "evra": "2.5.4-10.fc44.s390x"
     },
     "libunistring": {
-      "evra": "1.1-10.fc43.s390x"
+      "evra": "1.1-11.fc44.s390x"
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc43.s390x"
+      "evra": "1.0.29-5.fc44.s390x"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "libuv": {
-      "evra": "1:1.51.0-2.fc43.s390x"
+      "evra": "1:1.51.0-3.fc44.s390x"
     },
     "libverto": {
-      "evra": "0.3.2-11.fc43.s390x"
+      "evra": "0.3.2-12.fc44.s390x"
+    },
+    "libverto-libev": {
+      "evra": "0.3.2-12.fc44.s390x"
     },
     "libwbclient": {
-      "evra": "2:4.23.7-2.fc43.s390x"
+      "evra": "2:4.24.1-1.fc44.s390x"
     },
     "libxcrypt": {
-      "evra": "4.5.2-1.fc43.s390x"
+      "evra": "4.5.2-3.fc44.s390x"
     },
     "libxml2": {
-      "evra": "2.12.10-5.fc43.s390x"
+      "evra": "2.12.10-6.fc44.s390x"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc43.s390x"
+      "evra": "0.3.26-1.fc44.s390x"
     },
     "libyaml": {
-      "evra": "0.2.5-17.fc43.s390x"
+      "evra": "0.2.5-18.fc44.s390x"
     },
     "libzstd": {
-      "evra": "1.5.7-2.fc43.s390x"
+      "evra": "1.5.7-5.fc44.s390x"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-1.fc43.s390x"
+      "evra": "0.9.34-2.fc44.s390x"
     },
     "logrotate": {
-      "evra": "3.22.0-4.fc43.s390x"
+      "evra": "3.22.0-5.fc44.s390x"
     },
     "lsof": {
-      "evra": "4.98.0-8.fc43.s390x"
+      "evra": "4.98.0-9.fc44.s390x"
     },
     "lua-libs": {
-      "evra": "5.4.8-4.fc43.s390x"
+      "evra": "5.4.8-5.fc44.s390x"
     },
     "luksmeta": {
-      "evra": "10-1.fc43.s390x"
+      "evra": "10-2.fc44.s390x"
     },
     "lvm2": {
-      "evra": "2.03.34-2.fc43.s390x"
+      "evra": "2.03.38-2.fc44.s390x"
     },
     "lvm2-libs": {
-      "evra": "2.03.34-2.fc43.s390x"
+      "evra": "2.03.38-2.fc44.s390x"
     },
     "lz4-libs": {
-      "evra": "1.10.0-3.fc43.s390x"
+      "evra": "1.10.0-4.fc44.s390x"
     },
     "lzo": {
-      "evra": "2.10-15.fc43.s390x"
+      "evra": "2.10-16.fc44.s390x"
     },
     "makedumpfile": {
-      "evra": "1.7.8-1.fc43.s390x"
+      "evra": "1.7.8-2.fc44.s390x"
     },
     "mdadm": {
-      "evra": "4.3-9.fc43.s390x"
+      "evra": "4.3-11.fc44.s390x"
     },
     "moby-engine": {
-      "evra": "29.4.0-1.fc43.s390x"
+      "evra": "29.4.1-1.fc44.s390x"
     },
     "moby-filesystem": {
-      "evra": "29.4.0-1.fc43.noarch"
+      "evra": "29.4.1-1.fc44.noarch"
     },
     "mpfr": {
-      "evra": "4.2.2-2.fc43.s390x"
+      "evra": "4.2.2-3.fc44.s390x"
     },
     "nano": {
-      "evra": "8.5-2.fc43.s390x"
+      "evra": "8.7.1-1.fc44.s390x"
     },
     "nano-default-editor": {
-      "evra": "8.5-2.fc43.noarch"
+      "evra": "8.7.1-1.fc44.noarch"
     },
     "ncurses": {
-      "evra": "6.5-7.20250614.fc43.s390x"
+      "evra": "6.6-1.fc44.s390x"
     },
     "ncurses-base": {
-      "evra": "6.5-7.20250614.fc43.noarch"
+      "evra": "6.6-1.fc44.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.5-7.20250614.fc43.s390x"
+      "evra": "6.6-1.fc44.s390x"
     },
     "net-tools": {
-      "evra": "2.0-0.74.20160912git.fc43.s390x"
+      "evra": "2.0-0.77.20160912git.fc44.s390x"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc43.s390x"
+      "evra": "2:1.17.2-1.fc44.s390x"
     },
     "nettle": {
-      "evra": "3.10.1-2.fc43.s390x"
+      "evra": "3.10.1-3.fc44.s390x"
     },
     "newt": {
-      "evra": "0.52.25-5.fc43.s390x"
+      "evra": "0.52.25-6.fc44.s390x"
     },
-    "nfs-utils-coreos": {
-      "evra": "1:2.8.7-1.fc43.s390x"
+    "nfs-client-utils": {
+      "evra": "1:2.8.7-1.fc44.s390x"
+    },
+    "nfs-common-utils": {
+      "evra": "1:2.8.7-1.fc44.s390x"
+    },
+    "nfsv3-client-utils": {
+      "evra": "1:2.8.7-1.fc44.s390x"
+    },
+    "nfsv4-client-utils": {
+      "evra": "1:2.8.7-1.fc44.s390x"
     },
     "nftables": {
-      "evra": "1:1.1.3-6.fc43.1.s390x"
+      "evra": "1:1.1.6-2.fc44.s390x"
     },
     "nftables-services": {
-      "evra": "1:1.1.3-6.fc43.1.noarch"
+      "evra": "1:1.1.6-2.fc44.noarch"
     },
     "ngtcp2": {
-      "evra": "1.22.1-1.fc43.s390x"
+      "evra": "1.22.1-1.fc44.s390x"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.22.1-1.fc43.s390x"
+      "evra": "1.22.1-1.fc44.s390x"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc43.s390x"
+      "evra": "2.2.57-2.fc44.s390x"
     },
     "npth": {
-      "evra": "1.8-3.fc43.s390x"
+      "evra": "1.8-4.fc44.s390x"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-7.fc43.s390x"
+      "evra": "2.23.0-9.fc44.s390x"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-1.fc43.s390x"
+      "evra": "2.16-2.fc44.s390x"
     },
     "oniguruma": {
-      "evra": "6.9.10-3.fc43.s390x"
+      "evra": "6.9.10-4.fc44.s390x"
     },
     "openldap": {
-      "evra": "2.6.13-1.fc43.s390x"
+      "evra": "2.6.13-1.fc44.s390x"
     },
     "openssh": {
-      "evra": "10.0p1-9.fc43.s390x"
+      "evra": "10.2p1-9.fc44.s390x"
     },
     "openssh-clients": {
-      "evra": "10.0p1-9.fc43.s390x"
+      "evra": "10.2p1-9.fc44.s390x"
     },
     "openssh-server": {
-      "evra": "10.0p1-9.fc43.s390x"
+      "evra": "10.2p1-9.fc44.s390x"
     },
     "openssl": {
-      "evra": "1:3.5.4-3.fc43.s390x"
+      "evra": "1:3.5.5-2.fc44.s390x"
     },
     "openssl-libs": {
-      "evra": "1:3.5.4-3.fc43.s390x"
+      "evra": "1:3.5.5-2.fc44.s390x"
     },
     "ostree": {
-      "evra": "2026.1-1.fc43.s390x"
+      "evra": "2026.1-1.fc44.s390x"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc43.s390x"
+      "evra": "2026.1-1.fc44.s390x"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc43.s390x"
+      "evra": "0.26.2-1.fc44.s390x"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc43.s390x"
+      "evra": "0.26.2-1.fc44.s390x"
     },
     "pam": {
-      "evra": "1.7.1-4.fc43.s390x"
+      "evra": "1.7.2-1.fc44.s390x"
     },
     "pam-libs": {
-      "evra": "1.7.1-4.fc43.s390x"
+      "evra": "1.7.2-1.fc44.s390x"
     },
     "passim-libs": {
-      "evra": "0.1.11-1.fc43.s390x"
+      "evra": "0.1.11-1.fc44.s390x"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc43.s390x"
+      "evra": "0^20260120.g386b5f5-1.fc44.s390x"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc43.noarch"
+      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-2.fc43.s390x"
+      "evra": "3.14.0-3.fc44.s390x"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-2.fc43.s390x"
+      "evra": "3.14.0-3.fc44.s390x"
     },
     "pcre2": {
-      "evra": "10.47-1.fc43.s390x"
+      "evra": "10.47-1.fc44.1.s390x"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc43.noarch"
+      "evra": "10.47-1.fc44.1.noarch"
     },
     "pigz": {
-      "evra": "2.8-7.fc43.s390x"
+      "evra": "2.8-8.fc44.s390x"
     },
     "pkgconf": {
-      "evra": "2.3.0-3.fc43.s390x"
+      "evra": "2.5.1-1.fc44.s390x"
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-3.fc43.noarch"
+      "evra": "2.5.1-1.fc44.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-3.fc43.s390x"
+      "evra": "2.5.1-1.fc44.s390x"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc43.s390x"
+      "evra": "5:5.8.2-1.fc44.s390x"
     },
     "podman-sequoia": {
-      "evra": "0.2.0-3.fc43.s390x"
+      "evra": "0.3.2-1.fc44.s390x"
     },
     "policycoreutils": {
-      "evra": "3.9-7.fc43.s390x"
+      "evra": "3.10-1.fc44.s390x"
     },
     "polkit": {
-      "evra": "126-6.fc43.2.s390x"
+      "evra": "127-2.fc44.2.s390x"
     },
     "polkit-libs": {
-      "evra": "126-6.fc43.2.s390x"
+      "evra": "127-2.fc44.2.s390x"
     },
     "popt": {
-      "evra": "1.19-9.fc43.s390x"
+      "evra": "1.19-10.fc44.s390x"
     },
     "procps-ng": {
-      "evra": "4.0.4-7.fc43.1.s390x"
+      "evra": "4.0.6-1.fc44.s390x"
     },
     "protobuf-c": {
-      "evra": "1.5.2-1.fc43.s390x"
+      "evra": "1.5.2-2.fc44.s390x"
     },
     "psmisc": {
-      "evra": "23.7-6.fc43.s390x"
+      "evra": "23.7-7.fc44.s390x"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc43.noarch"
+      "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
-      "evra": "2:10.1.5-1.fc43.s390x"
+      "evra": "2:10.2.2-1.fc44.s390x"
+    },
+    "rdma-core-common": {
+      "evra": "61.0-2.fc44.noarch"
     },
     "readline": {
-      "evra": "8.3-2.fc43.s390x"
+      "evra": "8.3-4.fc44.s390x"
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc43.s390x"
+      "evra": "1.2.8-1.fc44.s390x"
     },
     "rpm": {
-      "evra": "6.0.1-1.fc43.s390x"
+      "evra": "6.0.1-2.fc44.s390x"
     },
     "rpm-libs": {
-      "evra": "6.0.1-1.fc43.s390x"
+      "evra": "6.0.1-2.fc44.s390x"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc43.s390x"
+      "evra": "2026.1-3.fc44.s390x"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc43.s390x"
+      "evra": "2026.1-3.fc44.s390x"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-1.fc43.s390x"
+      "evra": "6.0.1-2.fc44.s390x"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc43.s390x"
+      "evra": "1.10.2-1.fc44.s390x"
     },
     "rsync": {
-      "evra": "3.4.1-5.fc43.s390x"
+      "evra": "3.4.1-6.fc44.s390x"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc43.s390x"
+      "evra": "2:1.4.2-1.fc44.s390x"
     },
     "s390utils-core": {
-      "evra": "2:2.38.0-2.fc43.s390x"
+      "evra": "2:2.40.0-3.fc44.s390x"
     },
     "samba-client-libs": {
-      "evra": "2:4.23.7-2.fc43.s390x"
+      "evra": "2:4.24.1-1.fc44.s390x"
     },
     "samba-common": {
-      "evra": "2:4.23.7-2.fc43.noarch"
+      "evra": "2:4.24.1-1.fc44.noarch"
     },
-    "samba-common-libs": {
-      "evra": "2:4.23.7-2.fc43.s390x"
+    "samba-core-libs": {
+      "evra": "2:4.24.1-1.fc44.s390x"
+    },
+    "samba-ndr-libs": {
+      "evra": "2:4.24.1-1.fc44.s390x"
     },
     "sdbus-cpp": {
-      "evra": "2.1.0-3.fc43.s390x"
+      "evra": "2.2.1-2.fc44.s390x"
     },
     "sed": {
-      "evra": "4.9-5.fc43.s390x"
+      "evra": "4.9-7.fc44.s390x"
     },
     "selinux-policy": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "setup": {
-      "evra": "2.15.0-26.fc43.noarch"
+      "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-6.fc43.s390x"
+      "evra": "1.48-8.fc44.s390x"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-6.fc43.s390x"
+      "evra": "1.48-8.fc44.s390x"
     },
     "shadow-utils": {
-      "evra": "2:4.18.0-3.fc43.s390x"
+      "evra": "2:4.19.0-6.fc44.s390x"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.18.0-3.fc43.s390x"
+      "evra": "2:4.19.0-6.fc44.s390x"
     },
     "shared-mime-info": {
-      "evra": "2.4-2.fc43.s390x"
+      "evra": "2.4-3.fc44.s390x"
     },
     "skopeo": {
-      "evra": "1:1.22.2-1.fc43.s390x"
+      "evra": "1:1.22.2-1.fc44.s390x"
     },
     "slang": {
-      "evra": "2.3.3-8.fc43.s390x"
+      "evra": "2.3.3-9.fc44.s390x"
     },
     "slirp4netns": {
-      "evra": "1.3.1-3.fc43.s390x"
+      "evra": "1.3.1-4.fc44.s390x"
     },
     "snappy": {
-      "evra": "1.2.2-2.fc43.s390x"
+      "evra": "1.2.2-4.fc44.s390x"
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc43.s390x"
+      "evra": "1.8.1.0-2.fc44.s390x"
     },
     "sqlite-libs": {
-      "evra": "3.50.2-2.fc43.s390x"
+      "evra": "3.51.2-1.fc44.s390x"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-7.fc43.s390x"
+      "evra": "4.6.1-8.fc44.s390x"
     },
     "sssd-ad": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-client": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-common": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-1.fc43.s390x"
+      "evra": "2.13.0-1.fc44.s390x"
     },
     "stalld": {
-      "evra": "1.26.3-1.fc43.s390x"
+      "evra": "1.26.3-2.fc44.s390x"
     },
     "sudo": {
-      "evra": "1.9.17-7.p2.fc43.s390x"
+      "evra": "1.9.17-8.p2.fc44.s390x"
     },
     "systemd": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-container": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-libs": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-pam": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-resolved": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-shared": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-sysusers": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "systemd-udev": {
-      "evra": "258.7-1.fc43.s390x"
+      "evra": "259.5-1.fc44.s390x"
     },
     "tar": {
-      "evra": "2:1.35-6.fc43.s390x"
+      "evra": "2:1.35-8.fc44.s390x"
     },
     "teamd": {
-      "evra": "1.32-12.fc43.s390x"
+      "evra": "1.32-13.fc44.s390x"
     },
     "tini-static": {
-      "evra": "0.19.0-11.fc43.s390x"
+      "evra": "0.19.0-12.fc44.s390x"
     },
     "toolbox": {
-      "evra": "0.3-1.fc43.s390x"
+      "evra": "0.3-4.fc44.s390x"
     },
     "tpm2-tools": {
-      "evra": "5.7-4.fc43.s390x"
+      "evra": "5.7-5.fc44.s390x"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-8.fc43.s390x"
+      "evra": "4.1.3-9.fc44.s390x"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-8.fc43.s390x"
+      "evra": "4.1.3-9.fc44.s390x"
     },
     "tzdata": {
-      "evra": "2026a-1.fc43.noarch"
+      "evra": "2026a-1.fc44.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.3-2.fc43.s390x"
+      "evra": "0.15.6-1.fc44.s390x"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc43.s390x"
+      "evra": "2.41.4-7.fc44.s390x"
     },
     "veritysetup": {
-      "evra": "2.8.4-1.fc43.s390x"
+      "evra": "2.8.4-1.fc44.s390x"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc43.noarch"
+      "evra": "2:9.2.390-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc43.s390x"
+      "evra": "2:9.2.390-1.fc44.s390x"
     },
     "which": {
-      "evra": "2.23-3.fc43.s390x"
+      "evra": "2.23-4.fc44.s390x"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-2.fc43.s390x"
+      "evra": "1.0.20250521-3.fc44.s390x"
     },
     "xfsprogs": {
-      "evra": "6.15.0-3.fc43.s390x"
+      "evra": "6.18.0-2.fc44.s390x"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-3.fc43.s390x"
+      "evra": "0.8.3-4.fc44.s390x"
     },
     "xz": {
-      "evra": "1:5.8.1-4.fc43.s390x"
+      "evra": "1:5.8.2-2.fc44.s390x"
     },
     "xz-libs": {
-      "evra": "1:5.8.1-4.fc43.s390x"
+      "evra": "1:5.8.2-2.fc44.s390x"
     },
     "yajl": {
-      "evra": "2.1.0-38.fc43.s390x"
+      "evra": "2.1.0-40.fc44.s390x"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-3.fc43.s390x"
+      "evra": "1.5.1-4.fc44.s390x"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc43.s390x"
+      "evra": "0.0.32-1.fc44.s390x"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-2.fc43.s390x"
+      "evra": "2.3.3-3.fc44.s390x"
     },
     "zram-generator": {
-      "evra": "1.2.1-3.fc43.s390x"
+      "evra": "1.2.1-5.fc44.s390x"
     },
     "zstd": {
-      "evra": "1.5.7-2.fc43.s390x"
+      "evra": "1.5.7-5.fc44.s390x"
     }
   },
   "metadata": {

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,1354 +1,1375 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.56.0-1.fc44.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.56.0-1.fc44.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.56.0-1.fc44.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.56.0-1.fc44.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.54.3-2.fc43.x86_64"
+      "evra": "1:1.56.0-1.fc44.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.15.0.1-1.fc43.noarch"
+      "evra": "2.15.0.1-3.fc44.noarch"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.1-1.fc43.x86_64"
+      "evra": "2:1.17.1-1.fc44.x86_64"
     },
     "acl": {
-      "evra": "2.3.2-4.fc43.x86_64"
+      "evra": "2.3.2-6.fc44.x86_64"
     },
     "adcli": {
-      "evra": "0.9.2-10.fc43.x86_64"
+      "evra": "0.9.3.1-5.fc44.x86_64"
+    },
+    "adcli-selinux": {
+      "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc43.x86_64"
+      "evra": "5.10.0-6.fc44.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc43.x86_64"
+      "evra": "5.10.0-6.fc44.x86_64"
     },
     "alternatives": {
-      "evra": "1.33-3.fc43.x86_64"
+      "evra": "1.33-5.fc44.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-6.fc43.x86_64"
+      "evra": "2.5.2-8.fc44.x86_64"
     },
     "audit": {
-      "evra": "4.1.4-1.fc43.x86_64"
+      "evra": "4.1.4-1.fc44.x86_64"
     },
     "audit-libs": {
-      "evra": "4.1.4-1.fc43.x86_64"
+      "evra": "4.1.4-1.fc44.x86_64"
     },
     "audit-rules": {
-      "evra": "4.1.4-1.fc43.x86_64"
+      "evra": "4.1.4-1.fc44.x86_64"
     },
     "authselect": {
-      "evra": "1.6.2-1.fc43.x86_64"
+      "evra": "1.7.1-1.fc44.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.6.2-1.fc43.x86_64"
-    },
-    "avahi-libs": {
-      "evra": "0.9~rc2-6.fc43.x86_64"
+      "evra": "1.7.1-1.fc44.x86_64"
     },
     "azure-vm-utils": {
-      "evra": "0.7.0-1.fc43.x86_64"
+      "evra": "0.7.0-3.fc44.x86_64"
     },
     "bash": {
-      "evra": "5.3.0-2.fc43.x86_64"
+      "evra": "5.3.9-3.fc44.x86_64"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-2.fc43.noarch"
+      "evra": "0.7.1-3.fc44.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.16-2.fc43.noarch"
+      "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc43.x86_64"
+      "evra": "32:9.18.48-1.fc44.x86_64"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc43.x86_64"
+      "evra": "32:9.18.48-1.fc44.x86_64"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc43.x86_64"
+      "evra": "1.15.1-1.fc44.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc43.x86_64"
+      "evra": "0.2.33-1.fc44.x86_64"
     },
     "bsdtar": {
-      "evra": "3.8.4-1.fc43.x86_64"
+      "evra": "3.8.7-1.fc44.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc43.x86_64"
+      "evra": "6.19.1-1.fc44.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.11.0-2.fc43.x86_64"
+      "evra": "0.11.0-4.fc44.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-21.fc43.x86_64"
+      "evra": "1.0.8-23.fc44.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-21.fc43.x86_64"
+      "evra": "1.0.8-23.fc44.x86_64"
     },
     "c-ares": {
-      "evra": "1.34.5-2.fc43.x86_64"
+      "evra": "1.34.6-3.fc44.x86_64"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-1.2.fc43.noarch"
+      "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-3.fc43.x86_64"
+      "evra": "0.2.1-5.fc44.x86_64"
     },
     "chrony": {
-      "evra": "4.8-3.fc43.x86_64"
+      "evra": "4.8-5.fc44.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc43.x86_64"
+      "evra": "7.5-1.fc44.x86_64"
     },
     "clevis": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-dracut": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-luks": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-10.fc43.x86_64"
+      "evra": "0.5.4-1.fc44.x86_64"
     },
     "clevis-systemd": {
-      "evra": "21-12.fc43.x86_64"
+      "evra": "21-14.fc44.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-11.fc43.noarch"
+      "evra": "0.33-13.fc44.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-3.fc43.x86_64"
+      "evra": "1.0.8-5.fc44.x86_64"
     },
     "composefs-libs": {
-      "evra": "1.0.8-3.fc43.x86_64"
+      "evra": "1.0.8-5.fc44.x86_64"
     },
     "conmon": {
-      "evra": "2:2.2.1-2.fc43.x86_64"
+      "evra": "2:2.2.1-2.fc44.x86_64"
     },
     "console-login-helper-messages": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-issuegen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-motdgen": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "console-login-helper-messages-profile": {
-      "evra": "0.21.3-11.fc43.noarch"
+      "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc43.noarch"
+      "evra": "4:2.247.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.1.7-1.fc43.x86_64"
+      "evra": "2.2.3-1.fc44.x86_64"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc43.noarch"
+      "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc43.x86_64"
+      "evra": "0.26.0-1.fc44.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc43.x86_64"
+      "evra": "0.26.0-1.fc44.x86_64"
     },
     "coreutils": {
-      "evra": "9.7-8.fc43.x86_64"
+      "evra": "9.10-3.fc44.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.7-8.fc43.x86_64"
+      "evra": "9.10-3.fc44.x86_64"
     },
     "cpio": {
-      "evra": "2.15-6.fc43.x86_64"
+      "evra": "2.15-9.fc44.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.11-8.fc43.x86_64"
+      "evra": "2.9.11-10.fc44.x86_64"
     },
     "criu": {
-      "evra": "4.2-11.fc43.x86_64"
+      "evra": "4.2-13.fc44.x86_64"
     },
     "criu-libs": {
-      "evra": "4.2-11.fc43.x86_64"
+      "evra": "4.2-13.fc44.x86_64"
     },
     "crun": {
-      "evra": "1.27.1-1.fc43.x86_64"
+      "evra": "1.27.1-1.fc44.x86_64"
     },
     "crun-wasm": {
-      "evra": "1.27.1-1.fc43.x86_64"
+      "evra": "1.27.1-1.fc44.x86_64"
     },
     "crypto-policies": {
-      "evra": "20251125-1.git63291f8.fc43.noarch"
+      "evra": "20251128-3.git19878fe.fc44.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc43.x86_64"
+      "evra": "2.8.4-1.fc44.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc43.x86_64"
+      "evra": "2.8.4-1.fc44.x86_64"
     },
     "curl": {
-      "evra": "8.15.0-6.fc43.x86_64"
+      "evra": "8.18.0-6.fc44.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-33.fc43.x86_64"
+      "evra": "2.1.28-35.fc44.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-33.fc43.x86_64"
+      "evra": "2.1.28-35.fc44.x86_64"
     },
     "dbus": {
-      "evra": "1:1.16.0-4.fc43.x86_64"
+      "evra": "1:1.16.2-1.fc44.x86_64"
     },
     "dbus-broker": {
-      "evra": "37-2.fc43.x86_64"
+      "evra": "37-8.fc44.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-4.fc43.noarch"
+      "evra": "1:1.16.2-1.fc44.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-4.fc43.x86_64"
+      "evra": "1:1.16.2-1.fc44.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.208-2.fc43.x86_64"
+      "evra": "1.02.212-2.fc44.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.1.0-4.fc43.x86_64"
+      "evra": "1.3.1-3.fc44.x86_64"
     },
     "diffutils": {
-      "evra": "3.12-3.fc43.x86_64"
+      "evra": "3.12-5.fc44.x86_64"
     },
     "dnf5": {
-      "evra": "5.2.18.0-3.fc43.x86_64"
+      "evra": "5.4.2.0-1.fc44.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.92-1.fc43.x86_64"
+      "evra": "2.92-4.fc44.x86_64"
     },
     "docker-cli": {
-      "evra": "29.4.0-1.fc43.x86_64"
+      "evra": "29.4.1-1.fc44.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-16.fc43.x86_64"
+      "evra": "4.2-18.fc44.x86_64"
     },
     "dracut": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-6.fc44.x86_64"
     },
     "dracut-network": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-6.fc44.x86_64"
     },
     "dracut-squash": {
-      "evra": "107-8.fc43.x86_64"
+      "evra": "108-6.fc44.x86_64"
     },
     "duktape": {
-      "evra": "2.7.0-10.fc43.x86_64"
+      "evra": "2.7.0-11.fc44.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "efi-filesystem": {
-      "evra": "6-4.fc43.noarch"
+      "evra": "6-6.fc44.noarch"
     },
     "efibootmgr": {
-      "evra": "18-10.fc43.x86_64"
+      "evra": "18-11.fc44.x86_64"
     },
     "efivar-libs": {
-      "evra": "39-10.fc43.x86_64"
+      "evra": "39-12.fc44.x86_64"
     },
     "elfutils-default-yama-scope": {
-      "evra": "0.195-1.fc43.noarch"
+      "evra": "0.195-1.fc44.noarch"
     },
     "elfutils-libelf": {
-      "evra": "0.195-1.fc43.x86_64"
+      "evra": "0.195-1.fc44.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.195-1.fc43.x86_64"
+      "evra": "0.195-1.fc44.x86_64"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc43.x86_64"
+      "evra": "2:7.0-1.fc44.x86_64"
     },
     "expat": {
-      "evra": "2.7.3-1.fc43.x86_64"
+      "evra": "2.7.3-2.fc44.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "43-27.noarch"
+      "evra": "44-17.noarch"
     },
     "fedora-repos": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "43-1.noarch"
-    },
-    "fedora-repos-ostree": {
-      "evra": "43-1.noarch"
+      "evra": "44-1.noarch"
     },
     "file": {
-      "evra": "5.46-9.fc43.x86_64"
+      "evra": "5.46-10.fc44.x86_64"
     },
     "file-libs": {
-      "evra": "5.46-9.fc43.x86_64"
+      "evra": "5.46-10.fc44.x86_64"
     },
     "filesystem": {
-      "evra": "3.18-50.fc43.x86_64"
+      "evra": "3.18-52.fc44.x86_64"
     },
     "findutils": {
-      "evra": "1:4.10.0-6.fc43.x86_64"
+      "evra": "1:4.10.0-7.fc44.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.16.6-1.fc43.x86_64"
+      "evra": "1.17.6-1.fc44.x86_64"
     },
     "fmt": {
-      "evra": "11.2.0-3.fc43.x86_64"
+      "evra": "11.2.0-4.fc44.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-13.fc43.x86_64"
+      "evra": "0.6.1-14.fc44.x86_64"
     },
     "fuse-common": {
-      "evra": "3.16.2-6.fc43.x86_64"
+      "evra": "3.18.2-1.fc44.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.13-4.fc43.x86_64"
+      "evra": "1.16-2.fc44.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-1.fc43.x86_64"
+      "evra": "3.7.5-3.fc44.x86_64"
     },
     "fuse3": {
-      "evra": "3.16.2-6.fc43.x86_64"
+      "evra": "3.18.2-1.fc44.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.16.2-6.fc43.x86_64"
+      "evra": "3.18.2-1.fc44.x86_64"
     },
     "fwupd": {
-      "evra": "2.0.20-1.fc43.x86_64"
+      "evra": "2.1.1-1.fc44.x86_64"
     },
     "gawk": {
-      "evra": "5.3.2-2.fc43.x86_64"
+      "evra": "5.3.2-3.fc44.x86_64"
     },
     "gdbm": {
-      "evra": "1:1.23-10.fc43.x86_64"
+      "evra": "1:1.23-11.fc44.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-10.fc43.x86_64"
+      "evra": "1:1.23-11.fc44.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.10-4.fc43.x86_64"
+      "evra": "1.0.10-5.fc44.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc43.x86_64"
+      "evra": "2.54.0-1.fc44.x86_64"
     },
     "glib2": {
-      "evra": "2.86.5-1.fc43.x86_64"
+      "evra": "2.88.0-1.fc44.x86_64"
     },
     "glibc": {
-      "evra": "2.42-11.fc43.x86_64"
+      "evra": "2.43-3.fc44.x86_64"
     },
     "glibc-common": {
-      "evra": "2.42-11.fc43.x86_64"
+      "evra": "2.43-3.fc44.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.42-11.fc43.x86_64"
+      "evra": "2.43-3.fc44.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.42-11.fc43.x86_64"
+      "evra": "2.43-3.fc44.x86_64"
     },
     "gmp": {
-      "evra": "1:6.3.0-4.fc43.x86_64"
+      "evra": "1:6.3.0-5.fc44.x86_64"
     },
     "gnulib-l10n": {
-      "evra": "20241231-1.fc43.noarch"
+      "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc43.x86_64"
+      "evra": "2.4.9-7.fc44.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc43.x86_64"
+      "evra": "3.8.12-1.fc44.x86_64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-2.fc43.noarch"
+      "evra": "20250221.00-3.fc44.noarch"
     },
     "gpgme": {
-      "evra": "1.24.3-6.fc43.x86_64"
+      "evra": "2.0.1-3.fc44.x86_64"
     },
     "grep": {
-      "evra": "3.12-2.fc43.x86_64"
+      "evra": "3.12-3.fc44.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.12-43.fc43.noarch"
+      "evra": "1:2.12-56.fc44.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-43.fc43.x86_64"
+      "evra": "1:2.12-56.fc44.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.12-43.fc43.x86_64"
+      "evra": "1:2.12-56.fc44.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-43.fc43.noarch"
+      "evra": "1:2.12-56.fc44.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-43.fc43.x86_64"
+      "evra": "1:2.12-56.fc44.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-43.fc43.x86_64"
+      "evra": "1:2.12-56.fc44.x86_64"
+    },
+    "gssproxy": {
+      "evra": "0.9.2-10.fc44.x86_64"
     },
     "gzip": {
-      "evra": "1.13-4.fc43.x86_64"
+      "evra": "1.14-2.fc44.x86_64"
     },
     "hostname": {
-      "evra": "3.25-3.fc43.x86_64"
+      "evra": "3.25-4.fc44.x86_64"
     },
     "hwdata": {
-      "evra": "0.406-1.fc43.noarch"
+      "evra": "0.406-1.fc44.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-4.fc43.x86_64"
+      "evra": "2.26.0-4.fc44.x86_64"
     },
     "ignition-grub": {
-      "evra": "2.26.0-4.fc43.x86_64"
+      "evra": "2.26.0-4.fc44.x86_64"
     },
     "inih": {
-      "evra": "62-1.fc43.x86_64"
+      "evra": "62-2.fc44.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-12.fc43.x86_64"
+      "evra": "1.0.3-13.fc44.x86_64"
     },
     "iproute": {
-      "evra": "6.14.0-2.fc43.x86_64"
+      "evra": "6.17.0-2.fc44.x86_64"
     },
     "iproute-tc": {
-      "evra": "6.14.0-2.fc43.x86_64"
+      "evra": "6.17.0-2.fc44.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.11-12.fc43.noarch"
+      "evra": "1.8.11-13.fc44.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-12.fc43.x86_64"
+      "evra": "1.8.11-13.fc44.x86_64"
     },
     "iputils": {
-      "evra": "20250605-1.fc43.x86_64"
+      "evra": "20250605-2.fc44.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.9.4-7.fc43.x86_64"
+      "evra": "2:1.9.5-2.fc44.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc43.2.x86_64"
+      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.103-3.fc43.x86_64"
+      "evra": "0.103-4.fc44.x86_64"
     },
     "jansson": {
-      "evra": "2.14-3.fc43.x86_64"
+      "evra": "2.14-4.fc44.x86_64"
     },
     "jose": {
-      "evra": "14-5.fc43.x86_64"
+      "evra": "14-6.fc44.x86_64"
     },
     "jq": {
-      "evra": "1.8.1-3.fc43.x86_64"
+      "evra": "1.8.1-3.fc44.x86_64"
     },
     "json-c": {
-      "evra": "0.18-7.fc43.x86_64"
+      "evra": "0.18-8.fc44.x86_64"
     },
     "json-glib": {
-      "evra": "1.10.8-4.fc43.x86_64"
+      "evra": "1.10.8-5.fc44.x86_64"
     },
     "kbd": {
-      "evra": "2.8.0-3.fc43.x86_64"
+      "evra": "2.9.0-3.fc44.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kbd-misc": {
-      "evra": "2.8.0-3.fc43.noarch"
+      "evra": "2.9.0-3.fc44.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.61-1.fc43.x86_64"
+      "evra": "1.0.61-1.fc44.x86_64"
     },
     "kernel": {
-      "evra": "6.19.14-200.fc43.x86_64"
+      "evra": "6.19.14-300.fc44.x86_64"
     },
     "kernel-core": {
-      "evra": "6.19.14-200.fc43.x86_64"
+      "evra": "6.19.14-300.fc44.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.19.14-200.fc43.x86_64"
+      "evra": "6.19.14-300.fc44.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-200.fc43.x86_64"
+      "evra": "6.19.14-300.fc44.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.32-1.fc43.x86_64"
+      "evra": "2.0.32-3.fc44.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.3-6.fc43.x86_64"
+      "evra": "1.6.3-7.fc44.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-6.fc43.x86_64"
+      "evra": "1.6.3-7.fc44.x86_64"
     },
     "kmod": {
-      "evra": "34.2-2.fc43.x86_64"
+      "evra": "34.2-4.fc44.x86_64"
     },
     "kmod-libs": {
-      "evra": "34.2-2.fc43.x86_64"
+      "evra": "34.2-4.fc44.x86_64"
     },
     "kpartx": {
-      "evra": "0.11.1-2.fc43.x86_64"
+      "evra": "0.13.1-1.fc44.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc43.x86_64"
+      "evra": "1.22.2-3.fc44.x86_64"
     },
     "less": {
-      "evra": "692-5.fc43.x86_64"
+      "evra": "692-5.fc44.x86_64"
     },
     "libacl": {
-      "evra": "2.3.2-4.fc43.x86_64"
+      "evra": "2.3.2-6.fc44.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-22.fc43.x86_64"
+      "evra": "0.3.111-23.fc44.x86_64"
     },
     "libarchive": {
-      "evra": "3.8.4-1.fc43.x86_64"
+      "evra": "3.8.7-1.fc44.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.7-4.fc43.x86_64"
+      "evra": "2.5.7-5.fc44.x86_64"
     },
     "libattr": {
-      "evra": "2.5.2-6.fc43.x86_64"
+      "evra": "2.5.2-8.fc44.x86_64"
     },
     "libbasicobjects": {
-      "evra": "0.1.1-59.fc43.x86_64"
+      "evra": "0.1.1-61.fc44.x86_64"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libbpf": {
-      "evra": "2:1.6.1-3.fc43.x86_64"
+      "evra": "2:1.6.3-1.fc44.x86_64"
     },
     "libbsd": {
-      "evra": "0.12.2-6.fc43.x86_64"
+      "evra": "0.12.2-7.fc44.x86_64"
     },
     "libcap": {
-      "evra": "2.76-4.fc43.x86_64"
+      "evra": "2.78-1.fc44.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.9.3-1.fc43.x86_64"
+      "evra": "0.9.3-1.fc44.x86_64"
     },
     "libcbor": {
-      "evra": "0.12.0-6.fc43.x86_64"
+      "evra": "0.13.0-2.fc44.x86_64"
     },
     "libcollection": {
-      "evra": "0.7.0-59.fc43.x86_64"
+      "evra": "0.7.0-61.fc44.x86_64"
     },
     "libcom_err": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "libcurl-minimal": {
-      "evra": "8.15.0-6.fc43.x86_64"
+      "evra": "8.18.0-6.fc44.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-32.fc43.x86_64"
+      "evra": "0.14-33.fc44.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-59.fc43.x86_64"
+      "evra": "0.5.0-61.fc44.x86_64"
     },
     "libdnf5": {
-      "evra": "5.2.18.0-3.fc43.x86_64"
+      "evra": "5.4.2.0-1.fc44.x86_64"
     },
     "libdnf5-cli": {
-      "evra": "5.2.18.0-3.fc43.x86_64"
+      "evra": "5.4.2.0-1.fc44.x86_64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc43.x86_64"
+      "evra": "2.4.131-1.fc44.x86_64"
     },
     "libeconf": {
-      "evra": "0.7.9-2.fc43.x86_64"
+      "evra": "0.7.9-3.fc44.x86_64"
     },
     "libedit": {
-      "evra": "3.1-57.20251016cvs.fc43.x86_64"
+      "evra": "3.1-58.20251016cvs.fc44.x86_64"
+    },
+    "libev": {
+      "evra": "4.33-15.fc44.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-16.fc43.x86_64"
+      "evra": "2.1.12-17.fc44.x86_64"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libffi": {
-      "evra": "3.5.2-1.fc43.x86_64"
+      "evra": "3.5.2-2.fc44.x86_64"
     },
     "libfido2": {
-      "evra": "1.16.0-3.fc43.x86_64"
+      "evra": "1.16.0-5.fc44.x86_64"
     },
     "libgcc": {
-      "evra": "15.2.1-7.fc43.x86_64"
+      "evra": "16.0.1-0.10.fc44.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.11.1-4.fc43.x86_64"
+      "evra": "1.12.2-1.fc44.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.55-2.fc43.x86_64"
+      "evra": "1.58-2.fc44.x86_64"
     },
     "libibverbs": {
-      "evra": "58.0-4.fc43.x86_64"
+      "evra": "61.0-2.fc44.x86_64"
     },
     "libicu": {
-      "evra": "77.1-1.fc43.x86_64"
+      "evra": "77.1-2.fc44.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.8-2.fc43.x86_64"
+      "evra": "2.3.8-3.fc44.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-59.fc43.x86_64"
+      "evra": "1.3.1-61.fc44.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "libjcat": {
-      "evra": "0.2.6-1.fc43.x86_64"
+      "evra": "0.2.6-1.fc44.x86_64"
     },
     "libjose": {
-      "evra": "14-5.fc43.x86_64"
+      "evra": "14-6.fc44.x86_64"
     },
     "libkcapi": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-6.fc43.x86_64"
+      "evra": "1.5.0-7.fc44.x86_64"
     },
     "libksba": {
-      "evra": "1.6.7-4.fc43.x86_64"
+      "evra": "1.6.7-5.fc44.x86_64"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libldb": {
-      "evra": "2:4.23.7-2.fc43.x86_64"
+      "evra": "2:4.24.1-1.fc44.x86_64"
     },
     "libluksmeta": {
-      "evra": "10-1.fc43.x86_64"
+      "evra": "10-2.fc44.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.13.3-1.fc43.x86_64"
+      "evra": "1.13.3-1.fc44.x86_64"
     },
     "libmd": {
-      "evra": "1.1.0-8.fc43.x86_64"
+      "evra": "1.1.0-9.fc44.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.5-8.fc43.x86_64"
+      "evra": "1.0.5-9.fc44.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-4.fc43.x86_64"
+      "evra": "2.15.2-7.fc44.x86_64"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libndp": {
-      "evra": "1.9-4.fc43.x86_64"
+      "evra": "1.9-5.fc44.x86_64"
     },
     "libnet": {
-      "evra": "1.3-6.fc43.x86_64"
+      "evra": "1.3-7.fc44.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.1.1-1.fc43.x86_64"
+      "evra": "1.1.1-1.fc44.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-31.fc43.x86_64"
+      "evra": "1.0.1-32.fc44.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc43.x86_64"
+      "evra": "1:2.8.7-1.fc44.x86_64"
     },
     "libnftnl": {
-      "evra": "1.2.9-2.fc43.x86_64"
+      "evra": "1.3.1-2.fc44.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.66.0-2.fc43.x86_64"
+      "evra": "1.68.0-3.fc44.x86_64"
     },
     "libnl3": {
-      "evra": "3.12.0-2.fc43.x86_64"
+      "evra": "3.12.0-3.fc44.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-2.fc43.x86_64"
+      "evra": "3.12.0-3.fc44.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.1-4.fc43.x86_64"
+      "evra": "2.0.1-5.fc44.x86_64"
     },
     "libnvme": {
-      "evra": "1.16.1-1.fc43.x86_64"
+      "evra": "1.16.1-2.fc44.x86_64"
     },
     "libpath_utils": {
-      "evra": "0.2.1-59.fc43.x86_64"
+      "evra": "0.2.1-61.fc44.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.6-1.fc43.x86_64"
+      "evra": "14:1.10.6-2.fc44.x86_64"
     },
     "libpciaccess": {
-      "evra": "0.16-16.fc43.x86_64"
+      "evra": "0.16-17.fc44.x86_64"
     },
     "libpkgconf": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.5-6.fc43.x86_64"
+      "evra": "0.21.5-7.fc44.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.5-14.fc43.x86_64"
+      "evra": "1.4.5-15.fc44.x86_64"
     },
     "libref_array": {
-      "evra": "0.1.5-59.fc43.x86_64"
+      "evra": "0.1.5-61.fc44.x86_64"
     },
     "librepo": {
-      "evra": "1.20.0-4.fc43.x86_64"
+      "evra": "1.20.0-5.fc44.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-9.fc43.noarch"
+      "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-2.fc43.x86_64"
+      "evra": "2.6.0-3.fc44.x86_64"
     },
     "libselinux": {
-      "evra": "3.9-5.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.9-5.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libsemanage": {
-      "evra": "3.9-4.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libsepol": {
-      "evra": "3.9-2.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "libslirp": {
-      "evra": "4.9.1-2.fc43.x86_64"
+      "evra": "4.9.1-3.fc44.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.23.7-2.fc43.x86_64"
+      "evra": "2:4.24.1-1.fc44.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.36-3.fc43.x86_64"
+      "evra": "0.7.37-2.fc44.x86_64"
     },
     "libss": {
-      "evra": "1.47.3-2.fc43.x86_64"
+      "evra": "1.47.3-4.fc44.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "libstdc++": {
-      "evra": "15.2.1-7.fc43.x86_64"
+      "evra": "16.0.1-0.10.fc44.x86_64"
     },
     "libtalloc": {
-      "evra": "2.4.3-4.fc43.x86_64"
+      "evra": "2.4.4-1.fc44.x86_64"
     },
     "libtasn1": {
-      "evra": "4.21.0-1.fc43.x86_64"
+      "evra": "4.21.0-1.fc44.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.14-3.fc43.x86_64"
+      "evra": "1.4.15-1.fc44.x86_64"
     },
     "libteam": {
-      "evra": "1.32-12.fc43.x86_64"
+      "evra": "1.32-13.fc44.x86_64"
     },
     "libtevent": {
-      "evra": "0.17.1-3.fc43.x86_64"
+      "evra": "0.17.1-4.fc44.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.25.1-2.fc43.x86_64"
+      "evra": "0.26-4.fc44.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.7-1.fc43.x86_64"
+      "evra": "1.3.7-2.fc44.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-8.fc43.x86_64"
+      "evra": "2.5.4-10.fc44.x86_64"
     },
     "libunistring": {
-      "evra": "1.1-10.fc43.x86_64"
+      "evra": "1.1-11.fc44.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.29-4.fc43.x86_64"
+      "evra": "1.0.29-5.fc44.x86_64"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "libuv": {
-      "evra": "1:1.51.0-2.fc43.x86_64"
+      "evra": "1:1.51.0-3.fc44.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-11.fc43.x86_64"
+      "evra": "0.3.2-12.fc44.x86_64"
+    },
+    "libverto-libev": {
+      "evra": "0.3.2-12.fc44.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.23.7-2.fc43.x86_64"
+      "evra": "2:4.24.1-1.fc44.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.5.2-1.fc43.x86_64"
+      "evra": "4.5.2-3.fc44.x86_64"
     },
     "libxml2": {
-      "evra": "2.12.10-5.fc43.x86_64"
+      "evra": "2.12.10-6.fc44.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc43.x86_64"
+      "evra": "0.3.26-1.fc44.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-17.fc43.x86_64"
+      "evra": "0.2.5-18.fc44.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.7-2.fc43.x86_64"
+      "evra": "1.5.7-5.fc44.x86_64"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "lld18-libs": {
       "evra": "18.1.8-8.fc43.x86_64"
     },
     "llvm18-libs": {
-      "evra": "18.1.8-7.fc43.x86_64"
+      "evra": "18.1.8-8.fc44.x86_64"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-1.fc43.x86_64"
+      "evra": "0.9.34-2.fc44.x86_64"
     },
     "logrotate": {
-      "evra": "3.22.0-4.fc43.x86_64"
+      "evra": "3.22.0-5.fc44.x86_64"
     },
     "lsof": {
-      "evra": "4.98.0-8.fc43.x86_64"
+      "evra": "4.98.0-9.fc44.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.8-4.fc43.x86_64"
+      "evra": "5.4.8-5.fc44.x86_64"
     },
     "luksmeta": {
-      "evra": "10-1.fc43.x86_64"
+      "evra": "10-2.fc44.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.34-2.fc43.x86_64"
+      "evra": "2.03.38-2.fc44.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.34-2.fc43.x86_64"
+      "evra": "2.03.38-2.fc44.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.10.0-3.fc43.x86_64"
+      "evra": "1.10.0-4.fc44.x86_64"
     },
     "lzo": {
-      "evra": "2.10-15.fc43.x86_64"
+      "evra": "2.10-16.fc44.x86_64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-1.fc43.x86_64"
+      "evra": "1.7.8-2.fc44.x86_64"
     },
     "mdadm": {
-      "evra": "4.3-9.fc43.x86_64"
+      "evra": "4.3-11.fc44.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-71.1.fc43.x86_64"
+      "evra": "2:2.1-74.fc44.x86_64"
     },
     "moby-engine": {
-      "evra": "29.4.0-1.fc43.x86_64"
+      "evra": "29.4.1-1.fc44.x86_64"
     },
     "moby-filesystem": {
-      "evra": "29.4.0-1.fc43.noarch"
+      "evra": "29.4.1-1.fc44.noarch"
     },
     "mokutil": {
-      "evra": "2:0.7.2-2.fc43.x86_64"
+      "evra": "2:0.7.2-3.fc44.x86_64"
     },
     "mpfr": {
-      "evra": "4.2.2-2.fc43.x86_64"
+      "evra": "4.2.2-3.fc44.x86_64"
     },
     "nano": {
-      "evra": "8.5-2.fc43.x86_64"
+      "evra": "8.7.1-1.fc44.x86_64"
     },
     "nano-default-editor": {
-      "evra": "8.5-2.fc43.noarch"
+      "evra": "8.7.1-1.fc44.noarch"
     },
     "ncurses": {
-      "evra": "6.5-7.20250614.fc43.x86_64"
+      "evra": "6.6-1.fc44.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.5-7.20250614.fc43.noarch"
+      "evra": "6.6-1.fc44.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.5-7.20250614.fc43.x86_64"
+      "evra": "6.6-1.fc44.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.74.20160912git.fc43.x86_64"
+      "evra": "2.0-0.77.20160912git.fc44.x86_64"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc43.x86_64"
+      "evra": "2:1.17.2-1.fc44.x86_64"
     },
     "nettle": {
-      "evra": "3.10.1-2.fc43.x86_64"
+      "evra": "3.10.1-3.fc44.x86_64"
     },
     "newt": {
-      "evra": "0.52.25-5.fc43.x86_64"
+      "evra": "0.52.25-6.fc44.x86_64"
     },
-    "nfs-utils-coreos": {
-      "evra": "1:2.8.7-1.fc43.x86_64"
+    "nfs-client-utils": {
+      "evra": "1:2.8.7-1.fc44.x86_64"
+    },
+    "nfs-common-utils": {
+      "evra": "1:2.8.7-1.fc44.x86_64"
+    },
+    "nfsv3-client-utils": {
+      "evra": "1:2.8.7-1.fc44.x86_64"
+    },
+    "nfsv4-client-utils": {
+      "evra": "1:2.8.7-1.fc44.x86_64"
     },
     "nftables": {
-      "evra": "1:1.1.3-6.fc43.1.x86_64"
+      "evra": "1:1.1.6-2.fc44.x86_64"
     },
     "nftables-services": {
-      "evra": "1:1.1.3-6.fc43.1.noarch"
+      "evra": "1:1.1.6-2.fc44.noarch"
     },
     "ngtcp2": {
-      "evra": "1.22.1-1.fc43.x86_64"
+      "evra": "1.22.1-1.fc44.x86_64"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.22.1-1.fc43.x86_64"
+      "evra": "1.22.1-1.fc44.x86_64"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc43.x86_64"
+      "evra": "2.2.57-2.fc44.x86_64"
     },
     "npth": {
-      "evra": "1.8-3.fc43.x86_64"
+      "evra": "1.8-4.fc44.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-7.fc43.x86_64"
+      "evra": "2.23.0-9.fc44.x86_64"
     },
     "numactl": {
-      "evra": "2.0.19-3.fc43.x86_64"
+      "evra": "2.0.19-4.fc44.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.19-3.fc43.x86_64"
+      "evra": "2.0.19-4.fc44.x86_64"
     },
     "numad": {
-      "evra": "0.5-47.20150602git.fc43.x86_64"
+      "evra": "0.5-50.20251104git.fc44.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-1.fc43.x86_64"
+      "evra": "2.16-2.fc44.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.10-3.fc43.x86_64"
+      "evra": "6.9.10-4.fc44.x86_64"
     },
     "openldap": {
-      "evra": "2.6.13-1.fc43.x86_64"
+      "evra": "2.6.13-1.fc44.x86_64"
     },
     "openssh": {
-      "evra": "10.0p1-9.fc43.x86_64"
+      "evra": "10.2p1-9.fc44.x86_64"
     },
     "openssh-clients": {
-      "evra": "10.0p1-9.fc43.x86_64"
+      "evra": "10.2p1-9.fc44.x86_64"
     },
     "openssh-server": {
-      "evra": "10.0p1-9.fc43.x86_64"
+      "evra": "10.2p1-9.fc44.x86_64"
     },
     "openssl": {
-      "evra": "1:3.5.4-3.fc43.x86_64"
+      "evra": "1:3.5.5-2.fc44.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.4-3.fc43.x86_64"
+      "evra": "1:3.5.5-2.fc44.x86_64"
     },
     "os-prober": {
-      "evra": "1.81-10.fc43.x86_64"
+      "evra": "1.81-11.fc44.x86_64"
     },
     "ostree": {
-      "evra": "2026.1-1.fc43.x86_64"
+      "evra": "2026.1-1.fc44.x86_64"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc43.x86_64"
+      "evra": "2026.1-1.fc44.x86_64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc43.x86_64"
+      "evra": "0.26.2-1.fc44.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc43.x86_64"
+      "evra": "0.26.2-1.fc44.x86_64"
     },
     "pam": {
-      "evra": "1.7.1-4.fc43.x86_64"
+      "evra": "1.7.2-1.fc44.x86_64"
     },
     "pam-libs": {
-      "evra": "1.7.1-4.fc43.x86_64"
+      "evra": "1.7.2-1.fc44.x86_64"
     },
     "passim-libs": {
-      "evra": "0.1.11-1.fc43.x86_64"
+      "evra": "0.1.11-1.fc44.x86_64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc43.x86_64"
+      "evra": "0^20260120.g386b5f5-1.fc44.x86_64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc43.noarch"
+      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-2.fc43.x86_64"
+      "evra": "3.14.0-3.fc44.x86_64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-2.fc43.x86_64"
+      "evra": "3.14.0-3.fc44.x86_64"
     },
     "pcre2": {
-      "evra": "10.47-1.fc43.x86_64"
+      "evra": "10.47-1.fc44.1.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc43.noarch"
+      "evra": "10.47-1.fc44.1.noarch"
     },
     "pigz": {
-      "evra": "2.8-7.fc43.x86_64"
+      "evra": "2.8-8.fc44.x86_64"
     },
     "pkgconf": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "2.3.0-3.fc43.noarch"
+      "evra": "2.5.1-1.fc44.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.3.0-3.fc43.x86_64"
+      "evra": "2.5.1-1.fc44.x86_64"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc43.x86_64"
+      "evra": "5:5.8.2-1.fc44.x86_64"
     },
     "podman-sequoia": {
-      "evra": "0.2.0-3.fc43.x86_64"
+      "evra": "0.3.2-1.fc44.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.9-7.fc43.x86_64"
+      "evra": "3.10-1.fc44.x86_64"
     },
     "polkit": {
-      "evra": "126-6.fc43.2.x86_64"
+      "evra": "127-2.fc44.2.x86_64"
     },
     "polkit-libs": {
-      "evra": "126-6.fc43.2.x86_64"
+      "evra": "127-2.fc44.2.x86_64"
     },
     "popt": {
-      "evra": "1.19-9.fc43.x86_64"
+      "evra": "1.19-10.fc44.x86_64"
     },
     "procps-ng": {
-      "evra": "4.0.4-7.fc43.1.x86_64"
+      "evra": "4.0.6-1.fc44.x86_64"
     },
     "protobuf-c": {
-      "evra": "1.5.2-1.fc43.x86_64"
+      "evra": "1.5.2-2.fc44.x86_64"
     },
     "psmisc": {
-      "evra": "23.7-6.fc43.x86_64"
+      "evra": "23.7-7.fc44.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc43.noarch"
+      "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc43.noarch"
+      "evra": "20260410-1.fc44.noarch"
+    },
+    "rdma-core-common": {
+      "evra": "61.0-2.fc44.noarch"
     },
     "readline": {
-      "evra": "8.3-2.fc43.x86_64"
+      "evra": "8.3-4.fc44.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.8-0.fc43.x86_64"
+      "evra": "1.2.8-1.fc44.x86_64"
     },
     "rpm": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-libs": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc43.x86_64"
+      "evra": "2026.1-3.fc44.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc43.x86_64"
+      "evra": "2026.1-3.fc44.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-1.fc43.x86_64"
+      "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc43.x86_64"
+      "evra": "1.10.2-1.fc44.x86_64"
     },
     "rsync": {
-      "evra": "3.4.1-5.fc43.x86_64"
+      "evra": "3.4.1-6.fc44.x86_64"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc43.x86_64"
+      "evra": "2:1.4.2-1.fc44.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.23.7-2.fc43.x86_64"
+      "evra": "2:4.24.1-1.fc44.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.23.7-2.fc43.noarch"
+      "evra": "2:4.24.1-1.fc44.noarch"
     },
-    "samba-common-libs": {
-      "evra": "2:4.23.7-2.fc43.x86_64"
+    "samba-core-libs": {
+      "evra": "2:4.24.1-1.fc44.x86_64"
+    },
+    "samba-ndr-libs": {
+      "evra": "2:4.24.1-1.fc44.x86_64"
     },
     "sdbus-cpp": {
-      "evra": "2.1.0-3.fc43.x86_64"
+      "evra": "2.2.1-2.fc44.x86_64"
     },
     "sed": {
-      "evra": "4.9-5.fc43.x86_64"
+      "evra": "4.9-7.fc44.x86_64"
     },
     "selinux-policy": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "43.7-1.fc43.noarch"
+      "evra": "44.1-1.fc44.noarch"
     },
     "setup": {
-      "evra": "2.15.0-26.fc43.noarch"
+      "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-6.fc43.x86_64"
+      "evra": "1.48-8.fc44.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-6.fc43.x86_64"
+      "evra": "1.48-8.fc44.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.18.0-3.fc43.x86_64"
+      "evra": "2:4.19.0-6.fc44.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.18.0-3.fc43.x86_64"
+      "evra": "2:4.19.0-6.fc44.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.4-2.fc43.x86_64"
+      "evra": "2.4-3.fc44.x86_64"
     },
     "shim-x64": {
-      "evra": "15.8-3.x86_64"
+      "evra": "16.1-5.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.22.2-1.fc43.x86_64"
+      "evra": "1:1.22.2-1.fc44.x86_64"
     },
     "slang": {
-      "evra": "2.3.3-8.fc43.x86_64"
+      "evra": "2.3.3-9.fc44.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.3.1-3.fc43.x86_64"
+      "evra": "1.3.1-4.fc44.x86_64"
     },
     "snappy": {
-      "evra": "1.2.2-2.fc43.x86_64"
+      "evra": "1.2.2-4.fc44.x86_64"
     },
     "socat": {
-      "evra": "1.8.0.3-1.fc43.x86_64"
+      "evra": "1.8.1.0-2.fc44.x86_64"
     },
     "spdlog": {
-      "evra": "1.15.3-3.fc43.x86_64"
+      "evra": "1.15.3-4.fc44.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.50.2-2.fc43.x86_64"
+      "evra": "3.51.2-1.fc44.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-7.fc43.x86_64"
+      "evra": "4.6.1-8.fc44.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-client": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-common": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-1.fc43.x86_64"
+      "evra": "2.13.0-1.fc44.x86_64"
     },
     "stalld": {
-      "evra": "1.26.3-1.fc43.x86_64"
+      "evra": "1.26.3-2.fc44.x86_64"
     },
     "sudo": {
-      "evra": "1.9.17-7.p2.fc43.x86_64"
+      "evra": "1.9.17-8.p2.fc44.x86_64"
     },
     "systemd": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-container": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-libs": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-pam": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-resolved": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-shared": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-sysusers": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "systemd-udev": {
-      "evra": "258.7-1.fc43.x86_64"
+      "evra": "259.5-1.fc44.x86_64"
     },
     "tar": {
-      "evra": "2:1.35-6.fc43.x86_64"
+      "evra": "2:1.35-8.fc44.x86_64"
     },
     "teamd": {
-      "evra": "1.32-12.fc43.x86_64"
+      "evra": "1.32-13.fc44.x86_64"
     },
     "tini-static": {
-      "evra": "0.19.0-11.fc43.x86_64"
+      "evra": "0.19.0-12.fc44.x86_64"
     },
     "toolbox": {
-      "evra": "0.3-1.fc43.x86_64"
+      "evra": "0.3-4.fc44.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.7-4.fc43.x86_64"
+      "evra": "5.7-5.fc44.x86_64"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-8.fc43.x86_64"
+      "evra": "4.1.3-9.fc44.x86_64"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-8.fc43.x86_64"
+      "evra": "4.1.3-9.fc44.x86_64"
     },
     "tzdata": {
-      "evra": "2026a-1.fc43.noarch"
+      "evra": "2026a-1.fc44.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.3-2.fc43.x86_64"
+      "evra": "0.15.6-1.fc44.x86_64"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc43.x86_64"
+      "evra": "2.41.4-7.fc44.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc43.noarch"
+      "evra": "2:9.2.390-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc43.x86_64"
+      "evra": "2:9.2.390-1.fc44.x86_64"
     },
     "wasmedge-rt": {
-      "evra": "0.15.0-4.fc43.x86_64"
+      "evra": "0.16.1-1.fc44.x86_64"
     },
     "which": {
-      "evra": "2.23-3.fc43.x86_64"
+      "evra": "2.23-4.fc44.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-2.fc43.x86_64"
+      "evra": "1.0.20250521-3.fc44.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.15.0-3.fc43.x86_64"
+      "evra": "6.18.0-2.fc44.x86_64"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-3.fc43.x86_64"
+      "evra": "0.8.3-4.fc44.x86_64"
     },
     "xz": {
-      "evra": "1:5.8.1-4.fc43.x86_64"
+      "evra": "1:5.8.2-2.fc44.x86_64"
     },
     "xz-libs": {
-      "evra": "1:5.8.1-4.fc43.x86_64"
+      "evra": "1:5.8.2-2.fc44.x86_64"
     },
     "yajl": {
-      "evra": "2.1.0-38.fc43.x86_64"
+      "evra": "2.1.0-40.fc44.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-3.fc43.x86_64"
+      "evra": "1.5.1-4.fc44.x86_64"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc43.x86_64"
+      "evra": "0.0.32-1.fc44.x86_64"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-2.fc43.x86_64"
+      "evra": "2.3.3-3.fc44.x86_64"
     },
     "zram-generator": {
-      "evra": "1.2.1-3.fc43.x86_64"
+      "evra": "1.2.1-5.fc44.x86_64"
     },
     "zstd": {
-      "evra": "1.5.7-2.fc43.x86_64"
+      "evra": "1.5.7-5.fc44.x86_64"
     }
   },
   "metadata": {

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -29,34 +29,11 @@ conditional-include:
     include:
       ostree-layers:
         - overlay/10aarch64
-  # In F43 and older pull in the nfs-utils-coreos package
-  - if: releasever <= 43
-    include:
-      packages:
-        - nfs-utils-coreos
-  # In F44 we can use the nfs-client-utils package, which obsoletes nfs-utils-coreos
-  - if: releasever >= 44
-    include:
-      packages:
-        - nfs-client-utils
-  # Do the alternatives migration from 43
-  - if: releasever >= 43
+  # Do the alternatives migration on F44 and older
+  - if: releasever <= 44
     include:
       ostree-layers:
         - overlay/50alternatives
-  # Drop fedora-repos-ostree in F44
-  - if: releasever < 44
-    include:
-      packages:
-        - fedora-repos-ostree
-  # We carry our own ssh config for authorized keys in <44. In 44+
-  # The config is delivered via the ignition + afterburn RPMs
-  # https://src.fedoraproject.org/rpms/ignition/c/3ccce9fe2c0462f4a17923937933ab9c26db0aa5?branch=rawhide
-  # https://src.fedoraproject.org/rpms/rust-afterburn/c/e61c6e5f776410ea72e8f731cec88567577f6bb8?branch=rawhide
-  - if: releasever <= 43
-    include:
-      ostree-layers:
-        - overlay/18sshd-authorized-keys-file
 
 ostree-layers:
   - overlay/15fcos
@@ -75,6 +52,8 @@ packages:
   # Introduce a default colored prompt for Fedora's default shell bash.
   # https://github.com/coreos/fedora-coreos-tracker/issues/1567
   - bash-color-prompt
+  # obsoletes nfs-utils-coreos
+  - nfs-client-utils
 
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos-base.yaml

--- a/overlay.d/18sshd-authorized-keys-file/etc/ssh/sshd_config.d/40-authorized-keys-file.conf
+++ b/overlay.d/18sshd-authorized-keys-file/etc/ssh/sshd_config.d/40-authorized-keys-file.conf
@@ -1,2 +1,0 @@
-# Also accept keys configured by Ignition and Afterburn
-AuthorizedKeysFile=.ssh/authorized_keys .ssh/authorized_keys.d/*

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -46,14 +46,6 @@ here in a separate overlay to make it easy to include on specific
 streams for the time being. Eventually can probably put this in
 15fcos.
 
-18sshd-authorized-keys-file
----------------------------
-
-Configuration to have OpenSSH read authorized keys from files in
-`~/.ssh/authorized_keys.d/*` in addition to `~/.ssh/authorized_keys` (default).
-We can drop this overlay once we have moved this configuration file to be
-installed alongside the Afterburn and Ignition packages.
-
 20platform-chrony
 -----------------
 

--- a/tests/kola/data/commonlib.sh
+++ b/tests/kola/data/commonlib.sh
@@ -24,13 +24,13 @@ get_ipv4_for_nic() {
 
 get_fedora_container_ref() {
     local repo='quay.io/fedora/fedora'
-    local tag='43'
+    local tag='44'
     echo "${repo}:${tag}"
 }
 
 get_fedora_minimal_container_ref() {
     local repo='quay.io/fedora/fedora-minimal'
-    local tag='43'
+    local tag='44'
     echo "${repo}:${tag}"
 }
 


### PR DESCRIPTION
CI won't pass on this until F44 is officially released because the repos aren't populated yet. So this won't be able to merge until Tuesday.

See: https://github.com/coreos/fedora-coreos-tracker/issues/2055