### PR TITLE
[rawhide] overrides: pin dracut-109-7.fc45

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,3 +29,18 @@ packages:
     metadata:
       type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+  dracut:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin
+  dracut-network:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin
+  dracut-squash:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin


### PR DESCRIPTION
Requested by @angelcerveraroldan via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).