### PR TITLE
build-rootfs: sort overlay dirs to allow overriding

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -459,7 +459,7 @@ def inject_version_info(rootfs, replace_version, version):
 def gather_add_dirs(manifest, srcdir):
     add_dirs = []
     for layer in manifest.get('ostree-layers', []):
-        add_dirs.append(os.path.join(srcdir, layer))
+        add_dirs.append(os.path.normpath(os.path.join(srcdir, layer)))
 
     # sort by the base name of the directory to allow for overriding
     # files in layers that sort earlier. i.e. a file in 03-core/etc/foo.d/file

--- a/build-rootfs
+++ b/build-rootfs
@@ -461,6 +461,11 @@ def gather_add_dirs(manifest, srcdir):
     for layer in manifest.get('ostree-layers', []):
         add_dirs.append(os.path.join(srcdir, layer))
 
+    # sort by the base name of the directory to allow for overriding
+    # files in layers that sort earlier. i.e. a file in 03-core/etc/foo.d/file
+    # would override a file in 02-core/etc/foo.d/file.
+    add_dirs.sort(key=lambda x: os.path.basename(x))
+
     rootfs_override = os.path.join(srcdir, 'overrides/rootfs')
     if os.path.isdir(rootfs_override) and len(os.listdir(rootfs_override)) > 0:
         print("Injecting rootfs override")


### PR DESCRIPTION
This allows the final directory name of the overlay dir to determine the ordering the overlays are applied in.

A file in 03-core/etc/foo.d/file would override a file in 02-core/etc/foo.d/file.

Here's how that ends of looking when building against rhel-9.8 CoreOS (i.e. https://github.com/coreos/rhel-coreos-config/pull/276)

```
--add-dir=/src/fedora-coreos-config/overlay.d/05core
--add-dir=/src/overlay.d/05rhcos
--add-dir=/src/overlay.d/06gcp-routes
--add-dir=/src/fedora-coreos-config/overlay.d/08nouveau
--add-dir=/src/overlay.d/15rhcos-journald-backcompat
--add-dir=/src/overlay.d/15rhcos-networkmanager-dispatcher
--add-dir=/src/overlay.d/15rhcos-networkmanager-plugin-order
--add-dir=/src/overlay.d/15rhcos-tuned-bits
--add-dir=/src/fedora-coreos-config/overlay.d/20platform-chrony
--add-dir=/src/overlay.d/21dhcp-chrony
--add-dir=/src/overlay.d/30gcp-udev-rules
--add-dir=/src/fedora-coreos-config/overlay.d/30lvmdevices
--add-dir=/src/overlay.d/30rhcos-nvme-compat-udev
--add-dir=/src/fedora-coreos-config/overlay.d/40import-virtiofs-systemd-credentials
```