### PR TITLE
tests: generalise matching of bootupctl aleph version output

### DIFF
--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -78,8 +78,8 @@ fi
 
 # Verify `bootupctl status` output contains related content.
 # https://github.com/coreos/bootupd/issues/694
-if ! bootupctl status | grep "CoreOS aleph version"; then
-    fatal "bootupctl status output should include 'CoreOS aleph version'"
+if ! bootupctl status | grep -i "aleph version"; then
+    fatal "bootupctl status output should include 'aleph version'"
 fi
 
 ok bootupctl

--- a/tests/kola/boot/install-bootloader-multipath
+++ b/tests/kola/boot/install-bootloader-multipath
@@ -38,8 +38,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     ;;
 rebooted)
     ok "second boot"
-    if ! bootupctl status | grep "CoreOS aleph version"; then
-        fatal "bootupctl status output should include 'CoreOS aleph version'"
+    if ! bootupctl status | grep -i "aleph version"; then
+        fatal "bootupctl status output should include 'aleph version'"
     fi
 
     ok bootupctl

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -292,7 +292,7 @@ if vereq $version $target_version; then
     # log bootupctl information for inspection and check the status output
     state=$(/usr/bin/bootupctl status 2>&1)
     echo "$state"
-    if ! echo "$state" | grep -q "CoreOS aleph version"; then
+    if ! echo "$state" | grep -q -i "aleph version"; then
         fatal "check bootupctl status output"
     fi
     # One last check!


### PR DESCRIPTION
With https://github.com/coreos/bootupd/pull/1124 generalising the aleph handling to support bootc installs, the output status line changed from 'CoreOS aleph version' to just 'Aleph version'.

Adjust the matches present in our tests to match both cases to handle future bootupd versions and unblock bootupd CI (which is currently failing due to these tests). Also update the error messages to reflect the change.

See https://github.com/coreos/bootupd/pull/1136 for the bootupd companion PR which inspired this.