### PR TITLE
tests/upgrade: switch to downloading ostree tarball

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -235,11 +235,6 @@ selinux-sanity-check() {
         paths="$(echo "${mislabeled}" | grep "Would relabel" | cut -d ' ' -f 3)"
         found=""
         while read -r path; do
-            # Add in a glob exception for /usr/etc/systemd/system for <F43 releases
-            # https://github.com/coreos/fedora-coreos-tracker/issues/2030#issuecomment-3329932294
-            if [[ "${path}" =~ /usr/etc/systemd/system ]] && [ "$(get_fedora_ver)" -eq 42 ]; then
-                 continue
-             fi
             if [[ "${exceptions[$path]:-noexception}" == 'noexception' ]]; then
                 echo "Unexpected mislabeled file found: ${path}"
                 found="1"

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -3,7 +3,9 @@
 ##   # - needs-internet: to pull updates
 ##   tags: "needs-internet"
 ##   # Extend the timeout since a lot of updates/reboots can happen.
-##   timeoutMin: 75
+##   timeoutMin: 50
+##   # Bigger disk since we copy in the OSTree tarball
+##   minDisk: 30
 ##   # Only run this test when specifically requested.
 ##   requiredTag: extended-upgrade
 ##   description: Verify upgrade works.
@@ -55,6 +57,36 @@ set -eux -o pipefail
 
 need_restart='false'
 arch=$(arch)
+
+# If there is an ostree repo archive tarball, let's extract/use it.
+if [ -f "$KOLA_EXT_DATA/ostree-repo.tar" ]; then
+    tar -C /srv/ -xf "$KOLA_EXT_DATA/ostree-repo.tar"
+    rm -vf "$KOLA_EXT_DATA/ostree-repo.tar"
+
+    # Switch to pulling from local ostree repo
+    cat <<'EOF' > /etc/ostree/remotes.d/fedora.conf
+[remote "fedora"]
+url=file:///srv/
+gpg-verify=true
+gpgkeypath=/etc/pki/rpm-gpg/
+EOF
+
+    # make writable by all so below zincati ExecStartPre copy over it
+    chmod 666 /etc/ostree/remotes.d/fedora.conf
+
+    # The oci migration script had a check for the URL to make sure we only
+    # migrated the people who were using the defaults so we need to switch
+    # it back when the oci migration happens.
+    # https://github.com/coreos/fedora-coreos-config/blob/d4c815329d88dd9dbaf1902a2b60a08df4b41c1a/overlay.d/35oci-migration/usr/libexec/coreos-oci-rebase#L43
+    mkdir -p /etc/systemd/system/zincati.service.d
+    cat <<'EOF' > /etc/systemd/system/zincati.service.d/005-fixup-remote-url.conf
+[Service]
+ExecStartPre=/bin/bash -c \
+  "test -f /usr/lib/systemd/system/zincati.service.d/010-oci-migration.conf && \
+      cp -v /usr/etc/ostree/remotes.d/fedora.conf /etc/ostree/remotes.d/fedora.conf || true"
+EOF
+    need_restart='true'
+fi
 
 # delete the disabling of updates that was done by the test framework
 if [ -f /etc/zincati/config.d/90-disable-auto-updates.toml ]; then
@@ -235,6 +267,10 @@ selinux-sanity-check() {
         paths="$(echo "${mislabeled}" | grep "Would relabel" | cut -d ' ' -f 3)"
         found=""
         while read -r path; do
+            # Add in a glob exception for /var/srv since that's where our OSTree repo is
+            if [[ "${path}" =~ /var/srv ]]; then
+                 continue
+            fi
             if [[ "${exceptions[$path]:-noexception}" == 'noexception' ]]; then
                 echo "Unexpected mislabeled file found: ${path}"
                 found="1"

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -58,6 +58,9 @@ set -eux -o pipefail
 need_restart='false'
 arch=$(arch)
 
+# Stop zincati so we can avoid racing with zincati for some of the  setup here.
+systemctl disable zincati --now
+
 # If there is an ostree repo archive tarball, let's extract/use it.
 if [ -f "$KOLA_EXT_DATA/ostree-repo.tar" ]; then
     tar -C /srv/ -xf "$KOLA_EXT_DATA/ostree-repo.tar"
@@ -388,6 +391,9 @@ if [ "${need_restart}" == "true" ]; then
     /tmp/autopkgtest-reboot setup
     sleep infinity
 fi
+
+# We're ready for the update to happen. Start zincati.
+systemctl start zincati
 
 # Watch the Zincati logs to see if it got a lead on a new update.
 # Timeout after some time if no update. Unset pipefail since the


### PR DESCRIPTION
The OSTree repo in Fedora can be slow and might go away one day.
Since we know exactly the path updates are going to take let's
just download pre-built tarballs with an OSTree repo inside
that has exactly the contents that this upgrade will need.

The tarballs for this purpose can be created with the script in [1].
You can download the tarball into the external data directory before
running the test to have it exist and be used:

```
curl -o src/config/tests/kola/upgrade/extended/data/ostree-repo.tar \
    https://fcos-upgrade-test-fixtures.s3.us-east-1.amazonaws.com/ostree-repo-testing-x86_64-starting-f34.tar
cosa buildfetch --artifact=qemu --decompress --build=34.20210427.2.0
cosa kola run --build=34.20210427.2.0 --tag extended-upgrade
rm src/config/tests/kola/upgrade/extended/data/ostree-repo.tar
```

[1] https://github.com/coreos/fedora-coreos-releng-automation/pull/231
