### PR TITLE
denylist: Bump snooze for ext.config.docker.swarm-overlay-network

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,7 +31,7 @@
 
 - pattern: ext.config.docker.swarm-overlay-network
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
-  snooze: 2026-05-15
+  snooze: 2026-05-29
   warn: true
   arches:
     - s390x


### PR DESCRIPTION
This test is still failing. Let's bump the snooze by 2 weeks while the we continue to look into the issue.

See:
- [Latest test failure](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/bump-lockfile/761/pipeline-overview/?selected-node=752)
- [Tracking issue](https://github.com/coreos/fedora-coreos-tracker/issues/2143)
- [PR removing rawhide limitation](https://github.com/coreos/fedora-coreos-config/pull/4166)