### PR TITLE
denylist: skip fcos.upgrade.basic on s390x/rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -74,3 +74,11 @@
      - s390x
   streams:
     - rawhide
+- pattern: fcos.upgrade.basic
+  tracker: https://github.com/bootc-dev/bootc/issues/2151
+  snooze: 2026-05-21
+  warn: true
+  arches:
+    - s390x
+  streams:
+    - rawhide


### PR DESCRIPTION
On s390x, bootc fails to set zipl as the default bootloader when using `bootc install to-filesystem`, causing upgrades to boot into the wrong ostree path and leaving the system unbootable. Snoozed until 2026-05-12.

Tracker: https://github.com/bootc-dev/bootc/issues/2151