### PR TITLE
Disable automatic bootloader update for ppc64le, s390x

### DIFF
--- a/overlay.d/05core/usr/lib/systemd/system/bootloader-update.service.d/10-ppcle-s390x-disable.conf
+++ b/overlay.d/05core/usr/lib/systemd/system/bootloader-update.service.d/10-ppcle-s390x-disable.conf
@@ -1,0 +1,7 @@
+# Disable bootloader-update.service for s390x and ppc64le due to update issues
+# with raid setups
+#
+# See: https://github.com/coreos/fedora-coreos-tracker/issues/2134
+[Unit]
+ConditionArchitecture=!s390x
+ConditionArchitecture=!ppc64-le

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -29,6 +29,10 @@ case "$(arch)" in
         fi
         ;;
     ppc64le)
+        if ! systemctl status bootloader-update.service | grep -iq "ConditionArchitecture=!ppc64-le was not met"; then
+            fatal "bootloader-update.service was not skipped for ppc64le"
+        fi
+
         # ppc64le has it if built by osbuild, otherwise not
         if [ -e /sysroot/.aleph-version.json ]; then
             check_state_file=1
@@ -40,6 +44,12 @@ case "$(arch)" in
         fi
         ;& # fallthrough
     *)
+        if [[ "$(arch)" == "s390x" ]]; then
+            if ! systemctl status bootloader-update.service | grep -iq "ConditionArchitecture=!s390x was not met"; then
+                fatal "bootloader-update.service was not skipped for s390x"
+            fi
+        fi
+
         if ! rpm -q bootupd; then
             exit 0
         fi


### PR DESCRIPTION
Disabling this due to grub update issues with raid setups

See: https://github.com/coreos/fedora-coreos-tracker/issues/2134