### PR TITLE
DNM: overlay.d/15fcos: enable bootupd-varlink.socket by default

### DIFF
--- a/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
+++ b/overlay.d/15fcos/usr/lib/systemd/system-preset/45-fcos.preset
@@ -1,4 +1,6 @@
 enable coreos-check-ssh-keys.service
 # https://fedoraproject.org/wiki/Changes/EnableFwupdRefreshByDefault
 enable fwupd-refresh.timer
+# https://github.com/coreos/bootupd/pull/1138
+enable bootupd-varlink.socket
 enable coreos-warn-invalid-mounts.service


### PR DESCRIPTION
This should allow fwupd to call the socket-activated bootupd varlink interface when it needs to sync updates to other co-located ESPs (for RAID systems).

Part of the work for https://github.com/coreos/fedora-coreos-tracker/issues/1623, and related to https://github.com/coreos/bootupd/pull/1138. This should only be merged when we have a `bootupd` version with the varlink socket unit.