### PR TITLE
Revert "overlay/bootc: add a root filesystem install config"

### DIFF
--- a/overlay.d/10disk-images/usr/lib/bootc/install/12-root-filesystem.toml
+++ b/overlay.d/10disk-images/usr/lib/bootc/install/12-root-filesystem.toml
@@ -1,6 +1,0 @@
-# This is actually overwritten by image-builder's
-# disk.yaml partition table definition but is still required
-# Drop this when https://github.com/osbuild/images/issues/2380
-# is fixed.
-[install.filesystem.root]
-type = "xfs"


### PR DESCRIPTION
This reverts commit fb997446a311ed420a7b644801b9a2b2869c30e1.

Image builder learned to source the root filesystem from it's own partition table definition in https://github.com/osbuild/image-builder/pull/2405

See https://github.com/osbuild/image-builder/issues/2380