### PR TITLE
tests/toolbox: don't ignore error output from toolbox create

### DIFF
--- a/tests/kola/toolbox/test.sh
+++ b/tests/kola/toolbox/test.sh
@@ -20,7 +20,7 @@ run_as_core() {
 
 # Functions for testing basic functionality - overridden depending on toolbox being used
 toolbox_create() {
-    run_as_core /bin/toolbox create --assumeyes 1> /dev/null
+    run_as_core /bin/toolbox create --assumeyes
 }
 
 toolbox_run_basic() {


### PR DESCRIPTION
This should help diagnose issues which aren't just network flakes. The redirect was originally from e5b3bcd, but it's no longer required since 0d7d716.

This test failed in https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/bump-lockfile/839, and the output isn't very helpful: 

```
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[2338]: ++ run_as_core /bin/toolbox list --containers
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[2339]: ++ grep --count -E '(fedora|rhel)-toolbox-'
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[2340]: +++ printf '%q ' /bin/toolbox list --containers
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[2338]: ++ su - core -c '/bin/toolbox list --containers '
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 su[2341]: (to core) root on none
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 su[2341]: pam_unix(su-l:session): session opened for user core(uid=1000) by (uid=0)
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 su[2341]: pam_unix(su-l:session): session closed for user core
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[2337]: ++ true
[2026-06-19T04:51:49.467Z] Jun 19 04:51:37 qemu0 kola-runext-test.sh[1971]: + [[ 0 -eq 1 ]]
```

We can see the podman error from other failed tests but I think it makes sense for this one to also have useful output in case it's ever specific to toolbox.