### PR TITLE
overlay/bootc: add a root filesystem install config

### DIFF
--- a/overlay.d/10bootc/usr/lib/bootc/install/12-root-filesystem.toml
+++ b/overlay.d/10bootc/usr/lib/bootc/install/12-root-filesystem.toml
@@ -1,0 +1,6 @@
+# This is actually overwritten by image-builder's
+# disk.yaml partition table definition but is still required
+# Drop this when https://github.com/osbuild/images/issues/2380
+# is fixed.
+[install.filesystem.root]
+type = "xfs"


### PR DESCRIPTION
Right now the filesystems are defined in COSA and then `bootc install
to-filesystem` is invoked on the prepared disk.
In the image-builder case, that configuration should come from the
container.
    
This is preliminary work for https://github.com/coreos/fedora-coreos-tracker/issues/1906
