### PR TITLE
overlays/bootc: Move stateroot to FCOS-specific overlay

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -133,12 +133,3 @@ postprocess:
         echo "${actuals}" 1>&2
         exit 1
     fi
-
-  # We don't want auto-generated mount units. See also
-  # https://github.com/systemd/systemd/issues/13099
-  - |
-    #!/usr/bin/env bash
-    set -x
-    # Find the .build-id file and remove it too so we don't have a broken symlink.
-    build_id_file=$(find -L /usr/lib/.build-id/ -samefile /usr/lib/systemd/system-generators/systemd-gpt-auto-generator)
-    rm -vf $build_id_file /usr/lib/systemd/system-generators/systemd-gpt-auto-generator

--- a/manifests/shared-el9.yaml
+++ b/manifests/shared-el9.yaml
@@ -5,3 +5,12 @@ packages:
   - NetworkManager-team teamd
   # runc is not in C10S
   - runc
+postprocess:
+  # We don't want auto-generated mount units. See also
+  # https://github.com/systemd/systemd/issues/13099
+  - |
+    #!/usr/bin/env bash
+    set -x
+    # Find the .build-id file and remove it too so we don't have a broken symlink.
+    build_id_file=$(find -L /usr/lib/.build-id/ -samefile /usr/lib/systemd/system-generators/systemd-gpt-auto-generator)
+    rm -vf $build_id_file /usr/lib/systemd/system-generators/systemd-gpt-auto-generator


### PR DESCRIPTION
Move this postprocess to a manifest shared with rhel-9.6 as this service cause FIPS self tests to fail.

See https://redhat.atlassian.net/browse/OCPBUGS-86442