### PR TITLE
[testing] overlay.d/05core: disable systemd-oomd.socket again

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
+++ b/overlay.d/05core/usr/lib/systemd/system-preset/40-coreos-systemd.preset
@@ -1,8 +1,9 @@
 # This file contains overrides for systemd services that are
 # enabled by default, but conflict with things we ship.
 
-# We don't have swap by default, and systemd-oomd hard requires it.
+# We don't have swap by default, and systemd-oomd strongly recommends it.
 disable systemd-oomd.service
+disable systemd-oomd.socket
 
 # Disable systemd-firstboot because it conflicts with Ignition.
 # In most cases this is handled via the remove-from-packages


### PR DESCRIPTION
I previously did this cherry-pick in https://github.com/coreos/fedora-coreos-config/pull/4122 but the Fedora 44 GA meant that we promoted `testing` directly from `next` and not `testing-devel` such that the original fix 34d14ce20c75b487ab4e94e46300c8882da8287c didn't get promoted.

Let's do another fast-track here so the next `stable` build doesn't have systemd-oomd enabled. 