### PR TITLE
denylist: skip ext.config.disks.boot-partition-space on rawhide aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -44,3 +44,12 @@
   warn: true
   arches:
     - s390x
+
+- pattern: ext.config.disks.boot-partition-space
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2179
+  snooze: 2026-07-17
+  warn: true
+  streams:
+    - rawhide
+  arches:
+    - aarch64


### PR DESCRIPTION
Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2179