### PR TITLE
[next] Revert "rpm-ostreed: use env var rather than bind mounting"

### DIFF
--- a/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
+++ b/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
@@ -4,4 +4,4 @@
 #   mkdir /etc/systemd/system/rpm-ostreed.service.d
 #   ln -s /dev/null /etc/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
 [Service]
-Environment=CONTAINERS_POLICY_JSON=/usr/lib/coreos/coreos-containers-policy.json
+BindReadOnlyPaths=/usr/lib/coreos/coreos-containers-policy.json:/etc/containers/policy.json


### PR DESCRIPTION
This reverts commit 7f6256c5553b02cc7bf4c53238c2dcaf4b9876cf.

This broke updating from signed content in a registry on our F44 builds for now. See [1].

[1] https://github.com/coreos/fedora-coreos-tracker/issues/2218