### PR TITLE
overlay/disk-image: add missing partition GPT names

### DIFF
--- a/overlay.d/10disk-images/usr/lib/image-builder/bootc/aarch64.yaml
+++ b/overlay.d/10disk-images/usr/lib/image-builder/bootc/aarch64.yaml
@@ -11,11 +11,13 @@ partition_table:
   partitions:
     # Reserved partition — placeholder at position 1, mirrors the BIOS-BOOT
     # slot on x86_64 so partition numbering stays consistent across arches
-    - size: "1 MiB"
+    - label: "reserved"
+      size: "1 MiB"
       type: 8DA63339-0007-60C0-C436-083AC8230908
 
     # EFI System Partition — aarch64 is UEFI-only, no legacy BIOS boot
-    - size: "127 MiB"
+    - label: "EFI-SYSTEM"
+      size: "127 MiB"
       type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
       payload_type: "filesystem"
       payload:
@@ -27,7 +29,8 @@ partition_table:
         fstab_passno: 2
 
     # Extended Boot Loader partition
-    - size: "384 MiB"
+    - label: "boot"
+      size: "384 MiB"
       type: BC13C2FF-59E6-4262-A352-B275FD6F7172
       payload_type: "filesystem"
       payload:
@@ -40,7 +43,8 @@ partition_table:
         fstab_passno: 0
 
     # Root partition — DPS type for aarch64
-    - type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE
+    - label: "root"
+      type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE
       payload_type: "filesystem"
       payload:
         type: "xfs"

--- a/overlay.d/10disk-images/usr/lib/image-builder/bootc/ppc64le.yaml
+++ b/overlay.d/10disk-images/usr/lib/image-builder/bootc/ppc64le.yaml
@@ -10,16 +10,19 @@ partition_table:
   extra_padding: 1031168
   partitions:
     # PowerPC PReP Boot partition — required for GRUB on ppc64le (petitboot)
-    - size: "4 MiB"
+    - label: "PowerPC-PReP-boot"
+      size: "4 MiB"
       bootable: true
       type: 9E1A2D38-C612-4316-AA26-8B49521E5A8B
 
     # Reserved partition — placeholder at position 2, no EFI on ppc64le
-    - size: "1 MiB"
+    - label: "reserved"
+      size: "1 MiB"
       type: 8DA63339-0007-60C0-C436-083AC8230908
 
     # Extended Boot Loader partition
-    - size: "384 MiB"
+    - label: "boot"
+      size: "384 MiB"
       type: BC13C2FF-59E6-4262-A352-B275FD6F7172
       payload_type: "filesystem"
       payload:
@@ -32,7 +35,8 @@ partition_table:
         fstab_passno: 0
 
     # Root partition — DPS type for ppc64le
-    - type: C31C45E6-3F39-412E-80FB-4809C4980599
+    - label: "root"
+      type: C31C45E6-3F39-412E-80FB-4809C4980599
       payload_type: "filesystem"
       payload:
         type: "xfs"

--- a/overlay.d/10disk-images/usr/lib/image-builder/bootc/s390x.yaml
+++ b/overlay.d/10disk-images/usr/lib/image-builder/bootc/s390x.yaml
@@ -14,7 +14,8 @@ partition_table:
     # (slots 1 and 2 are left unused).
 
     # Extended Boot Loader partition
-    - partnum: 3
+    - label: "boot"
+      partnum: 3
       size: "384 MiB"
       type: BC13C2FF-59E6-4262-A352-B275FD6F7172
       payload_type: "filesystem"
@@ -28,7 +29,8 @@ partition_table:
         fstab_passno: 0
 
     # Root partition — DPS type for s390x
-    - partnum: 4
+    - label: "root"
+      partnum: 4
       type: 5EEAD9A9-FE09-4A1E-A1D7-520D00531306
       payload_type: "filesystem"
       payload:

--- a/overlay.d/10disk-images/usr/lib/image-builder/bootc/x86_64.yaml
+++ b/overlay.d/10disk-images/usr/lib/image-builder/bootc/x86_64.yaml
@@ -10,12 +10,14 @@ partition_table:
   extra_padding: 1031168
   partitions:
     # BIOS Boot partition — required for legacy BIOS boot on x86_64
-    - size: "1 MiB"
+    - label: "BIOS-BOOT"
+      size: "1 MiB"
       bootable: true
       type: 21686148-6449-6E6F-744E-656564454649
 
     # EFI System Partition
-    - size: "127 MiB"
+    - label: "EFI-SYSTEM"
+      size: "127 MiB"
       type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
       payload_type: "filesystem"
       payload:
@@ -27,7 +29,8 @@ partition_table:
         fstab_passno: 2
 
     # Extended Boot Loader partition
-    - size: "384 MiB"
+    - label: "boot"
+      size: "384 MiB"
       type: BC13C2FF-59E6-4262-A352-B275FD6F7172
       payload_type: "filesystem"
       payload:
@@ -40,7 +43,8 @@ partition_table:
         fstab_passno: 0
 
     # Root partition — DPS type for x86_64
-    - type: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+    - label: "root"
+      type: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
       payload_type: "filesystem"
       payload:
         type: "xfs"


### PR DESCRIPTION
Add the partition names to the `disk.yaml` image-builder configuration file. The partitions were correctly labelled at the filesystem level but were missing names from the GPT parition table.
This was causing some issues with reprovisionning. Let's make sure the resulting partition table is identical to what we have when building disk-images with COSA.

See how partitions names are set in COSA at the GPT table : https://github.com/coreos/coreos-assembler/blob/a2b4dd6c901c074fb36e6d61df114b4386c4bc74/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml#L65