### PR TITLE
[rawhide] overrides: fast-track bootc-1.15.2-1.fc45

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,10 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  bootc:
+    evr: 1.15.2-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-1447df8f2e
+      reason: https://github.com/coreos/fedora-coreos-config/pull/4149#issuecomment-4386855702
+      type: fast-track


### PR DESCRIPTION
Requested by @jbtrystram via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).