### PR TITLE
tests/container-origin-imgref : add fcos tag

### DIFF
--- a/tests/kola/disks/container-origin-imgref
+++ b/tests/kola/disks/container-origin-imgref
@@ -3,6 +3,7 @@
 ##   # We need internet to check the container imgref
 ##   tags: needs-internet
 ##   exclusive: false
+##   distros: fcos
 ##   description: |
 ##      Verify that the deployed container image on the disk image has
 ##      a correct ostree sigverify prefix.


### PR DESCRIPTION
This test will only work on FCOS so let's add a filter for that to avoid it failing downstream.

This was supposed to go in the initial PR but I messed up the review follow-up and forgot to add this.

See https://github.com/coreos/fedora-coreos-config/pull/4099#issuecomment-4386934297