### PR TITLE
[next-devel] manifest.yaml: align with testing-devel

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -7,7 +7,7 @@ STREAM=next-devel
 DESCRIPTION=Fedora CoreOS next-devel
 VERSION=44
 MUTATE_OS_RELEASE=44
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:1093a468e82abb1f410e362ee5e8cb3d938ebe6e92bdc6e87f876fcce44b810a
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:3ffaedbf5b28717e6c3ff5f06767c231a0516689acf81c92abab63954ddea72e
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest-lock.aarch64.json
+++ b/manifest-lock.aarch64.json
@@ -1,19 +1,19 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.56.0-1.fc44.aarch64"
+      "evra": "1:1.56.1-2.fc44.aarch64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.56.0-1.fc44.aarch64"
+      "evra": "1:1.56.1-2.fc44.aarch64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.56.0-1.fc44.aarch64"
+      "evra": "1:1.56.1-2.fc44.aarch64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.56.0-1.fc44.aarch64"
+      "evra": "1:1.56.1-2.fc44.aarch64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.56.0-1.fc44.aarch64"
+      "evra": "1:1.56.1-2.fc44.aarch64"
     },
     "WALinuxAgent-udev": {
       "evra": "2.15.0.1-3.fc44.noarch"
@@ -22,7 +22,7 @@
       "evra": "2:1.17.1-1.fc44.aarch64"
     },
     "acl": {
-      "evra": "2.3.2-6.fc44.aarch64"
+      "evra": "2.4.0-1.fc44.aarch64"
     },
     "adcli": {
       "evra": "0.9.3.1-5.fc44.aarch64"
@@ -31,19 +31,19 @@
       "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc44.aarch64"
+      "evra": "5.10.0-7.fc44.aarch64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc44.aarch64"
+      "evra": "5.10.0-7.fc44.aarch64"
     },
     "alternatives": {
       "evra": "1.33-5.fc44.aarch64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-8.fc44.aarch64"
+      "evra": "2.6.0-1.fc44.aarch64"
     },
     "audit": {
       "evra": "4.1.4-1.fc44.aarch64"
@@ -73,22 +73,22 @@
       "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc44.aarch64"
+      "evra": "32:9.18.50-1.fc44.aarch64"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc44.aarch64"
+      "evra": "32:9.18.50-1.fc44.aarch64"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc44.aarch64"
+      "evra": "1.16.3-1.fc44.aarch64"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc44.aarch64"
+      "evra": "0.2.35-1.fc44.aarch64"
     },
     "bsdtar": {
       "evra": "3.8.7-1.fc44.aarch64"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc44.aarch64"
+      "evra": "7.0-1.fc44.aarch64"
     },
     "bubblewrap": {
       "evra": "0.11.0-4.fc44.aarch64"
@@ -100,7 +100,7 @@
       "evra": "1.0.8-23.fc44.aarch64"
     },
     "c-ares": {
-      "evra": "1.34.6-3.fc44.aarch64"
+      "evra": "1.34.8-1.fc44.aarch64"
     },
     "ca-certificates": {
       "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
@@ -112,7 +112,7 @@
       "evra": "4.8-5.fc44.aarch64"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc44.aarch64"
+      "evra": "7.6-2.fc44.aarch64"
     },
     "clevis": {
       "evra": "21-14.fc44.aarch64"
@@ -154,10 +154,10 @@
       "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc44.noarch"
+      "evra": "4:2.250.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.2.3-1.fc44.aarch64"
+      "evra": "2.3.3-1.fc44.aarch64"
     },
     "containers-common": {
       "evra": "5:0.67.0-1.fc44.noarch"
@@ -166,34 +166,34 @@
       "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc44.aarch64"
+      "evra": "0.26.0-2.fc44.aarch64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc44.aarch64"
+      "evra": "0.26.0-2.fc44.aarch64"
     },
     "coreutils": {
-      "evra": "9.10-3.fc44.aarch64"
+      "evra": "9.10-4.fc44.aarch64"
     },
     "coreutils-common": {
-      "evra": "9.10-3.fc44.aarch64"
+      "evra": "9.10-4.fc44.aarch64"
     },
     "cpio": {
       "evra": "2.15-9.fc44.aarch64"
     },
     "cracklib": {
-      "evra": "2.9.11-10.fc44.aarch64"
+      "evra": "2.10.3-1.fc44.aarch64"
     },
     "criu": {
-      "evra": "4.2-13.fc44.aarch64"
+      "evra": "4.2-21.fc44.aarch64"
     },
     "criu-libs": {
-      "evra": "4.2-13.fc44.aarch64"
+      "evra": "4.2-21.fc44.aarch64"
     },
     "crun": {
-      "evra": "1.27.1-1.fc44.aarch64"
+      "evra": "1.28-1.fc44.aarch64"
     },
     "crun-wasm": {
-      "evra": "1.27.1-1.fc44.aarch64"
+      "evra": "1.28-1.fc44.aarch64"
     },
     "crypto-policies": {
       "evra": "20251128-3.git19878fe.fc44.noarch"
@@ -244,31 +244,31 @@
       "evra": "0.13.1-1.fc44.aarch64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.3.1-3.fc44.aarch64"
+      "evra": "1.3.3-1.fc44.aarch64"
     },
     "diffutils": {
       "evra": "3.12-5.fc44.aarch64"
     },
     "dnf5": {
-      "evra": "5.4.2.0-1.fc44.aarch64"
+      "evra": "5.4.2.1-1.fc44.aarch64"
     },
     "dnsmasq": {
-      "evra": "2.92-4.fc44.aarch64"
+      "evra": "2.92rel2-9.fc44.aarch64"
     },
     "docker-cli": {
-      "evra": "29.4.1-1.fc44.aarch64"
+      "evra": "29.6.0-1.fc44.aarch64"
     },
     "dosfstools": {
       "evra": "4.2-18.fc44.aarch64"
     },
     "dracut": {
-      "evra": "108-6.fc44.aarch64"
+      "evra": "108-7.fc44.aarch64"
     },
     "dracut-network": {
-      "evra": "108-6.fc44.aarch64"
+      "evra": "108-7.fc44.aarch64"
     },
     "dracut-squash": {
-      "evra": "108-6.fc44.aarch64"
+      "evra": "108-7.fc44.aarch64"
     },
     "duktape": {
       "evra": "2.7.0-11.fc44.aarch64"
@@ -298,22 +298,22 @@
       "evra": "0.195-1.fc44.aarch64"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc44.aarch64"
+      "evra": "2:7.1-1.fc44.aarch64"
     },
     "expat": {
-      "evra": "2.7.3-2.fc44.aarch64"
+      "evra": "2.8.1-1.fc44.aarch64"
     },
     "fedora-gpg-keys": {
       "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-repos": {
       "evra": "44-1.noarch"
@@ -334,7 +334,7 @@
       "evra": "1:4.10.0-7.fc44.aarch64"
     },
     "flatpak-session-helper": {
-      "evra": "1.17.6-1.fc44.aarch64"
+      "evra": "1.18.0-1.fc44.aarch64"
     },
     "fmt": {
       "evra": "11.2.0-4.fc44.aarch64"
@@ -349,7 +349,7 @@
       "evra": "1.16-2.fc44.aarch64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-3.fc44.aarch64"
+      "evra": "3.7.6-1.fc44.aarch64"
     },
     "fuse3": {
       "evra": "3.18.2-1.fc44.aarch64"
@@ -358,7 +358,7 @@
       "evra": "3.18.2-1.fc44.aarch64"
     },
     "fwupd": {
-      "evra": "2.1.1-1.fc44.aarch64"
+      "evra": "2.1.3-1.fc44.aarch64"
     },
     "gawk": {
       "evra": "5.3.2-3.fc44.aarch64"
@@ -373,31 +373,31 @@
       "evra": "1.0.10-5.fc44.aarch64"
     },
     "gettext-envsubst": {
-      "evra": "0.26-4.fc44.aarch64"
+      "evra": "0.26-5.fc44.aarch64"
     },
     "gettext-libs": {
-      "evra": "0.26-4.fc44.aarch64"
+      "evra": "0.26-5.fc44.aarch64"
     },
     "gettext-runtime": {
-      "evra": "0.26-4.fc44.aarch64"
+      "evra": "0.26-5.fc44.aarch64"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc44.aarch64"
+      "evra": "2.55.0-1.fc44.aarch64"
     },
     "glib2": {
-      "evra": "2.88.0-1.fc44.aarch64"
+      "evra": "2.88.2-1.fc44.aarch64"
     },
     "glibc": {
-      "evra": "2.43-3.fc44.aarch64"
+      "evra": "2.43-7.fc44.aarch64"
     },
     "glibc-common": {
-      "evra": "2.43-3.fc44.aarch64"
+      "evra": "2.43-7.fc44.aarch64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.43-3.fc44.aarch64"
+      "evra": "2.43-7.fc44.aarch64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.43-3.fc44.aarch64"
+      "evra": "2.43-7.fc44.aarch64"
     },
     "gmp": {
       "evra": "1:6.3.0-5.fc44.aarch64"
@@ -406,46 +406,46 @@
       "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-7.fc44.aarch64"
+      "evra": "2.4.9-16.fc44.aarch64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc44.aarch64"
+      "evra": "3.8.13-1.fc44.aarch64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-3.fc44.noarch"
+      "evra": "20260623.00-3.fc44.noarch"
     },
     "gpgme": {
-      "evra": "2.0.1-3.fc44.aarch64"
+      "evra": "2.0.1-5.fc44.aarch64"
     },
     "grep": {
       "evra": "3.12-3.fc44.aarch64"
     },
     "grub2-common": {
-      "evra": "1:2.12-56.fc44.noarch"
+      "evra": "1:2.12-60.fc44.noarch"
     },
     "grub2-efi-aa64": {
-      "evra": "1:2.12-56.fc44.aarch64"
+      "evra": "1:2.12-60.fc44.aarch64"
     },
     "grub2-tools": {
-      "evra": "1:2.12-56.fc44.aarch64"
+      "evra": "1:2.12-60.fc44.aarch64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-56.fc44.aarch64"
+      "evra": "1:2.12-60.fc44.aarch64"
     },
     "gssproxy": {
       "evra": "0.9.2-10.fc44.aarch64"
@@ -457,7 +457,7 @@
       "evra": "3.25-4.fc44.aarch64"
     },
     "hwdata": {
-      "evra": "0.406-1.fc44.noarch"
+      "evra": "0.409-1.fc44.noarch"
     },
     "ignition": {
       "evra": "2.26.0-4.fc44.aarch64"
@@ -469,7 +469,7 @@
       "evra": "62-2.fc44.aarch64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "ipcalc": {
       "evra": "1.0.3-13.fc44.aarch64"
@@ -535,16 +535,16 @@
       "evra": "1.0.61-1.fc44.aarch64"
     },
     "kernel": {
-      "evra": "6.19.14-300.fc44.aarch64"
+      "evra": "7.1.4-200.fc44.aarch64"
     },
     "kernel-core": {
-      "evra": "6.19.14-300.fc44.aarch64"
+      "evra": "7.1.4-200.fc44.aarch64"
     },
     "kernel-modules": {
-      "evra": "6.19.14-300.fc44.aarch64"
+      "evra": "7.1.4-200.fc44.aarch64"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-300.fc44.aarch64"
+      "evra": "7.1.4-200.fc44.aarch64"
     },
     "kexec-tools": {
       "evra": "2.0.32-3.fc44.aarch64"
@@ -565,13 +565,13 @@
       "evra": "0.13.1-1.fc44.aarch64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc44.aarch64"
+      "evra": "1.22.2-4.fc44.aarch64"
     },
     "less": {
-      "evra": "692-5.fc44.aarch64"
+      "evra": "704-2.fc44.aarch64"
     },
     "libacl": {
-      "evra": "2.3.2-6.fc44.aarch64"
+      "evra": "2.4.0-1.fc44.aarch64"
     },
     "libaio": {
       "evra": "0.3.111-23.fc44.aarch64"
@@ -583,16 +583,16 @@
       "evra": "2.5.7-5.fc44.aarch64"
     },
     "libattr": {
-      "evra": "2.5.2-8.fc44.aarch64"
+      "evra": "2.6.0-1.fc44.aarch64"
     },
     "libbasicobjects": {
       "evra": "0.1.1-61.fc44.aarch64"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libbpf": {
-      "evra": "2:1.6.3-1.fc44.aarch64"
+      "evra": "2:1.6.3-2.fc44.aarch64"
     },
     "libbsd": {
       "evra": "0.12.2-7.fc44.aarch64"
@@ -622,19 +622,19 @@
       "evra": "0.5.0-61.fc44.aarch64"
     },
     "libdnf5": {
-      "evra": "5.4.2.0-1.fc44.aarch64"
+      "evra": "5.4.2.1-1.fc44.aarch64"
     },
     "libdnf5-cli": {
-      "evra": "5.4.2.0-1.fc44.aarch64"
+      "evra": "5.4.2.1-1.fc44.aarch64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc44.aarch64"
+      "evra": "2.4.134-1.fc44.aarch64"
     },
     "libeconf": {
       "evra": "0.7.9-3.fc44.aarch64"
     },
     "libedit": {
-      "evra": "3.1-58.20251016cvs.fc44.aarch64"
+      "evra": "3.1-59.20260512cvs.fc44.aarch64"
     },
     "libev": {
       "evra": "4.33-15.fc44.aarch64"
@@ -643,7 +643,7 @@
       "evra": "2.1.12-17.fc44.aarch64"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libffi": {
       "evra": "3.5.2-2.fc44.aarch64"
@@ -652,7 +652,7 @@
       "evra": "1.16.0-5.fc44.aarch64"
     },
     "libgcc": {
-      "evra": "16.0.1-0.10.fc44.aarch64"
+      "evra": "16.1.1-2.fc44.aarch64"
     },
     "libgcrypt": {
       "evra": "1.12.2-1.fc44.aarch64"
@@ -664,7 +664,7 @@
       "evra": "61.0-2.fc44.aarch64"
     },
     "libicu": {
-      "evra": "77.1-2.fc44.aarch64"
+      "evra": "77.1-3.fc44.aarch64"
     },
     "libidn2": {
       "evra": "2.3.8-3.fc44.aarch64"
@@ -673,7 +673,7 @@
       "evra": "1.3.1-61.fc44.aarch64"
     },
     "libipa_hbac": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "libjcat": {
       "evra": "0.2.6-1.fc44.aarch64"
@@ -694,10 +694,10 @@
       "evra": "1.6.7-5.fc44.aarch64"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libldb": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "libluksmeta": {
       "evra": "10-2.fc44.aarch64"
@@ -706,16 +706,16 @@
       "evra": "1.13.3-1.fc44.aarch64"
     },
     "libmd": {
-      "evra": "1.1.0-9.fc44.aarch64"
+      "evra": "1.2.0-1.fc44.aarch64"
     },
     "libmnl": {
       "evra": "1.0.5-9.fc44.aarch64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-7.fc44.aarch64"
+      "evra": "2.15.3-1.fc44.aarch64"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libndp": {
       "evra": "1.9-5.fc44.aarch64"
@@ -730,13 +730,13 @@
       "evra": "1.0.1-32.fc44.aarch64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc44.aarch64"
+      "evra": "1:2.8.7-6.fc44.aarch64"
     },
     "libnftnl": {
       "evra": "1.3.1-2.fc44.aarch64"
     },
     "libnghttp2": {
-      "evra": "1.68.0-3.fc44.aarch64"
+      "evra": "1.68.0-4.fc44.aarch64"
     },
     "libnl3": {
       "evra": "3.12.0-3.fc44.aarch64"
@@ -778,7 +778,7 @@
       "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-3.fc44.aarch64"
+      "evra": "2.6.1-2.fc44.aarch64"
     },
     "libselinux": {
       "evra": "3.10-1.fc44.aarch64"
@@ -796,31 +796,31 @@
       "evra": "4.9.1-3.fc44.aarch64"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libsmbclient": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "libsolv": {
-      "evra": "0.7.37-2.fc44.aarch64"
+      "evra": "0.7.39-1.fc44.aarch64"
     },
     "libss": {
       "evra": "1.47.3-4.fc44.aarch64"
     },
     "libsss_certmap": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "libsss_idmap": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "libsss_sudo": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "libstdc++": {
-      "evra": "16.0.1-0.10.fc44.aarch64"
+      "evra": "16.1.1-2.fc44.aarch64"
     },
     "libtalloc": {
       "evra": "2.4.4-1.fc44.aarch64"
@@ -838,7 +838,7 @@
       "evra": "0.17.1-4.fc44.aarch64"
     },
     "libtextstyle": {
-      "evra": "0.26-4.fc44.aarch64"
+      "evra": "0.26-5.fc44.aarch64"
     },
     "libtirpc": {
       "evra": "1.3.7-2.fc44.aarch64"
@@ -850,13 +850,13 @@
       "evra": "1.1-11.fc44.aarch64"
     },
     "libusb1": {
-      "evra": "1.0.29-5.fc44.aarch64"
+      "evra": "1.0.30-1.fc44.aarch64"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "libuv": {
-      "evra": "1:1.51.0-3.fc44.aarch64"
+      "evra": "1:1.52.1-2.fc44.aarch64"
     },
     "libverto": {
       "evra": "0.3.2-12.fc44.aarch64"
@@ -865,7 +865,7 @@
       "evra": "0.3.2-12.fc44.aarch64"
     },
     "libwbclient": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "libxcrypt": {
       "evra": "4.5.2-3.fc44.aarch64"
@@ -874,7 +874,7 @@
       "evra": "2.12.10-6.fc44.aarch64"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc44.aarch64"
+      "evra": "0.3.28-1.fc44.aarch64"
     },
     "libyaml": {
       "evra": "0.2.5-18.fc44.aarch64"
@@ -883,10 +883,10 @@
       "evra": "1.5.7-5.fc44.aarch64"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "lld18-libs": {
       "evra": "18.1.8-8.fc43.aarch64"
@@ -922,16 +922,16 @@
       "evra": "2.10-16.fc44.aarch64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-2.fc44.aarch64"
+      "evra": "1.7.9-1.fc44.aarch64"
     },
     "mdadm": {
       "evra": "4.3-11.fc44.aarch64"
     },
     "moby-engine": {
-      "evra": "29.4.1-1.fc44.aarch64"
+      "evra": "29.6.0-1.fc44.aarch64"
     },
     "moby-filesystem": {
-      "evra": "29.4.1-1.fc44.noarch"
+      "evra": "29.6.0-1.fc44.noarch"
     },
     "mokutil": {
       "evra": "2:0.7.2-3.fc44.aarch64"
@@ -940,10 +940,10 @@
       "evra": "4.2.2-3.fc44.aarch64"
     },
     "nano": {
-      "evra": "8.7.1-1.fc44.aarch64"
+      "evra": "8.7.1-2.fc44.aarch64"
     },
     "nano-default-editor": {
-      "evra": "8.7.1-1.fc44.noarch"
+      "evra": "8.7.1-2.fc44.noarch"
     },
     "ncurses": {
       "evra": "6.6-1.fc44.aarch64"
@@ -967,16 +967,16 @@
       "evra": "0.52.25-6.fc44.aarch64"
     },
     "nfs-client-utils": {
-      "evra": "1:2.8.7-1.fc44.aarch64"
+      "evra": "1:2.8.7-6.fc44.aarch64"
     },
     "nfs-common-utils": {
-      "evra": "1:2.8.7-1.fc44.aarch64"
+      "evra": "1:2.8.7-6.fc44.aarch64"
     },
     "nfsv3-client-utils": {
-      "evra": "1:2.8.7-1.fc44.aarch64"
+      "evra": "1:2.8.7-6.fc44.aarch64"
     },
     "nfsv4-client-utils": {
-      "evra": "1:2.8.7-1.fc44.aarch64"
+      "evra": "1:2.8.7-6.fc44.aarch64"
     },
     "nftables": {
       "evra": "1:1.1.6-2.fc44.aarch64"
@@ -1009,7 +1009,7 @@
       "evra": "0.5-50.20251104git.fc44.aarch64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "nvme-cli": {
       "evra": "2.16-2.fc44.aarch64"
@@ -1021,55 +1021,55 @@
       "evra": "2.6.13-1.fc44.aarch64"
     },
     "openssh": {
-      "evra": "10.2p1-9.fc44.aarch64"
+      "evra": "10.2p1-13.fc44.aarch64"
     },
     "openssh-clients": {
-      "evra": "10.2p1-9.fc44.aarch64"
+      "evra": "10.2p1-13.fc44.aarch64"
     },
     "openssh-server": {
-      "evra": "10.2p1-9.fc44.aarch64"
+      "evra": "10.2p1-13.fc44.aarch64"
     },
     "openssl": {
-      "evra": "1:3.5.5-2.fc44.aarch64"
+      "evra": "1:3.5.7-2.fc44.aarch64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.5-2.fc44.aarch64"
+      "evra": "1:3.5.7-2.fc44.aarch64"
     },
     "os-prober": {
       "evra": "1.81-11.fc44.aarch64"
     },
     "ostree": {
-      "evra": "2026.1-1.fc44.aarch64"
+      "evra": "2026.2-1.fc44.aarch64"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc44.aarch64"
+      "evra": "2026.2-1.fc44.aarch64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc44.aarch64"
+      "evra": "0.26.4-1.fc44.aarch64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc44.aarch64"
+      "evra": "0.26.4-1.fc44.aarch64"
     },
     "pam": {
-      "evra": "1.7.2-1.fc44.aarch64"
+      "evra": "1.7.2-2.fc44.aarch64"
     },
     "pam-libs": {
-      "evra": "1.7.2-1.fc44.aarch64"
+      "evra": "1.7.2-2.fc44.aarch64"
     },
     "passim-libs": {
       "evra": "0.1.11-1.fc44.aarch64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc44.aarch64"
+      "evra": "0^20260716.g090d739-2.fc44.aarch64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
+      "evra": "0^20260716.g090d739-2.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-3.fc44.aarch64"
+      "evra": "3.15.0-1.fc44.aarch64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-3.fc44.aarch64"
+      "evra": "3.15.0-1.fc44.aarch64"
     },
     "pcre2": {
       "evra": "10.47-1.fc44.1.aarch64"
@@ -1090,13 +1090,13 @@
       "evra": "2.5.1-1.fc44.aarch64"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc44.aarch64"
+      "evra": "5:5.8.4-1.fc44.aarch64"
     },
     "podman-sequoia": {
-      "evra": "0.3.2-1.fc44.aarch64"
+      "evra": "0.3.2-2.fc44.aarch64"
     },
     "policycoreutils": {
-      "evra": "3.10-1.fc44.aarch64"
+      "evra": "3.10-4.fc44.aarch64"
     },
     "polkit": {
       "evra": "127-2.fc44.2.aarch64"
@@ -1120,7 +1120,7 @@
       "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
       "evra": "2:10.2.2-1.fc44.aarch64"
@@ -1132,7 +1132,7 @@
       "evra": "8.3-4.fc44.aarch64"
     },
     "rpcbind": {
-      "evra": "1.2.8-1.fc44.aarch64"
+      "evra": "1.2.9-2.fc44.aarch64"
     },
     "rpm": {
       "evra": "6.0.1-2.fc44.aarch64"
@@ -1141,34 +1141,34 @@
       "evra": "6.0.1-2.fc44.aarch64"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc44.aarch64"
+      "evra": "2026.2-1.fc44.aarch64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc44.aarch64"
+      "evra": "2026.2-1.fc44.aarch64"
     },
     "rpm-plugin-selinux": {
       "evra": "6.0.1-2.fc44.aarch64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc44.aarch64"
+      "evra": "1.10.2-4.fc44.aarch64"
     },
     "rsync": {
-      "evra": "3.4.1-6.fc44.aarch64"
+      "evra": "3.4.4-1.fc44.aarch64"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc44.aarch64"
+      "evra": "2:1.5.0-2.fc44.aarch64"
     },
     "samba-client-libs": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "samba-common": {
-      "evra": "2:4.24.1-1.fc44.noarch"
+      "evra": "2:4.24.4-1.fc44.noarch"
     },
     "samba-core-libs": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "samba-ndr-libs": {
-      "evra": "2:4.24.1-1.fc44.aarch64"
+      "evra": "2:4.24.4-1.fc44.aarch64"
     },
     "sdbus-cpp": {
       "evra": "2.2.1-2.fc44.aarch64"
@@ -1177,25 +1177,25 @@
       "evra": "4.9-7.fc44.aarch64"
     },
     "selinux-policy": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "setup": {
       "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-8.fc44.aarch64"
+      "evra": "1.48-10.fc44.aarch64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-8.fc44.aarch64"
+      "evra": "1.48-10.fc44.aarch64"
     },
     "shadow-utils": {
-      "evra": "2:4.19.0-6.fc44.aarch64"
+      "evra": "2:4.19.0-7.fc44.aarch64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.19.0-6.fc44.aarch64"
+      "evra": "2:4.19.0-7.fc44.aarch64"
     },
     "shared-mime-info": {
       "evra": "2.4-3.fc44.aarch64"
@@ -1216,7 +1216,7 @@
       "evra": "1.2.2-4.fc44.aarch64"
     },
     "socat": {
-      "evra": "1.8.1.0-2.fc44.aarch64"
+      "evra": "1.8.1.1-1.fc44.aarch64"
     },
     "spdlog": {
       "evra": "1.15.3-4.fc44.aarch64"
@@ -1228,61 +1228,61 @@
       "evra": "4.6.1-8.fc44.aarch64"
     },
     "sssd-ad": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-client": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-common": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-common-pac": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-ipa": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-krb5": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-krb5-common": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-ldap": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.13.0-1.fc44.aarch64"
+      "evra": "2.13.1-2.fc44.aarch64"
     },
     "stalld": {
-      "evra": "1.26.3-2.fc44.aarch64"
+      "evra": "1.28.1-1.fc44.aarch64"
     },
     "sudo": {
       "evra": "1.9.17-8.p2.fc44.aarch64"
     },
     "systemd": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-container": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-libs": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-pam": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-resolved": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-shared": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-sysusers": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "systemd-udev": {
-      "evra": "259.5-1.fc44.aarch64"
+      "evra": "259.7-1.fc44.aarch64"
     },
     "tar": {
       "evra": "2:1.35-8.fc44.aarch64"
@@ -1306,34 +1306,34 @@
       "evra": "4.1.3-9.fc44.aarch64"
     },
     "tzdata": {
-      "evra": "2026a-1.fc44.noarch"
+      "evra": "2026b-1.fc44.noarch"
     },
     "userspace-rcu": {
       "evra": "0.15.6-1.fc44.aarch64"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc44.aarch64"
+      "evra": "2.41.5-1.fc44.aarch64"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc44.noarch"
+      "evra": "2:9.2.782-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc44.aarch64"
+      "evra": "2:9.2.782-1.fc44.aarch64"
     },
     "wasmedge-rt": {
-      "evra": "0.16.1-1.fc44.aarch64"
+      "evra": "0.17.1-1.fc44.aarch64"
     },
     "which": {
-      "evra": "2.23-4.fc44.aarch64"
+      "evra": "2.25-1.fc44.aarch64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-3.fc44.aarch64"
+      "evra": "1.0.20260223-1.fc44.aarch64"
     },
     "xfsprogs": {
-      "evra": "6.18.0-2.fc44.aarch64"
+      "evra": "7.0.1-2.fc44.aarch64"
     },
     "xxhash-libs": {
       "evra": "0.8.3-4.fc44.aarch64"
@@ -1343,9 +1343,6 @@
     },
     "xz-libs": {
       "evra": "1:5.8.2-2.fc44.aarch64"
-    },
-    "yajl": {
-      "evra": "2.1.0-40.fc44.aarch64"
     },
     "zchunk-libs": {
       "evra": "1.5.1-4.fc44.aarch64"
@@ -1364,6 +1361,6 @@
     }
   },
   "metadata": {
-    "generated": "2026-05-01T00:00:00Z"
+    "generated": "2026-07-20T00:00:00Z"
   }
 }

--- a/manifest-lock.ppc64le.json
+++ b/manifest-lock.ppc64le.json
@@ -1,25 +1,25 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.56.0-1.fc44.ppc64le"
+      "evra": "1:1.56.1-2.fc44.ppc64le"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.56.0-1.fc44.ppc64le"
+      "evra": "1:1.56.1-2.fc44.ppc64le"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.56.0-1.fc44.ppc64le"
+      "evra": "1:1.56.1-2.fc44.ppc64le"
     },
     "NetworkManager-team": {
-      "evra": "1:1.56.0-1.fc44.ppc64le"
+      "evra": "1:1.56.1-2.fc44.ppc64le"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.56.0-1.fc44.ppc64le"
+      "evra": "1:1.56.1-2.fc44.ppc64le"
     },
     "aardvark-dns": {
       "evra": "2:1.17.1-1.fc44.ppc64le"
     },
     "acl": {
-      "evra": "2.3.2-6.fc44.ppc64le"
+      "evra": "2.4.0-1.fc44.ppc64le"
     },
     "adcli": {
       "evra": "0.9.3.1-5.fc44.ppc64le"
@@ -28,19 +28,19 @@
       "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc44.ppc64le"
+      "evra": "5.10.0-7.fc44.ppc64le"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc44.ppc64le"
+      "evra": "5.10.0-7.fc44.ppc64le"
     },
     "alternatives": {
       "evra": "1.33-5.fc44.ppc64le"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-8.fc44.ppc64le"
+      "evra": "2.6.0-1.fc44.ppc64le"
     },
     "audit": {
       "evra": "4.1.4-1.fc44.ppc64le"
@@ -70,22 +70,22 @@
       "evra": "1.08.2-4.fc44.ppc64le"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc44.ppc64le"
+      "evra": "32:9.18.50-1.fc44.ppc64le"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc44.ppc64le"
+      "evra": "32:9.18.50-1.fc44.ppc64le"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc44.ppc64le"
+      "evra": "1.16.3-1.fc44.ppc64le"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc44.ppc64le"
+      "evra": "0.2.35-1.fc44.ppc64le"
     },
     "bsdtar": {
       "evra": "3.8.7-1.fc44.ppc64le"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc44.ppc64le"
+      "evra": "7.0-1.fc44.ppc64le"
     },
     "bubblewrap": {
       "evra": "0.11.0-4.fc44.ppc64le"
@@ -97,7 +97,7 @@
       "evra": "1.0.8-23.fc44.ppc64le"
     },
     "c-ares": {
-      "evra": "1.34.6-3.fc44.ppc64le"
+      "evra": "1.34.8-1.fc44.ppc64le"
     },
     "ca-certificates": {
       "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
@@ -109,7 +109,7 @@
       "evra": "4.8-5.fc44.ppc64le"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc44.ppc64le"
+      "evra": "7.6-2.fc44.ppc64le"
     },
     "clevis": {
       "evra": "21-14.fc44.ppc64le"
@@ -151,10 +151,10 @@
       "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc44.noarch"
+      "evra": "4:2.250.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.2.3-1.fc44.ppc64le"
+      "evra": "2.3.3-1.fc44.ppc64le"
     },
     "containers-common": {
       "evra": "5:0.67.0-1.fc44.noarch"
@@ -163,31 +163,31 @@
       "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc44.ppc64le"
+      "evra": "0.26.0-2.fc44.ppc64le"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc44.ppc64le"
+      "evra": "0.26.0-2.fc44.ppc64le"
     },
     "coreutils": {
-      "evra": "9.10-3.fc44.ppc64le"
+      "evra": "9.10-4.fc44.ppc64le"
     },
     "coreutils-common": {
-      "evra": "9.10-3.fc44.ppc64le"
+      "evra": "9.10-4.fc44.ppc64le"
     },
     "cpio": {
       "evra": "2.15-9.fc44.ppc64le"
     },
     "cracklib": {
-      "evra": "2.9.11-10.fc44.ppc64le"
+      "evra": "2.10.3-1.fc44.ppc64le"
     },
     "criu": {
-      "evra": "4.2-13.fc44.ppc64le"
+      "evra": "4.2-21.fc44.ppc64le"
     },
     "criu-libs": {
-      "evra": "4.2-13.fc44.ppc64le"
+      "evra": "4.2-21.fc44.ppc64le"
     },
     "crun": {
-      "evra": "1.27.1-1.fc44.ppc64le"
+      "evra": "1.28-1.fc44.ppc64le"
     },
     "crypto-policies": {
       "evra": "20251128-3.git19878fe.fc44.noarch"
@@ -238,31 +238,31 @@
       "evra": "0.13.1-1.fc44.ppc64le"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.3.1-3.fc44.ppc64le"
+      "evra": "1.3.3-1.fc44.ppc64le"
     },
     "diffutils": {
       "evra": "3.12-5.fc44.ppc64le"
     },
     "dnf5": {
-      "evra": "5.4.2.0-1.fc44.ppc64le"
+      "evra": "5.4.2.1-1.fc44.ppc64le"
     },
     "dnsmasq": {
-      "evra": "2.92-4.fc44.ppc64le"
+      "evra": "2.92rel2-9.fc44.ppc64le"
     },
     "docker-cli": {
-      "evra": "29.4.1-1.fc44.ppc64le"
+      "evra": "29.6.0-1.fc44.ppc64le"
     },
     "dosfstools": {
       "evra": "4.2-18.fc44.ppc64le"
     },
     "dracut": {
-      "evra": "108-6.fc44.ppc64le"
+      "evra": "108-7.fc44.ppc64le"
     },
     "dracut-network": {
-      "evra": "108-6.fc44.ppc64le"
+      "evra": "108-7.fc44.ppc64le"
     },
     "dracut-squash": {
-      "evra": "108-6.fc44.ppc64le"
+      "evra": "108-7.fc44.ppc64le"
     },
     "duktape": {
       "evra": "2.7.0-11.fc44.ppc64le"
@@ -283,22 +283,22 @@
       "evra": "0.195-1.fc44.ppc64le"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc44.ppc64le"
+      "evra": "2:7.1-1.fc44.ppc64le"
     },
     "expat": {
-      "evra": "2.7.3-2.fc44.ppc64le"
+      "evra": "2.8.1-1.fc44.ppc64le"
     },
     "fedora-gpg-keys": {
       "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-repos": {
       "evra": "44-1.noarch"
@@ -319,7 +319,7 @@
       "evra": "1:4.10.0-7.fc44.ppc64le"
     },
     "flatpak-session-helper": {
-      "evra": "1.17.6-1.fc44.ppc64le"
+      "evra": "1.18.0-1.fc44.ppc64le"
     },
     "fmt": {
       "evra": "11.2.0-4.fc44.ppc64le"
@@ -334,7 +334,7 @@
       "evra": "1.16-2.fc44.ppc64le"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-3.fc44.ppc64le"
+      "evra": "3.7.6-1.fc44.ppc64le"
     },
     "fuse3": {
       "evra": "3.18.2-1.fc44.ppc64le"
@@ -343,7 +343,7 @@
       "evra": "3.18.2-1.fc44.ppc64le"
     },
     "fwupd": {
-      "evra": "2.1.1-1.fc44.ppc64le"
+      "evra": "2.1.3-1.fc44.ppc64le"
     },
     "gawk": {
       "evra": "5.3.2-3.fc44.ppc64le"
@@ -358,31 +358,31 @@
       "evra": "1.0.10-5.fc44.ppc64le"
     },
     "gettext-envsubst": {
-      "evra": "0.26-4.fc44.ppc64le"
+      "evra": "0.26-5.fc44.ppc64le"
     },
     "gettext-libs": {
-      "evra": "0.26-4.fc44.ppc64le"
+      "evra": "0.26-5.fc44.ppc64le"
     },
     "gettext-runtime": {
-      "evra": "0.26-4.fc44.ppc64le"
+      "evra": "0.26-5.fc44.ppc64le"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc44.ppc64le"
+      "evra": "2.55.0-1.fc44.ppc64le"
     },
     "glib2": {
-      "evra": "2.88.0-1.fc44.ppc64le"
+      "evra": "2.88.2-1.fc44.ppc64le"
     },
     "glibc": {
-      "evra": "2.43-3.fc44.ppc64le"
+      "evra": "2.43-7.fc44.ppc64le"
     },
     "glibc-common": {
-      "evra": "2.43-3.fc44.ppc64le"
+      "evra": "2.43-7.fc44.ppc64le"
     },
     "glibc-gconv-extra": {
-      "evra": "2.43-3.fc44.ppc64le"
+      "evra": "2.43-7.fc44.ppc64le"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.43-3.fc44.ppc64le"
+      "evra": "2.43-7.fc44.ppc64le"
     },
     "gmp": {
       "evra": "1:6.3.0-5.fc44.ppc64le"
@@ -391,46 +391,46 @@
       "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-7.fc44.ppc64le"
+      "evra": "2.4.9-16.fc44.ppc64le"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc44.ppc64le"
+      "evra": "3.8.13-1.fc44.ppc64le"
     },
     "gpgme": {
-      "evra": "2.0.1-3.fc44.ppc64le"
+      "evra": "2.0.1-5.fc44.ppc64le"
     },
     "grep": {
       "evra": "3.12-3.fc44.ppc64le"
     },
     "grub2-common": {
-      "evra": "1:2.12-56.fc44.noarch"
+      "evra": "1:2.12-60.fc44.noarch"
     },
     "grub2-ppc64le": {
-      "evra": "1:2.12-56.fc44.ppc64le"
+      "evra": "1:2.12-60.fc44.ppc64le"
     },
     "grub2-ppc64le-modules": {
-      "evra": "1:2.12-56.fc44.noarch"
+      "evra": "1:2.12-60.fc44.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-56.fc44.ppc64le"
+      "evra": "1:2.12-60.fc44.ppc64le"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-56.fc44.ppc64le"
+      "evra": "1:2.12-60.fc44.ppc64le"
     },
     "gssproxy": {
       "evra": "0.9.2-10.fc44.ppc64le"
@@ -442,7 +442,7 @@
       "evra": "3.25-4.fc44.ppc64le"
     },
     "hwdata": {
-      "evra": "0.406-1.fc44.noarch"
+      "evra": "0.409-1.fc44.noarch"
     },
     "ignition": {
       "evra": "2.26.0-4.fc44.ppc64le"
@@ -454,7 +454,7 @@
       "evra": "62-2.fc44.ppc64le"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "ipcalc": {
       "evra": "1.0.3-13.fc44.ppc64le"
@@ -520,16 +520,16 @@
       "evra": "1.0.61-1.fc44.ppc64le"
     },
     "kernel": {
-      "evra": "6.19.14-300.fc44.ppc64le"
+      "evra": "7.1.4-200.fc44.ppc64le"
     },
     "kernel-core": {
-      "evra": "6.19.14-300.fc44.ppc64le"
+      "evra": "7.1.4-200.fc44.ppc64le"
     },
     "kernel-modules": {
-      "evra": "6.19.14-300.fc44.ppc64le"
+      "evra": "7.1.4-200.fc44.ppc64le"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-300.fc44.ppc64le"
+      "evra": "7.1.4-200.fc44.ppc64le"
     },
     "kexec-tools": {
       "evra": "2.0.32-3.fc44.ppc64le"
@@ -550,13 +550,13 @@
       "evra": "0.13.1-1.fc44.ppc64le"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc44.ppc64le"
+      "evra": "1.22.2-4.fc44.ppc64le"
     },
     "less": {
-      "evra": "692-5.fc44.ppc64le"
+      "evra": "704-2.fc44.ppc64le"
     },
     "libacl": {
-      "evra": "2.3.2-6.fc44.ppc64le"
+      "evra": "2.4.0-1.fc44.ppc64le"
     },
     "libaio": {
       "evra": "0.3.111-23.fc44.ppc64le"
@@ -568,16 +568,16 @@
       "evra": "2.5.7-5.fc44.ppc64le"
     },
     "libattr": {
-      "evra": "2.5.2-8.fc44.ppc64le"
+      "evra": "2.6.0-1.fc44.ppc64le"
     },
     "libbasicobjects": {
       "evra": "0.1.1-61.fc44.ppc64le"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libbpf": {
-      "evra": "2:1.6.3-1.fc44.ppc64le"
+      "evra": "2:1.6.3-2.fc44.ppc64le"
     },
     "libbsd": {
       "evra": "0.12.2-7.fc44.ppc64le"
@@ -607,19 +607,19 @@
       "evra": "0.5.0-61.fc44.ppc64le"
     },
     "libdnf5": {
-      "evra": "5.4.2.0-1.fc44.ppc64le"
+      "evra": "5.4.2.1-1.fc44.ppc64le"
     },
     "libdnf5-cli": {
-      "evra": "5.4.2.0-1.fc44.ppc64le"
+      "evra": "5.4.2.1-1.fc44.ppc64le"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc44.ppc64le"
+      "evra": "2.4.134-1.fc44.ppc64le"
     },
     "libeconf": {
       "evra": "0.7.9-3.fc44.ppc64le"
     },
     "libedit": {
-      "evra": "3.1-58.20251016cvs.fc44.ppc64le"
+      "evra": "3.1-59.20260512cvs.fc44.ppc64le"
     },
     "libev": {
       "evra": "4.33-15.fc44.ppc64le"
@@ -628,7 +628,7 @@
       "evra": "2.1.12-17.fc44.ppc64le"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libffi": {
       "evra": "3.5.2-2.fc44.ppc64le"
@@ -637,7 +637,7 @@
       "evra": "1.16.0-5.fc44.ppc64le"
     },
     "libgcc": {
-      "evra": "16.0.1-0.10.fc44.ppc64le"
+      "evra": "16.1.1-2.fc44.ppc64le"
     },
     "libgcrypt": {
       "evra": "1.12.2-1.fc44.ppc64le"
@@ -649,7 +649,7 @@
       "evra": "61.0-2.fc44.ppc64le"
     },
     "libicu": {
-      "evra": "77.1-2.fc44.ppc64le"
+      "evra": "77.1-3.fc44.ppc64le"
     },
     "libidn2": {
       "evra": "2.3.8-3.fc44.ppc64le"
@@ -658,7 +658,7 @@
       "evra": "1.3.1-61.fc44.ppc64le"
     },
     "libipa_hbac": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "libjcat": {
       "evra": "0.2.6-1.fc44.ppc64le"
@@ -679,10 +679,10 @@
       "evra": "1.6.7-5.fc44.ppc64le"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libldb": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "libluksmeta": {
       "evra": "10-2.fc44.ppc64le"
@@ -691,16 +691,16 @@
       "evra": "1.13.3-1.fc44.ppc64le"
     },
     "libmd": {
-      "evra": "1.1.0-9.fc44.ppc64le"
+      "evra": "1.2.0-1.fc44.ppc64le"
     },
     "libmnl": {
       "evra": "1.0.5-9.fc44.ppc64le"
     },
     "libmodulemd": {
-      "evra": "2.15.2-7.fc44.ppc64le"
+      "evra": "2.15.3-1.fc44.ppc64le"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libndp": {
       "evra": "1.9-5.fc44.ppc64le"
@@ -715,13 +715,13 @@
       "evra": "1.0.1-32.fc44.ppc64le"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc44.ppc64le"
+      "evra": "1:2.8.7-6.fc44.ppc64le"
     },
     "libnftnl": {
       "evra": "1.3.1-2.fc44.ppc64le"
     },
     "libnghttp2": {
-      "evra": "1.68.0-3.fc44.ppc64le"
+      "evra": "1.68.0-4.fc44.ppc64le"
     },
     "libnl3": {
       "evra": "3.12.0-3.fc44.ppc64le"
@@ -763,10 +763,10 @@
       "evra": "2.17.15-10.fc44.noarch"
     },
     "librtas": {
-      "evra": "2.0.6-6.fc44.ppc64le"
+      "evra": "2.0.7-1.fc44.ppc64le"
     },
     "libseccomp": {
-      "evra": "2.6.0-3.fc44.ppc64le"
+      "evra": "2.6.1-2.fc44.ppc64le"
     },
     "libselinux": {
       "evra": "3.10-1.fc44.ppc64le"
@@ -787,31 +787,31 @@
       "evra": "4.9.1-3.fc44.ppc64le"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libsmbclient": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "libsolv": {
-      "evra": "0.7.37-2.fc44.ppc64le"
+      "evra": "0.7.39-1.fc44.ppc64le"
     },
     "libss": {
       "evra": "1.47.3-4.fc44.ppc64le"
     },
     "libsss_certmap": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "libsss_idmap": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "libsss_nss_idmap": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "libsss_sudo": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "libstdc++": {
-      "evra": "16.0.1-0.10.fc44.ppc64le"
+      "evra": "16.1.1-2.fc44.ppc64le"
     },
     "libtalloc": {
       "evra": "2.4.4-1.fc44.ppc64le"
@@ -829,7 +829,7 @@
       "evra": "0.17.1-4.fc44.ppc64le"
     },
     "libtextstyle": {
-      "evra": "0.26-4.fc44.ppc64le"
+      "evra": "0.26-5.fc44.ppc64le"
     },
     "libtirpc": {
       "evra": "1.3.7-2.fc44.ppc64le"
@@ -841,13 +841,13 @@
       "evra": "1.1-11.fc44.ppc64le"
     },
     "libusb1": {
-      "evra": "1.0.29-5.fc44.ppc64le"
+      "evra": "1.0.30-1.fc44.ppc64le"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "libuv": {
-      "evra": "1:1.51.0-3.fc44.ppc64le"
+      "evra": "1:1.52.1-2.fc44.ppc64le"
     },
     "libverto": {
       "evra": "0.3.2-12.fc44.ppc64le"
@@ -856,7 +856,7 @@
       "evra": "0.3.2-12.fc44.ppc64le"
     },
     "libwbclient": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "libxcrypt": {
       "evra": "4.5.2-3.fc44.ppc64le"
@@ -865,7 +865,7 @@
       "evra": "2.12.10-6.fc44.ppc64le"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc44.ppc64le"
+      "evra": "0.3.28-1.fc44.ppc64le"
     },
     "libyaml": {
       "evra": "0.2.5-18.fc44.ppc64le"
@@ -874,10 +874,10 @@
       "evra": "1.5.7-5.fc44.ppc64le"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.34-2.fc44.ppc64le"
@@ -907,25 +907,25 @@
       "evra": "2.10-16.fc44.ppc64le"
     },
     "makedumpfile": {
-      "evra": "1.7.8-2.fc44.ppc64le"
+      "evra": "1.7.9-1.fc44.ppc64le"
     },
     "mdadm": {
       "evra": "4.3-11.fc44.ppc64le"
     },
     "moby-engine": {
-      "evra": "29.4.1-1.fc44.ppc64le"
+      "evra": "29.6.0-1.fc44.ppc64le"
     },
     "moby-filesystem": {
-      "evra": "29.4.1-1.fc44.noarch"
+      "evra": "29.6.0-1.fc44.noarch"
     },
     "mpfr": {
       "evra": "4.2.2-3.fc44.ppc64le"
     },
     "nano": {
-      "evra": "8.7.1-1.fc44.ppc64le"
+      "evra": "8.7.1-2.fc44.ppc64le"
     },
     "nano-default-editor": {
-      "evra": "8.7.1-1.fc44.noarch"
+      "evra": "8.7.1-2.fc44.noarch"
     },
     "ncurses": {
       "evra": "6.6-1.fc44.ppc64le"
@@ -949,16 +949,16 @@
       "evra": "0.52.25-6.fc44.ppc64le"
     },
     "nfs-client-utils": {
-      "evra": "1:2.8.7-1.fc44.ppc64le"
+      "evra": "1:2.8.7-6.fc44.ppc64le"
     },
     "nfs-common-utils": {
-      "evra": "1:2.8.7-1.fc44.ppc64le"
+      "evra": "1:2.8.7-6.fc44.ppc64le"
     },
     "nfsv3-client-utils": {
-      "evra": "1:2.8.7-1.fc44.ppc64le"
+      "evra": "1:2.8.7-6.fc44.ppc64le"
     },
     "nfsv4-client-utils": {
-      "evra": "1:2.8.7-1.fc44.ppc64le"
+      "evra": "1:2.8.7-6.fc44.ppc64le"
     },
     "nftables": {
       "evra": "1:1.1.6-2.fc44.ppc64le"
@@ -991,7 +991,7 @@
       "evra": "0.5-50.20251104git.fc44.ppc64le"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "nvme-cli": {
       "evra": "2.16-2.fc44.ppc64le"
@@ -1003,58 +1003,58 @@
       "evra": "2.6.13-1.fc44.ppc64le"
     },
     "openssh": {
-      "evra": "10.2p1-9.fc44.ppc64le"
+      "evra": "10.2p1-13.fc44.ppc64le"
     },
     "openssh-clients": {
-      "evra": "10.2p1-9.fc44.ppc64le"
+      "evra": "10.2p1-13.fc44.ppc64le"
     },
     "openssh-server": {
-      "evra": "10.2p1-9.fc44.ppc64le"
+      "evra": "10.2p1-13.fc44.ppc64le"
     },
     "openssl": {
-      "evra": "1:3.5.5-2.fc44.ppc64le"
+      "evra": "1:3.5.7-2.fc44.ppc64le"
     },
     "openssl-libs": {
-      "evra": "1:3.5.5-2.fc44.ppc64le"
+      "evra": "1:3.5.7-2.fc44.ppc64le"
     },
     "os-prober": {
       "evra": "1.81-11.fc44.ppc64le"
     },
     "ostree": {
-      "evra": "2026.1-1.fc44.ppc64le"
+      "evra": "2026.2-1.fc44.ppc64le"
     },
     "ostree-grub2": {
-      "evra": "2026.1-1.fc44.ppc64le"
+      "evra": "2026.2-1.fc44.ppc64le"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc44.ppc64le"
+      "evra": "2026.2-1.fc44.ppc64le"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc44.ppc64le"
+      "evra": "0.26.4-1.fc44.ppc64le"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc44.ppc64le"
+      "evra": "0.26.4-1.fc44.ppc64le"
     },
     "pam": {
-      "evra": "1.7.2-1.fc44.ppc64le"
+      "evra": "1.7.2-2.fc44.ppc64le"
     },
     "pam-libs": {
-      "evra": "1.7.2-1.fc44.ppc64le"
+      "evra": "1.7.2-2.fc44.ppc64le"
     },
     "passim-libs": {
       "evra": "0.1.11-1.fc44.ppc64le"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc44.ppc64le"
+      "evra": "0^20260716.g090d739-2.fc44.ppc64le"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
+      "evra": "0^20260716.g090d739-2.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-3.fc44.ppc64le"
+      "evra": "3.15.0-1.fc44.ppc64le"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-3.fc44.ppc64le"
+      "evra": "3.15.0-1.fc44.ppc64le"
     },
     "pcre2": {
       "evra": "10.47-1.fc44.1.ppc64le"
@@ -1075,13 +1075,13 @@
       "evra": "2.5.1-1.fc44.ppc64le"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc44.ppc64le"
+      "evra": "5:5.8.4-1.fc44.ppc64le"
     },
     "podman-sequoia": {
-      "evra": "0.3.2-1.fc44.ppc64le"
+      "evra": "0.3.2-2.fc44.ppc64le"
     },
     "policycoreutils": {
-      "evra": "3.10-1.fc44.ppc64le"
+      "evra": "3.10-4.fc44.ppc64le"
     },
     "polkit": {
       "evra": "127-2.fc44.2.ppc64le"
@@ -1111,7 +1111,7 @@
       "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
       "evra": "2:10.2.2-1.fc44.ppc64le"
@@ -1123,7 +1123,7 @@
       "evra": "8.3-4.fc44.ppc64le"
     },
     "rpcbind": {
-      "evra": "1.2.8-1.fc44.ppc64le"
+      "evra": "1.2.9-2.fc44.ppc64le"
     },
     "rpm": {
       "evra": "6.0.1-2.fc44.ppc64le"
@@ -1132,34 +1132,34 @@
       "evra": "6.0.1-2.fc44.ppc64le"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc44.ppc64le"
+      "evra": "2026.2-1.fc44.ppc64le"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc44.ppc64le"
+      "evra": "2026.2-1.fc44.ppc64le"
     },
     "rpm-plugin-selinux": {
       "evra": "6.0.1-2.fc44.ppc64le"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc44.ppc64le"
+      "evra": "1.10.2-4.fc44.ppc64le"
     },
     "rsync": {
-      "evra": "3.4.1-6.fc44.ppc64le"
+      "evra": "3.4.4-1.fc44.ppc64le"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc44.ppc64le"
+      "evra": "2:1.5.0-2.fc44.ppc64le"
     },
     "samba-client-libs": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "samba-common": {
-      "evra": "2:4.24.1-1.fc44.noarch"
+      "evra": "2:4.24.4-1.fc44.noarch"
     },
     "samba-core-libs": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "samba-ndr-libs": {
-      "evra": "2:4.24.1-1.fc44.ppc64le"
+      "evra": "2:4.24.4-1.fc44.ppc64le"
     },
     "sdbus-cpp": {
       "evra": "2.2.1-2.fc44.ppc64le"
@@ -1168,10 +1168,10 @@
       "evra": "4.9-7.fc44.ppc64le"
     },
     "selinux-policy": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "servicelog": {
       "evra": "1.1.16-10.fc44.ppc64le"
@@ -1180,16 +1180,16 @@
       "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-8.fc44.ppc64le"
+      "evra": "1.48-10.fc44.ppc64le"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-8.fc44.ppc64le"
+      "evra": "1.48-10.fc44.ppc64le"
     },
     "shadow-utils": {
-      "evra": "2:4.19.0-6.fc44.ppc64le"
+      "evra": "2:4.19.0-7.fc44.ppc64le"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.19.0-6.fc44.ppc64le"
+      "evra": "2:4.19.0-7.fc44.ppc64le"
     },
     "shared-mime-info": {
       "evra": "2.4-3.fc44.ppc64le"
@@ -1207,7 +1207,7 @@
       "evra": "1.2.2-4.fc44.ppc64le"
     },
     "socat": {
-      "evra": "1.8.1.0-2.fc44.ppc64le"
+      "evra": "1.8.1.1-1.fc44.ppc64le"
     },
     "sqlite-libs": {
       "evra": "3.51.2-1.fc44.ppc64le"
@@ -1216,61 +1216,61 @@
       "evra": "4.6.1-8.fc44.ppc64le"
     },
     "sssd-ad": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-client": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-common": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-common-pac": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-ipa": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-krb5": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-krb5-common": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-ldap": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.13.0-1.fc44.ppc64le"
+      "evra": "2.13.1-2.fc44.ppc64le"
     },
     "stalld": {
-      "evra": "1.26.3-2.fc44.ppc64le"
+      "evra": "1.28.1-1.fc44.ppc64le"
     },
     "sudo": {
       "evra": "1.9.17-8.p2.fc44.ppc64le"
     },
     "systemd": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-container": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-libs": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-pam": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-resolved": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-shared": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-sysusers": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "systemd-udev": {
-      "evra": "259.5-1.fc44.ppc64le"
+      "evra": "259.7-1.fc44.ppc64le"
     },
     "tar": {
       "evra": "2:1.35-8.fc44.ppc64le"
@@ -1294,31 +1294,31 @@
       "evra": "4.1.3-9.fc44.ppc64le"
     },
     "tzdata": {
-      "evra": "2026a-1.fc44.noarch"
+      "evra": "2026b-1.fc44.noarch"
     },
     "userspace-rcu": {
       "evra": "0.15.6-1.fc44.ppc64le"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc44.ppc64le"
+      "evra": "2.41.5-1.fc44.ppc64le"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc44.noarch"
+      "evra": "2:9.2.782-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc44.ppc64le"
+      "evra": "2:9.2.782-1.fc44.ppc64le"
     },
     "which": {
-      "evra": "2.23-4.fc44.ppc64le"
+      "evra": "2.25-1.fc44.ppc64le"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-3.fc44.ppc64le"
+      "evra": "1.0.20260223-1.fc44.ppc64le"
     },
     "xfsprogs": {
-      "evra": "6.18.0-2.fc44.ppc64le"
+      "evra": "7.0.1-2.fc44.ppc64le"
     },
     "xxhash-libs": {
       "evra": "0.8.3-4.fc44.ppc64le"
@@ -1328,9 +1328,6 @@
     },
     "xz-libs": {
       "evra": "1:5.8.2-2.fc44.ppc64le"
-    },
-    "yajl": {
-      "evra": "2.1.0-40.fc44.ppc64le"
     },
     "zchunk-libs": {
       "evra": "1.5.1-4.fc44.ppc64le"
@@ -1349,6 +1346,6 @@
     }
   },
   "metadata": {
-    "generated": "2026-05-01T00:00:00Z"
+    "generated": "2026-07-20T00:00:00Z"
   }
 }

--- a/manifest-lock.s390x.json
+++ b/manifest-lock.s390x.json
@@ -1,25 +1,25 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.56.0-1.fc44.s390x"
+      "evra": "1:1.56.1-2.fc44.s390x"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.56.0-1.fc44.s390x"
+      "evra": "1:1.56.1-2.fc44.s390x"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.56.0-1.fc44.s390x"
+      "evra": "1:1.56.1-2.fc44.s390x"
     },
     "NetworkManager-team": {
-      "evra": "1:1.56.0-1.fc44.s390x"
+      "evra": "1:1.56.1-2.fc44.s390x"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.56.0-1.fc44.s390x"
+      "evra": "1:1.56.1-2.fc44.s390x"
     },
     "aardvark-dns": {
       "evra": "2:1.17.1-1.fc44.s390x"
     },
     "acl": {
-      "evra": "2.3.2-6.fc44.s390x"
+      "evra": "2.4.0-1.fc44.s390x"
     },
     "adcli": {
       "evra": "0.9.3.1-5.fc44.s390x"
@@ -28,19 +28,19 @@
       "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc44.s390x"
+      "evra": "5.10.0-7.fc44.s390x"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc44.s390x"
+      "evra": "5.10.0-7.fc44.s390x"
     },
     "alternatives": {
       "evra": "1.33-5.fc44.s390x"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-8.fc44.s390x"
+      "evra": "2.6.0-1.fc44.s390x"
     },
     "audit": {
       "evra": "4.1.4-1.fc44.s390x"
@@ -67,22 +67,22 @@
       "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc44.s390x"
+      "evra": "32:9.18.50-1.fc44.s390x"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc44.s390x"
+      "evra": "32:9.18.50-1.fc44.s390x"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc44.s390x"
+      "evra": "1.16.3-1.fc44.s390x"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc44.s390x"
+      "evra": "0.2.35-1.fc44.s390x"
     },
     "bsdtar": {
       "evra": "3.8.7-1.fc44.s390x"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc44.s390x"
+      "evra": "7.0-1.fc44.s390x"
     },
     "bubblewrap": {
       "evra": "0.11.0-4.fc44.s390x"
@@ -94,7 +94,7 @@
       "evra": "1.0.8-23.fc44.s390x"
     },
     "c-ares": {
-      "evra": "1.34.6-3.fc44.s390x"
+      "evra": "1.34.8-1.fc44.s390x"
     },
     "ca-certificates": {
       "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
@@ -106,7 +106,7 @@
       "evra": "4.8-5.fc44.s390x"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc44.s390x"
+      "evra": "7.6-2.fc44.s390x"
     },
     "clevis": {
       "evra": "21-14.fc44.s390x"
@@ -148,10 +148,10 @@
       "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc44.noarch"
+      "evra": "4:2.250.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.2.3-1.fc44.s390x"
+      "evra": "2.3.3-1.fc44.s390x"
     },
     "containers-common": {
       "evra": "5:0.67.0-1.fc44.noarch"
@@ -160,31 +160,31 @@
       "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc44.s390x"
+      "evra": "0.26.0-2.fc44.s390x"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc44.s390x"
+      "evra": "0.26.0-2.fc44.s390x"
     },
     "coreutils": {
-      "evra": "9.10-3.fc44.s390x"
+      "evra": "9.10-4.fc44.s390x"
     },
     "coreutils-common": {
-      "evra": "9.10-3.fc44.s390x"
+      "evra": "9.10-4.fc44.s390x"
     },
     "cpio": {
       "evra": "2.15-9.fc44.s390x"
     },
     "cracklib": {
-      "evra": "2.9.11-10.fc44.s390x"
+      "evra": "2.10.3-1.fc44.s390x"
     },
     "criu": {
-      "evra": "4.2-13.fc44.s390x"
+      "evra": "4.2-21.fc44.s390x"
     },
     "criu-libs": {
-      "evra": "4.2-13.fc44.s390x"
+      "evra": "4.2-21.fc44.s390x"
     },
     "crun": {
-      "evra": "1.27.1-1.fc44.s390x"
+      "evra": "1.28-1.fc44.s390x"
     },
     "crypto-policies": {
       "evra": "20251128-3.git19878fe.fc44.noarch"
@@ -235,31 +235,31 @@
       "evra": "0.13.1-1.fc44.s390x"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.3.1-3.fc44.s390x"
+      "evra": "1.3.3-1.fc44.s390x"
     },
     "diffutils": {
       "evra": "3.12-5.fc44.s390x"
     },
     "dnf5": {
-      "evra": "5.4.2.0-1.fc44.s390x"
+      "evra": "5.4.2.1-1.fc44.s390x"
     },
     "dnsmasq": {
-      "evra": "2.92-4.fc44.s390x"
+      "evra": "2.92rel2-9.fc44.s390x"
     },
     "docker-cli": {
-      "evra": "29.4.1-1.fc44.s390x"
+      "evra": "29.6.0-1.fc44.s390x"
     },
     "dosfstools": {
       "evra": "4.2-18.fc44.s390x"
     },
     "dracut": {
-      "evra": "108-6.fc44.s390x"
+      "evra": "108-7.fc44.s390x"
     },
     "dracut-network": {
-      "evra": "108-6.fc44.s390x"
+      "evra": "108-7.fc44.s390x"
     },
     "dracut-squash": {
-      "evra": "108-6.fc44.s390x"
+      "evra": "108-7.fc44.s390x"
     },
     "duktape": {
       "evra": "2.7.0-11.fc44.s390x"
@@ -280,22 +280,22 @@
       "evra": "0.195-1.fc44.s390x"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc44.s390x"
+      "evra": "2:7.1-1.fc44.s390x"
     },
     "expat": {
-      "evra": "2.7.3-2.fc44.s390x"
+      "evra": "2.8.1-1.fc44.s390x"
     },
     "fedora-gpg-keys": {
       "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-repos": {
       "evra": "44-1.noarch"
@@ -316,7 +316,7 @@
       "evra": "1:4.10.0-7.fc44.s390x"
     },
     "flatpak-session-helper": {
-      "evra": "1.17.6-1.fc44.s390x"
+      "evra": "1.18.0-1.fc44.s390x"
     },
     "fmt": {
       "evra": "11.2.0-4.fc44.s390x"
@@ -331,7 +331,7 @@
       "evra": "1.16-2.fc44.s390x"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-3.fc44.s390x"
+      "evra": "3.7.6-1.fc44.s390x"
     },
     "fuse3": {
       "evra": "3.18.2-1.fc44.s390x"
@@ -340,7 +340,7 @@
       "evra": "3.18.2-1.fc44.s390x"
     },
     "fwupd": {
-      "evra": "2.1.1-1.fc44.s390x"
+      "evra": "2.1.3-1.fc44.s390x"
     },
     "gawk": {
       "evra": "5.3.2-3.fc44.s390x"
@@ -355,22 +355,22 @@
       "evra": "1.0.10-5.fc44.s390x"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc44.s390x"
+      "evra": "2.55.0-1.fc44.s390x"
     },
     "glib2": {
-      "evra": "2.88.0-1.fc44.s390x"
+      "evra": "2.88.2-1.fc44.s390x"
     },
     "glibc": {
-      "evra": "2.43-3.fc44.s390x"
+      "evra": "2.43-7.fc44.s390x"
     },
     "glibc-common": {
-      "evra": "2.43-3.fc44.s390x"
+      "evra": "2.43-7.fc44.s390x"
     },
     "glibc-gconv-extra": {
-      "evra": "2.43-3.fc44.s390x"
+      "evra": "2.43-7.fc44.s390x"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.43-3.fc44.s390x"
+      "evra": "2.43-7.fc44.s390x"
     },
     "gmp": {
       "evra": "1:6.3.0-5.fc44.s390x"
@@ -379,28 +379,28 @@
       "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-7.fc44.s390x"
+      "evra": "2.4.9-16.fc44.s390x"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc44.s390x"
+      "evra": "3.8.13-1.fc44.s390x"
     },
     "gpgme": {
-      "evra": "2.0.1-3.fc44.s390x"
+      "evra": "2.0.1-5.fc44.s390x"
     },
     "grep": {
       "evra": "3.12-3.fc44.s390x"
@@ -415,7 +415,7 @@
       "evra": "3.25-4.fc44.s390x"
     },
     "hwdata": {
-      "evra": "0.406-1.fc44.noarch"
+      "evra": "0.409-1.fc44.noarch"
     },
     "ignition": {
       "evra": "2.26.0-4.fc44.s390x"
@@ -427,7 +427,7 @@
       "evra": "62-2.fc44.s390x"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "ipcalc": {
       "evra": "1.0.3-13.fc44.s390x"
@@ -490,16 +490,16 @@
       "evra": "1.0.61-1.fc44.s390x"
     },
     "kernel": {
-      "evra": "6.19.14-300.fc44.s390x"
+      "evra": "7.1.4-200.fc44.s390x"
     },
     "kernel-core": {
-      "evra": "6.19.14-300.fc44.s390x"
+      "evra": "7.1.4-200.fc44.s390x"
     },
     "kernel-modules": {
-      "evra": "6.19.14-300.fc44.s390x"
+      "evra": "7.1.4-200.fc44.s390x"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-300.fc44.s390x"
+      "evra": "7.1.4-200.fc44.s390x"
     },
     "kexec-tools": {
       "evra": "2.0.32-3.fc44.s390x"
@@ -520,13 +520,13 @@
       "evra": "0.13.1-1.fc44.s390x"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc44.s390x"
+      "evra": "1.22.2-4.fc44.s390x"
     },
     "less": {
-      "evra": "692-5.fc44.s390x"
+      "evra": "704-2.fc44.s390x"
     },
     "libacl": {
-      "evra": "2.3.2-6.fc44.s390x"
+      "evra": "2.4.0-1.fc44.s390x"
     },
     "libaio": {
       "evra": "0.3.111-23.fc44.s390x"
@@ -538,16 +538,16 @@
       "evra": "2.5.7-5.fc44.s390x"
     },
     "libattr": {
-      "evra": "2.5.2-8.fc44.s390x"
+      "evra": "2.6.0-1.fc44.s390x"
     },
     "libbasicobjects": {
       "evra": "0.1.1-61.fc44.s390x"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libbpf": {
-      "evra": "2:1.6.3-1.fc44.s390x"
+      "evra": "2:1.6.3-2.fc44.s390x"
     },
     "libbsd": {
       "evra": "0.12.2-7.fc44.s390x"
@@ -577,19 +577,19 @@
       "evra": "0.5.0-61.fc44.s390x"
     },
     "libdnf5": {
-      "evra": "5.4.2.0-1.fc44.s390x"
+      "evra": "5.4.2.1-1.fc44.s390x"
     },
     "libdnf5-cli": {
-      "evra": "5.4.2.0-1.fc44.s390x"
+      "evra": "5.4.2.1-1.fc44.s390x"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc44.s390x"
+      "evra": "2.4.134-1.fc44.s390x"
     },
     "libeconf": {
       "evra": "0.7.9-3.fc44.s390x"
     },
     "libedit": {
-      "evra": "3.1-58.20251016cvs.fc44.s390x"
+      "evra": "3.1-59.20260512cvs.fc44.s390x"
     },
     "libev": {
       "evra": "4.33-15.fc44.s390x"
@@ -598,7 +598,7 @@
       "evra": "2.1.12-17.fc44.s390x"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libffi": {
       "evra": "3.5.2-2.fc44.s390x"
@@ -607,7 +607,7 @@
       "evra": "1.16.0-5.fc44.s390x"
     },
     "libgcc": {
-      "evra": "16.0.1-0.10.fc44.s390x"
+      "evra": "16.1.1-2.fc44.s390x"
     },
     "libgcrypt": {
       "evra": "1.12.2-1.fc44.s390x"
@@ -619,7 +619,7 @@
       "evra": "61.0-2.fc44.s390x"
     },
     "libicu": {
-      "evra": "77.1-2.fc44.s390x"
+      "evra": "77.1-3.fc44.s390x"
     },
     "libidn2": {
       "evra": "2.3.8-3.fc44.s390x"
@@ -628,7 +628,7 @@
       "evra": "1.3.1-61.fc44.s390x"
     },
     "libipa_hbac": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "libjcat": {
       "evra": "0.2.6-1.fc44.s390x"
@@ -649,10 +649,10 @@
       "evra": "1.6.7-5.fc44.s390x"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libldb": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "libluksmeta": {
       "evra": "10-2.fc44.s390x"
@@ -661,16 +661,16 @@
       "evra": "1.13.3-1.fc44.s390x"
     },
     "libmd": {
-      "evra": "1.1.0-9.fc44.s390x"
+      "evra": "1.2.0-1.fc44.s390x"
     },
     "libmnl": {
       "evra": "1.0.5-9.fc44.s390x"
     },
     "libmodulemd": {
-      "evra": "2.15.2-7.fc44.s390x"
+      "evra": "2.15.3-1.fc44.s390x"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libndp": {
       "evra": "1.9-5.fc44.s390x"
@@ -685,13 +685,13 @@
       "evra": "1.0.1-32.fc44.s390x"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc44.s390x"
+      "evra": "1:2.8.7-6.fc44.s390x"
     },
     "libnftnl": {
       "evra": "1.3.1-2.fc44.s390x"
     },
     "libnghttp2": {
-      "evra": "1.68.0-3.fc44.s390x"
+      "evra": "1.68.0-4.fc44.s390x"
     },
     "libnl3": {
       "evra": "3.12.0-3.fc44.s390x"
@@ -733,7 +733,7 @@
       "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-3.fc44.s390x"
+      "evra": "2.6.1-2.fc44.s390x"
     },
     "libselinux": {
       "evra": "3.10-1.fc44.s390x"
@@ -751,31 +751,31 @@
       "evra": "4.9.1-3.fc44.s390x"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libsmbclient": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "libsolv": {
-      "evra": "0.7.37-2.fc44.s390x"
+      "evra": "0.7.39-1.fc44.s390x"
     },
     "libss": {
       "evra": "1.47.3-4.fc44.s390x"
     },
     "libsss_certmap": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "libsss_idmap": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "libsss_nss_idmap": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "libsss_sudo": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "libstdc++": {
-      "evra": "16.0.1-0.10.fc44.s390x"
+      "evra": "16.1.1-2.fc44.s390x"
     },
     "libtalloc": {
       "evra": "2.4.4-1.fc44.s390x"
@@ -802,13 +802,13 @@
       "evra": "1.1-11.fc44.s390x"
     },
     "libusb1": {
-      "evra": "1.0.29-5.fc44.s390x"
+      "evra": "1.0.30-1.fc44.s390x"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "libuv": {
-      "evra": "1:1.51.0-3.fc44.s390x"
+      "evra": "1:1.52.1-2.fc44.s390x"
     },
     "libverto": {
       "evra": "0.3.2-12.fc44.s390x"
@@ -817,7 +817,7 @@
       "evra": "0.3.2-12.fc44.s390x"
     },
     "libwbclient": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "libxcrypt": {
       "evra": "4.5.2-3.fc44.s390x"
@@ -826,7 +826,7 @@
       "evra": "2.12.10-6.fc44.s390x"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc44.s390x"
+      "evra": "0.3.28-1.fc44.s390x"
     },
     "libyaml": {
       "evra": "0.2.5-18.fc44.s390x"
@@ -835,10 +835,10 @@
       "evra": "1.5.7-5.fc44.s390x"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "lmdb-libs": {
       "evra": "0.9.34-2.fc44.s390x"
@@ -868,25 +868,25 @@
       "evra": "2.10-16.fc44.s390x"
     },
     "makedumpfile": {
-      "evra": "1.7.8-2.fc44.s390x"
+      "evra": "1.7.9-1.fc44.s390x"
     },
     "mdadm": {
       "evra": "4.3-11.fc44.s390x"
     },
     "moby-engine": {
-      "evra": "29.4.1-1.fc44.s390x"
+      "evra": "29.6.0-1.fc44.s390x"
     },
     "moby-filesystem": {
-      "evra": "29.4.1-1.fc44.noarch"
+      "evra": "29.6.0-1.fc44.noarch"
     },
     "mpfr": {
       "evra": "4.2.2-3.fc44.s390x"
     },
     "nano": {
-      "evra": "8.7.1-1.fc44.s390x"
+      "evra": "8.7.1-2.fc44.s390x"
     },
     "nano-default-editor": {
-      "evra": "8.7.1-1.fc44.noarch"
+      "evra": "8.7.1-2.fc44.noarch"
     },
     "ncurses": {
       "evra": "6.6-1.fc44.s390x"
@@ -910,16 +910,16 @@
       "evra": "0.52.25-6.fc44.s390x"
     },
     "nfs-client-utils": {
-      "evra": "1:2.8.7-1.fc44.s390x"
+      "evra": "1:2.8.7-6.fc44.s390x"
     },
     "nfs-common-utils": {
-      "evra": "1:2.8.7-1.fc44.s390x"
+      "evra": "1:2.8.7-6.fc44.s390x"
     },
     "nfsv3-client-utils": {
-      "evra": "1:2.8.7-1.fc44.s390x"
+      "evra": "1:2.8.7-6.fc44.s390x"
     },
     "nfsv4-client-utils": {
-      "evra": "1:2.8.7-1.fc44.s390x"
+      "evra": "1:2.8.7-6.fc44.s390x"
     },
     "nftables": {
       "evra": "1:1.1.6-2.fc44.s390x"
@@ -943,7 +943,7 @@
       "evra": "2.23.0-9.fc44.s390x"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "nvme-cli": {
       "evra": "2.16-2.fc44.s390x"
@@ -955,52 +955,52 @@
       "evra": "2.6.13-1.fc44.s390x"
     },
     "openssh": {
-      "evra": "10.2p1-9.fc44.s390x"
+      "evra": "10.2p1-13.fc44.s390x"
     },
     "openssh-clients": {
-      "evra": "10.2p1-9.fc44.s390x"
+      "evra": "10.2p1-13.fc44.s390x"
     },
     "openssh-server": {
-      "evra": "10.2p1-9.fc44.s390x"
+      "evra": "10.2p1-13.fc44.s390x"
     },
     "openssl": {
-      "evra": "1:3.5.5-2.fc44.s390x"
+      "evra": "1:3.5.7-2.fc44.s390x"
     },
     "openssl-libs": {
-      "evra": "1:3.5.5-2.fc44.s390x"
+      "evra": "1:3.5.7-2.fc44.s390x"
     },
     "ostree": {
-      "evra": "2026.1-1.fc44.s390x"
+      "evra": "2026.2-1.fc44.s390x"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc44.s390x"
+      "evra": "2026.2-1.fc44.s390x"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc44.s390x"
+      "evra": "0.26.4-1.fc44.s390x"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc44.s390x"
+      "evra": "0.26.4-1.fc44.s390x"
     },
     "pam": {
-      "evra": "1.7.2-1.fc44.s390x"
+      "evra": "1.7.2-2.fc44.s390x"
     },
     "pam-libs": {
-      "evra": "1.7.2-1.fc44.s390x"
+      "evra": "1.7.2-2.fc44.s390x"
     },
     "passim-libs": {
       "evra": "0.1.11-1.fc44.s390x"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc44.s390x"
+      "evra": "0^20260716.g090d739-2.fc44.s390x"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
+      "evra": "0^20260716.g090d739-2.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-3.fc44.s390x"
+      "evra": "3.15.0-1.fc44.s390x"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-3.fc44.s390x"
+      "evra": "3.15.0-1.fc44.s390x"
     },
     "pcre2": {
       "evra": "10.47-1.fc44.1.s390x"
@@ -1021,13 +1021,13 @@
       "evra": "2.5.1-1.fc44.s390x"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc44.s390x"
+      "evra": "5:5.8.4-1.fc44.s390x"
     },
     "podman-sequoia": {
-      "evra": "0.3.2-1.fc44.s390x"
+      "evra": "0.3.2-2.fc44.s390x"
     },
     "policycoreutils": {
-      "evra": "3.10-1.fc44.s390x"
+      "evra": "3.10-4.fc44.s390x"
     },
     "polkit": {
       "evra": "127-2.fc44.2.s390x"
@@ -1051,7 +1051,7 @@
       "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "qemu-user-static-x86": {
       "evra": "2:10.2.2-1.fc44.s390x"
@@ -1063,7 +1063,7 @@
       "evra": "8.3-4.fc44.s390x"
     },
     "rpcbind": {
-      "evra": "1.2.8-1.fc44.s390x"
+      "evra": "1.2.9-2.fc44.s390x"
     },
     "rpm": {
       "evra": "6.0.1-2.fc44.s390x"
@@ -1072,37 +1072,37 @@
       "evra": "6.0.1-2.fc44.s390x"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc44.s390x"
+      "evra": "2026.2-1.fc44.s390x"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc44.s390x"
+      "evra": "2026.2-1.fc44.s390x"
     },
     "rpm-plugin-selinux": {
       "evra": "6.0.1-2.fc44.s390x"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc44.s390x"
+      "evra": "1.10.2-4.fc44.s390x"
     },
     "rsync": {
-      "evra": "3.4.1-6.fc44.s390x"
+      "evra": "3.4.4-1.fc44.s390x"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc44.s390x"
+      "evra": "2:1.5.0-2.fc44.s390x"
     },
     "s390utils-core": {
-      "evra": "2:2.40.0-3.fc44.s390x"
+      "evra": "2:2.41.0-2.fc44.s390x"
     },
     "samba-client-libs": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "samba-common": {
-      "evra": "2:4.24.1-1.fc44.noarch"
+      "evra": "2:4.24.4-1.fc44.noarch"
     },
     "samba-core-libs": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "samba-ndr-libs": {
-      "evra": "2:4.24.1-1.fc44.s390x"
+      "evra": "2:4.24.4-1.fc44.s390x"
     },
     "sdbus-cpp": {
       "evra": "2.2.1-2.fc44.s390x"
@@ -1111,25 +1111,25 @@
       "evra": "4.9-7.fc44.s390x"
     },
     "selinux-policy": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "setup": {
       "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-8.fc44.s390x"
+      "evra": "1.48-10.fc44.s390x"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-8.fc44.s390x"
+      "evra": "1.48-10.fc44.s390x"
     },
     "shadow-utils": {
-      "evra": "2:4.19.0-6.fc44.s390x"
+      "evra": "2:4.19.0-7.fc44.s390x"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.19.0-6.fc44.s390x"
+      "evra": "2:4.19.0-7.fc44.s390x"
     },
     "shared-mime-info": {
       "evra": "2.4-3.fc44.s390x"
@@ -1147,7 +1147,7 @@
       "evra": "1.2.2-4.fc44.s390x"
     },
     "socat": {
-      "evra": "1.8.1.0-2.fc44.s390x"
+      "evra": "1.8.1.1-1.fc44.s390x"
     },
     "sqlite-libs": {
       "evra": "3.51.2-1.fc44.s390x"
@@ -1156,61 +1156,61 @@
       "evra": "4.6.1-8.fc44.s390x"
     },
     "sssd-ad": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-client": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-common": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-common-pac": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-ipa": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-krb5": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-krb5-common": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-ldap": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.13.0-1.fc44.s390x"
+      "evra": "2.13.1-2.fc44.s390x"
     },
     "stalld": {
-      "evra": "1.26.3-2.fc44.s390x"
+      "evra": "1.28.1-1.fc44.s390x"
     },
     "sudo": {
       "evra": "1.9.17-8.p2.fc44.s390x"
     },
     "systemd": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-container": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-libs": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-pam": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-resolved": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-shared": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-sysusers": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "systemd-udev": {
-      "evra": "259.5-1.fc44.s390x"
+      "evra": "259.7-1.fc44.s390x"
     },
     "tar": {
       "evra": "2:1.35-8.fc44.s390x"
@@ -1234,34 +1234,34 @@
       "evra": "4.1.3-9.fc44.s390x"
     },
     "tzdata": {
-      "evra": "2026a-1.fc44.noarch"
+      "evra": "2026b-1.fc44.noarch"
     },
     "userspace-rcu": {
       "evra": "0.15.6-1.fc44.s390x"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc44.s390x"
+      "evra": "2.41.5-1.fc44.s390x"
     },
     "veritysetup": {
       "evra": "2.8.4-1.fc44.s390x"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc44.noarch"
+      "evra": "2:9.2.782-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc44.s390x"
+      "evra": "2:9.2.782-1.fc44.s390x"
     },
     "which": {
-      "evra": "2.23-4.fc44.s390x"
+      "evra": "2.25-1.fc44.s390x"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-3.fc44.s390x"
+      "evra": "1.0.20260223-1.fc44.s390x"
     },
     "xfsprogs": {
-      "evra": "6.18.0-2.fc44.s390x"
+      "evra": "7.0.1-2.fc44.s390x"
     },
     "xxhash-libs": {
       "evra": "0.8.3-4.fc44.s390x"
@@ -1271,9 +1271,6 @@
     },
     "xz-libs": {
       "evra": "1:5.8.2-2.fc44.s390x"
-    },
-    "yajl": {
-      "evra": "2.1.0-40.fc44.s390x"
     },
     "zchunk-libs": {
       "evra": "1.5.1-4.fc44.s390x"
@@ -1292,6 +1289,6 @@
     }
   },
   "metadata": {
-    "generated": "2026-05-01T00:00:00Z"
+    "generated": "2026-07-20T00:00:00Z"
   }
 }

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,19 +1,19 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.56.0-1.fc44.x86_64"
+      "evra": "1:1.56.1-2.fc44.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.56.0-1.fc44.x86_64"
+      "evra": "1:1.56.1-2.fc44.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.56.0-1.fc44.x86_64"
+      "evra": "1:1.56.1-2.fc44.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.56.0-1.fc44.x86_64"
+      "evra": "1:1.56.1-2.fc44.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.56.0-1.fc44.x86_64"
+      "evra": "1:1.56.1-2.fc44.x86_64"
     },
     "WALinuxAgent-udev": {
       "evra": "2.15.0.1-3.fc44.noarch"
@@ -22,7 +22,7 @@
       "evra": "2:1.17.1-1.fc44.x86_64"
     },
     "acl": {
-      "evra": "2.3.2-6.fc44.x86_64"
+      "evra": "2.4.0-1.fc44.x86_64"
     },
     "adcli": {
       "evra": "0.9.3.1-5.fc44.x86_64"
@@ -31,22 +31,22 @@
       "evra": "0.9.3.1-5.fc44.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-6.fc44.x86_64"
+      "evra": "5.10.0-7.fc44.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-6.fc44.x86_64"
+      "evra": "5.10.0-7.fc44.x86_64"
     },
     "alternatives": {
       "evra": "1.33-5.fc44.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "attr": {
-      "evra": "2.5.2-8.fc44.x86_64"
+      "evra": "2.6.0-1.fc44.x86_64"
     },
     "audit": {
       "evra": "4.1.4-1.fc44.x86_64"
@@ -76,22 +76,22 @@
       "evra": "1:2.17-2.fc44.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.48-1.fc44.x86_64"
+      "evra": "32:9.18.50-1.fc44.x86_64"
     },
     "bind-utils": {
-      "evra": "32:9.18.48-1.fc44.x86_64"
+      "evra": "32:9.18.50-1.fc44.x86_64"
     },
     "bootc": {
-      "evra": "1.15.1-1.fc44.x86_64"
+      "evra": "1.16.3-1.fc44.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.33-1.fc44.x86_64"
+      "evra": "0.2.35-1.fc44.x86_64"
     },
     "bsdtar": {
       "evra": "3.8.7-1.fc44.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.19.1-1.fc44.x86_64"
+      "evra": "7.0-1.fc44.x86_64"
     },
     "bubblewrap": {
       "evra": "0.11.0-4.fc44.x86_64"
@@ -103,7 +103,7 @@
       "evra": "1.0.8-23.fc44.x86_64"
     },
     "c-ares": {
-      "evra": "1.34.6-3.fc44.x86_64"
+      "evra": "1.34.8-1.fc44.x86_64"
     },
     "ca-certificates": {
       "evra": "2025.2.80_v9.0.304-7.fc44.noarch"
@@ -115,7 +115,7 @@
       "evra": "4.8-5.fc44.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.5-1.fc44.x86_64"
+      "evra": "7.6-2.fc44.x86_64"
     },
     "clevis": {
       "evra": "21-14.fc44.x86_64"
@@ -157,10 +157,10 @@
       "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.247.0-1.fc44.noarch"
+      "evra": "4:2.250.0-1.fc44.noarch"
     },
     "containerd": {
-      "evra": "2.2.3-1.fc44.x86_64"
+      "evra": "2.3.3-1.fc44.x86_64"
     },
     "containers-common": {
       "evra": "5:0.67.0-1.fc44.noarch"
@@ -169,34 +169,34 @@
       "evra": "5:0.67.0-1.fc44.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-1.fc44.x86_64"
+      "evra": "0.26.0-2.fc44.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-1.fc44.x86_64"
+      "evra": "0.26.0-2.fc44.x86_64"
     },
     "coreutils": {
-      "evra": "9.10-3.fc44.x86_64"
+      "evra": "9.10-4.fc44.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.10-3.fc44.x86_64"
+      "evra": "9.10-4.fc44.x86_64"
     },
     "cpio": {
       "evra": "2.15-9.fc44.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.11-10.fc44.x86_64"
+      "evra": "2.10.3-1.fc44.x86_64"
     },
     "criu": {
-      "evra": "4.2-13.fc44.x86_64"
+      "evra": "4.2-21.fc44.x86_64"
     },
     "criu-libs": {
-      "evra": "4.2-13.fc44.x86_64"
+      "evra": "4.2-21.fc44.x86_64"
     },
     "crun": {
-      "evra": "1.27.1-1.fc44.x86_64"
+      "evra": "1.28-1.fc44.x86_64"
     },
     "crun-wasm": {
-      "evra": "1.27.1-1.fc44.x86_64"
+      "evra": "1.28-1.fc44.x86_64"
     },
     "crypto-policies": {
       "evra": "20251128-3.git19878fe.fc44.noarch"
@@ -247,31 +247,31 @@
       "evra": "0.13.1-1.fc44.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.3.1-3.fc44.x86_64"
+      "evra": "1.3.3-1.fc44.x86_64"
     },
     "diffutils": {
       "evra": "3.12-5.fc44.x86_64"
     },
     "dnf5": {
-      "evra": "5.4.2.0-1.fc44.x86_64"
+      "evra": "5.4.2.1-1.fc44.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.92-4.fc44.x86_64"
+      "evra": "2.92rel2-9.fc44.x86_64"
     },
     "docker-cli": {
-      "evra": "29.4.1-1.fc44.x86_64"
+      "evra": "29.6.0-1.fc44.x86_64"
     },
     "dosfstools": {
       "evra": "4.2-18.fc44.x86_64"
     },
     "dracut": {
-      "evra": "108-6.fc44.x86_64"
+      "evra": "108-7.fc44.x86_64"
     },
     "dracut-network": {
-      "evra": "108-6.fc44.x86_64"
+      "evra": "108-7.fc44.x86_64"
     },
     "dracut-squash": {
-      "evra": "108-6.fc44.x86_64"
+      "evra": "108-7.fc44.x86_64"
     },
     "duktape": {
       "evra": "2.7.0-11.fc44.x86_64"
@@ -301,22 +301,22 @@
       "evra": "0.195-1.fc44.x86_64"
     },
     "ethtool": {
-      "evra": "2:7.0-1.fc44.x86_64"
+      "evra": "2:7.1-1.fc44.x86_64"
     },
     "expat": {
-      "evra": "2.7.3-2.fc44.x86_64"
+      "evra": "2.8.1-1.fc44.x86_64"
     },
     "fedora-gpg-keys": {
       "evra": "44-1.noarch"
     },
     "fedora-release-common": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "44-17.noarch"
+      "evra": "44-18.noarch"
     },
     "fedora-repos": {
       "evra": "44-1.noarch"
@@ -337,7 +337,7 @@
       "evra": "1:4.10.0-7.fc44.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.17.6-1.fc44.x86_64"
+      "evra": "1.18.0-1.fc44.x86_64"
     },
     "fmt": {
       "evra": "11.2.0-4.fc44.x86_64"
@@ -352,7 +352,7 @@
       "evra": "1.16-2.fc44.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-3.fc44.x86_64"
+      "evra": "3.7.6-1.fc44.x86_64"
     },
     "fuse3": {
       "evra": "3.18.2-1.fc44.x86_64"
@@ -361,7 +361,7 @@
       "evra": "3.18.2-1.fc44.x86_64"
     },
     "fwupd": {
-      "evra": "2.1.1-1.fc44.x86_64"
+      "evra": "2.1.3-1.fc44.x86_64"
     },
     "gawk": {
       "evra": "5.3.2-3.fc44.x86_64"
@@ -376,31 +376,31 @@
       "evra": "1.0.10-5.fc44.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "0.26-5.fc44.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "0.26-5.fc44.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "0.26-5.fc44.x86_64"
     },
     "git-core": {
-      "evra": "2.54.0-1.fc44.x86_64"
+      "evra": "2.55.0-1.fc44.x86_64"
     },
     "glib2": {
-      "evra": "2.88.0-1.fc44.x86_64"
+      "evra": "2.88.2-1.fc44.x86_64"
     },
     "glibc": {
-      "evra": "2.43-3.fc44.x86_64"
+      "evra": "2.43-7.fc44.x86_64"
     },
     "glibc-common": {
-      "evra": "2.43-3.fc44.x86_64"
+      "evra": "2.43-7.fc44.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.43-3.fc44.x86_64"
+      "evra": "2.43-7.fc44.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.43-3.fc44.x86_64"
+      "evra": "2.43-7.fc44.x86_64"
     },
     "gmp": {
       "evra": "1:6.3.0-5.fc44.x86_64"
@@ -409,52 +409,52 @@
       "evra": "20241231-2.fc44.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-7.fc44.x86_64"
+      "evra": "2.4.9-16.fc44.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc44.x86_64"
+      "evra": "3.8.13-1.fc44.x86_64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-3.fc44.noarch"
+      "evra": "20260623.00-3.fc44.noarch"
     },
     "gpgme": {
-      "evra": "2.0.1-3.fc44.x86_64"
+      "evra": "2.0.1-5.fc44.x86_64"
     },
     "grep": {
       "evra": "3.12-3.fc44.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.12-56.fc44.noarch"
+      "evra": "1:2.12-60.fc44.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-56.fc44.x86_64"
+      "evra": "1:2.12-60.fc44.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.12-56.fc44.x86_64"
+      "evra": "1:2.12-60.fc44.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-56.fc44.noarch"
+      "evra": "1:2.12-60.fc44.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-56.fc44.x86_64"
+      "evra": "1:2.12-60.fc44.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-56.fc44.x86_64"
+      "evra": "1:2.12-60.fc44.x86_64"
     },
     "gssproxy": {
       "evra": "0.9.2-10.fc44.x86_64"
@@ -466,7 +466,7 @@
       "evra": "3.25-4.fc44.x86_64"
     },
     "hwdata": {
-      "evra": "0.406-1.fc44.noarch"
+      "evra": "0.409-1.fc44.noarch"
     },
     "ignition": {
       "evra": "2.26.0-4.fc44.x86_64"
@@ -478,7 +478,7 @@
       "evra": "62-2.fc44.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "ipcalc": {
       "evra": "1.0.3-13.fc44.x86_64"
@@ -544,16 +544,16 @@
       "evra": "1.0.61-1.fc44.x86_64"
     },
     "kernel": {
-      "evra": "6.19.14-300.fc44.x86_64"
+      "evra": "7.1.4-200.fc44.x86_64"
     },
     "kernel-core": {
-      "evra": "6.19.14-300.fc44.x86_64"
+      "evra": "7.1.4-200.fc44.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.19.14-300.fc44.x86_64"
+      "evra": "7.1.4-200.fc44.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.19.14-300.fc44.x86_64"
+      "evra": "7.1.4-200.fc44.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.32-3.fc44.x86_64"
@@ -574,13 +574,13 @@
       "evra": "0.13.1-1.fc44.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-3.fc44.x86_64"
+      "evra": "1.22.2-4.fc44.x86_64"
     },
     "less": {
-      "evra": "692-5.fc44.x86_64"
+      "evra": "704-2.fc44.x86_64"
     },
     "libacl": {
-      "evra": "2.3.2-6.fc44.x86_64"
+      "evra": "2.4.0-1.fc44.x86_64"
     },
     "libaio": {
       "evra": "0.3.111-23.fc44.x86_64"
@@ -592,16 +592,16 @@
       "evra": "2.5.7-5.fc44.x86_64"
     },
     "libattr": {
-      "evra": "2.5.2-8.fc44.x86_64"
+      "evra": "2.6.0-1.fc44.x86_64"
     },
     "libbasicobjects": {
       "evra": "0.1.1-61.fc44.x86_64"
     },
     "libblkid": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libbpf": {
-      "evra": "2:1.6.3-1.fc44.x86_64"
+      "evra": "2:1.6.3-2.fc44.x86_64"
     },
     "libbsd": {
       "evra": "0.12.2-7.fc44.x86_64"
@@ -631,19 +631,19 @@
       "evra": "0.5.0-61.fc44.x86_64"
     },
     "libdnf5": {
-      "evra": "5.4.2.0-1.fc44.x86_64"
+      "evra": "5.4.2.1-1.fc44.x86_64"
     },
     "libdnf5-cli": {
-      "evra": "5.4.2.0-1.fc44.x86_64"
+      "evra": "5.4.2.1-1.fc44.x86_64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc44.x86_64"
+      "evra": "2.4.134-1.fc44.x86_64"
     },
     "libeconf": {
       "evra": "0.7.9-3.fc44.x86_64"
     },
     "libedit": {
-      "evra": "3.1-58.20251016cvs.fc44.x86_64"
+      "evra": "3.1-59.20260512cvs.fc44.x86_64"
     },
     "libev": {
       "evra": "4.33-15.fc44.x86_64"
@@ -652,7 +652,7 @@
       "evra": "2.1.12-17.fc44.x86_64"
     },
     "libfdisk": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libffi": {
       "evra": "3.5.2-2.fc44.x86_64"
@@ -661,7 +661,7 @@
       "evra": "1.16.0-5.fc44.x86_64"
     },
     "libgcc": {
-      "evra": "16.0.1-0.10.fc44.x86_64"
+      "evra": "16.1.1-2.fc44.x86_64"
     },
     "libgcrypt": {
       "evra": "1.12.2-1.fc44.x86_64"
@@ -673,7 +673,7 @@
       "evra": "61.0-2.fc44.x86_64"
     },
     "libicu": {
-      "evra": "77.1-2.fc44.x86_64"
+      "evra": "77.1-3.fc44.x86_64"
     },
     "libidn2": {
       "evra": "2.3.8-3.fc44.x86_64"
@@ -682,7 +682,7 @@
       "evra": "1.3.1-61.fc44.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "libjcat": {
       "evra": "0.2.6-1.fc44.x86_64"
@@ -703,10 +703,10 @@
       "evra": "1.6.7-5.fc44.x86_64"
     },
     "liblastlog2": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libldb": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "libluksmeta": {
       "evra": "10-2.fc44.x86_64"
@@ -715,16 +715,16 @@
       "evra": "1.13.3-1.fc44.x86_64"
     },
     "libmd": {
-      "evra": "1.1.0-9.fc44.x86_64"
+      "evra": "1.2.0-1.fc44.x86_64"
     },
     "libmnl": {
       "evra": "1.0.5-9.fc44.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-7.fc44.x86_64"
+      "evra": "2.15.3-1.fc44.x86_64"
     },
     "libmount": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libndp": {
       "evra": "1.9-5.fc44.x86_64"
@@ -739,13 +739,13 @@
       "evra": "1.0.1-32.fc44.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.7-1.fc44.x86_64"
+      "evra": "1:2.8.7-6.fc44.x86_64"
     },
     "libnftnl": {
       "evra": "1.3.1-2.fc44.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.68.0-3.fc44.x86_64"
+      "evra": "1.68.0-4.fc44.x86_64"
     },
     "libnl3": {
       "evra": "3.12.0-3.fc44.x86_64"
@@ -787,7 +787,7 @@
       "evra": "2.17.15-10.fc44.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-3.fc44.x86_64"
+      "evra": "2.6.1-2.fc44.x86_64"
     },
     "libselinux": {
       "evra": "3.10-1.fc44.x86_64"
@@ -805,31 +805,31 @@
       "evra": "4.9.1-3.fc44.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.37-2.fc44.x86_64"
+      "evra": "0.7.39-1.fc44.x86_64"
     },
     "libss": {
       "evra": "1.47.3-4.fc44.x86_64"
     },
     "libsss_certmap": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "libstdc++": {
-      "evra": "16.0.1-0.10.fc44.x86_64"
+      "evra": "16.1.1-2.fc44.x86_64"
     },
     "libtalloc": {
       "evra": "2.4.4-1.fc44.x86_64"
@@ -847,7 +847,7 @@
       "evra": "0.17.1-4.fc44.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "0.26-5.fc44.x86_64"
     },
     "libtirpc": {
       "evra": "1.3.7-2.fc44.x86_64"
@@ -859,13 +859,13 @@
       "evra": "1.1-11.fc44.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.29-5.fc44.x86_64"
+      "evra": "1.0.30-1.fc44.x86_64"
     },
     "libuuid": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "libuv": {
-      "evra": "1:1.51.0-3.fc44.x86_64"
+      "evra": "1:1.52.1-2.fc44.x86_64"
     },
     "libverto": {
       "evra": "0.3.2-12.fc44.x86_64"
@@ -874,7 +874,7 @@
       "evra": "0.3.2-12.fc44.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "libxcrypt": {
       "evra": "4.5.2-3.fc44.x86_64"
@@ -883,7 +883,7 @@
       "evra": "2.12.10-6.fc44.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.26-1.fc44.x86_64"
+      "evra": "0.3.28-1.fc44.x86_64"
     },
     "libyaml": {
       "evra": "0.2.5-18.fc44.x86_64"
@@ -892,10 +892,10 @@
       "evra": "1.5.7-5.fc44.x86_64"
     },
     "linux-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "lld18-libs": {
       "evra": "18.1.8-8.fc43.x86_64"
@@ -931,7 +931,7 @@
       "evra": "2.10-16.fc44.x86_64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-2.fc44.x86_64"
+      "evra": "1.7.9-1.fc44.x86_64"
     },
     "mdadm": {
       "evra": "4.3-11.fc44.x86_64"
@@ -940,10 +940,10 @@
       "evra": "2:2.1-74.fc44.x86_64"
     },
     "moby-engine": {
-      "evra": "29.4.1-1.fc44.x86_64"
+      "evra": "29.6.0-1.fc44.x86_64"
     },
     "moby-filesystem": {
-      "evra": "29.4.1-1.fc44.noarch"
+      "evra": "29.6.0-1.fc44.noarch"
     },
     "mokutil": {
       "evra": "2:0.7.2-3.fc44.x86_64"
@@ -952,10 +952,10 @@
       "evra": "4.2.2-3.fc44.x86_64"
     },
     "nano": {
-      "evra": "8.7.1-1.fc44.x86_64"
+      "evra": "8.7.1-2.fc44.x86_64"
     },
     "nano-default-editor": {
-      "evra": "8.7.1-1.fc44.noarch"
+      "evra": "8.7.1-2.fc44.noarch"
     },
     "ncurses": {
       "evra": "6.6-1.fc44.x86_64"
@@ -979,16 +979,16 @@
       "evra": "0.52.25-6.fc44.x86_64"
     },
     "nfs-client-utils": {
-      "evra": "1:2.8.7-1.fc44.x86_64"
+      "evra": "1:2.8.7-6.fc44.x86_64"
     },
     "nfs-common-utils": {
-      "evra": "1:2.8.7-1.fc44.x86_64"
+      "evra": "1:2.8.7-6.fc44.x86_64"
     },
     "nfsv3-client-utils": {
-      "evra": "1:2.8.7-1.fc44.x86_64"
+      "evra": "1:2.8.7-6.fc44.x86_64"
     },
     "nfsv4-client-utils": {
-      "evra": "1:2.8.7-1.fc44.x86_64"
+      "evra": "1:2.8.7-6.fc44.x86_64"
     },
     "nftables": {
       "evra": "1:1.1.6-2.fc44.x86_64"
@@ -1021,7 +1021,7 @@
       "evra": "0.5-50.20251104git.fc44.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "nvme-cli": {
       "evra": "2.16-2.fc44.x86_64"
@@ -1033,55 +1033,55 @@
       "evra": "2.6.13-1.fc44.x86_64"
     },
     "openssh": {
-      "evra": "10.2p1-9.fc44.x86_64"
+      "evra": "10.2p1-13.fc44.x86_64"
     },
     "openssh-clients": {
-      "evra": "10.2p1-9.fc44.x86_64"
+      "evra": "10.2p1-13.fc44.x86_64"
     },
     "openssh-server": {
-      "evra": "10.2p1-9.fc44.x86_64"
+      "evra": "10.2p1-13.fc44.x86_64"
     },
     "openssl": {
-      "evra": "1:3.5.5-2.fc44.x86_64"
+      "evra": "1:3.5.7-2.fc44.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.5-2.fc44.x86_64"
+      "evra": "1:3.5.7-2.fc44.x86_64"
     },
     "os-prober": {
       "evra": "1.81-11.fc44.x86_64"
     },
     "ostree": {
-      "evra": "2026.1-1.fc44.x86_64"
+      "evra": "2026.2-1.fc44.x86_64"
     },
     "ostree-libs": {
-      "evra": "2026.1-1.fc44.x86_64"
+      "evra": "2026.2-1.fc44.x86_64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc44.x86_64"
+      "evra": "0.26.4-1.fc44.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc44.x86_64"
+      "evra": "0.26.4-1.fc44.x86_64"
     },
     "pam": {
-      "evra": "1.7.2-1.fc44.x86_64"
+      "evra": "1.7.2-2.fc44.x86_64"
     },
     "pam-libs": {
-      "evra": "1.7.2-1.fc44.x86_64"
+      "evra": "1.7.2-2.fc44.x86_64"
     },
     "passim-libs": {
       "evra": "0.1.11-1.fc44.x86_64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc44.x86_64"
+      "evra": "0^20260716.g090d739-2.fc44.x86_64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
+      "evra": "0^20260716.g090d739-2.fc44.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-3.fc44.x86_64"
+      "evra": "3.15.0-1.fc44.x86_64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-3.fc44.x86_64"
+      "evra": "3.15.0-1.fc44.x86_64"
     },
     "pcre2": {
       "evra": "10.47-1.fc44.1.x86_64"
@@ -1102,13 +1102,13 @@
       "evra": "2.5.1-1.fc44.x86_64"
     },
     "podman": {
-      "evra": "5:5.8.2-1.fc44.x86_64"
+      "evra": "5:5.8.4-1.fc44.x86_64"
     },
     "podman-sequoia": {
-      "evra": "0.3.2-1.fc44.x86_64"
+      "evra": "0.3.2-2.fc44.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.10-4.fc44.x86_64"
     },
     "polkit": {
       "evra": "127-2.fc44.2.x86_64"
@@ -1132,7 +1132,7 @@
       "evra": "20260116-1.fc44.noarch"
     },
     "qed-firmware": {
-      "evra": "20260410-1.fc44.noarch"
+      "evra": "20260622-1.fc44.noarch"
     },
     "rdma-core-common": {
       "evra": "61.0-2.fc44.noarch"
@@ -1141,7 +1141,7 @@
       "evra": "8.3-4.fc44.x86_64"
     },
     "rpcbind": {
-      "evra": "1.2.8-1.fc44.x86_64"
+      "evra": "1.2.9-2.fc44.x86_64"
     },
     "rpm": {
       "evra": "6.0.1-2.fc44.x86_64"
@@ -1150,34 +1150,34 @@
       "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2026.1-3.fc44.x86_64"
+      "evra": "2026.2-1.fc44.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-3.fc44.x86_64"
+      "evra": "2026.2-1.fc44.x86_64"
     },
     "rpm-plugin-selinux": {
       "evra": "6.0.1-2.fc44.x86_64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.2-1.fc44.x86_64"
+      "evra": "1.10.2-4.fc44.x86_64"
     },
     "rsync": {
-      "evra": "3.4.1-6.fc44.x86_64"
+      "evra": "3.4.4-1.fc44.x86_64"
     },
     "runc": {
-      "evra": "2:1.4.2-1.fc44.x86_64"
+      "evra": "2:1.5.0-2.fc44.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.24.1-1.fc44.noarch"
+      "evra": "2:4.24.4-1.fc44.noarch"
     },
     "samba-core-libs": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "samba-ndr-libs": {
-      "evra": "2:4.24.1-1.fc44.x86_64"
+      "evra": "2:4.24.4-1.fc44.x86_64"
     },
     "sdbus-cpp": {
       "evra": "2.2.1-2.fc44.x86_64"
@@ -1186,25 +1186,25 @@
       "evra": "4.9-7.fc44.x86_64"
     },
     "selinux-policy": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "44.1-1.fc44.noarch"
+      "evra": "44.4-1.fc44.noarch"
     },
     "setup": {
       "evra": "2.15.0-28.fc44.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-8.fc44.x86_64"
+      "evra": "1.48-10.fc44.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-8.fc44.x86_64"
+      "evra": "1.48-10.fc44.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.19.0-6.fc44.x86_64"
+      "evra": "2:4.19.0-7.fc44.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.19.0-6.fc44.x86_64"
+      "evra": "2:4.19.0-7.fc44.x86_64"
     },
     "shared-mime-info": {
       "evra": "2.4-3.fc44.x86_64"
@@ -1225,7 +1225,7 @@
       "evra": "1.2.2-4.fc44.x86_64"
     },
     "socat": {
-      "evra": "1.8.1.0-2.fc44.x86_64"
+      "evra": "1.8.1.1-1.fc44.x86_64"
     },
     "spdlog": {
       "evra": "1.15.3-4.fc44.x86_64"
@@ -1237,61 +1237,61 @@
       "evra": "4.6.1-8.fc44.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-client": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-common": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.13.0-1.fc44.x86_64"
+      "evra": "2.13.1-2.fc44.x86_64"
     },
     "stalld": {
-      "evra": "1.26.3-2.fc44.x86_64"
+      "evra": "1.28.1-1.fc44.x86_64"
     },
     "sudo": {
       "evra": "1.9.17-8.p2.fc44.x86_64"
     },
     "systemd": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-container": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-libs": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-pam": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-resolved": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-shared": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-sysusers": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "systemd-udev": {
-      "evra": "259.5-1.fc44.x86_64"
+      "evra": "259.7-1.fc44.x86_64"
     },
     "tar": {
       "evra": "2:1.35-8.fc44.x86_64"
@@ -1315,34 +1315,34 @@
       "evra": "4.1.3-9.fc44.x86_64"
     },
     "tzdata": {
-      "evra": "2026a-1.fc44.noarch"
+      "evra": "2026b-1.fc44.noarch"
     },
     "userspace-rcu": {
       "evra": "0.15.6-1.fc44.x86_64"
     },
     "util-linux": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.41.4-7.fc44.x86_64"
+      "evra": "2.41.5-1.fc44.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.2.390-1.fc44.noarch"
+      "evra": "2:9.2.782-1.fc44.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.390-1.fc44.x86_64"
+      "evra": "2:9.2.782-1.fc44.x86_64"
     },
     "wasmedge-rt": {
-      "evra": "0.16.1-1.fc44.x86_64"
+      "evra": "0.17.1-1.fc44.x86_64"
     },
     "which": {
-      "evra": "2.23-4.fc44.x86_64"
+      "evra": "2.25-1.fc44.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-3.fc44.x86_64"
+      "evra": "1.0.20260223-1.fc44.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.18.0-2.fc44.x86_64"
+      "evra": "7.0.1-2.fc44.x86_64"
     },
     "xxhash-libs": {
       "evra": "0.8.3-4.fc44.x86_64"
@@ -1352,9 +1352,6 @@
     },
     "xz-libs": {
       "evra": "1:5.8.2-2.fc44.x86_64"
-    },
-    "yajl": {
-      "evra": "2.1.0-40.fc44.x86_64"
     },
     "zchunk-libs": {
       "evra": "1.5.1-4.fc44.x86_64"
@@ -1373,6 +1370,6 @@
     }
   },
   "metadata": {
-    "generated": "2026-05-01T00:00:00Z"
+    "generated": "2026-07-20T00:00:00Z"
   }
 }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,15 +1,11 @@
-metadata:
-  # tell `cosa build` to default to buildah path
-  build_with_buildah: true
-
 repos:
   # These repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned. These repos are also used by the remove-graduated-overrides
   # GitHub Action.
-  # - fedora
-  # - fedora-updates
-  - fedora-next
-  - fedora-next-updates
+  - fedora
+  - fedora-updates
+  # - fedora-next
+  # - fedora-next-updates
   # - fedora-candidate-compose
 include: manifests/fedora-coreos.yaml


### PR DESCRIPTION
Drop build_with_buildah, switch from fedora-next to fedora (same as testing-devel).

See: https://github.com/coreos/fedora-coreos-config/pull/4276#issuecomment-5062307183