### PR TITLE
overrides: fast-track ignition-2.27.0-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -27,3 +27,13 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-fce4201fed
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2172#issuecomment-5395194209
       type: fast-track
+  ignition:
+    evr: 2.27.0-1.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-199ec5afb1
+      type: fast-track
+  ignition-grub:
+    evr: 2.27.0-1.fc44
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-199ec5afb1
+      type: fast-track


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).