### PR TITLE
tests/upgrade: detect finish_pipe rpm-ostree stall

### DIFF
--- a/tests/kola/upgrade/extended/config.bu
+++ b/tests/kola/upgrade/extended/config.bu
@@ -22,3 +22,10 @@ storage:
           # Increase the frequency at which we check for updates
           [agent.timing]
           steady_interval_secs = 20
+    # Get some more logs from rpm-ostree (shows image pull progress)
+    - path: /etc/systemd/system/rpm-ostreed.service.d/debug.conf
+      mode: 0644
+      contents:
+        inline: |
+          [Service]
+          Environment="RUST_LOG=debug"

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -390,11 +390,25 @@ while true; do
     # the services isn't active.
     systemctl status rpm-ostreed zincati --lines=0 || true
 
-    # If the upgrade stalls out (remote infra flaking?) let's best effort
-    # try to restart zincati to get it back on track.
-    lastline="$(journalctl -b0 --since='5 minutes ago' -u rpm-ostreed -n 1)"
-    if [ "${lastline}"  == '-- No entries --' ]; then
-        echo "rpm-ostree has stalled for more than 5 minutes; restarting zincati"
+    # Determine if we've stalled and need to best-effort retry
+    need_reset='false'
+
+    # If the upgrade stalls out (remote infra flaking?) for 5 minutes -> reset
+    line="$(journalctl -b0 --since='5 minutes ago' -u rpm-ostreed -n 1)"
+    if [ "${line}"  == '-- No entries --' ]; then
+        echo "rpm-ostree has stalled for 5 minutes; restarting zincati"
+        need_reset='true'
+    fi
+
+    # If we've hit the finish_pipe bug -> reset
+    # https://github.com/coreos/fedora-coreos-tracker/issues/2149
+    line="$(journalctl --until='30 seconds ago' -u rpm-ostreed -n 1)"
+    if [[ "${line}"  =~ 'DEBUG finish_pipe: closing pipe' ]]; then
+        echo "rpm-ostree has stalled on finish_pipe bug; restarting zincati"
+        need_reset='true'
+    fi
+
+    if [ "${need_reset}" == "true" ]; then
         sudo systemctl stop zincati
         sudo rpm-ostree cancel
         sudo systemctl stop rpm-ostreed

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -389,4 +389,15 @@ while true; do
     # Ignore error here. Older systemd (~F32) errors here if one of
     # the services isn't active.
     systemctl status rpm-ostreed zincati --lines=0 || true
+
+    # If the upgrade stalls out (remote infra flaking?) let's best effort
+    # try to restart zincati to get it back on track.
+    lastline="$(journalctl -b0 --since='5 minutes ago' -u rpm-ostreed -n 1)"
+    if [ "${lastline}"  == '-- No entries --' ]; then
+        echo "rpm-ostree has stalled for more than 5 minutes; restarting zincati"
+        sudo systemctl stop zincati
+        sudo rpm-ostree cancel
+        sudo systemctl stop rpm-ostreed
+        sudo systemctl start zincati
+    fi
 done


### PR DESCRIPTION
RPM-OSTree can hang forever if the remote CDN (or maybe network
environment is acting up) [1]. Let's detect this case and get our
upgrade back on track.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/2149
