### PR TITLE
denylist: skip ext.config.rpm-ostree.kernel-replace on rawhide

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,3 +46,10 @@
     - rawhide
   arches:
     - aarch64
+
+- pattern: ext.config.rpm-ostree.kernel-replace
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2205
+  snooze: 2026-08-15
+  warn: true
+  streams:
+    - rawhide


### PR DESCRIPTION
bump-lockfile job fails on this test possibly due to crun 1.29 changes (new mount API, OPEN_TREE_NAMESPACE, trusted /proc fd).

Tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2205