### PR TITLE
Containerfile: support chunking with chunkah

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,13 +51,13 @@ RUN --mount=type=bind,target=/run/src,rw \
         --bootc --format-version=1 --rootfs /target-rootfs \
         --output oci-archive:/run/src/out.ociarchive \
         --label com.coreos.inputhash=$(cat /run/inputhash) \
-        --label com.coreos.stream=$STREAM \
         ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
         ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
 
 FROM oci-archive:./out.ociarchive
 ARG VERSION
 ARG NAME=overridden
+ARG STREAM=overridden
 ARG DESCRIPTION=overridden
 # Need to reference builder here to force ordering. But since we have to run
 # something anyway, we might as well cleanup after ourselves.
@@ -69,6 +69,7 @@ LABEL containers.bootc=1 \
       ostree.bootable=1 \
       org.opencontainers.image.version=$VERSION \
       com.coreos.osname=$NAME \
+      com.coreos.stream=$STREAM \
       org.opencontainers.image.title=$DESCRIPTION \
       org.opencontainers.image.description=$DESCRIPTION
 STOPSIGNAL SIGRTMIN+3

--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,8 @@ ARG IMAGE_CONFIG=overridden
 ARG PASSWD_GROUP_DIR
 ARG STRICT_MODE=0
 ARG INJECT_OPENSHIFT_VERSION_LABELS=""
+ARG BUILDER_IMG_CHUNKER=""
+ARG BUILDER_IMG_CHUNKER_MAX_LAYERS=""
 
 COPY . /src
 # canonicalize permission bits, see also https://gitlab.com/fedora/bootc/base-images/-/merge_requests/274
@@ -50,12 +52,33 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
 # NOTE: use 'bash <<EOF' here instead of '<<EOF' because of our konflux integration [1]
 #       [1] https://github.com/coreos/fedora-coreos-config/pull/4263#issuecomment-5005085765
 RUN --mount=type=bind,target=/run/src,rw bash <<EOF
-    rpm-ostree experimental compose build-chunked-oci                                                 \
-        --bootc --format-version=1 --rootfs /target-rootfs                                            \
-        --output oci-archive:/run/src/out.ociarchive                                                  \
-        --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
-        ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
-        ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+    set -eux -o pipefail
+    case "${BUILDER_IMG_CHUNKER:-}" in
+        'chunkah')
+            # The '--prune /sysroot/ --label ostree.commit- --label ostree.final-diffid-'
+            # will strip OSTree data and labels for bootc compatibility; see
+            # https://github.com/coreos/chunkah#compatibility-with-bootable-bootc-images
+            chunkah build --rootfs /target-rootfs                                                             \
+                --prune /sysroot/ --label ostree.commit- --label ostree.final-diffid-                         \
+                --output oci-archive:/run/src/out.ociarchive                                                  \
+                --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
+                ${BUILDER_IMG_CHUNKER_MAX_LAYERS:+--max-layers=${BUILDER_IMG_CHUNKER_MAX_LAYERS}}             \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+            ;;
+        "")
+            rpm-ostree experimental compose build-chunked-oci                                                 \
+                --bootc --format-version=1 --rootfs /target-rootfs                                            \
+                --output oci-archive:/run/src/out.ociarchive                                                  \
+                --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+            ;;
+        *)
+            echo "error: unknown BUILDER_IMG_CHUNKER value: ${BUILDER_IMG_CHUNKER}" >&2
+            exit 1
+            ;;
+    esac
 EOF
 
 FROM oci-archive:./out.ociarchive

--- a/Containerfile
+++ b/Containerfile
@@ -46,13 +46,17 @@ RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
     --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
     --mount=type=secret,id=contentsets \
         /src/build-rootfs --srcdir=/src make-rootfs --target-rootfs /target-rootfs
-RUN --mount=type=bind,target=/run/src,rw \
-      rpm-ostree experimental compose build-chunked-oci \
-        --bootc --format-version=1 --rootfs /target-rootfs \
-        --output oci-archive:/run/src/out.ociarchive \
-        --label com.coreos.inputhash=$(cat /run/inputhash) \
+# Take the rootfs and created a chunked container out of it
+# NOTE: use 'bash <<EOF' here instead of '<<EOF' because of our konflux integration [1]
+#       [1] https://github.com/coreos/fedora-coreos-config/pull/4263#issuecomment-5005085765
+RUN --mount=type=bind,target=/run/src,rw bash <<EOF
+    rpm-ostree experimental compose build-chunked-oci                                                 \
+        --bootc --format-version=1 --rootfs /target-rootfs                                            \
+        --output oci-archive:/run/src/out.ociarchive                                                  \
+        --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
         ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
         ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+EOF
 
 FROM oci-archive:./out.ociarchive
 ARG VERSION

--- a/build-args.conf
+++ b/build-args.conf
@@ -12,3 +12,5 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 IMAGE_CONFIG=image.yaml
+#BUILDER_IMG_CHUNKER=
+#BUILDER_IMG_CHUNKER_MAX_LAYERS=


### PR DESCRIPTION
This will implement chunking with chunkah based on the
BUILDER_IMG_CHUNKER build arg.

Also the BUILDER_IMG_CHUNKER_MAX_LAYERS build arg can be
used to set the maximum number of layers for a chunked image.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/2145
