### PR TITLE
[next-devel] disable candidate-compose repo 2026-05

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,5 +11,5 @@ repos:
   # - fedora-updates
   - fedora-next
   - fedora-next-updates
-  - fedora-candidate-compose
+  # - fedora-candidate-compose
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
xref: https://github.com/coreos/fedora-coreos-tracker/issues/2055