### PR TITLE
denylist: Drop rawhide stream limitation for fcos.upgrade.basic on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,8 +28,6 @@
   warn: true
   arches:
     - ppc64le
-  streams:
-    - rawhide
 
 - pattern: ext.config.docker.swarm-overlay-network
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143


### PR DESCRIPTION
As with 45c0745, this is most likely due to the 7.0 kernel.

See https://github.com/coreos/fedora-coreos-tracker/issues/2129 and https://github.com/coreos/fedora-coreos-tracker/issues/2115#issuecomment-4442010325