### PR TITLE
build-rootfs: Only symlink existing image builder configs

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -652,9 +652,12 @@ def inject_platforms_json(rootfs, srcdir):
 
 def inject_disk_yaml(rootfs, srcdir):
     dst = os.path.join(rootfs, 'usr/lib/image-builder/bootc/disk.yaml')
-    # We write a relative symlink otherwise it get resolved under `/target-rootfs`
-    # which does not exist in the final image.
-    os.symlink(f'{ARCH}.yaml', dst)
+    if os.path.exists(dst):
+        # We write a relative symlink otherwise it get resolved under `/target-rootfs`
+        # which does not exist in the final image.
+        os.symlink(f'{ARCH}.yaml', dst)
+    else:
+        print("Not creating arch specific symlink for image-builder disk config (does not exist)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The image-builer disk configuration have only been added to FCOS for now. Skip this step on RHCOS.

Fixes: https://github.com/coreos/fedora-coreos-config/pull/4195
Fixes: af0d6638 build-rootfs: inject disk partition layouts for image-builder