### PR TITLE
manifests: Move openssl to a manifest shared with EL

### DIFF
--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -137,7 +137,6 @@ packages:
   - sssd-client sssd-ad sssd-ipa sssd-krb5 sssd-ldap
   # Used by admins interactively
   - attr
-  - openssl
   # Provides terminal tools like clear, reset, tput, and tset
   - ncurses
   # file-transfer: note fuse-sshfs is not in RHEL

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -42,3 +42,5 @@ packages:
   - which
   # provides utilities for inspecting/setting devices connected to the PCI bus
   - pciutils
+  # Used by admins interactively and wanted on EL systems (RHCOS)
+  - openssl


### PR DESCRIPTION
Starting with EL 10, openssl (the binary) is not longer pulled into the image via dependencies. Move it to a manifest that is shared with EL variants to keep it explicitely included.

See: https://redhat.atlassian.net/browse/OCPBUGS-90400