### PR TITLE
[next-devel] overrides: unpin fwupd and libjcat

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,14 +8,5 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  fwupd:
-    evr: 2.1.3-1.fc44
-    metadata:
-      type: pin
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
-  libjcat:
-    evr: 0.2.6-1.fc44
-    metadata:
-      type: pin
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2176
+packages: {}
+


### PR DESCRIPTION
Fixes: coreos/fedora-coreos-tracker#2176