### PR TITLE
Containerfile: prefix Konflux build secret IDs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,8 +45,8 @@ RUN chmod -R a=rX,u+w /src
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
         rm -rf /cache/cache/*lock*
 RUN --mount=type=cache,rw,id=coreos-build-cache,target=/cache \
-    --mount=type=secret,id=yumrepos,target=/etc/yum.repos.d/secret.repo \
-    --mount=type=secret,id=contentsets \
+    --mount=type=secret,id=container-image-build/yumrepos,target=/etc/yum.repos.d/secret.repo \
+    --mount=type=secret,id=container-image-build/contentsets \
         /src/build-rootfs --srcdir=/src make-rootfs --target-rootfs /target-rootfs
 # Take the rootfs and created a chunked container out of it
 RUN --mount=type=bind,target=/run/src,rw <<EOF

--- a/build-rootfs
+++ b/build-rootfs
@@ -491,7 +491,7 @@ def inject_image_json(rootfs, image_cfg_path, stream):
 
 
 def inject_content_manifest(target_rootfs, manifest):
-    content_manifest_path = '/run/secrets/contentsets'
+    content_manifest_path = '/run/secrets/container-image-build/contentsets'
     if not os.path.exists(content_manifest_path):
         return
 


### PR DESCRIPTION
Konflux exposes ADDITIONAL_SECRET files using IDs in the form `<secret-name>/<filename>`. Prefix the yumrepos and contentsets secret IDs with container-image-build and update build-rootfs to use the corresponding contentsets path.

Depends on https://github.com/coreos/coreos-assembler/pull/4613

ref: https://github.com/coreos/rhel-coreos-config/issues/307