### PR TITLE
[branched] overrides: fast-track ignition-2.27.0-1.fc45

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -12,23 +12,23 @@ packages:
   console-login-helper-messages:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-issuegen:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-motdgen:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   console-login-helper-messages-profile:
     evra: 0.21.3-13.fc44.noarch
     metadata:
-      type: pin
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
+      type: pin
   dracut:
     evr: 109-7.fc45
     metadata:
@@ -44,3 +44,13 @@ packages:
     metadata:
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2206
       type: pin
+  ignition:
+    evr: 2.27.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e9b6491300
+      type: fast-track
+  ignition-grub:
+    evr: 2.27.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e9b6491300
+      type: fast-track


### PR DESCRIPTION
Requested by @prestist via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).