### PR TITLE
[testing-devel] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,22 +8,4 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages:
-  fedora-gpg-keys:
-    evra: 44-2.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
-      type: fast-track
-  fedora-repos:
-    evra: 44-2.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
-      type: fast-track
-  fedora-repos-archive:
-    evra: 44-2.noarch
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
-      type: fast-track
+packages: {}


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).