### PR TITLE
test/bootupd: fix pipefail interaction with systemctl status

### DIFF
--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -29,7 +29,8 @@ case "$(arch)" in
         fi
         ;;
     ppc64le)
-        if ! systemctl status bootloader-update.service | grep -iq "ConditionArchitecture=!ppc64-le was not met"; then
+        bl_status=$(systemctl status bootloader-update.service 2>&1 || true)
+        if ! echo "$bl_status" | grep -iq "ConditionArchitecture=!ppc64-le was not met"; then
             fatal "bootloader-update.service was not skipped for ppc64le"
         fi
 
@@ -45,7 +46,8 @@ case "$(arch)" in
         ;& # fallthrough
     *)
         if [[ "$(arch)" == "s390x" ]]; then
-            if ! systemctl status bootloader-update.service | grep -iq "ConditionArchitecture=!s390x was not met"; then
+            bl_status=$(systemctl status bootloader-update.service 2>&1 || true)
+            if ! echo "$bl_status" | grep -iq "ConditionArchitecture=!s390x was not met"; then
                 fatal "bootloader-update.service was not skipped for s390x"
             fi
         fi


### PR DESCRIPTION
The bootloader-update.service skip checks added in 82ab7dd always fail because `systemctl status` returns exit code 3 for an inactive/skipped service. With `set -o pipefail`, the pipeline `systemctl status ... | grep ...` inherits this non-zero exit code even when grep matches, causing the `if !` to always enter the failure branch.

Fix by capturing the status output into a variable first (suppressing the exit code), then grepping the variable.

Relates to : https://github.com/coreos/fedora-coreos-config/pull/4149