### PR TITLE
overrides: pin fwupd-2.1.3-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,3 +14,8 @@ packages:
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-629714e3d0
       type: fast-track
+  fwupd:
+    evr: 2.1.3-1.fc44
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
+      type: pin


### PR DESCRIPTION
Requested by @Rolv-Apneseth via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).