### PR TITLE
overlays/bootc: Move stateroot to FCOS-specific overlay

### DIFF
--- a/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
@@ -1,6 +1,4 @@
 [install]
-# Name of the ostree stateroot
-stateroot = "fedora-coreos"
 # Make sure bootc enforces that
 # `/etc/containers/policy.json` includes
 # a default policy that verifies our images signature.

--- a/overlay.d/15fcos/usr/lib/bootc/install/15-ostree.toml
+++ b/overlay.d/15fcos/usr/lib/bootc/install/15-ostree.toml
@@ -1,0 +1,3 @@
+[install]
+# Name of the ostree stateroot
+stateroot = "fedora-coreos"


### PR DESCRIPTION
The stateroot name is specific to FCOS, so move it from 10bootc overlay to 15fcos overlay. This way if the 10bootc layer is ever shared with RHCOS, the stateroot won't be hardcoded to the wrong value.

See https://github.com/coreos/fedora-coreos-config/pull/4170#discussion_r3227154358

Assisted-by: Opencode.ai <Opus 4.6>"