### PR TITLE
[next-devel] use chunkah for chunking

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -12,3 +12,11 @@ MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests
 IMAGE_CONFIG=image.yaml
+# Use chunkah for chunking and also set the number of
+# layers to something high to increase the chances of
+# one SRPM per layer granularity.
+#
+# From memory the upper limit on layers is around ~500. Set
+# it to 400 here to see if we find any limitiations anywhere.
+BUILDER_IMG_CHUNKER=chunkah
+BUILDER_IMG_CHUNKER_MAX_LAYERS=400

--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,7 @@
+packages:
+  ostree-grub2:
+    evra: 2026.3-1.fc44.ppc64le
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da86341d50
+      reason: https://github.com/coreos/fedora-coreos-config/pull/4265#issuecomment-5091027307
+      type: fast-track

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,5 +8,16 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
-
+packages:
+  ostree:
+    evr: 2026.3-1.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da86341d50
+      reason: https://github.com/coreos/fedora-coreos-config/pull/4265#issuecomment-5091027307
+      type: fast-track
+  ostree-libs:
+    evr: 2026.3-1.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-da86341d50
+      reason: https://github.com/coreos/fedora-coreos-config/pull/4265#issuecomment-5091027307
+      type: fast-track


### PR DESCRIPTION
Chunkah support was added in [1]. As part of [2] Let's start to chunk our container images using chunkah.

[1] https://github.com/coreos/fedora-coreos-config/pull/4263
[2] https://github.com/coreos/fedora-coreos-tracker/issues/2145

(cherry picked from commit d8d3ae2ced72423919b78fb9c9891e4145d43a3b)