### PR TITLE
kola/boot/bootupd: Fix shell syntax

### DIFF
--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -68,7 +68,7 @@ case "$current_arch" in
             check_grub_version "grub2-tools" '%{NEVRA}'
         fi
         ;;
-    *) fatal "Unhandled architecture: $(current_arch)" ;;
+    *) fatal "Unhandled architecture: ${current_arch}" ;;
 esac
 
 state_file=/boot/bootupd-state.json


### PR DESCRIPTION
Update `$(..)` to `${..}` so that `current_arch` isn't run as a command