### PR TITLE
build-rootfs: inject build-args to postprocess env

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,7 @@ ARG BUILDER_IMG=overridden
 FROM ${BUILDER_IMG} as builder
 
 ARG ID=overridden
+ARG NAME=overridden
 ARG VERSION=overridden
 ARG DESCRIPTION=overridden
 ARG STREAM=overridden

--- a/build-rootfs
+++ b/build-rootfs
@@ -22,6 +22,11 @@ import yaml
 ARCH = os.uname().machine
 INPUTHASH = '/run/inputhash'
 HERMETIC_REPO = '/etc/yum.repos.d/cachi2.repo'
+
+# Build-args to propagate as env vars into the postprocess bwrap sandbox.
+# Add entries here as needed; they must also be declared as ARG in the
+# Containerfile builder stage so they are present in os.environ.
+POSTPROCESS_ENV_VARS = ['NAME']
 IS_HERMETIC = os.path.exists(HERMETIC_REPO)
 
 
@@ -308,18 +313,25 @@ def inject_passwd_group(parent_dir):
     shutil.copy(os.path.join(parent_dir, 'group'), dst_group)
 
 
+
 def run_postprocess_scripts(rootfs, manifest):
     # Since we have the derive-only manifest handy, just run the scripts now. An
     # alternative is to run it as a second stage, which would avoid the bwrap,
     # but operating on the raw rootfs means we don't pay for deleted files (nor
     # without requiring another rechunk).
+    # Propagate select build-args as env vars for postprocess scripts.
+    env = {}
+    for var in POSTPROCESS_ENV_VARS:
+        val = os.getenv(var)
+        if val:
+            env[var] = val
     for i, script in enumerate(manifest.get('postprocess', [])):
         name = f'usr/libexec/coreos-postprocess-{i}'
         with open(os.path.join(rootfs, name), mode='w') as f:
             os.fchmod(f.fileno(), 0o755)
             f.write(script)
         print(f"Running CoreOS postprocess script {i}", flush=True)
-        bwrap(rootfs, [f'/{name}'])
+        bwrap(rootfs, [f'/{name}'], env=env)
         os.unlink(os.path.join(rootfs, name))
 
 
@@ -327,9 +339,9 @@ def run_dracut(rootfs):
     print(f"Running dracut to generate the initramfs", flush=True)
     # https://docs.fedoraproject.org/en-US/bootc/initramfs/#_modifying_and_regenerating_the_initrd
     kver = bwrap(rootfs, ['ls', '/usr/lib/modules'], capture=True).strip()
-    bwrap(rootfs, ['env', 'DRACUT_NO_XATTR=1',
-                   'dracut', '--verbose', '--force',  '--reproducible',
-                   '--no-hostonly', f"/usr/lib/modules/{kver}/initramfs.img", kver])
+    bwrap(rootfs, env={'DRACUT_NO_XATTR': '1'},
+          args=['dracut', '--verbose', '--force',  '--reproducible',
+                '--no-hostonly', f"/usr/lib/modules/{kver}/initramfs.img", kver])
 
 
 def prepare_local_rpm_overrides(rootfs, srcdir):
@@ -366,11 +378,15 @@ priority=1
 
 # Could upstream this as e.g. `bootc-base-imagectl runroot /rootfs <cmd>` maybe?
 # But we'd need to carry it anyway at least for RHCOS 9.6.
-def bwrap(rootfs, args, capture=False):
+def bwrap(rootfs, args, env=dict(), capture=False):
+    env_args = []
+    for k, v in env.items():
+        env_args.extend(['--setenv', k, v])
+
     args = ['bwrap', '--bind', f'{rootfs}', '/', '--dev', '/dev',
             '--proc', '/proc', '--tmpfs', '/tmp', '--tmpfs', '/var',
             '--tmpfs', '/var/tmp', '--tmpfs', '/run',
-            '--bind', '/run/.containerenv', '/run/.containerenv', '--'] + args
+            '--bind', '/run/.containerenv', '/run/.containerenv'] + env_args + ['--'] + args
     if capture:
         return subprocess.check_output(args, encoding='utf-8')
     subprocess.check_call(args)

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -44,6 +44,7 @@ documentation: false
 # ⚠⚠⚠ ONLY TEMPORARY HACKS ALLOWED HERE; ALL ENTRIES NEED TRACKER LINKS ⚠⚠⚠
 # See also the version of this in fedora-coreos.yaml
 postprocess:
+
   # Mask dnsmasq. We include dnsmasq for host services that use the dnsmasq
   # binary but intentionally mask the systemd service so users can't easily
   # use it as an external dns server. We prefer they use a container for that.
@@ -82,6 +83,17 @@ postprocess:
     #!/usr/bin/env bash
     set -eux -o pipefail
     rm -vrf /usr/lib/modules/*aarch64/dtb/qcom/
+
+  # Inject the ostree stateroot name from the NAME build-arg.
+  # This is done in postprocess rather than an overlay so that the
+  # value is sourced from build-args and shared across FCOS/RHCOS/SCOS.
+  - |
+    #!/usr/bin/bash
+    set -eux -o pipefail
+    cat > /usr/lib/bootc/install/20-ostree-stateroot.toml << EOF
+    [install]
+    stateroot = "${NAME}"
+    EOF
 
 # Packages listed here should be specific to Fedore CoreOS (as in not yet
 # available in RHCOS or not desired in RHCOS). All other packages should go

--- a/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/15-ostree.toml
@@ -1,6 +1,4 @@
 [install]
-# Name of the ostree stateroot
-stateroot = "fedora-coreos"
 # Make sure bootc enforces that
 # `/etc/containers/policy.json` includes
 # a default policy that verifies our images signature.


### PR DESCRIPTION
Injects all the build-args as environnement variables into the
postprocess bwrap. This will allow postprocess scripts to reuse these
values and make arbitrary changes based on it.

See discussion on #4173
for context.

Assisted-by: Opencode.ai <Opus 4.6>