### PR TITLE
[testing] overrides: pin fwupd-2.1.3-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,14 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  fwupd:
+    evr: 2.1.3-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
+  libjcat:
+    evr: 0.2.6-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176


### PR DESCRIPTION
> An issue introduced in fwupd-2.1.4-1 causes the fwupd-refresh.service to fail every time it is called, including on the automated timer. Let's pin this to a working version until there is a fix upstream.
> 
> Cherry-pick of 7ad83a4204ed8d0a4961389444a655bd3fa1f6d5 to prevent the issue going into the next stable release.

Copy of https://github.com/coreos/fedora-coreos-config/pull/4242