### PR TITLE
tests/upgrade: select latest reachable upgrade release

### DIFF
--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -134,15 +134,29 @@ fi
 # Pick up the last release for the current stream from the update server
 test -f /srv/updateinfo.json || \
     curl -L "https://updates.coreos.fedoraproject.org/v1/graph?basearch=${arch}&stream=${stream}&rollout_wariness=0&oci=true" > /srv/updateinfo.json
-last_release=$(jq -r .nodes[-1].version /srv/updateinfo.json)
-last_release_index=$(jq '.nodes | length-1' /srv/updateinfo.json)
-latest_edge=$(jq -r .edges[0][1] /srv/updateinfo.json)
-
-# Now that we have the release from update json, let's check if it has an edge pointing to it
-# The latest_edge would ideally have the value of last_release_index if the release has rolled out
-# If the edge does not exist, we would pick the second last release as our last_release
-if [ $last_release_index != $latest_edge ]; then
-    last_release=$(jq -r .nodes[-2].version /srv/updateinfo.json)
+# Extract all destination indexes and select the newest one.
+#
+# Edges contain [source, destination] node indexes.
+# [.edges[][1]] | max // empty means:
+#   [.edges[][1]]
+#   - Iterate over every edge in .edges.
+#   - Extract element 1, the edge’s destination node index.
+#   - Collect those indexes into an array.
+#   max
+#   - Select the largest destination index.
+#   - If there are no edges, the result is null.
+#   // empty
+#   - If the result is null, emit no output.
+#   - In Bash, command substitution then produces an empty string.
+last_release_index=$(jq -r '[.edges[][1]] | max // empty' /srv/updateinfo.json)
+if [ -z "${last_release_index}" ]; then
+    fatal "Update graph contains no usable edges"
+fi
+# Grab the actual version string from the index.
+last_release=$(jq -r --argjson index "${last_release_index}" \
+    '.nodes[$index].version' /srv/updateinfo.json)
+if [ -z "${last_release}" ] || [ "${last_release}" == "null" ]; then
+    fatal "Update graph edge points to a missing node"
 fi
 
 # If the user dropped down a /etc/target_stream file then we'll


### PR DESCRIPTION
The previous code here had some logic for if the latest release in the index wasn't actually in the update graph (i.e. we had stopped the rollout), but it didn't handle the case where there were multiple releases where we had stopped the rollout, which is the case for the last few testing and next releases we've done.

Assisted-by: <openai/gpt-5.6-luna>