### PR TITLE
overlays/bootc: Add missing bootc install options

### DIFF
--- a/overlay.d/10bootc/usr/lib/bootc/install/10-boot.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/10-boot.toml
@@ -1,0 +1,13 @@
+# We don't want bootupd to stamp the boot and UEFI partitions
+# with the boot uuid because these will change at first boot.
+# See https://github.com/coreos/fedora-coreos-config/pull/3898
+[install.bootupd]
+skip-boot-uuid = true
+
+# We don't want bootc to append the kargs list with boot=UUID= and root=UUID= info
+# as CoreOS already handles this.
+# Empty strings mean mount spec kargs are omitted entirely.
+# See https://github.com/bootc-dev/bootc/issues/1441
+[install]
+root-mount-spec = ""
+boot-mount-spec = ""

--- a/overlay.d/10bootc/usr/lib/bootc/install/10-ostree-signed-remote.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/10-ostree-signed-remote.toml
@@ -1,2 +1,0 @@
-[install]
-enforce-container-sigpolicy = true

--- a/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
@@ -1,0 +1,7 @@
+[install]
+# Name of the ostree stateroot
+stateroot = "fedora-coreos"
+# Make sure bootc enforces that
+# `/etc/containers/policy.json` includes
+# a default policy that verifies our images signature.
+enforce-container-sigpolicy = true


### PR DESCRIPTION
There are a few options that we are hard-coding in COSA right now, but with [1] we can pull them from the OCI container, so let's do that instead and make the container the canonical source of truth.

Also rework this overlay a bit in two files : the firstboot related options and the one related to the ostree repository.

[1] https://github.com/coreos/coreos-assembler/commit/364ccaebeb006c1653771158432541524954b604