### PR TITLE
overrides: add bootc to trivial fast tracks

### DIFF
--- a/ci/overrides.py
+++ b/ci/overrides.py
@@ -19,6 +19,7 @@ KOJI_URL = 'https://koji.fedoraproject.org/kojihub'
 ARCHES = ['s390x', 'x86_64', 'ppc64le', 'aarch64']
 TRIVIAL_FAST_TRACKS = [
     # Packages that don't need a reason URL when fast-tracking
+    'bootc',
     'console-login-helper-messages',
     'ignition',
     'ostree',


### PR DESCRIPTION
Now that bootc is a load-bearing part of our pipeline to build disk images, let's allow fast-tracks without having to have a tracker link for why.