### PR TITLE
remove old policy.json path workaround

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -35,24 +35,6 @@ conditional-include:
     include:
       ostree-layers:
         - overlay.d/10aarch64
-  # Temporary workaround. containers-common moved policy.json from
-  # /etc/containers to /usr/share/containers. The rpm-ostreed bind mount
-  # could use CONTAINERS_POLICY_JSON env var instead, but bootc has a
-  # hardcoded path that prevents this approach.
-  # Copy the file until bootc supports the new config location.
-  #
-  # See:
-  # https://github.com/bootc-dev/bootc/issues/2258
-  # https://github.com/coreos/fedora-coreos-config/issues/4215
-  - if: releasever == 45
-    include:
-      postprocess:
-        - |
-          #!/usr/bin/bash
-          set -eux -o pipefail
-          src=/usr/share/containers/policy.json
-          dest=/etc/containers/policy.json
-          cp "${src}" "${dest}"
 
   # WARN: Temporary workaround
   #

--- a/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
+++ b/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
@@ -4,4 +4,4 @@
 #   mkdir /etc/systemd/system/rpm-ostreed.service.d
 #   ln -s /dev/null /etc/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
 [Service]
-BindReadOnlyPaths=/usr/lib/coreos/coreos-containers-policy.json:/etc/containers/policy.json
+Environment=CONTAINERS_POLICY_JSON=/usr/lib/coreos/coreos-containers-policy.json


### PR DESCRIPTION
The workaround, which needed to be dropped by now, only takes place in f45, so f46 CI is failing. This should fix those issues (#4320)

wip since tests are still running