### PR TITLE
extend workaround entry and denylist entry to f46/branched

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -44,5 +44,6 @@
   warn: true
   streams:
     - rawhide
+    - branched
   arches:
     - aarch64

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -49,7 +49,7 @@ conditional-include:
   # - https://bugzilla.redhat.com/show_bug.cgi?id=2503149
   #
   # TODO: delete if openssh ever supports AuthorizedKeysFile+= (https://bugzilla.mindrot.org/show_bug.cgi?id=3957)
-  - if: releasever <= 45
+  - if: releasever <= 46
     include:
       ostree-layers:
         - overlay.d/16fcos-sshd-workaround

--- a/tests/kola/boot/bootupd
+++ b/tests/kola/boot/bootupd
@@ -78,8 +78,8 @@ fi
 
 # Verify `bootupctl status` output contains related content.
 # https://github.com/coreos/bootupd/issues/694
-if ! bootupctl status | grep "CoreOS aleph version"; then
-    fatal "bootupctl status output should include 'CoreOS aleph version'"
+if ! bootupctl status | grep -i "aleph version"; then
+    fatal "bootupctl status output should include 'Aleph version'"
 fi
 
 ok bootupctl

--- a/tests/kola/boot/install-bootloader-multipath
+++ b/tests/kola/boot/install-bootloader-multipath
@@ -38,8 +38,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     ;;
 rebooted)
     ok "second boot"
-    if ! bootupctl status | grep "CoreOS aleph version"; then
-        fatal "bootupctl status output should include 'CoreOS aleph version'"
+    if ! bootupctl status | grep -i "aleph version"; then
+        fatal "bootupctl status output should include 'Aleph version'"
     fi
 
     ok bootupctl


### PR DESCRIPTION
denylist: add boot-partition-space denial to branched stream
    
    This affects `branched` too now that it has cut over to F45 and
    been enabled.

manifest/fedora-coreos: extend ssh AuthorizedKeysFile to F46

    Still need to wait for upstreams to adjust.