### PR TITLE
tests: remove reprovision tag from kola tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -5,8 +5,9 @@ properties([
     disableConcurrentBuilds(abortPrevious: true)
 ])
 
-// We run kola tests, including iso.* tests, which require at least 8Gi. Add 1Gi for overhead.
-cosaPod(cpus: 4, memory: "9Gi") {
+// We run kola tests including iso.* tests which are resource
+// intensive. Let's give the system a lot of memory.
+cosaPod(cpus: 4, memory: "12Gi") {
     checkoutToDir(scm, 'config')
 
     def basearch = shwrapCapture("cosa basearch")

--- a/tests/kola/boot/raid1-boot/aarch64/test.sh
+++ b/tests/kola/boot/raid1-boot/aarch64/test.sh
@@ -10,8 +10,6 @@
 ##   # timeout value than the default.
 ##   timeoutMin: 15
 ##   architectures: "aarch64"
-##   # This test reprovisions the boot and rootfs.
-##   tags: reprovision
 ##   description: Verify updating multiple EFIs using RAID 1 works.
 ##   creationDate: 2026-05-06
 

--- a/tests/kola/boot/raid1-boot/x86_64/test.sh
+++ b/tests/kola/boot/raid1-boot/x86_64/test.sh
@@ -10,8 +10,6 @@
 ##   # timeout value than the default.
 ##   timeoutMin: 15
 ##   architectures: "x86_64"
-##   # This test reprovisions the boot and rootfs.
-##   tags: reprovision
 ##   description: Verify updating the bootloader while using RAID 1 works.
 ##   creationDate: 2026-05-06
 

--- a/tests/kola/root-reprovision/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/autosave-xfs/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs automatically.
-##   tags: "platform-independent reprovision"
+##   tags: "platform-independent"
 ##   # Trigger automatic XFS reprovisioning (heuristic)
 ##   minDisk: 1000
 ##   # Root reprovisioning requires at least 4GiB of memory.

--- a/tests/kola/root-reprovision/filesystem-only/test.sh
+++ b/tests/kola/root-reprovision/filesystem-only/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs.
-##   tags: "platform-independent reprovision"
+##   tags: "platform-independent"
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # This test includes a lot of disk I/O and needs a higher

--- a/tests/kola/root-reprovision/luks/512e/test.sh
+++ b/tests/kola/root-reprovision/luks/512e/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs.
-##   tags: "reprovision"
 ##   # This uses additionalDisks, which is QEMU only
 ##   platforms: qemu
 ##   # Root reprovisioning requires at least 4GiB of memory.

--- a/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
+++ b/tests/kola/root-reprovision/luks/autosave-xfs/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs.
-##   tags: "platform-independent reprovision"
+##   tags: "platform-independent"
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # A TPM backend device is not available on s390x to suport TPM.

--- a/tests/kola/root-reprovision/luks/multipath/test.sh
+++ b/tests/kola/root-reprovision/luks/multipath/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs.
-##   tags: "reprovision"
 ##   # This uses appendKernelArgs and multipath, which is QEMU only
 ##   platforms: qemu
 ##   # Root reprovisioning requires at least 4GiB of memory.

--- a/tests/kola/root-reprovision/luks/test.sh
+++ b/tests/kola/root-reprovision/luks/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 ## kola:
-##   # This test reprovisions the rootfs.
-##   tags: "platform-independent reprovision"
+##   tags: "platform-independent"
 ##   # Root reprovisioning requires at least 4GiB of memory.
 ##   minMemory: 4096
 ##   # A TPM backend device is not available on s390x to suport TPM.

--- a/tests/kola/root-reprovision/raid1/test.sh
+++ b/tests/kola/root-reprovision/raid1/test.sh
@@ -9,8 +9,6 @@
 ##   # This test includes a lot of disk I/O and needs a higher
 ##   # timeout value than the default.
 ##   timeoutMin: 15
-##   # This test reprovisions the rootfs.
-##   tags: reprovision
 ##   description: Verify the root reprovision with RAID 1 works.
 
 set -xeuo pipefail

--- a/tests/kola/root-reprovision/swap-before-root/test.sh
+++ b/tests/kola/root-reprovision/swap-before-root/test.sh
@@ -8,8 +8,7 @@
 ##   # We intentionally put the root filesystem on partition 5.  This is
 ##   # legal but usually not intended, so Butane warns about it.
 ##   allowConfigWarnings: true
-##   # This test reprovisions the rootfs.
-##   tags: reprovision platform-independent
+##   tags: platform-independent
 ##   description: Verify the root reprovision and swap enabled are supported.
 
 set -xeuo pipefail

--- a/tests/kola/rpm-ostree/kernel-replace
+++ b/tests/kola/rpm-ostree/kernel-replace
@@ -8,11 +8,7 @@
 ##   # We do a bunch of copies/rebuilds of the whole OS.
 ##   minDisk: 20
 ##   # Needs internet access as we fetch files from koji
-##   # We add the "reprovision" tag here even though we aren't
-##   # reprovisioning as a hack so that in our pipeline the test
-##   # will execute with no other tests. We were seeing a lot of
-##   # timeouts on ppc64le.
-##   tags: "needs-internet platform-independent reprovision"
+##   tags: "needs-internet platform-independent"
 ##   description: Verify that build of a container image with a new kernel
 ##     and reboot into it succeeds.
 


### PR DESCRIPTION
With resource based scheduling [1] we should now be able to run all the tests together and not split them up into separate !reprovision and reprovision runs.

[1] https://github.com/coreos/coreos-assembler/pull/4470