### PR TITLE
denylist: extend snooze date

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -10,28 +10,28 @@
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2115
-  snooze: 2026-08-03
+  snooze: 2026-08-31
   warn: true
   arches:
     - ppc64le
 
 - pattern: ext.config.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2124
-  snooze: 2026-08-03
+  snooze: 2026-08-31
   warn: true
   arches:
     - aarch64
 
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2129
-  snooze: 2026-08-03
+  snooze: 2026-08-31
   warn: true
   arches:
     - ppc64le
 
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2174
-  snooze: 2026-08-03
+  snooze: 2026-08-31
   warn: true
   arches:
     - aarch64
@@ -40,7 +40,7 @@
 
 - pattern: ext.config.disks.boot-partition-space
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2179
-  snooze: 2026-08-03
+  snooze: 2026-08-31
   warn: true
   streams:
     - rawhide


### PR DESCRIPTION
The kola tests snooze date needs to be extended as the investigation is ongoing.