### PR TITLE
[testing] overrides: pin libselinux and related packages to 3.10-*.fc44 - #4335

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -8,4 +8,29 @@
 # in the `metadata.reason` key, though it's acceptable to omit a `reason`
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
-packages: {}
+packages:
+  policycoreutils:
+    evr: 3.10-4.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216
+  libselinux:
+    evr: 3.10-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216
+  libselinux-utils:
+    evr: 3.10-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216
+  libsemanage:
+    evr: 3.10-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216
+  libsepol:
+    evr: 3.10-1.fc44
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216

--- a/tests/kola/ignition/home-dir-symlink/config.ign
+++ b/tests/kola/ignition/home-dir-symlink/config.ign
@@ -1,0 +1,16 @@
+{
+  "ignition": {
+    "version": "3.5.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "wheel"
+        ],
+        "homeDir": "/home/core",
+        "name": "core"
+      }
+    ]
+  }
+}

--- a/tests/kola/ignition/home-dir-symlink/data/commonlib.sh
+++ b/tests/kola/ignition/home-dir-symlink/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/ignition/home-dir-symlink/test.sh
+++ b/tests/kola/ignition/home-dir-symlink/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+## kola:
+##   tags: platform-independent
+##   creationDate: 2026-09-02
+##   description: Verify that specifying an unresolved symlink for the homeDir
+##                field does not lead to a relabelling issue.
+#
+# This test checks for a regression in our path-handling with the homeDir field.
+# Ignition should resolve the user-given homeDir to prevent the node
+# from failing to provision.
+#
+# See https://github.com/coreos/fedora-coreos-tracker/issues/2216
+#
+# The primary check here is implicit on whether the node is successfully
+# provisioned at all, but some additional sanity checks are also included below.
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+if ! id -u core; then
+    fatal "no core user"
+fi
+if [[ ! -L /home ]]; then
+    fatal "/home not a symlink"
+fi
+if [[ ! -d /home/core ]]; then
+    fatal "/home/core not a directory"
+fi
+ok "homeDir handles unresolved symlinks"


### PR DESCRIPTION
Port of https://github.com/coreos/fedora-coreos-config/pull/4335 for the `testing` branch. See https://github.com/coreos/fedora-coreos-tracker/issues/2216.