### PR TITLE
pqc/test: Skip test on rhcos9 and c9s

### DIFF
--- a/tests/kola/pqc/test.sh
+++ b/tests/kola/pqc/test.sh
@@ -9,6 +9,11 @@ set -xeuo pipefail
 # shellcheck disable=SC1091
 . "$KOLA_EXT_DATA/commonlib.sh"
 
+if ! is_fcos && match_maj_ver "9"; then
+    ok "Skipping: PQC not in DEFAULT crypto policy on rhcos9 and c9s"
+    exit 0
+fi
+
 # A list of websites all which support PQC algorithms
 pqcsites=(
     "https://cloud.google.com"


### PR DESCRIPTION
The DEFAULT policy for rhcos10 and c10s [1] support PQC algorithms by default, however this is not the case for rhcos9 and c9s [2]. Because of this, this test will fail when the major version is 9, since MLKEM won't be negotiated.

[1] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/blob/rhel10/policies/DEFAULT.pol
[2] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/blob/rhel9/policies/DEFAULT.pol