### PR TITLE
[stable] overrides: fast-track kernel-6.19.13-200.fc43

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,28 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  kernel:
+    evr: 6.19.13-200.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e7ccc45410
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2140
+      type: fast-track
+  kernel-core:
+    evr: 6.19.13-200.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e7ccc45410
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2140
+      type: fast-track
+  kernel-modules:
+    evr: 6.19.13-200.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e7ccc45410
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2140
+      type: fast-track
+  kernel-modules-core:
+    evr: 6.19.13-200.fc43
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e7ccc45410
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2140
+      type: fast-track


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).

Fixes #2140