### PR TITLE
build-rootfs: always add lockfile repos

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -161,7 +161,7 @@ def build_rootfs(target_rootfs, srcdir, manifest_name,
         if lockfile_repos == ['fedora-coreos-pool']:
             if not IS_HERMETIC:
                 modify_pool_repo(locked_nevras)
-                repos += lockfile_repos
+            repos += lockfile_repos
         elif len(lockfile_repos) > 0:
             raise Exception(f"unknown lockfile-repo found in {lockfile_repos}")
 


### PR DESCRIPTION
Previously, we didn't add the `fedora-coreos-pool` repo when building hermetically but it is required since the merge of [1] which privileges this repo when crafting the RPM URLs.
Note that we don't need to modify the pool repo in hermetic mode as it is handled by Hermeto i.e. in cachi2.repo.

[1] https://github.com/coreos/coreos-assembler/pull/4600