### PR TITLE
denylist: bump snooze for all entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,28 +10,28 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-05-21
+  snooze: 2026-06-04
   warn: true
   arches:
     - ppc64le
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2124
-  snooze: 2026-05-21
+  snooze: 2026-06-04
   warn: true
   arches:
     - aarch64
 
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2129
-  snooze: 2026-05-21
+  snooze: 2026-06-04
   warn: true
   arches:
     - ppc64le
 
 - pattern: ext.config.docker.swarm-overlay-network
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
-  snooze: 2026-05-29
+  snooze: 2026-06-04
   warn: true
   arches:
     - s390x


### PR DESCRIPTION
All these issues are still being worked on. Let's bump their snooze timer by 2 weeks (and bring `swarm-overlay-network` inline with the other entries so they can be on the same timer).

Latest failure of `kernel-replace` test on aarch64 and ppc64le: https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/bump-lockfile/776/display/redirect