### PR TITLE
[testing] overrides: fast-track kernel-7.1.6-201.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -12,10 +12,34 @@ packages:
   fwupd:
     evr: 2.1.3-1.fc44
     metadata:
-      type: pin
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
+      type: pin
+  kernel:
+    evr: 7.1.6-201.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-864f36550e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2203
+      type: fast-track
+  kernel-core:
+    evr: 7.1.6-201.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-864f36550e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2203
+      type: fast-track
+  kernel-modules:
+    evr: 7.1.6-201.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-864f36550e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2203
+      type: fast-track
+  kernel-modules-core:
+    evr: 7.1.6-201.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-864f36550e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2203
+      type: fast-track
   libjcat:
     evr: 0.2.6-1.fc44
     metadata:
-      type: pin
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
+      type: pin


### PR DESCRIPTION
Requested by @Rolv-Apneseth via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).