### PR TITLE
denylist: drop ext.config.docker.swarm-overlay-network entry

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -38,13 +38,6 @@
   platforms:
     - gcp
 
-- pattern: ext.config.docker.swarm-overlay-network
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2143
-  snooze: 2026-07-17
-  warn: true
-  arches:
-    - s390x
-
 - pattern: ext.config.disks.boot-partition-space
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2179
   snooze: 2026-07-17


### PR DESCRIPTION
This test is no longer failing on any stream due to updated docker versions (F44 is now on v29.6.0, F45 is on v29.6.1).

cc @nikita-dubrovskii 