### PR TITLE
overlay/16fcos: add a systemd generator to fix socket-activated sshd auth

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -54,6 +54,24 @@ conditional-include:
           dest=/etc/containers/policy.json
           cp "${src}" "${dest}"
 
+  # WARN: Temporary workaround
+  #
+  # The Fedora sshd@.service overrides AuthorizedKeysFile on the
+  # ExecStart command line, excluding .ssh/authorized_keys.d/* where
+  # Ignition and Afterburn place SSH keys. This breaks auth for
+  # socket-activated sshd.
+  #
+  # See:
+  # - https://github.com/coreos/fedora-coreos-tracker/issues/2098
+  # - https://bugzilla.mindrot.org/show_bug.cgi?id=3957
+  # - https://bugzilla.redhat.com/show_bug.cgi?id=2503149
+  #
+  # TODO: delete if openssh ever supports AuthorizedKeysFile+= (https://bugzilla.mindrot.org/show_bug.cgi?id=3957)
+  - if: releasever <= 45
+    include:
+      ostree-layers:
+        - overlay.d/16fcos-sshd-workaround
+
 ostree-layers:
   - overlay.d/09misc
   - overlay.d/10disk-images

--- a/overlay.d/16fcos-sshd-workaround/usr/lib/systemd/system-generators/coreos-sshd-generator
+++ b/overlay.d/16fcos-sshd-workaround/usr/lib/systemd/system-generators/coreos-sshd-generator
@@ -1,0 +1,32 @@
+#!/bin/bash
+# The upstream sshd@.service overrides AuthorizedKeysFile in the
+# ExecStart command, which excludes .ssh/authorized_keys.d/* where ignition
+# and afterburn place SSH keys. This generator reads the configured
+# AuthorizedKeysFile via sshd -G and appends the systemd credentials
+# path so that both user/distro config and ephemeral keys are honoured.
+#
+# See https://github.com/coreos/fedora-coreos-tracker/issues/2098
+
+NORMAL_DIR="$1"
+
+# First, ensure that the ExecStart line hasn't changed
+upstream_service="/usr/lib/systemd/system/sshd@.service"
+if ! grep -q -- '-o "AuthorizedKeysFile ${CREDENTIALS_DIRECTORY}/ssh.ephemeral-authorized_keys-all .ssh/authorized_keys"' "$upstream_service" 2>/dev/null; then
+    echo "coreos-sshd-generator: upstream sshd@.service ExecStart has changed" >&2
+    exit 1
+fi
+
+# Parse AuthorizedKeysFile value from sshd -G
+auth_keys=$(sshd -G | grep -i "^authorizedkeysfile " | cut -d" " -f2-)
+if [ -z "$auth_keys" ]; then
+    echo "coreos-sshd-generator: failed to get AuthorizedKeysFile from sshd -G" >&2
+    exit 1
+fi
+
+# Write drop-in to override ExecStart
+mkdir -p "$NORMAL_DIR/sshd@.service.d"
+cat > "$NORMAL_DIR/sshd@.service.d/50-authorized-keys-file.conf" <<EOF
+[Service]
+ExecStart=
+ExecStart=-/usr/sbin/sshd -i \$OPTIONS -o "AuthorizedKeysFile \${CREDENTIALS_DIRECTORY}/ssh.ephemeral-authorized_keys-all $auth_keys"
+EOF

--- a/tests/kola/ssh/socket-auth/config.bu
+++ b/tests/kola/ssh/socket-auth/config.bu
@@ -1,0 +1,8 @@
+variant: fcos
+version: 1.6.0
+systemd:
+  units:
+    - name: sshd.service
+      mask: true
+    - name: sshd.socket
+      enabled: true

--- a/tests/kola/ssh/socket-auth/data/commonlib.sh
+++ b/tests/kola/ssh/socket-auth/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/ssh/socket-auth/test.sh
+++ b/tests/kola/ssh/socket-auth/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+## kola:
+##   distros: fcos
+##   tags: platform-independent
+##   creationDate: 2026-07-20
+##   description: Verify that Ignition-provided SSH keys work
+##     with socket-activated sshd.
+##   timeoutMin: 5
+
+# This test masks sshd.service and enables sshd.socket using butane,
+# which forces kola to connect through the socket-activated path.
+#
+# See https://github.com/coreos/fedora-coreos-tracker/issues/2098
+#
+# The primary check here is implicit on whether the SSH connection to
+# the kola VM succeeds at all, but some additional sanity checks are
+# also included below.
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if systemctl is-active sshd.service 2> /dev/null; then
+    fatal "sshd.service is active; expected only sshd.socket"
+fi
+ok "sshd.service is not active"
+
+if ! systemctl is-active sshd.socket 2> /dev/null; then
+    systemctl status sshd.socket
+    fatal "sshd.socket is not active"
+fi
+ok "sshd.socket is active"
+
+ok "SSH authentication works via socket-activated sshd"


### PR DESCRIPTION
> tests/ssh: add test to confirm socket-activated sshd works
> 
> Add a test to confirm that Ignition-provided SSH keys work with
> socket-activated sshd.
> 
> overlay/15fcos: add openssh drop-in to fix SSH login on socket-activated sshd
> 
> The upstream sshd@.service overrides AuthorizedKeysFile in the ExecStart
> command, which excludes .ssh/authorized_keys.d/* where Ignition and
> Afterburn place SSH keys. This breaks SSH logins for systems using
> socket-activated sshd.
>
> Add this drop-in suggested by @travier as a workaround to override ExecStart
> while a better solution is discussed upstream.

See https://github.com/coreos/fedora-coreos-tracker/issues/2098

**EDIT:** for context, we ended up with a dynamic approach using a systemd generator instead