### PR TITLE
denylist: bump snooze for all entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,28 +10,28 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-06-04
+  snooze: 2026-06-18
   warn: true
   arches:
     - ppc64le
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2124
-  snooze: 2026-06-04
+  snooze: 2026-06-18
   warn: true
   arches:
     - aarch64
 
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2129
-  snooze: 2026-06-04
+  snooze: 2026-06-18
   warn: true
   arches:
     - ppc64le
 
 - pattern: ext.config.docker.swarm-overlay-network
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
-  snooze: 2026-06-04
+  snooze: 2026-06-18
   warn: true
   arches:
     - s390x


### PR DESCRIPTION
The snooze on the denylist entries expired, and all tests except `ext.config.docker.swarm-overlay-network` still appear to be failing.

See:
- [Latest run with test failures](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/bump-lockfile/812/pipeline-overview/)
- [Run with swarm-overlay-network pass](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build-arch/1884/pipeline-overview/?selected-node=319)

  ```
  [2026-06-07T10:56:23.194Z] ⏰ Snooze for kola test pattern "ext.config.docker.swarm-overlay-network" expired on Jun 04 2026
  [2026-06-07T10:56:23.194Z] ⚠️  Will warn on failure for kola test pattern "ext.config.docker.swarm-overlay-network":
  [2026-06-07T10:56:23.194Z]   👉 https://github.com/coreos/fedora-coreos-tracker/issues/2143
  ...
  [2026-06-07T11:09:12.834Z] --- [32mPASS[0m: ext.config.docker.swarm-overlay-network (40.48s)
  ```
  
  **EDIT**: dropped the commit to remove `ext.config.docker.swarm-overlay-network` since we're not sure if it's still failing. Just bumping all snooze values instead.