### PR TITLE
tests/upgrade: try for more console messages on shutdown

### DIFF
--- a/tests/kola/upgrade/extended/config.bu
+++ b/tests/kola/upgrade/extended/config.bu
@@ -8,6 +8,10 @@ systemd:
     # the setup steps in the tests.
     - name: zincati.service
       enabled: false
+    # We want the messages from systemd coming to the console
+    # throughout the update process.
+    - name: coreos-printk-quiet.service
+      enabled: false
 storage:
   files:
     - path: /etc/systemd/journald.conf.d/forward-to-console.conf

--- a/tests/kola/upgrade/extended/config.bu
+++ b/tests/kola/upgrade/extended/config.bu
@@ -2,6 +2,12 @@ variant: fcos
 # Must use version 1.0.0 here to use Ignition spec 3.0.0 for
 # our oldest supported starting points (i.e. 31.20200108.3.0)
 version: 1.0.0
+systemd:
+  units:
+    # Disable zincati on startup so we can avoid racing with zincati
+    # the setup steps in the tests.
+    - name: zincati.service
+      enabled: false
 storage:
   files:
     - path: /etc/systemd/journald.conf.d/forward-to-console.conf

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -58,9 +58,6 @@ set -eux -o pipefail
 need_restart='false'
 arch=$(arch)
 
-# Stop zincati so we can avoid racing with zincati for some of the  setup here.
-systemctl disable zincati --now
-
 # If there is an ostree repo archive tarball, let's extract/use it.
 if [ -f "$KOLA_EXT_DATA/ostree-repo.tar" ]; then
     tar -C /srv/ -xf "$KOLA_EXT_DATA/ostree-repo.tar"


### PR DESCRIPTION
Let's disable coreos-printk-quiet.service so hopefully we'll
get more messages from the shut down of an instance on each
upgrade transition.
