### PR TITLE
[rawhide] lockfiles: drop graduated overrides 🎓

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -29,18 +29,6 @@ packages:
     metadata:
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
       type: pin
-  coreos-installer:
-    evr: 0.26.0-5.fc46
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-ab3f874092
-      reason: https://github.com/coreos/coreos-installer/pull/1763
-      type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.26.0-5.fc46
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-ab3f874092
-      reason: https://github.com/coreos/coreos-installer/pull/1763
-      type: fast-track
   dracut:
     evr: 109-7.fc45
     metadata:


### PR DESCRIPTION
Created by remove-graduated-overrides [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/remove-graduated-overrides.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/remove-graduated-overrides.yml)).