### PR TITLE
denylist: kernel-replace on rawhide is failing

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -22,6 +22,13 @@
   arches:
     - aarch64
 
+- pattern: ext.config.rpm-ostree.kernel-replace
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2209
+  snooze: 2026-08-31
+  warn: true
+  streams:
+    - rawhide
+
 - pattern: fcos.upgrade.basic
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2129
   snooze: 2026-08-31


### PR DESCRIPTION
Due to the transition from f45 to f46 we are seeing a failure on the kernel-replace test on all arches.

See: https://github.com/coreos/fedora-coreos-tracker/issues/2209