### PR TITLE
Rawhide now maps to Fedora 46

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -5,8 +5,8 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=rawhide
 DESCRIPTION=Fedora CoreOS rawhide
-VERSION=45
-MUTATE_OS_RELEASE=45
+VERSION=46
+MUTATE_OS_RELEASE=46
 BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:5eb504c065a996c03524cd32d6d9e690592e0eb800433c6cda16291f46facf3a
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs


### PR DESCRIPTION
Fedora 45 has branched.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/2210