### PR TITLE
overrides: pin selinux-policy to 44.6-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -34,3 +34,14 @@ packages:
     metadata:
       type: pin
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2216
+
+  selinux-policy:
+    evra: 44.6-1.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2217
+  selinux-policy-targeted:
+    evra: 44.6-1.fc44.noarch
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2217

--- a/tests/kola/podman/remote-ssh/config.bu
+++ b/tests/kola/podman/remote-ssh/config.bu
@@ -1,0 +1,28 @@
+variant: fcos
+version: 1.6.0
+systemd:
+  units:
+    - name: podman.socket
+      enabled: true
+passwd:
+  users:
+    - name: root
+      ssh_authorized_keys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEdRYc7DLXX6EJX6sZsr3LDEqn/1W9SGhcleXRdmSczL core@test
+storage:
+  files:
+    - path: /home/core/.ssh/test_key
+      mode: 0600
+      user:
+        name: core
+      group:
+        name: core
+      contents:
+        inline: |
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+          QyNTUxOQAAACBHUWHOwy11+hCV+rGbK9ywxKp/9VvUhoXJXl0XZknMywAAAJgerWOqHq1j
+          qgAAAAtzc2gtZWQyNTUxOQAAACBHUWHOwy11+hCV+rGbK9ywxKp/9VvUhoXJXl0XZknMyw
+          AAAEC1e4w/76P1M9BK9wralN+XICltcHhpDd+jGUJD68FJcUdRYc7DLXX6EJX6sZsr3LDE
+          qn/1W9SGhcleXRdmSczLAAAAFHNhbmRib3hAMTc3ZjU0MWI2MTI3AQ==
+          -----END OPENSSH PRIVATE KEY-----

--- a/tests/kola/podman/remote-ssh/data/commonlib.sh
+++ b/tests/kola/podman/remote-ssh/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../data/commonlib.sh

--- a/tests/kola/podman/remote-ssh/test.sh
+++ b/tests/kola/podman/remote-ssh/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+## kola:
+##   tags: platform-independent
+##   exclusive: true
+##   creationDate: 2026-09-02
+##   description: Verify that podman-remote can connect to the podman
+##     socket via SSH.
+#
+# This test catches SELinux regressions where sshd_session_t is
+# denied connectto on container_runtime_t:unix_stream_socket.
+#
+# See:
+# - https://github.com/coreos/fedora-coreos-tracker/issues/2217
+# - https://github.com/fedora-selinux/selinux-policy/issues/3392
+
+set -xeuo pipefail
+
+# shellcheck disable=SC1091
+. "$KOLA_EXT_DATA/commonlib.sh"
+
+# TODO: use run_as_core_user from commonlib once it lands
+run_as_core_user() {
+    sudo -iu core -- "$@" 2>&1 | cat
+}
+
+# Private key, root authorized_keys, and podman.socket are provisioned via config.bu
+run_as_core_user podman system connection add --identity /home/core/.ssh/test_key con1 root@localhost
+if ! run_as_core_user podman --connection con1 info; then
+    ausearch -m avc -ts recent || true
+    fatal "podman-remote SSH connection to localhost failed"
+fi
+ok "podman-remote SSH connection to localhost succeeded"


### PR DESCRIPTION
    tests/kola: add test to verify podman-remote can connect to the podman socket over SSH

    This test uses podman-remote to connect to the root podman socket over
    SSH to localhost, catching SELinux regressions where sshd_session_t is
    denied connectto on container_runtime_t:unix_stream_socket.

    overrides: pin selinux-policy to 44.6-1.fc44

    This pin is to avoid an SELinux regression in 44.7-1+ where
    sshd_session_t is denied connectto on
    container_runtime_t:unix_stream_socket for podman, breaking SSH
    connections for podman-remote.

See https://github.com/coreos/fedora-coreos-tracker/issues/2217.

Test is a modified version of the suggestion from https://github.com/coreos/fedora-coreos-tracker/issues/2217#issuecomment-5512997176, thanks @Luap99. I chose to have the socket activation and key setup handled directly in the butane config though.

Verified that the test fails without the pin. 