### PR TITLE
[next] overrides: unpin fwupd and libjcat

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,11 +9,6 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  fwupd:
-    evr: 2.1.3-1.fc44
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
-      type: pin
   kernel:
     evr: 7.1.6-201.fc44
     metadata:
@@ -38,8 +33,3 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-864f36550e
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2203
       type: fast-track
-  libjcat:
-    evr: 0.2.6-1.fc44
-    metadata:
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
-      type: pin


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/2176