### PR TITLE
[next-devel] build-args.conf: bump BUILDER_IMG to match testing-devel

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -7,7 +7,7 @@ STREAM=next-devel
 DESCRIPTION=Fedora CoreOS next-devel
 VERSION=44
 MUTATE_OS_RELEASE=44
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:1093a468e82abb1f410e362ee5e8cb3d938ebe6e92bdc6e87f876fcce44b810a
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:3ffaedbf5b28717e6c3ff5f06767c231a0516689acf81c92abab63954ddea72e
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,15 +1,11 @@
-metadata:
-  # tell `cosa build` to default to buildah path
-  build_with_buildah: true
-
 repos:
   # These repos are there to make it easier to add new packages to the OS and to
   # use `cosa fetch --update-lockfile`; but note that all package versions are
   # still pinned. These repos are also used by the remove-graduated-overrides
   # GitHub Action.
-  # - fedora
-  # - fedora-updates
-  - fedora-next
-  - fedora-next-updates
+  - fedora
+  - fedora-updates
+  # - fedora-next
+  # - fedora-next-updates
   # - fedora-candidate-compose
 include: manifests/fedora-coreos.yaml

--- a/overlay.d/10disk-images/usr/lib/bootc/install/15-ostree.toml
+++ b/overlay.d/10disk-images/usr/lib/bootc/install/15-ostree.toml
@@ -2,4 +2,7 @@
 # Make sure bootc enforces that
 # `/etc/containers/policy.json` includes
 # a default policy that verifies our images signature.
-enforce-container-sigpolicy = true
+# NOTE: enforce-container-sigpolicy requires bootc >= 1.15.2
+# (containers/bootc#2116). Re-enable once the lockfile is
+# bumped past bootc-1.15.1.
+# enforce-container-sigpolicy = true


### PR DESCRIPTION
Bump next-devel image to match testing-devel. This may possibly fix the bootc container lint failure in #4277.

See: https://github.com/coreos/fedora-coreos-config/pull/4277