### PR TITLE
[branched] Branched is now Fedora Linux 45

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -12,3 +12,11 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 IMAGE_CONFIG=image.yaml
+# Use chunkah for chunking and also set the number of
+# layers to something high to increase the chances of
+# one SRPM per layer granularity.
+#
+# From memory the upper limit on layers is around ~500. Set
+# it to 400 here to see if we find any limitiations anywhere.
+BUILDER_IMG_CHUNKER=chunkah
+BUILDER_IMG_CHUNKER_MAX_LAYERS=400

--- a/build-args.conf
+++ b/build-args.conf
@@ -5,9 +5,9 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=branched
 DESCRIPTION=Fedora CoreOS branched
-VERSION=44
-MUTATE_OS_RELEASE=44
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-44-standard@sha256:230a707fe23fc447c1658643ab043d3d989c278ded2d6b9668dad0ed41712120
+VERSION=45
+MUTATE_OS_RELEASE=45
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-45-standard@sha256:bad0158c48b5f689894099df0c7f72258e2270f65ad1dd8a60cf855e374d0c46
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/image.yaml
+++ b/image.yaml
@@ -2,3 +2,12 @@
 # similarly to manifest.yaml. Unlike image-base.yaml, which is shared by all
 # streams.
 include: image-base.yaml
+
+# Use bootc install to-filesystem to build the disk image
+# Only for this stream for now
+# See https://github.com/coreos/fedora-coreos-tracker/issues/1827
+bootc-install-to-fs: true
+
+# Bootc will inject the ostree prefix when doing the ostree
+# deployement so we need only the OCI imgref here
+container-imgref: "quay.io/fedora/fedora-coreos:{stream}"

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,39 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  console-login-helper-messages:
+    evra: 0.21.3-13.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+  console-login-helper-messages-issuegen:
+    evra: 0.21.3-13.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+  console-login-helper-messages-motdgen:
+    evra: 0.21.3-13.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+  console-login-helper-messages-profile:
+    evra: 0.21.3-13.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+  dracut:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin
+  dracut-network:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin
+  dracut-squash:
+    evr: 109-7.fc45
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
+      type: pin

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,148 +1,148 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.55.91-3.fc44.x86_64"
+      "evra": "1:1.58.1-1.fc45.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.55.91-3.fc44.x86_64"
+      "evra": "1:1.58.1-1.fc45.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.55.91-3.fc44.x86_64"
+      "evra": "1:1.58.1-1.fc45.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.55.91-3.fc44.x86_64"
+      "evra": "1:1.58.1-1.fc45.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.55.91-3.fc44.x86_64"
+      "evra": "1:1.58.1-1.fc45.x86_64"
     },
     "WALinuxAgent-udev": {
-      "evra": "2.15.0.1-3.fc44.noarch"
+      "evra": "2.15.0.1-6.fc45.noarch"
     },
     "aardvark-dns": {
-      "evra": "2:1.17.0-3.fc44.x86_64"
+      "evra": "2:2.1.0-1.fc45.x86_64"
     },
     "acl": {
-      "evra": "2.3.2-6.fc44.x86_64"
+      "evra": "2.4.0-2.fc45.x86_64"
     },
     "adcli": {
-      "evra": "0.9.3.1-5.fc44.x86_64"
+      "evra": "0.9.3.1-6.fc45.x86_64"
     },
     "adcli-selinux": {
-      "evra": "0.9.3.1-5.fc44.noarch"
+      "evra": "0.9.3.1-6.fc45.noarch"
     },
     "afterburn": {
-      "evra": "5.10.0-4.fc44.x86_64"
+      "evra": "5.10.0-9.fc45.x86_64"
     },
     "afterburn-dracut": {
-      "evra": "5.10.0-4.fc44.x86_64"
+      "evra": "5.10.0-9.fc45.x86_64"
     },
     "alternatives": {
-      "evra": "1.33-5.fc44.x86_64"
+      "evra": "1.33-6.fc45.x86_64"
     },
     "amd-gpu-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "amd-ucode-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "attr": {
-      "evra": "2.5.2-8.fc44.x86_64"
+      "evra": "2.6.0-2.fc45.x86_64"
     },
     "audit": {
-      "evra": "4.1.3-1.fc44.x86_64"
+      "evra": "4.2.1-2.fc45.x86_64"
     },
     "audit-libs": {
-      "evra": "4.1.3-1.fc44.x86_64"
+      "evra": "4.2.1-2.fc45.x86_64"
     },
     "audit-rules": {
-      "evra": "4.1.3-1.fc44.x86_64"
+      "evra": "4.2.1-2.fc45.x86_64"
     },
     "authselect": {
-      "evra": "1.7.1-1.fc44.x86_64"
+      "evra": "1.8.0-1.fc45.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.7.1-1.fc44.x86_64"
+      "evra": "1.8.0-1.fc45.x86_64"
     },
     "azure-vm-utils": {
-      "evra": "0.7.0-3.fc44.x86_64"
+      "evra": "0.7.0-4.fc45.x86_64"
     },
     "bash": {
-      "evra": "5.3.9-3.fc44.x86_64"
+      "evra": "5.3.15-2.fc45.x86_64"
     },
     "bash-color-prompt": {
-      "evra": "0.7.1-3.fc44.noarch"
+      "evra": "0.7.1-4.fc45.noarch"
     },
     "bash-completion": {
-      "evra": "1:2.17-2.fc44.noarch"
+      "evra": "1:2.18-1.fc45.noarch"
     },
     "bind-libs": {
-      "evra": "32:9.18.44-2.fc44.x86_64"
+      "evra": "32:9.18.50-22.fc45.x86_64"
     },
     "bind-utils": {
-      "evra": "32:9.18.44-2.fc44.x86_64"
+      "evra": "32:9.18.50-22.fc45.x86_64"
     },
     "bootc": {
-      "evra": "1.12.1-1.fc44.x86_64"
+      "evra": "1.16.9-1.fc45.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.32-3.fc44.x86_64"
+      "evra": "0.2.35-3.fc45.x86_64"
     },
     "bsdtar": {
-      "evra": "3.8.4-2.fc44.x86_64"
+      "evra": "3.8.8-3.fc45.x86_64"
     },
     "btrfs-progs": {
-      "evra": "6.19-1.fc44.x86_64"
+      "evra": "7.1-1.fc45.x86_64"
     },
     "bubblewrap": {
-      "evra": "0.11.0-4.fc44.x86_64"
+      "evra": "0.11.2-2.fc45.x86_64"
     },
     "bzip2": {
-      "evra": "1.0.8-23.fc44.x86_64"
+      "evra": "1.0.8-24.fc45.x86_64"
     },
     "bzip2-libs": {
-      "evra": "1.0.8-23.fc44.x86_64"
+      "evra": "1.0.8-24.fc45.x86_64"
     },
     "c-ares": {
-      "evra": "1.34.6-3.fc44.x86_64"
+      "evra": "1.34.8-2.fc45.x86_64"
     },
     "ca-certificates": {
-      "evra": "2025.2.80_v9.0.304-5.fc44.noarch"
+      "evra": "2025.2.80_v9.0.304-9.fc45.noarch"
     },
     "catatonit": {
-      "evra": "0.2.1-5.fc44.x86_64"
+      "evra": "0.2.1-6.fc45.x86_64"
     },
     "chrony": {
-      "evra": "4.8-5.fc44.x86_64"
+      "evra": "4.9-0.2.pre1.fc45.x86_64"
     },
     "cifs-utils": {
-      "evra": "7.4-3.fc44.x86_64"
+      "evra": "7.6-3.fc45.x86_64"
     },
     "clevis": {
-      "evra": "21-14.fc44.x86_64"
+      "evra": "22-3.fc45.x86_64"
     },
     "clevis-dracut": {
-      "evra": "21-14.fc44.x86_64"
+      "evra": "22-3.fc45.x86_64"
     },
     "clevis-luks": {
-      "evra": "21-14.fc44.x86_64"
+      "evra": "22-3.fc45.x86_64"
     },
     "clevis-pin-tpm2": {
-      "evra": "0.5.3-12.fc44.x86_64"
+      "evra": "0.5.5-1.fc45.x86_64"
     },
     "clevis-systemd": {
-      "evra": "21-14.fc44.x86_64"
+      "evra": "22-3.fc45.x86_64"
     },
     "cloud-utils-growpart": {
-      "evra": "0.33-13.fc44.noarch"
+      "evra": "0.34-2.fc45.noarch"
     },
     "composefs": {
-      "evra": "1.0.8-5.fc44.x86_64"
+      "evra": "1.0.8-7.fc45.x86_64"
     },
     "composefs-libs": {
-      "evra": "1.0.8-5.fc44.x86_64"
+      "evra": "1.0.8-7.fc45.x86_64"
     },
     "conmon": {
-      "evra": "2:2.2.0-3.fc44.x86_64"
+      "evra": "2:2.2.1-2.fc45.x86_64"
     },
     "console-login-helper-messages": {
       "evra": "0.21.3-13.fc44.noarch"
@@ -157,1216 +157,1237 @@
       "evra": "0.21.3-13.fc44.noarch"
     },
     "container-selinux": {
-      "evra": "4:2.245.0-3.fc44.noarch"
+      "evra": "4:2.250.0-2.fc45.noarch"
     },
     "containerd": {
-      "evra": "2.2.0-4.fc44.x86_64"
+      "evra": "2.3.4-1.fc45.x86_64"
     },
     "containers-common": {
-      "evra": "5:0.67.0-1.fc44.noarch"
+      "evra": "5:0.69.0-1.fc45.noarch"
     },
     "containers-common-extra": {
-      "evra": "5:0.67.0-1.fc44.noarch"
+      "evra": "5:0.69.0-1.fc45.noarch"
     },
     "coreos-installer": {
-      "evra": "0.25.0-5.fc44.x86_64"
+      "evra": "0.26.0-4.fc45.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.25.0-5.fc44.x86_64"
+      "evra": "0.26.0-4.fc45.x86_64"
     },
     "coreutils": {
-      "evra": "9.9-4.fc44.x86_64"
+      "evra": "9.11-6.fc45.x86_64"
     },
     "coreutils-common": {
-      "evra": "9.9-4.fc44.x86_64"
+      "evra": "9.11-6.fc45.x86_64"
     },
     "cpio": {
-      "evra": "2.15-9.fc44.x86_64"
+      "evra": "2.15-10.fc45.x86_64"
     },
     "cracklib": {
-      "evra": "2.9.11-10.fc44.x86_64"
+      "evra": "2.10.3-2.fc45.x86_64"
     },
     "criu": {
-      "evra": "4.2-13.fc44.x86_64"
+      "evra": "4.2.1-2.fc45.x86_64"
     },
     "criu-libs": {
-      "evra": "4.2-13.fc44.x86_64"
+      "evra": "4.2.1-2.fc45.x86_64"
     },
     "crun": {
-      "evra": "1.26-3.fc44.x86_64"
+      "evra": "1.29.1-1.fc45.x86_64"
     },
     "crun-wasm": {
-      "evra": "1.26-3.fc44.x86_64"
+      "evra": "1.29.1-1.fc45.x86_64"
     },
     "crypto-policies": {
-      "evra": "20251128-3.git19878fe.fc44.noarch"
+      "evra": "20260713-2.gitc42da77.fc45.noarch"
     },
     "cryptsetup": {
-      "evra": "2.8.4-1.fc44.x86_64"
+      "evra": "2.8.7-1.fc45.x86_64"
     },
     "cryptsetup-libs": {
-      "evra": "2.8.4-1.fc44.x86_64"
+      "evra": "2.8.7-1.fc45.x86_64"
     },
     "curl": {
-      "evra": "8.18.0-4.fc44.x86_64"
+      "evra": "8.21.0-5.fc45.x86_64"
     },
     "cyrus-sasl-gssapi": {
-      "evra": "2.1.28-35.fc44.x86_64"
+      "evra": "2.1.28-37.fc45.x86_64"
     },
     "cyrus-sasl-lib": {
-      "evra": "2.1.28-35.fc44.x86_64"
+      "evra": "2.1.28-37.fc45.x86_64"
     },
     "dbus": {
-      "evra": "1:1.16.0-8.fc44.x86_64"
+      "evra": "1:1.16.2-6.fc45.x86_64"
     },
     "dbus-broker": {
-      "evra": "37-8.fc44.x86_64"
+      "evra": "37-9.fc45.x86_64"
     },
     "dbus-common": {
-      "evra": "1:1.16.0-8.fc44.noarch"
+      "evra": "1:1.16.2-6.fc45.noarch"
     },
     "dbus-libs": {
-      "evra": "1:1.16.0-8.fc44.x86_64"
+      "evra": "1:1.16.2-6.fc45.x86_64"
     },
     "device-mapper": {
-      "evra": "1.02.212-2.fc44.x86_64"
+      "evra": "1.02.216-1.fc45.x86_64"
     },
     "device-mapper-event": {
-      "evra": "1.02.212-2.fc44.x86_64"
+      "evra": "1.02.216-1.fc45.x86_64"
     },
     "device-mapper-event-libs": {
-      "evra": "1.02.212-2.fc44.x86_64"
+      "evra": "1.02.216-1.fc45.x86_64"
     },
     "device-mapper-libs": {
-      "evra": "1.02.212-2.fc44.x86_64"
+      "evra": "1.02.216-1.fc45.x86_64"
     },
     "device-mapper-multipath": {
-      "evra": "0.13.1-1.fc44.x86_64"
+      "evra": "0.14.3-2.fc45.x86_64"
     },
     "device-mapper-multipath-libs": {
-      "evra": "0.13.1-1.fc44.x86_64"
+      "evra": "0.14.3-2.fc45.x86_64"
     },
     "device-mapper-persistent-data": {
-      "evra": "1.3.1-3.fc44.x86_64"
+      "evra": "1.3.3-2.fc45.x86_64"
     },
     "diffutils": {
-      "evra": "3.12-5.fc44.x86_64"
+      "evra": "3.12-6.fc45.x86_64"
     },
     "dnf5": {
-      "evra": "5.3.0.0-7.fc44.x86_64"
+      "evra": "5.4.3.0-2.fc45.x86_64"
     },
     "dnsmasq": {
-      "evra": "2.92-4.fc44.x86_64"
+      "evra": "2.93-2.fc45.x86_64"
     },
     "docker-cli": {
-      "evra": "29.2.1-2.fc44.x86_64"
+      "evra": "29.7.2-1.fc45.x86_64"
     },
     "dosfstools": {
-      "evra": "4.2-18.fc44.x86_64"
+      "evra": "4.2-19.fc45.x86_64"
     },
     "dracut": {
-      "evra": "108-5.fc44.x86_64"
+      "evra": "109-7.fc45.x86_64"
     },
     "dracut-network": {
-      "evra": "108-5.fc44.x86_64"
+      "evra": "109-7.fc45.x86_64"
     },
     "dracut-squash": {
-      "evra": "108-5.fc44.x86_64"
+      "evra": "109-7.fc45.x86_64"
     },
     "duktape": {
-      "evra": "2.7.0-11.fc44.x86_64"
+      "evra": "2.7.0-12.fc45.x86_64"
     },
     "e2fsprogs": {
-      "evra": "1.47.3-4.fc44.x86_64"
+      "evra": "1.47.4-2.fc45.x86_64"
     },
     "e2fsprogs-libs": {
-      "evra": "1.47.3-4.fc44.x86_64"
+      "evra": "1.47.4-2.fc45.x86_64"
     },
     "efi-filesystem": {
-      "evra": "6-6.fc44.noarch"
+      "evra": "6-9.fc45.noarch"
     },
     "efibootmgr": {
-      "evra": "18-11.fc44.x86_64"
+      "evra": "18-13.fc45.x86_64"
     },
     "efivar-libs": {
-      "evra": "39-12.fc44.x86_64"
-    },
-    "elfutils-default-yama-scope": {
-      "evra": "0.194-3.fc44.noarch"
+      "evra": "39-13.fc45.x86_64"
     },
     "elfutils-libelf": {
-      "evra": "0.194-3.fc44.x86_64"
+      "evra": "0.195-3.fc45.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.194-3.fc44.x86_64"
+      "evra": "0.195-3.fc45.x86_64"
     },
     "ethtool": {
-      "evra": "2:6.15-4.fc44.x86_64"
+      "evra": "2:7.1-1.fc45.x86_64"
     },
     "expat": {
-      "evra": "2.7.3-2.fc44.x86_64"
+      "evra": "2.8.1-2.fc45.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "44-0.3.noarch"
+      "evra": "45-0.6.noarch"
     },
     "fedora-release-common": {
-      "evra": "44-0.14.noarch"
+      "evra": "45-0.10.noarch"
     },
     "fedora-release-coreos": {
-      "evra": "44-0.14.noarch"
+      "evra": "45-0.10.noarch"
     },
     "fedora-release-identity-coreos": {
-      "evra": "44-0.14.noarch"
+      "evra": "45-0.10.noarch"
     },
     "fedora-repos": {
-      "evra": "44-0.3.noarch"
+      "evra": "45-0.6.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "44-0.3.noarch"
+      "evra": "45-0.6.noarch"
     },
     "file": {
-      "evra": "5.46-9.fc44.x86_64"
+      "evra": "5.47-3.fc45.x86_64"
     },
     "file-libs": {
-      "evra": "5.46-9.fc44.x86_64"
+      "evra": "5.47-3.fc45.x86_64"
     },
     "filesystem": {
-      "evra": "3.18-52.fc44.x86_64"
+      "evra": "3.18-59.fc45.x86_64"
     },
     "findutils": {
-      "evra": "1:4.10.0-7.fc44.x86_64"
+      "evra": "1:4.11.0-2.fc45.x86_64"
+    },
+    "fips-provider": {
+      "evra": "1.5.2-3.fc45.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.17.2-2.fc44.x86_64"
+      "evra": "1.19.0^really1.18.1-2.fc45.x86_64"
     },
     "fmt": {
-      "evra": "11.2.0-4.fc44.x86_64"
+      "evra": "12.1.0-3.fc45.x86_64"
     },
     "fstrm": {
-      "evra": "0.6.1-14.fc44.x86_64"
+      "evra": "0.6.1-15.fc45.x86_64"
     },
     "fuse-common": {
-      "evra": "3.18.1-2.fc44.x86_64"
+      "evra": "3.18.2-2.fc45.x86_64"
     },
     "fuse-overlayfs": {
-      "evra": "1.16-2.fc44.x86_64"
+      "evra": "1.17-1.fc45.x86_64"
     },
     "fuse-sshfs": {
-      "evra": "3.7.5-3.fc44.x86_64"
+      "evra": "3.7.6-2.fc45.x86_64"
     },
     "fuse3": {
-      "evra": "3.18.1-2.fc44.x86_64"
+      "evra": "3.18.2-2.fc45.x86_64"
     },
     "fuse3-libs": {
-      "evra": "3.18.1-2.fc44.x86_64"
+      "evra": "3.18.2-2.fc45.x86_64"
     },
     "fwupd": {
-      "evra": "2.0.19-1.fc44.x86_64"
+      "evra": "2.1.7-1.fc45.x86_64"
     },
     "gawk": {
-      "evra": "5.3.2-3.fc44.x86_64"
+      "evra": "5.4.1-1.fc45.x86_64"
     },
     "gdbm": {
-      "evra": "1:1.23-11.fc44.x86_64"
+      "evra": "1:1.23-12.fc45.x86_64"
     },
     "gdbm-libs": {
-      "evra": "1:1.23-11.fc44.x86_64"
+      "evra": "1:1.23-12.fc45.x86_64"
     },
     "gdisk": {
-      "evra": "1.0.10-5.fc44.x86_64"
+      "evra": "1.0.10-6.fc45.x86_64"
     },
     "gettext-envsubst": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "1.0-3.fc45.x86_64"
     },
     "gettext-libs": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "1.0-3.fc45.x86_64"
     },
     "gettext-runtime": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "1.0-3.fc45.x86_64"
     },
     "git-core": {
-      "evra": "2.53.0-1.fc44.x86_64"
+      "evra": "2.55.0-2.fc45.x86_64"
     },
     "glib2": {
-      "evra": "2.87.2-2.fc44.x86_64"
+      "evra": "2.89.4-1.fc45.x86_64"
     },
     "glibc": {
-      "evra": "2.43-1.fc44.x86_64"
+      "evra": "2.44-1.fc45.x86_64"
     },
     "glibc-common": {
-      "evra": "2.43-1.fc44.x86_64"
+      "evra": "2.44-1.fc45.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.43-1.fc44.x86_64"
+      "evra": "2.44-1.fc45.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.43-1.fc44.x86_64"
+      "evra": "2.44-1.fc45.x86_64"
     },
     "gmp": {
-      "evra": "1:6.3.0-5.fc44.x86_64"
+      "evra": "1:6.3.0-6.fc45.x86_64"
     },
     "gnulib-l10n": {
-      "evra": "20241231-2.fc44.noarch"
+      "evra": "20241231-4.fc45.noarch"
     },
     "gnupg2": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnupg2-dirmngr": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnupg2-gpg-agent": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnupg2-gpgconf": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnupg2-keyboxd": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnupg2-verify": {
-      "evra": "2.4.9-5.fc44.x86_64"
+      "evra": "2.4.9-18.fc45.x86_64"
     },
     "gnutls": {
-      "evra": "3.8.12-1.fc44.x86_64"
+      "evra": "3.8.13-3.fc45.x86_64"
     },
     "google-compute-engine-guest-configs-udev": {
-      "evra": "20250221.00-3.fc44.noarch"
+      "evra": "20260623.00-4.fc45.noarch"
     },
     "gpgme": {
-      "evra": "2.0.1-3.fc44.x86_64"
+      "evra": "2.0.1-6.fc45.x86_64"
     },
     "grep": {
-      "evra": "3.12-3.fc44.x86_64"
+      "evra": "3.12-4.fc45.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.12-53.fc44.noarch"
+      "evra": "1:2.12-76.fc45.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-53.fc44.x86_64"
+      "evra": "1:2.12-76.fc45.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.12-53.fc44.x86_64"
+      "evra": "1:2.12-76.fc45.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-53.fc44.noarch"
+      "evra": "1:2.12-76.fc45.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-53.fc44.x86_64"
+      "evra": "1:2.12-76.fc45.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-53.fc44.x86_64"
+      "evra": "1:2.12-76.fc45.x86_64"
     },
     "gssproxy": {
-      "evra": "0.9.2-10.fc44.x86_64"
+      "evra": "0.9.2-12.fc45.x86_64"
     },
     "gzip": {
-      "evra": "1.14-2.fc44.x86_64"
+      "evra": "1.14-4.fc45.x86_64"
     },
     "hostname": {
-      "evra": "3.25-4.fc44.x86_64"
+      "evra": "3.25-5.fc45.x86_64"
     },
     "hwdata": {
-      "evra": "0.404-1.fc44.noarch"
+      "evra": "0.410-1.fc45.noarch"
     },
     "ignition": {
-      "evra": "2.26.0-2.fc44.x86_64"
+      "evra": "2.26.0-5.fc45.x86_64"
     },
     "ignition-grub": {
-      "evra": "2.26.0-2.fc44.x86_64"
+      "evra": "2.26.0-5.fc45.x86_64"
     },
     "inih": {
-      "evra": "62-2.fc44.x86_64"
+      "evra": "62-3.fc45.x86_64"
     },
     "intel-gpu-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "ipcalc": {
-      "evra": "1.0.3-13.fc44.x86_64"
+      "evra": "1.0.3-14.fc45.x86_64"
     },
     "iproute": {
-      "evra": "6.17.0-2.fc44.x86_64"
+      "evra": "7.0.0-2.fc45.x86_64"
     },
     "iproute-tc": {
-      "evra": "6.17.0-2.fc44.x86_64"
+      "evra": "7.0.0-2.fc45.x86_64"
     },
     "iptables-libs": {
-      "evra": "1.8.11-13.fc44.x86_64"
+      "evra": "1.8.13-2.fc45.x86_64"
     },
     "iptables-nft": {
-      "evra": "1.8.11-13.fc44.x86_64"
+      "evra": "1.8.13-2.fc45.x86_64"
     },
     "iptables-services": {
-      "evra": "1.8.11-13.fc44.noarch"
+      "evra": "1.8.13-2.fc45.noarch"
     },
     "iptables-utils": {
-      "evra": "1.8.11-13.fc44.x86_64"
+      "evra": "1.8.13-2.fc45.x86_64"
     },
     "iputils": {
-      "evra": "20250605-2.fc44.x86_64"
+      "evra": "20250605-3.fc45.x86_64"
     },
     "irqbalance": {
-      "evra": "2:1.9.5-2.fc44.x86_64"
+      "evra": "2:1.9.5-3.fc45.x86_64"
     },
     "iscsi-initiator-utils": {
-      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
+      "evra": "6.2.1.12-1.fc45.x86_64"
     },
     "iscsi-initiator-utils-iscsiuio": {
-      "evra": "6.2.1.11-0.git4b3e853.fc44.3.x86_64"
+      "evra": "6.2.1.12-1.fc45.x86_64"
     },
     "isns-utils-libs": {
-      "evra": "0.103-4.fc44.x86_64"
+      "evra": "0.103-8.fc45.x86_64"
     },
     "jansson": {
-      "evra": "2.14-4.fc44.x86_64"
+      "evra": "2.14-5.fc45.x86_64"
     },
     "jose": {
-      "evra": "14-6.fc44.x86_64"
+      "evra": "14-8.fc45.x86_64"
     },
     "jq": {
-      "evra": "1.8.1-2.fc44.x86_64"
+      "evra": "1.8.2-5.fc45.x86_64"
     },
     "json-c": {
-      "evra": "0.18-8.fc44.x86_64"
+      "evra": "0.18-9.fc45.x86_64"
     },
     "json-glib": {
-      "evra": "1.10.8-5.fc44.x86_64"
+      "evra": "1.10.8-11.fc45.x86_64"
     },
     "kbd": {
-      "evra": "2.9.0-2.fc44.x86_64"
+      "evra": "2.10.0-2.fc45.x86_64"
     },
     "kbd-legacy": {
-      "evra": "2.9.0-2.fc44.noarch"
+      "evra": "2.10.0-2.fc45.noarch"
     },
     "kbd-misc": {
-      "evra": "2.9.0-2.fc44.noarch"
+      "evra": "2.10.0-2.fc45.noarch"
     },
     "kdump-utils": {
-      "evra": "1.0.59-2.fc44.x86_64"
+      "evra": "1.0.61-2.fc45.x86_64"
     },
     "kernel": {
-      "evra": "6.19.2-300.fc44.x86_64"
+      "evra": "7.2.0-61.fc45.x86_64"
     },
     "kernel-core": {
-      "evra": "6.19.2-300.fc44.x86_64"
+      "evra": "7.2.0-61.fc45.x86_64"
     },
     "kernel-modules": {
-      "evra": "6.19.2-300.fc44.x86_64"
+      "evra": "7.2.0-61.fc45.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "6.19.2-300.fc44.x86_64"
+      "evra": "7.2.0-61.fc45.x86_64"
     },
     "kexec-tools": {
-      "evra": "2.0.32-3.fc44.x86_64"
+      "evra": "2.0.32-4.fc45.x86_64"
     },
     "keyutils": {
-      "evra": "1.6.3-7.fc44.x86_64"
+      "evra": "1.6.3-8.fc45.x86_64"
     },
     "keyutils-libs": {
-      "evra": "1.6.3-7.fc44.x86_64"
+      "evra": "1.6.3-8.fc45.x86_64"
     },
     "kmod": {
-      "evra": "34.2-4.fc44.x86_64"
+      "evra": "34.2-6.fc45.x86_64"
     },
     "kmod-libs": {
-      "evra": "34.2-4.fc44.x86_64"
+      "evra": "34.2-6.fc45.x86_64"
     },
     "kpartx": {
-      "evra": "0.13.1-1.fc44.x86_64"
+      "evra": "0.14.3-2.fc45.x86_64"
     },
     "krb5-libs": {
-      "evra": "1.22.2-2.fc44.x86_64"
+      "evra": "1.22.2-9.fc45.x86_64"
     },
     "less": {
-      "evra": "691-2.fc44.x86_64"
+      "evra": "704-4.fc45.x86_64"
     },
     "libacl": {
-      "evra": "2.3.2-6.fc44.x86_64"
+      "evra": "2.4.0-2.fc45.x86_64"
     },
     "libaio": {
-      "evra": "0.3.111-23.fc44.x86_64"
+      "evra": "0.3.111-24.fc45.x86_64"
     },
     "libarchive": {
-      "evra": "3.8.4-2.fc44.x86_64"
+      "evra": "3.8.8-3.fc45.x86_64"
     },
     "libassuan": {
-      "evra": "2.5.7-5.fc44.x86_64"
+      "evra": "2.5.7-6.fc45.x86_64"
     },
     "libattr": {
-      "evra": "2.5.2-8.fc44.x86_64"
-    },
-    "libbasicobjects": {
-      "evra": "0.1.1-61.fc44.x86_64"
+      "evra": "2.6.0-2.fc45.x86_64"
     },
     "libblkid": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libbpf": {
-      "evra": "2:1.6.3-1.fc44.x86_64"
+      "evra": "2:1.7.0-2.fc45.x86_64"
+    },
+    "libbrotli": {
+      "evra": "1.2.0-6.fc45.x86_64"
     },
     "libbsd": {
-      "evra": "0.12.2-7.fc44.x86_64"
+      "evra": "0.12.2-8.fc45.x86_64"
     },
     "libcap": {
-      "evra": "2.77-2.fc44.x86_64"
+      "evra": "2.78-2.fc45.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.9-7.fc44.x86_64"
+      "evra": "0.9.5-1.fc45.x86_64"
     },
     "libcbor": {
-      "evra": "0.13.0-2.fc44.x86_64"
-    },
-    "libcollection": {
-      "evra": "0.7.0-61.fc44.x86_64"
+      "evra": "0.14.0-3.fc45.x86_64"
     },
     "libcom_err": {
-      "evra": "1.47.3-4.fc44.x86_64"
+      "evra": "1.47.4-2.fc45.x86_64"
     },
-    "libcurl-minimal": {
-      "evra": "8.18.0-4.fc44.x86_64"
+    "libcurl": {
+      "evra": "8.21.0-5.fc45.x86_64"
     },
     "libdaemon": {
-      "evra": "0.14-33.fc44.x86_64"
+      "evra": "0.14-34.fc45.x86_64"
     },
     "libdhash": {
-      "evra": "0.5.0-61.fc44.x86_64"
+      "evra": "0.5.0-63.fc45.x86_64"
     },
     "libdnf5": {
-      "evra": "5.3.0.0-7.fc44.x86_64"
+      "evra": "5.4.3.0-2.fc45.x86_64"
     },
     "libdnf5-cli": {
-      "evra": "5.3.0.0-7.fc44.x86_64"
+      "evra": "5.4.3.0-2.fc45.x86_64"
     },
     "libdrm": {
-      "evra": "2.4.131-1.fc44.x86_64"
+      "evra": "2.4.134-2.fc45.x86_64"
     },
     "libeconf": {
-      "evra": "0.7.9-3.fc44.x86_64"
+      "evra": "0.7.9-4.fc45.x86_64"
     },
     "libedit": {
-      "evra": "3.1-58.20251016cvs.fc44.x86_64"
+      "evra": "3.1-60.20260512cvs.fc45.x86_64"
     },
     "libev": {
-      "evra": "4.33-15.fc44.x86_64"
+      "evra": "4.33-16.fc45.x86_64"
     },
     "libevent": {
-      "evra": "2.1.12-17.fc44.x86_64"
+      "evra": "2.1.12-19.fc45.x86_64"
     },
     "libfdisk": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libffi": {
-      "evra": "3.5.2-2.fc44.x86_64"
+      "evra": "3.5.2-3.fc45.x86_64"
     },
     "libfido2": {
-      "evra": "1.16.0-5.fc44.x86_64"
+      "evra": "1.17.0-5.fc45.x86_64"
     },
     "libgcc": {
-      "evra": "16.0.1-0.5.fc44.x86_64"
+      "evra": "16.2.1-2.fc45.x86_64"
     },
     "libgcrypt": {
-      "evra": "1.11.2-1.fc44.x86_64"
+      "evra": "1.12.2-2.fc45.x86_64"
     },
     "libgpg-error": {
-      "evra": "1.58-2.fc44.x86_64"
+      "evra": "1.61-2.fc45.x86_64"
     },
     "libibverbs": {
-      "evra": "61.0-2.fc44.x86_64"
+      "evra": "64.0-3.fc45.x86_64"
     },
     "libicu": {
-      "evra": "77.1-2.fc44.x86_64"
+      "evra": "78.3-8.fc45.x86_64"
     },
     "libidn2": {
-      "evra": "2.3.8-3.fc44.x86_64"
+      "evra": "2.3.8-4.fc45.x86_64"
     },
     "libini_config": {
-      "evra": "1.3.1-61.fc44.x86_64"
+      "evra": "2.0.0-63.fc45.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.12.0-3.fc44.x86_64"
-    },
-    "libjcat": {
-      "evra": "0.2.5-2.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "libjose": {
-      "evra": "14-6.fc44.x86_64"
+      "evra": "14-8.fc45.x86_64"
     },
     "libkcapi": {
-      "evra": "1.5.0-7.fc44.x86_64"
+      "evra": "1.5.1-2.fc45.x86_64"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-7.fc44.x86_64"
+      "evra": "1.5.1-2.fc45.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-7.fc44.x86_64"
+      "evra": "1.5.1-2.fc45.x86_64"
     },
     "libksba": {
-      "evra": "1.6.7-5.fc44.x86_64"
+      "evra": "1.8.0-3.fc45.x86_64"
     },
     "liblastlog2": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libldb": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "libluksmeta": {
-      "evra": "10-2.fc44.x86_64"
+      "evra": "10-3.fc45.x86_64"
     },
     "libmaxminddb": {
-      "evra": "1.12.2-5.fc44.x86_64"
+      "evra": "1.13.3-2.fc45.x86_64"
     },
     "libmd": {
-      "evra": "1.1.0-9.fc44.x86_64"
+      "evra": "1.2.0-2.fc45.x86_64"
     },
     "libmnl": {
-      "evra": "1.0.5-9.fc44.x86_64"
+      "evra": "1.0.5-10.fc45.x86_64"
     },
     "libmodulemd": {
-      "evra": "2.15.2-6.fc44.x86_64"
+      "evra": "2.15.3-3.fc45.x86_64"
     },
     "libmount": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libndp": {
-      "evra": "1.9-5.fc44.x86_64"
+      "evra": "1.9-6.fc45.x86_64"
     },
     "libnet": {
-      "evra": "1.3-7.fc44.x86_64"
+      "evra": "1.3-8.fc45.x86_64"
     },
     "libnetfilter_conntrack": {
-      "evra": "1.0.9-10.fc44.x86_64"
+      "evra": "1.1.1-2.fc45.x86_64"
     },
     "libnfnetlink": {
-      "evra": "1.0.1-32.fc44.x86_64"
+      "evra": "1.0.2-2.fc45.x86_64"
     },
     "libnfsidmap": {
-      "evra": "1:2.8.5-0.fc44.x86_64"
+      "evra": "1:2.9.2-1.rc1.fc45.x86_64"
     },
     "libnftnl": {
-      "evra": "1.3.1-2.fc44.x86_64"
+      "evra": "1.3.1-3.fc45.x86_64"
     },
     "libnghttp2": {
-      "evra": "1.68.0-3.fc44.x86_64"
+      "evra": "1.69.0-5.fc45.x86_64"
+    },
+    "libnghttp3": {
+      "evra": "1.18.0-1.fc45.x86_64"
     },
     "libnl3": {
-      "evra": "3.12.0-3.fc44.x86_64"
+      "evra": "3.12.0-4.fc45.x86_64"
     },
     "libnl3-cli": {
-      "evra": "3.12.0-3.fc44.x86_64"
+      "evra": "3.12.0-4.fc45.x86_64"
     },
     "libnsl2": {
-      "evra": "2.0.1-5.fc44.x86_64"
+      "evra": "2.0.1-6.fc45.x86_64"
     },
     "libnvme": {
-      "evra": "1.16.1-2.fc44.x86_64"
-    },
-    "libpath_utils": {
-      "evra": "0.2.1-61.fc44.x86_64"
+      "evra": "1.16.2-1.fc45.x86_64"
     },
     "libpcap": {
-      "evra": "14:1.10.6-2.fc44.x86_64"
+      "evra": "14:1.10.6-3.fc45.x86_64"
     },
     "libpciaccess": {
-      "evra": "0.16-17.fc44.x86_64"
+      "evra": "0.16-18.fc45.x86_64"
     },
     "libpkgconf": {
-      "evra": "2.5.1-1.fc44.x86_64"
+      "evra": "2.5.1-2.fc45.x86_64"
     },
     "libpsl": {
-      "evra": "0.21.5-7.fc44.x86_64"
+      "evra": "0.23.1-1.fc45.x86_64"
     },
     "libpwquality": {
-      "evra": "1.4.5-15.fc44.x86_64"
-    },
-    "libref_array": {
-      "evra": "0.1.5-61.fc44.x86_64"
+      "evra": "1.4.5-18.fc45.x86_64"
     },
     "librepo": {
-      "evra": "1.20.0-5.fc44.x86_64"
+      "evra": "1.20.0-9.fc45.x86_64"
     },
     "libreport-filesystem": {
-      "evra": "2.17.15-10.fc44.noarch"
+      "evra": "2.17.15-13.fc45.noarch"
     },
     "libseccomp": {
-      "evra": "2.6.0-3.fc44.x86_64"
+      "evra": "2.6.1-3.fc45.x86_64"
     },
     "libselinux": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.11-4.fc45.x86_64"
     },
     "libselinux-utils": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.11-4.fc45.x86_64"
     },
     "libsemanage": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.11-3.fc45.x86_64"
     },
     "libsepol": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.11-2.fc45.x86_64"
     },
     "libslirp": {
-      "evra": "4.9.1-3.fc44.x86_64"
+      "evra": "4.9.3-2.fc45.x86_64"
     },
     "libsmartcols": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libsmbclient": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "libsolv": {
-      "evra": "0.7.35-4.fc44.x86_64"
+      "evra": "0.7.39-7.fc45.x86_64"
     },
     "libss": {
-      "evra": "1.47.3-4.fc44.x86_64"
+      "evra": "1.47.4-2.fc45.x86_64"
+    },
+    "libssh": {
+      "evra": "0.12.2-1.fc45.x86_64"
+    },
+    "libssh-config": {
+      "evra": "0.12.2-1.fc45.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "libstdc++": {
-      "evra": "16.0.1-0.5.fc44.x86_64"
+      "evra": "16.2.1-2.fc45.x86_64"
     },
     "libtalloc": {
-      "evra": "2.4.4-1.fc44.x86_64"
+      "evra": "2.4.4-4.fc45.x86_64"
     },
     "libtasn1": {
-      "evra": "4.20.0-3.fc44.x86_64"
+      "evra": "4.21.0-2.fc45.x86_64"
     },
     "libtdb": {
-      "evra": "1.4.15-1.fc44.x86_64"
+      "evra": "1.4.15-4.fc45.x86_64"
     },
     "libteam": {
-      "evra": "1.32-13.fc44.x86_64"
+      "evra": "1.32-14.fc45.x86_64"
     },
     "libtevent": {
-      "evra": "0.17.1-4.fc44.x86_64"
+      "evra": "0.17.1-7.fc45.x86_64"
     },
     "libtextstyle": {
-      "evra": "0.26-4.fc44.x86_64"
+      "evra": "1.0-3.fc45.x86_64"
     },
     "libtirpc": {
-      "evra": "1.3.7-2.fc44.x86_64"
+      "evra": "1.3.7-3.fc45.x86_64"
     },
     "libtool-ltdl": {
-      "evra": "2.5.4-10.fc44.x86_64"
+      "evra": "2.5.4-11.fc45.x86_64"
     },
     "libunistring": {
-      "evra": "1.1-11.fc44.x86_64"
+      "evra": "1.1-12.fc45.x86_64"
     },
     "libusb1": {
-      "evra": "1.0.29-5.fc44.x86_64"
+      "evra": "1.0.30-2.fc45.x86_64"
     },
     "libuuid": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "libuv": {
-      "evra": "1:1.51.0-3.fc44.x86_64"
+      "evra": "1:1.52.1-2.fc45.x86_64"
     },
     "libverto": {
-      "evra": "0.3.2-12.fc44.x86_64"
+      "evra": "0.3.2-13.fc45.x86_64"
     },
     "libverto-libev": {
-      "evra": "0.3.2-12.fc44.x86_64"
+      "evra": "0.3.2-13.fc45.x86_64"
     },
     "libwbclient": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "libxcrypt": {
-      "evra": "4.5.2-3.fc44.x86_64"
+      "evra": "4.5.2-4.fc45.x86_64"
+    },
+    "libxkbcommon": {
+      "evra": "1.13.1-3.fc45.x86_64"
     },
     "libxml2": {
-      "evra": "2.12.10-6.fc44.x86_64"
+      "evra": "2.13.9-4.fc45.x86_64"
     },
     "libxmlb": {
-      "evra": "0.3.25-1.fc44.x86_64"
+      "evra": "0.3.29-1.fc45.x86_64"
     },
     "libyaml": {
-      "evra": "0.2.5-18.fc44.x86_64"
+      "evra": "0.2.5-19.fc45.x86_64"
     },
     "libzstd": {
-      "evra": "1.5.7-5.fc44.x86_64"
+      "evra": "1.5.7-6.fc45.x86_64"
     },
     "linux-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "linux-firmware-whence": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "lld18-libs": {
-      "evra": "18.1.8-8.fc43.x86_64"
+      "evra": "18.1.8-10.fc45.x86_64"
     },
     "llvm18-libs": {
-      "evra": "18.1.8-8.fc44.x86_64"
+      "evra": "18.1.8-9.fc45.x86_64"
     },
     "lmdb-libs": {
-      "evra": "0.9.34-2.fc44.x86_64"
+      "evra": "0.9.34-3.fc45.x86_64"
     },
     "logrotate": {
-      "evra": "3.22.0-5.fc44.x86_64"
+      "evra": "3.22.0-6.fc45.x86_64"
     },
     "lsof": {
-      "evra": "4.98.0-9.fc44.x86_64"
+      "evra": "4.99.6-2.fc45.x86_64"
     },
     "lua-libs": {
-      "evra": "5.4.8-5.fc44.x86_64"
+      "evra": "5.5.1-1.fc45.x86_64"
     },
     "luksmeta": {
-      "evra": "10-2.fc44.x86_64"
+      "evra": "10-3.fc45.x86_64"
     },
     "lvm2": {
-      "evra": "2.03.38-2.fc44.x86_64"
+      "evra": "2.03.42-1.fc45.x86_64"
     },
     "lvm2-libs": {
-      "evra": "2.03.38-2.fc44.x86_64"
+      "evra": "2.03.42-1.fc45.x86_64"
     },
     "lz4-libs": {
-      "evra": "1.10.0-4.fc44.x86_64"
+      "evra": "1.10.0-5.fc45.x86_64"
     },
     "lzo": {
-      "evra": "2.10-16.fc44.x86_64"
+      "evra": "2.10-17.fc45.x86_64"
     },
     "makedumpfile": {
-      "evra": "1.7.8-2.fc44.x86_64"
+      "evra": "1.7.9-2.fc45.x86_64"
     },
     "mdadm": {
-      "evra": "4.3-9.fc44.x86_64"
+      "evra": "4.6-2.fc45.x86_64"
     },
     "microcode_ctl": {
-      "evra": "2:2.1-73.fc44.x86_64"
+      "evra": "2:2.1-76.fc45.x86_64"
     },
     "moby-engine": {
-      "evra": "29.2.1-2.fc44.x86_64"
+      "evra": "29.7.2-1.fc45.x86_64"
     },
     "moby-filesystem": {
-      "evra": "29.2.1-2.fc44.noarch"
+      "evra": "29.7.2-1.fc45.noarch"
     },
     "mokutil": {
-      "evra": "2:0.7.2-3.fc44.x86_64"
+      "evra": "2:0.7.2-7.fc45.x86_64"
     },
     "mpfr": {
-      "evra": "4.2.2-3.fc44.x86_64"
+      "evra": "4.2.2-4.fc45.x86_64"
     },
     "nano": {
-      "evra": "8.7.1-1.fc44.x86_64"
+      "evra": "9.2-1.fc45.x86_64"
     },
     "nano-default-editor": {
-      "evra": "8.7.1-1.fc44.noarch"
+      "evra": "9.2-1.fc45.noarch"
     },
     "ncurses": {
-      "evra": "6.6-1.fc44.x86_64"
+      "evra": "6.6-3.fc45.x86_64"
     },
     "ncurses-base": {
-      "evra": "6.6-1.fc44.noarch"
+      "evra": "6.6-3.fc45.noarch"
     },
     "ncurses-libs": {
-      "evra": "6.6-1.fc44.x86_64"
+      "evra": "6.6-3.fc45.x86_64"
     },
     "net-tools": {
-      "evra": "2.0-0.77.20160912git.fc44.x86_64"
+      "evra": "2.0-0.79.20160912git.fc45.x86_64"
     },
     "netavark": {
-      "evra": "2:1.17.2-1.fc44.x86_64"
+      "evra": "2:2.1.0-1.fc45.x86_64"
     },
     "nettle": {
-      "evra": "3.10.1-3.fc44.x86_64"
+      "evra": "4.0-5.fc45.x86_64"
+    },
+    "nettle3.10": {
+      "evra": "3.10.1-7.fc45.x86_64"
     },
     "newt": {
-      "evra": "0.52.25-6.fc44.x86_64"
+      "evra": "0.52.25-9.fc45.x86_64"
     },
     "nfs-client-utils": {
-      "evra": "1:2.8.5-0.fc44.x86_64"
+      "evra": "1:2.9.2-1.rc1.fc45.x86_64"
     },
     "nfs-common-utils": {
-      "evra": "1:2.8.5-0.fc44.x86_64"
+      "evra": "1:2.9.2-1.rc1.fc45.x86_64"
     },
     "nfsv3-client-utils": {
-      "evra": "1:2.8.5-0.fc44.x86_64"
+      "evra": "1:2.9.2-1.rc1.fc45.x86_64"
     },
     "nfsv4-client-utils": {
-      "evra": "1:2.8.5-0.fc44.x86_64"
+      "evra": "1:2.9.2-1.rc1.fc45.x86_64"
     },
     "nftables": {
-      "evra": "1:1.1.6-2.fc44.x86_64"
+      "evra": "1:1.1.6-4.fc45.x86_64"
     },
     "nftables-services": {
-      "evra": "1:1.1.6-2.fc44.noarch"
+      "evra": "1:1.1.6-4.fc45.noarch"
     },
     "ngtcp2": {
-      "evra": "1.19.0-2.fc44.x86_64"
+      "evra": "1.22.1-3.fc45.x86_64"
     },
     "ngtcp2-crypto-gnutls": {
-      "evra": "1.19.0-2.fc44.x86_64"
+      "evra": "1.22.1-3.fc45.x86_64"
+    },
+    "ngtcp2-crypto-ossl": {
+      "evra": "1.22.1-3.fc45.x86_64"
     },
     "nmstate": {
-      "evra": "2.2.57-2.fc44.x86_64"
+      "evra": "2.2.60-5.fc45.x86_64"
     },
     "npth": {
-      "evra": "1.8-4.fc44.x86_64"
+      "evra": "1.8-5.fc45.x86_64"
     },
     "nss-altfiles": {
-      "evra": "2.23.0-8.fc44.x86_64"
+      "evra": "2.23.0-10.fc45.x86_64"
+    },
+    "numactl": {
+      "evra": "2.0.19-5.fc45.x86_64"
     },
     "numactl-libs": {
-      "evra": "2.0.19-4.fc44.x86_64"
+      "evra": "2.0.19-5.fc45.x86_64"
+    },
+    "numad": {
+      "evra": "0.5-51.20251104git.fc45.x86_64"
     },
     "nvidia-gpu-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "nvme-cli": {
-      "evra": "2.16-2.fc44.x86_64"
+      "evra": "2.16-5.fc45.x86_64"
     },
     "oniguruma": {
-      "evra": "6.9.10-4.fc44.x86_64"
+      "evra": "6.9.10-5.fc45.x86_64"
     },
     "openldap": {
-      "evra": "2.6.10-7.fc44.x86_64"
+      "evra": "2.6.13-4.fc45.x86_64"
     },
     "openssh": {
-      "evra": "10.2p1-3.fc44.x86_64"
+      "evra": "10.5p1-1.fc45.x86_64"
     },
     "openssh-clients": {
-      "evra": "10.2p1-3.fc44.x86_64"
+      "evra": "10.5p1-1.fc45.x86_64"
     },
     "openssh-server": {
-      "evra": "10.2p1-3.fc44.x86_64"
+      "evra": "10.5p1-1.fc45.x86_64"
     },
     "openssl": {
-      "evra": "1:3.5.5-1.fc44.x86_64"
+      "evra": "1:4.0.1-5.fc45.x86_64"
     },
     "openssl-libs": {
-      "evra": "1:3.5.5-1.fc44.x86_64"
+      "evra": "1:4.0.1-5.fc45.x86_64"
+    },
+    "openssl3-libs": {
+      "evra": "1:3.5.7-2.fc45.x86_64"
     },
     "os-prober": {
-      "evra": "1.81-11.fc44.x86_64"
+      "evra": "1.81-12.fc45.x86_64"
     },
     "ostree": {
-      "evra": "2025.7-2.fc44.x86_64"
+      "evra": "2026.4-1.fc45.x86_64"
     },
     "ostree-libs": {
-      "evra": "2025.7-2.fc44.x86_64"
+      "evra": "2026.4-1.fc45.x86_64"
     },
     "p11-kit": {
-      "evra": "0.26.2-1.fc44.x86_64"
+      "evra": "0.26.5-1.fc45.x86_64"
     },
     "p11-kit-trust": {
-      "evra": "0.26.2-1.fc44.x86_64"
+      "evra": "0.26.5-1.fc45.x86_64"
     },
     "pam": {
-      "evra": "1.7.2-1.fc44.x86_64"
+      "evra": "1.7.2-4.fc45.x86_64"
     },
     "pam-libs": {
-      "evra": "1.7.2-1.fc44.x86_64"
+      "evra": "1.7.2-4.fc45.x86_64"
     },
     "passim-libs": {
-      "evra": "0.1.10-3.fc44.x86_64"
+      "evra": "0.1.12-1.fc45.x86_64"
     },
     "passt": {
-      "evra": "0^20260120.g386b5f5-1.fc44.x86_64"
+      "evra": "0^20260728.gf8df3f1-2.fc45.x86_64"
     },
     "passt-selinux": {
-      "evra": "0^20260120.g386b5f5-1.fc44.noarch"
+      "evra": "0^20260728.gf8df3f1-2.fc45.noarch"
     },
     "pciutils": {
-      "evra": "3.14.0-3.fc44.x86_64"
+      "evra": "3.15.0-2.fc45.x86_64"
     },
     "pciutils-libs": {
-      "evra": "3.14.0-3.fc44.x86_64"
+      "evra": "3.15.0-2.fc45.x86_64"
     },
     "pcre2": {
-      "evra": "10.47-1.fc44.1.x86_64"
+      "evra": "10.47-1.fc45.2.x86_64"
     },
     "pcre2-syntax": {
-      "evra": "10.47-1.fc44.1.noarch"
+      "evra": "10.47-1.fc45.2.noarch"
     },
     "pigz": {
-      "evra": "2.8-8.fc44.x86_64"
+      "evra": "2.8-11.fc45.x86_64"
     },
     "pkgconf": {
-      "evra": "2.5.1-1.fc44.x86_64"
+      "evra": "2.5.1-2.fc45.x86_64"
     },
     "pkgconf-m4": {
-      "evra": "2.5.1-1.fc44.noarch"
+      "evra": "2.5.1-2.fc45.noarch"
     },
     "pkgconf-pkg-config": {
-      "evra": "2.5.1-1.fc44.x86_64"
+      "evra": "2.5.1-2.fc45.x86_64"
     },
     "podman": {
-      "evra": "5:5.8.0-1.fc44.x86_64"
+      "evra": "5:6.1.0-2.fc45.x86_64"
     },
     "podman-sequoia": {
-      "evra": "0.3.2-1.fc44.x86_64"
+      "evra": "0.3.2-4.fc45.x86_64"
     },
     "policycoreutils": {
-      "evra": "3.10-1.fc44.x86_64"
+      "evra": "3.11-2.fc45.x86_64"
     },
     "polkit": {
-      "evra": "127-2.fc44.x86_64"
+      "evra": "127-5.fc45.x86_64"
     },
     "polkit-libs": {
-      "evra": "127-2.fc44.x86_64"
+      "evra": "127-5.fc45.x86_64"
     },
     "popt": {
-      "evra": "1.19-10.fc44.x86_64"
+      "evra": "1.19-11.fc45.x86_64"
     },
     "procps-ng": {
-      "evra": "4.0.6-1.fc44.x86_64"
+      "evra": "4.0.6-2.fc45.x86_64"
     },
-    "protobuf-c": {
-      "evra": "1.5.2-2.fc44.x86_64"
+    "protobuf3-c": {
+      "evra": "1.5.2-52.fc45.x86_64"
     },
     "psmisc": {
-      "evra": "23.7-7.fc44.x86_64"
+      "evra": "23.7-9.fc45.x86_64"
     },
     "publicsuffix-list-dafsa": {
-      "evra": "20260116-1.fc44.noarch"
+      "evra": "20260624-2.fc45.noarch"
     },
     "qed-firmware": {
-      "evra": "20260110-1.fc44.noarch"
+      "evra": "20260810-1.fc45.noarch"
     },
     "rdma-core-common": {
-      "evra": "61.0-2.fc44.noarch"
+      "evra": "64.0-3.fc45.noarch"
     },
     "readline": {
-      "evra": "8.3-4.fc44.x86_64"
+      "evra": "8.3-6.fc45.x86_64"
+    },
+    "redhat-systemd-presets": {
+      "evra": "102-3.fc45.noarch"
+    },
+    "redhat-systemd-presets-common": {
+      "evra": "102-3.fc45.noarch"
     },
     "rpcbind": {
-      "evra": "1.2.8-1.fc44.x86_64"
+      "evra": "1.2.9-3.fc45.x86_64"
     },
     "rpm": {
-      "evra": "6.0.1-2.fc44.x86_64"
+      "evra": "6.1.0-1.fc45.x86_64"
     },
     "rpm-libs": {
-      "evra": "6.0.1-2.fc44.x86_64"
+      "evra": "6.1.0-1.fc45.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2026.1-1.fc44.x86_64"
+      "evra": "2026.2-4.fc45.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.1-1.fc44.x86_64"
+      "evra": "2026.2-4.fc45.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.1-2.fc44.x86_64"
+      "evra": "6.1.0-1.fc45.x86_64"
     },
     "rpm-sequoia": {
-      "evra": "1.10.0-2.fc44.x86_64"
+      "evra": "1.10.2-5.fc45.x86_64"
     },
     "rsync": {
-      "evra": "3.4.1-6.fc44.x86_64"
+      "evra": "3.5.0-1.fc45.x86_64"
     },
     "runc": {
-      "evra": "2:1.4.0-3.fc44.x86_64"
+      "evra": "2:1.5.1-2.fc45.x86_64"
     },
     "samba-client-libs": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "samba-common": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.noarch"
+      "evra": "2:4.24.5-1.fc45.noarch"
     },
     "samba-core-libs": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "samba-ndr-libs": {
-      "evra": "2:4.24.0-0.5.rc3.fc44.x86_64"
+      "evra": "2:4.24.5-1.fc45.x86_64"
     },
     "sdbus-cpp": {
-      "evra": "2.2.1-2.fc44.x86_64"
+      "evra": "2.3.1-3.fc45.x86_64"
     },
     "sed": {
-      "evra": "4.9-7.fc44.x86_64"
+      "evra": "4.10-2.fc45.x86_64"
     },
     "selinux-policy": {
-      "evra": "42.23-1.fc44.noarch"
+      "evra": "45.14-1.fc45.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "42.23-1.fc44.noarch"
+      "evra": "45.14-1.fc45.noarch"
     },
     "setup": {
-      "evra": "2.15.0-28.fc44.noarch"
+      "evra": "2.15.1-2.fc45.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-8.fc44.x86_64"
+      "evra": "1.48-11.fc45.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-8.fc44.x86_64"
+      "evra": "1.48-11.fc45.x86_64"
     },
     "shadow-utils": {
-      "evra": "2:4.19.0-6.fc44.x86_64"
+      "evra": "2:4.20.0-1.fc45.x86_64"
     },
     "shadow-utils-subid": {
-      "evra": "2:4.19.0-6.fc44.x86_64"
+      "evra": "2:4.20.0-1.fc45.x86_64"
     },
     "shared-mime-info": {
-      "evra": "2.4-3.fc44.x86_64"
+      "evra": "2.5.1-2.fc45.x86_64"
     },
     "shim-x64": {
-      "evra": "16.1-5.x86_64"
+      "evra": "16.1-7.x86_64"
     },
     "skopeo": {
-      "evra": "1:1.22.0-2.fc44.x86_64"
+      "evra": "1:1.24.0-2.fc45.x86_64"
     },
     "slang": {
-      "evra": "2.3.3-9.fc44.x86_64"
+      "evra": "2.3.3-10.fc45.x86_64"
     },
     "slirp4netns": {
-      "evra": "1.3.1-4.fc44.x86_64"
+      "evra": "1.3.1-5.fc45.x86_64"
     },
     "snappy": {
-      "evra": "1.2.2-4.fc44.x86_64"
+      "evra": "1.2.2-6.fc45.x86_64"
     },
     "socat": {
-      "evra": "1.8.1.0-2.fc44.x86_64"
+      "evra": "1.8.1.1-5.fc45.x86_64"
     },
     "spdlog": {
-      "evra": "1.15.3-4.fc44.x86_64"
+      "evra": "1.17.0-3.fc45.x86_64"
     },
     "sqlite-libs": {
-      "evra": "3.51.2-1.fc44.x86_64"
+      "evra": "3.53.4-1.fc45.x86_64"
     },
     "squashfs-tools": {
-      "evra": "4.6.1-8.fc44.x86_64"
+      "evra": "4.7.4-2.fc45.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-client": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-common": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.12.0-3.fc44.x86_64"
+      "evra": "2.13.1-6.fc45.x86_64"
     },
     "stalld": {
-      "evra": "1.26.3-2.fc44.x86_64"
+      "evra": "1.28.1-2.fc45.x86_64"
     },
     "sudo": {
-      "evra": "1.9.17-7.p2.fc44.x86_64"
+      "evra": "1.9.17-16.p2.fc45.x86_64"
     },
     "systemd": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-container": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-libs": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-pam": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-resolved": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-shared": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-sysusers": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "systemd-udev": {
-      "evra": "259.1-1.fc44.x86_64"
+      "evra": "261.2-1.fc45.x86_64"
     },
     "tar": {
-      "evra": "2:1.35-8.fc44.x86_64"
+      "evra": "2:1.35-9.fc45.x86_64"
     },
     "teamd": {
-      "evra": "1.32-13.fc44.x86_64"
+      "evra": "1.32-14.fc45.x86_64"
     },
     "tini-static": {
       "evra": "0.19.0-12.fc44.x86_64"
     },
     "toolbox": {
-      "evra": "0.3-4.fc44.x86_64"
+      "evra": "0.3-7.fc45.x86_64"
     },
     "tpm2-tools": {
-      "evra": "5.7-5.fc44.x86_64"
+      "evra": "5.8-1.fc45.x86_64"
     },
     "tpm2-tss": {
-      "evra": "4.1.3-9.fc44.x86_64"
+      "evra": "4.2.0-1.fc45.x86_64"
     },
     "tpm2-tss-fapi": {
-      "evra": "4.1.3-9.fc44.x86_64"
+      "evra": "4.2.0-1.fc45.x86_64"
     },
     "tzdata": {
-      "evra": "2025c-2.fc44.noarch"
+      "evra": "2026c-1.fc45.noarch"
     },
     "userspace-rcu": {
-      "evra": "0.15.6-1.fc44.x86_64"
+      "evra": "0.15.6-2.fc45.x86_64"
     },
     "util-linux": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "util-linux-core": {
-      "evra": "2.41.3-12.fc44.x86_64"
+      "evra": "2.42.2-3.fc45.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.1.2146-2.fc44.noarch"
+      "evra": "2:9.2.967-1.fc45.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.1.2146-2.fc44.x86_64"
+      "evra": "2:9.2.967-1.fc45.x86_64"
     },
     "wasmedge-rt": {
-      "evra": "0.16.1-1.fc44.x86_64"
+      "evra": "0.17.1-2.fc45.x86_64"
     },
     "which": {
-      "evra": "2.23-4.fc44.x86_64"
+      "evra": "2.25-2.fc45.x86_64"
     },
     "wireguard-tools": {
-      "evra": "1.0.20250521-3.fc44.x86_64"
+      "evra": "1.0.20260223-2.fc45.x86_64"
     },
     "xfsprogs": {
-      "evra": "6.18.0-2.fc44.x86_64"
+      "evra": "7.1.1-1.fc45.x86_64"
+    },
+    "xkeyboard-config": {
+      "evra": "2.48-4.fc45.noarch"
     },
     "xxhash-libs": {
-      "evra": "0.8.3-4.fc44.x86_64"
+      "evra": "0.8.3-5.fc45.x86_64"
     },
     "xz": {
-      "evra": "1:5.8.2-2.fc44.x86_64"
+      "evra": "1:5.8.3-2.fc45.x86_64"
     },
     "xz-libs": {
-      "evra": "1:5.8.2-2.fc44.x86_64"
-    },
-    "yajl": {
-      "evra": "2.1.0-40.fc44.x86_64"
+      "evra": "1:5.8.3-2.fc45.x86_64"
     },
     "zchunk-libs": {
-      "evra": "1.5.1-4.fc44.x86_64"
+      "evra": "1.5.4-1.fc45.x86_64"
     },
     "zincati": {
-      "evra": "0.0.32-1.fc44.x86_64"
+      "evra": "0.0.32-1.fc45.x86_64"
     },
     "zlib-ng-compat": {
-      "evra": "2.3.3-2.fc44.x86_64"
+      "evra": "2.3.3-6.fc45.x86_64"
     },
     "zram-generator": {
-      "evra": "1.2.1-5.fc44.x86_64"
+      "evra": "1.2.1-6.fc45.x86_64"
     },
     "zstd": {
-      "evra": "1.5.7-5.fc44.x86_64"
+      "evra": "1.5.7-6.fc45.x86_64"
     }
   },
   "metadata": {
-    "generated": "2026-03-01T00:00:00Z"
+    "generated": "2026-08-25T00:00:00Z"
   }
 }


### PR DESCRIPTION
Fedora 45 has been branched off of rawhide so we can update our branched stream definitions here.

---

The `fedora-bootc-45-standard` image doesn't exist yet, so this PR will remain in draft state until the image is available.