### PR TITLE
denylist: skip ext.config.docker.swarm-overlay-network on s390x/rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -82,3 +82,12 @@
     - s390x
   streams:
     - rawhide
+
+- pattern: ext.config.docker.swarm-overlay-network
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
+  snooze: 2026-05-15
+  warn: true
+  arches:
+    - s390x
+  streams:
+    - rawhide


### PR DESCRIPTION
Test fails with:
  + docker run -t --network=testnetwork quay.io/fedora/fedora-minimal:44 curl https://icanhazip.com/ curl: (6) Could not resolve host: icanhazip.com
  + fatal 'Docker swarm overlay working not functional. Test fails.'

Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143