### PR TITLE
Switch our gpg key path locations to /usr/

### DIFF
--- a/build-rootfs
+++ b/build-rootfs
@@ -117,10 +117,10 @@ def inject_yumrepos(srcdir):
             shutil.copy(repo, "/etc/yum.repos.d")
 
 
-def run_buildroot_prep():
+def run_buildroot_prep(srcdir):
     # This allows FCOS/SCOS/RHCOS to do specific things before the main
     # build process. Runs after inject_yumrepos() so repos are available.
-    buildroot_prep = os.path.join(SRCDIR, 'buildroot-prep')
+    buildroot_prep = os.path.join(srcdir, 'buildroot-prep')
     if os.path.isfile(buildroot_prep):
         subprocess.check_call([buildroot_prep])
 
@@ -148,6 +148,9 @@ def build_rootfs(target_rootfs, srcdir, manifest_name,
     lockfile_repos = manifest.get('lockfile-repos', [])
     if repos or lockfile_repos:
         inject_yumrepos(srcdir)
+
+    # prepare buildroot (if anything needs to be done)
+    run_buildroot_prep(srcdir)
 
     local_overrides = prepare_local_rpm_overrides(target_rootfs, srcdir)
     if local_overrides:

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -6,11 +6,3 @@ set -euo pipefail
 # are to fast-track fixes or work around bugs.
 # Note that any dowloaded packages here needs to be included in lockfiles (the main
 # or overrides one).
-
-arch=$(uname -m)
-. /etc/os-release
-
-# make sure we have https://github.com/coreos/rpm-ostree/pull/5454
-if ! rpm-ostree compose build-chunked-oci -h | grep -q -- --label; then
-    sudo dnf update rpm-ostree -y
-fi

--- a/buildroot-prep
+++ b/buildroot-prep
@@ -6,3 +6,17 @@ set -euo pipefail
 # are to fast-track fixes or work around bugs.
 # Note that any dowloaded packages here needs to be included in lockfiles (the main
 # or overrides one).
+
+# Get the newer fedora-repos with gpgkeys in /usr/
+# https://github.com/coreos/fedora-coreos-tracker/issues/2172
+if [ "$(rpm -q fedora-repos)" == 'fedora-repos-44-1.noarch' ]; then
+    # cachi2 is the repo Konflux injects when hermetic build is enabled
+    # and if it's there we can just update from it.
+    if [ -f "/etc/yum.repos.d/cachi2.repo" ]; then
+        sudo dnf update -y fedora-{repos,repos-archive,gpg-keys}
+    else
+        # else we need to pull from koji for now
+        sudo dnf update -y --disablerepo=* \
+            https://kojipkgs.fedoraproject.org//packages/fedora-repos/44/2/noarch/fedora-{repos,repos-archive,gpg-keys}-44-2.noarch.rpm
+    fi
+fi

--- a/fedora-candidate-compose.repo
+++ b/fedora-candidate-compose.repo
@@ -17,5 +17,5 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/fedora-next.repo
+++ b/fedora-next.repo
@@ -11,7 +11,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-next-updates]
@@ -24,7 +24,7 @@ repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-next-updates-testing]
@@ -35,5 +35,5 @@ baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releaseve
 enabled=1
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/fedora-rawhide.repo
+++ b/fedora-rawhide.repo
@@ -12,5 +12,5 @@ metadata_expire=6h
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
 skip_if_unavailable=False

--- a/fedora.repo
+++ b/fedora.repo
@@ -11,7 +11,7 @@ enabled=1
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates]
@@ -24,7 +24,7 @@ repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False
 
 [fedora-updates-testing]
@@ -35,5 +35,5 @@ baseurl=https://dl.fedoraproject.org/pub/fedora/linux/updates/testing/$releaseve
 enabled=1
 gpgcheck=1
 metadata_expire=6h
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
+gpgkey=file:///usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-primary
 skip_if_unavailable=False

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,5 +8,22 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
-
+packages:
+  fedora-gpg-keys:
+    evra: 44-2.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
+      type: fast-track
+  fedora-repos:
+    evra: 44-2.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
+      type: fast-track
+  fedora-repos-archive:
+    evra: 44-2.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
+      type: fast-track

--- a/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
+++ b/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
@@ -44,9 +44,9 @@
           "type": "signedBy",
           "keyType": "GPGKeys",
           "keyPaths": [
-            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-43-primary",
-            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-primary",
-            "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-45-primary"
+            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-43-primary",
+            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-primary",
+            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-45-primary"
           ]
         }
       ]

--- a/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
+++ b/overlay.d/17fcos-container-signing/usr/lib/coreos/coreos-containers-policy.json
@@ -44,9 +44,9 @@
           "type": "signedBy",
           "keyType": "GPGKeys",
           "keyPaths": [
-            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-43-primary",
             "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-44-primary",
-            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-45-primary"
+            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-45-primary",
+            "/usr/share/pki/rpm-gpg/RPM-GPG-KEY-fedora-46-primary"
           ]
         }
       ]


### PR DESCRIPTION
Part of:

- https://github.com/coreos/fedora-coreos-tracker/issues/2172
- https://fedoraproject.org/wiki/Changes/RelocateRpmRepoConfigsToUsr

Because of [1] we now have the gpgkeys also in /usr on F44 so we can
go ahead and start using those paths everywhere.

[1] https://src.fedoraproject.org/rpms/fedora-repos/c/107895f6f8dc26d329d3e40dbd5ccbabe1e8f301?branch=f44


See individual commit messages.