### PR TITLE
test/custom-host-key: fix case sensitive issue

### DIFF
--- a/tests/kola/ssh/custom-host-key-permissions/test.sh
+++ b/tests/kola/ssh/custom-host-key-permissions/test.sh
@@ -19,7 +19,7 @@ set -xeuo pipefail
 
 # make sure our key was actually used
 # grep -q causes sshd -T to fail on SIGPIPE
-if ! sshd -T | grep "^hostkey /etc/ssh-host-key$" >/dev/null; then
+if ! sshd -T | grep -i "^hostkey /etc/ssh-host-key$" >/dev/null; then
     sshd -T
     fatal "configured host key not used by sshd"
 fi
@@ -28,8 +28,8 @@ ok "configured host key used by sshd"
 # sshd starts successfully if any keys are mode 600, which would invalidate
 # the test except that our HostKey directive should replace the default
 # keys.  verify this.
-if [[ $(sshd -T | grep "^hostkey " | wc -l) != 1 ]]; then
-    sshd -T | grep "^hostkey "
+if [[ $(sshd -T | grep -i "^hostkey " | wc -l) != 1 ]]; then
+    sshd -T | grep -i "^hostkey "
     fatal "sshd uses multiple host keys"
 fi
 ok "sshd uses only the configured host key"


### PR DESCRIPTION
In new versions of openssh, `sshd -T` will display `HostKey` rather than `hostkey`, [leading to test failing](https://bodhi.fedoraproject.org/updates/FEDORA-2026-31f102385c) . Let's ignore casing so that both cases are covered.

The openssh 10.4 release notes list this as a potentially-incompatible change [1]:
> sshd(8): configuration dump mode ("sshd -G") now writes directives
> in mixed case (e.g. "PubkeyAuthentication") whereas previously it
> emitted only lower-case names.

[1] https://www.openssh.com/txt/release-10.4