### PR TITLE
Containerfile: fix quoting for OCP label

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -64,7 +64,7 @@ RUN --mount=type=bind,target=/run/src,rw bash <<EOF
                 --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
                 ${BUILDER_IMG_CHUNKER_MAX_LAYERS:+--max-layers=${BUILDER_IMG_CHUNKER_MAX_LAYERS}}             \
                 ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"}
             ;;
         "")
             rpm-ostree experimental compose build-chunked-oci                                                 \
@@ -72,7 +72,7 @@ RUN --mount=type=bind,target=/run/src,rw bash <<EOF
                 --output oci-archive:/run/src/out.ociarchive                                                  \
                 --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
                 ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os="${DESCRIPTION}"}
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"}
             ;;
         *)
             echo "error: unknown BUILDER_IMG_CHUNKER value: ${BUILDER_IMG_CHUNKER}" >&2


### PR DESCRIPTION
In 60131984 we switched to a heredoc and the downstream builds don't work with it:

```
 + rpm-ostree experimental compose build-chunked-oci
   --bootc --format-version=1 --rootfs /target-rootfs
   --output oci-archive:/run/src/out.ociarchive
   --label com.coreos.inputhash=21c232c31c93fea53caef132eb6633df0f683a560cc0843cdf63017839edb3d4
   --label io.openshift.build.versions=machine-os=9.8.20260720-dev0
   --label io.openshift.build.version-display-names=machine-os=Red Hat Enterprise Linux CoreOS 9.8

error: unexpected argument 'Hat' found
```

Fix the quoting so we don't have this problem.