### PR TITLE
denylist: drop rawhide stream limit for kernel-replace on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,8 +21,6 @@
   warn: true
   arches:
     - aarch64
-  streams:
-    - rawhide
 
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2129


### PR DESCRIPTION
Looks like this one is also now flaky in `testing-devel` with kernel 7.0.