### PR TITLE
overlay.d/05core: Remove fips & modsign dracut modules

### DIFF
--- a/overlay.d/15fcos/usr/lib/dracut/dracut.conf.d/61-fedora-coreos-omits.conf
+++ b/overlay.d/15fcos/usr/lib/dracut/dracut.conf.d/61-fedora-coreos-omits.conf
@@ -1,0 +1,6 @@
+# FIPS is not supported on Fedora
+# See: https://fedoraproject.org/wiki/Changes/RemoveFipsModeSetup
+# See: https://docs.fedoraproject.org/en-US/bootc/fips-crypto-policies/
+omit_dracutmodules+=" fips fips-crypto-policies "
+# We don't include kernel module keys in the initrd
+omit_dracutmodules+=" modsign "


### PR DESCRIPTION
- FIPS is not supported on Fedora
  See: https://fedoraproject.org/wiki/Changes/RemoveFipsModeSetup
  See: https://docs.fedoraproject.org/en-US/bootc/fips-crypto-policies/
- We don't include kernel module keys in the initrd

---

I'll do a before/after size comparison.

And add a link to https://github.com/coreos/fedora-coreos-tracker/issues/302