### PR TITLE
[ppc64le] overrides: pin kernel-7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46

### DIFF
--- a/manifest-lock.overrides.ppc64le.yaml
+++ b/manifest-lock.overrides.ppc64le.yaml
@@ -1,0 +1,21 @@
+packages:
+  kernel:
+    evra: 7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.ppc64le
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2212
+  kernel-core:
+    evra: 7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.ppc64le
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2212
+  kernel-modules:
+    evra: 7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.ppc64le
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2212
+  kernel-modules-core:
+    evra: 7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.ppc64le
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2212


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/2212

Followed the pattern used in https://github.com/coreos/fedora-coreos-config/pull/3481