### PR TITLE
denylist: skip fcos.upgrade.basic on aarch64/gcp

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -29,6 +29,15 @@
   arches:
     - ppc64le
 
+- pattern: fcos.upgrade.basic
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2174
+  snooze: 2026-07-10
+  warn: true
+  arches:
+    - aarch64
+  platforms:
+    - gcp
+
 - pattern: ext.config.docker.swarm-overlay-network
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
   snooze: 2026-07-03


### PR DESCRIPTION
`fcos.upgrade.basic/upgrade-from-previous` consistently fails on aarch64 GCP
instances with SSH reboot timeout errors (~23s). The same build passes on AWS
aarch64 and GCP x86_64, pointing to a GCP platform issue with aarch64 instance
reboot timing.

**Failing builds (all kola-gcp, all aarch64):**
- [#1136](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/1136/) - testing-devel
- [#1138](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/1138/) - testing-devel
- [#1141](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/1141/) - rawhide
- [#1143](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/1143/) - testing-devel

Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2174