### PR TITLE
[rawhide] Rawhide is now Fedora Linux 46

### DIFF
--- a/build-args.conf
+++ b/build-args.conf
@@ -5,9 +5,9 @@ ID=fedora
 NAME=fedora-coreos
 STREAM=rawhide
 DESCRIPTION=Fedora CoreOS rawhide
-VERSION=45
-MUTATE_OS_RELEASE=45
-BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:5eb504c065a996c03524cd32d6d9e690592e0eb800433c6cda16291f46facf3a
+VERSION=46
+MUTATE_OS_RELEASE=46
+BUILDER_IMG=quay.io/bootc-devel/fedora-bootc-rawhide-standard@sha256:baec162b0cccf77ac0bba77241ca6b2dd5e22eec4883f962aa08de4231bd7c31
 MANIFEST=manifest.yaml
 # XXX: see inject_passwd_group() in build-rootfs
 PASSWD_GROUP_DIR=manifests

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -12,23 +12,35 @@ packages:
   console-login-helper-messages:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-issuegen:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-motdgen:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-profile:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
+  coreos-installer:
+    evr: 0.26.0-5.fc46
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-ab3f874092
+      reason: https://github.com/coreos/coreos-installer/pull/1763
+      type: fast-track
+  coreos-installer-bootinfra:
+    evr: 0.26.0-5.fc46
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-ab3f874092
+      reason: https://github.com/coreos/coreos-installer/pull/1763
+      type: fast-track
   dracut:
     evr: 109-7.fc45
     metadata:

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,19 +1,19 @@
 {
   "packages": {
     "NetworkManager": {
-      "evra": "1:1.58.0-1.fc45.x86_64"
+      "evra": "1:1.58.1-1.fc46.x86_64"
     },
     "NetworkManager-cloud-setup": {
-      "evra": "1:1.58.0-1.fc45.x86_64"
+      "evra": "1:1.58.1-1.fc46.x86_64"
     },
     "NetworkManager-libnm": {
-      "evra": "1:1.58.0-1.fc45.x86_64"
+      "evra": "1:1.58.1-1.fc46.x86_64"
     },
     "NetworkManager-team": {
-      "evra": "1:1.58.0-1.fc45.x86_64"
+      "evra": "1:1.58.1-1.fc46.x86_64"
     },
     "NetworkManager-tui": {
-      "evra": "1:1.58.0-1.fc45.x86_64"
+      "evra": "1:1.58.1-1.fc46.x86_64"
     },
     "WALinuxAgent-udev": {
       "evra": "2.15.0.1-6.fc45.noarch"
@@ -58,10 +58,10 @@
       "evra": "4.2.1-2.fc45.x86_64"
     },
     "authselect": {
-      "evra": "1.7.1-2.fc45.x86_64"
+      "evra": "1.8.0-1.fc46.x86_64"
     },
     "authselect-libs": {
-      "evra": "1.7.1-2.fc45.x86_64"
+      "evra": "1.8.0-1.fc46.x86_64"
     },
     "azure-vm-utils": {
       "evra": "0.7.0-4.fc45.x86_64"
@@ -85,10 +85,10 @@
       "evra": "1.16.7-1.fc45.x86_64"
     },
     "bootupd": {
-      "evra": "0.2.35-3.fc45.x86_64"
+      "evra": "0.2.36-3.fc46.x86_64"
     },
     "bsdtar": {
-      "evra": "3.8.8-3.fc45.x86_64"
+      "evra": "3.8.9-1.fc46.x86_64"
     },
     "btrfs-progs": {
       "evra": "7.1-1.fc46.x86_64"
@@ -112,7 +112,7 @@
       "evra": "0.2.1-6.fc45.x86_64"
     },
     "chrony": {
-      "evra": "4.9-0.1.pre1.fc46.x86_64"
+      "evra": "4.9-0.2.pre1.fc46.x86_64"
     },
     "cifs-utils": {
       "evra": "7.6-3.fc45.x86_64"
@@ -169,10 +169,10 @@
       "evra": "5:0.69.0-1.fc46.noarch"
     },
     "coreos-installer": {
-      "evra": "0.26.0-4.fc45.x86_64"
+      "evra": "0.26.0-5.fc46.x86_64"
     },
     "coreos-installer-bootinfra": {
-      "evra": "0.26.0-4.fc45.x86_64"
+      "evra": "0.26.0-5.fc46.x86_64"
     },
     "coreutils": {
       "evra": "9.11-6.fc45.x86_64"
@@ -208,7 +208,7 @@
       "evra": "2.8.7-1.fc45.x86_64"
     },
     "curl": {
-      "evra": "8.21.0-5.fc45.x86_64"
+      "evra": "8.22.0~rc2-1.fc46.x86_64"
     },
     "cyrus-sasl-gssapi": {
       "evra": "2.1.28-37.fc45.x86_64"
@@ -253,7 +253,7 @@
       "evra": "3.12-6.fc45.x86_64"
     },
     "dnf5": {
-      "evra": "5.4.2.1-10.fc45.x86_64"
+      "evra": "5.4.3.0-2.fc46.x86_64"
     },
     "dnsmasq": {
       "evra": "2.93-2.fc45.x86_64"
@@ -292,10 +292,10 @@
       "evra": "39-13.fc45.x86_64"
     },
     "elfutils-libelf": {
-      "evra": "0.195-3.fc45.x86_64"
+      "evra": "0.196-1.fc46.x86_64"
     },
     "elfutils-libs": {
-      "evra": "0.195-3.fc45.x86_64"
+      "evra": "0.196-1.fc46.x86_64"
     },
     "ethtool": {
       "evra": "2:7.1-1.fc45.x86_64"
@@ -304,7 +304,7 @@
       "evra": "2.8.1-2.fc45.x86_64"
     },
     "fedora-gpg-keys": {
-      "evra": "46-0.1.noarch"
+      "evra": "46-0.3.noarch"
     },
     "fedora-release-common": {
       "evra": "46-0.1.noarch"
@@ -316,13 +316,13 @@
       "evra": "46-0.1.noarch"
     },
     "fedora-repos": {
-      "evra": "46-0.1.noarch"
+      "evra": "46-0.3.noarch"
     },
     "fedora-repos-archive": {
-      "evra": "46-0.1.noarch"
+      "evra": "46-0.3.noarch"
     },
     "fedora-repos-rawhide": {
-      "evra": "46-0.1.noarch"
+      "evra": "46-0.3.noarch"
     },
     "file": {
       "evra": "5.47-3.fc45.x86_64"
@@ -340,7 +340,7 @@
       "evra": "1.5.2-3.fc45.x86_64"
     },
     "flatpak-session-helper": {
-      "evra": "1.19.0-1.fc46.x86_64"
+      "evra": "1.19.0-2.fc46.x86_64"
     },
     "fmt": {
       "evra": "12.1.0-3.fc45.x86_64"
@@ -391,19 +391,19 @@
       "evra": "2.55.0-2.fc45.x86_64"
     },
     "glib2": {
-      "evra": "2.89.3-1.fc45.x86_64"
+      "evra": "2.89.4-1.fc46.x86_64"
     },
     "glibc": {
-      "evra": "2.44-1.fc45.x86_64"
+      "evra": "2.44-2.fc46.x86_64"
     },
     "glibc-common": {
-      "evra": "2.44-1.fc45.x86_64"
+      "evra": "2.44-2.fc46.x86_64"
     },
     "glibc-gconv-extra": {
-      "evra": "2.44-1.fc45.x86_64"
+      "evra": "2.44-2.fc46.x86_64"
     },
     "glibc-minimal-langpack": {
-      "evra": "2.44-1.fc45.x86_64"
+      "evra": "2.44-2.fc46.x86_64"
     },
     "gmp": {
       "evra": "1:6.3.0-6.fc45.x86_64"
@@ -442,22 +442,22 @@
       "evra": "3.12-4.fc45.x86_64"
     },
     "grub2-common": {
-      "evra": "1:2.12-74.fc45.noarch"
+      "evra": "1:2.12-78.fc46.noarch"
     },
     "grub2-efi-x64": {
-      "evra": "1:2.12-74.fc45.x86_64"
+      "evra": "1:2.12-78.fc46.x86_64"
     },
     "grub2-pc": {
-      "evra": "1:2.12-74.fc45.x86_64"
+      "evra": "1:2.12-78.fc46.x86_64"
     },
     "grub2-pc-modules": {
-      "evra": "1:2.12-74.fc45.noarch"
+      "evra": "1:2.12-78.fc46.noarch"
     },
     "grub2-tools": {
-      "evra": "1:2.12-74.fc45.x86_64"
+      "evra": "1:2.12-78.fc46.x86_64"
     },
     "grub2-tools-minimal": {
-      "evra": "1:2.12-74.fc45.x86_64"
+      "evra": "1:2.12-78.fc46.x86_64"
     },
     "gssproxy": {
       "evra": "0.9.2-12.fc45.x86_64"
@@ -547,16 +547,16 @@
       "evra": "1.0.61-2.fc45.x86_64"
     },
     "kernel": {
-      "evra": "7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.x86_64"
+      "evra": "7.3.0-0.rc0.260819gbd5f485f3f02.5.fc46.x86_64"
     },
     "kernel-core": {
-      "evra": "7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.x86_64"
+      "evra": "7.3.0-0.rc0.260819gbd5f485f3f02.5.fc46.x86_64"
     },
     "kernel-modules": {
-      "evra": "7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.x86_64"
+      "evra": "7.3.0-0.rc0.260819gbd5f485f3f02.5.fc46.x86_64"
     },
     "kernel-modules-core": {
-      "evra": "7.3.0-0.rc0.260818g0f23d56f17fd.3.fc46.x86_64"
+      "evra": "7.3.0-0.rc0.260819gbd5f485f3f02.5.fc46.x86_64"
     },
     "kexec-tools": {
       "evra": "2.0.32-4.fc45.x86_64"
@@ -580,7 +580,7 @@
       "evra": "1.22.2-9.fc45.x86_64"
     },
     "less": {
-      "evra": "704-3.fc45.x86_64"
+      "evra": "704-4.fc46.x86_64"
     },
     "libacl": {
       "evra": "2.4.0-2.fc45.x86_64"
@@ -589,7 +589,7 @@
       "evra": "0.3.111-24.fc45.x86_64"
     },
     "libarchive": {
-      "evra": "3.8.8-3.fc45.x86_64"
+      "evra": "3.8.9-1.fc46.x86_64"
     },
     "libassuan": {
       "evra": "2.5.7-6.fc45.x86_64"
@@ -613,7 +613,7 @@
       "evra": "2.78-2.fc45.x86_64"
     },
     "libcap-ng": {
-      "evra": "0.9.3-5.fc45.x86_64"
+      "evra": "0.9.5-1.fc46.x86_64"
     },
     "libcbor": {
       "evra": "0.14.0-3.fc45.x86_64"
@@ -622,7 +622,7 @@
       "evra": "1.47.4-2.fc45.x86_64"
     },
     "libcurl": {
-      "evra": "8.21.0-5.fc45.x86_64"
+      "evra": "8.22.0~rc2-1.fc46.x86_64"
     },
     "libdaemon": {
       "evra": "0.14-34.fc45.x86_64"
@@ -631,10 +631,10 @@
       "evra": "0.5.0-63.fc45.x86_64"
     },
     "libdnf5": {
-      "evra": "5.4.2.1-10.fc45.x86_64"
+      "evra": "5.4.3.0-2.fc46.x86_64"
     },
     "libdnf5-cli": {
-      "evra": "5.4.2.1-10.fc45.x86_64"
+      "evra": "5.4.3.0-2.fc46.x86_64"
     },
     "libdrm": {
       "evra": "2.4.134-2.fc45.x86_64"
@@ -661,7 +661,7 @@
       "evra": "1.17.0-5.fc45.x86_64"
     },
     "libgcc": {
-      "evra": "16.1.1-4.fc45.1.x86_64"
+      "evra": "16.2.1-2.fc46.x86_64"
     },
     "libgcrypt": {
       "evra": "1.12.2-2.fc45.x86_64"
@@ -682,19 +682,19 @@
       "evra": "2.0.0-63.fc45.x86_64"
     },
     "libipa_hbac": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "libjose": {
       "evra": "14-8.fc45.x86_64"
     },
     "libkcapi": {
-      "evra": "1.5.0-11.fc45.x86_64"
+      "evra": "1.5.1-2.fc46.x86_64"
     },
     "libkcapi-hasher": {
-      "evra": "1.5.0-11.fc45.x86_64"
+      "evra": "1.5.1-2.fc46.x86_64"
     },
     "libkcapi-hmaccalc": {
-      "evra": "1.5.0-11.fc45.x86_64"
+      "evra": "1.5.1-2.fc46.x86_64"
     },
     "libksba": {
       "evra": "1.8.0-3.fc45.x86_64"
@@ -817,19 +817,19 @@
       "evra": "0.12.2-1.fc45.noarch"
     },
     "libsss_certmap": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "libsss_idmap": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "libsss_nss_idmap": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "libsss_sudo": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "libstdc++": {
-      "evra": "16.1.1-4.fc45.1.x86_64"
+      "evra": "16.2.1-2.fc46.x86_64"
     },
     "libtalloc": {
       "evra": "2.4.4-4.fc45.x86_64"
@@ -1039,16 +1039,16 @@
       "evra": "6.9.10-5.fc45.x86_64"
     },
     "openldap": {
-      "evra": "2.6.13-4.fc45.x86_64"
+      "evra": "2.6.14-1.fc46.x86_64"
     },
     "openssh": {
-      "evra": "10.4p1-4.fc45.x86_64"
+      "evra": "10.5p1-1.fc46.x86_64"
     },
     "openssh-clients": {
-      "evra": "10.4p1-4.fc45.x86_64"
+      "evra": "10.5p1-1.fc46.x86_64"
     },
     "openssh-server": {
-      "evra": "10.4p1-4.fc45.x86_64"
+      "evra": "10.5p1-1.fc46.x86_64"
     },
     "openssl": {
       "evra": "1:4.0.1-5.fc45.x86_64"
@@ -1063,10 +1063,10 @@
       "evra": "1.81-12.fc45.x86_64"
     },
     "ostree": {
-      "evra": "2026.2-3.fc45.x86_64"
+      "evra": "2026.4-1.fc46.x86_64"
     },
     "ostree-libs": {
-      "evra": "2026.2-3.fc45.x86_64"
+      "evra": "2026.4-1.fc46.x86_64"
     },
     "p11-kit": {
       "evra": "0.26.5-1.fc45.x86_64"
@@ -1114,7 +1114,7 @@
       "evra": "2.5.1-2.fc45.x86_64"
     },
     "podman": {
-      "evra": "5:6.1.0-1.fc46.x86_64"
+      "evra": "5:6.1.0-2.fc46.x86_64"
     },
     "podman-sequoia": {
       "evra": "0.3.2-4.fc45.x86_64"
@@ -1162,25 +1162,25 @@
       "evra": "1.2.9-3.fc45.x86_64"
     },
     "rpm": {
-      "evra": "6.0.92-2.fc45.x86_64"
+      "evra": "6.1.0-1.fc46.x86_64"
     },
     "rpm-libs": {
-      "evra": "6.0.92-2.fc45.x86_64"
+      "evra": "6.1.0-1.fc46.x86_64"
     },
     "rpm-ostree": {
-      "evra": "2026.2-3.fc45.x86_64"
+      "evra": "2026.2-4.fc46.x86_64"
     },
     "rpm-ostree-libs": {
-      "evra": "2026.2-3.fc45.x86_64"
+      "evra": "2026.2-4.fc46.x86_64"
     },
     "rpm-plugin-selinux": {
-      "evra": "6.0.92-2.fc45.x86_64"
+      "evra": "6.1.0-1.fc46.x86_64"
     },
     "rpm-sequoia": {
       "evra": "1.10.2-5.fc45.x86_64"
     },
     "rsync": {
-      "evra": "3.4.4-3.fc45.x86_64"
+      "evra": "3.5.0-1.fc46.x86_64"
     },
     "runc": {
       "evra": "2:1.5.1-2.fc45.x86_64"
@@ -1204,19 +1204,19 @@
       "evra": "4.10-2.fc45.x86_64"
     },
     "selinux-policy": {
-      "evra": "45.12-1.fc46.noarch"
+      "evra": "45.14-1.fc46.noarch"
     },
     "selinux-policy-targeted": {
-      "evra": "45.12-1.fc46.noarch"
+      "evra": "45.14-1.fc46.noarch"
     },
     "setup": {
       "evra": "2.15.1-2.fc45.noarch"
     },
     "sg3_utils": {
-      "evra": "1.48-11.fc45.x86_64"
+      "evra": "1.49-1.fc46.x86_64"
     },
     "sg3_utils-libs": {
-      "evra": "1.48-11.fc45.x86_64"
+      "evra": "1.49-1.fc46.x86_64"
     },
     "shadow-utils": {
       "evra": "2:4.20.0-1.fc45.x86_64"
@@ -1255,31 +1255,31 @@
       "evra": "4.7.4-2.fc45.x86_64"
     },
     "sssd-ad": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-client": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-common": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-common-pac": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-ipa": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-krb5": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-krb5-common": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-ldap": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "sssd-nfs-idmap": {
-      "evra": "2.13.1-5.fc45.x86_64"
+      "evra": "2.13.1-6.fc46.x86_64"
     },
     "stalld": {
       "evra": "1.28.1-2.fc45.x86_64"
@@ -1345,10 +1345,10 @@
       "evra": "2.42.2-3.fc45.x86_64"
     },
     "vim-data": {
-      "evra": "2:9.2.920-1.fc45.noarch"
+      "evra": "2:9.2.967-1.fc46.noarch"
     },
     "vim-minimal": {
-      "evra": "2:9.2.920-1.fc45.x86_64"
+      "evra": "2:9.2.967-1.fc46.x86_64"
     },
     "wasmedge-rt": {
       "evra": "0.17.1-2.fc45.x86_64"
@@ -1391,6 +1391,6 @@
     }
   },
   "metadata": {
-    "generated": "2026-08-20T00:00:00Z"
+    "generated": "2026-08-25T00:00:00Z"
   }
 }


### PR DESCRIPTION
Branching for F45 has happened so we need to switch rawhide to be based on F46.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/2127