### PR TITLE
[next-devel] overrides: unpin fwupd and libjcat

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,13 +9,3 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
-  fwupd:
-    evr: 2.1.3-1.fc44
-    metadata:
-      type: pin
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
-  libjcat:
-    evr: 0.2.6-1.fc44
-    metadata:
-      type: pin
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/2176