### PR TITLE
Containerfile: quote labels to fix heredoc parsing without bash

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -61,16 +61,16 @@ RUN --mount=type=bind,target=/run/src,rw <<EOF
                 --output oci-archive:/run/src/out.ociarchive                                                  \
                 --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
                 ${BUILDER_IMG_CHUNKER_MAX_LAYERS:+--max-layers=${BUILDER_IMG_CHUNKER_MAX_LAYERS}}             \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"}
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label 'io.openshift.build.versions=machine-os=${VERSION}'} \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label 'io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"'}
             ;;
         "")
             rpm-ostree experimental compose build-chunked-oci                                                 \
                 --bootc --format-version=1 --rootfs /target-rootfs                                            \
                 --output oci-archive:/run/src/out.ociarchive                                                  \
                 --label com.coreos.inputhash=$(cat /run/inputhash)                                            \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.versions=machine-os=${VERSION}} \
-                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"}
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label 'io.openshift.build.versions=machine-os=${VERSION}'} \
+                ${INJECT_OPENSHIFT_VERSION_LABELS:+--label 'io.openshift.build.version-display-names=machine-os=\"${DESCRIPTION}\"'}
             ;;
         *)
             echo "error: unknown BUILDER_IMG_CHUNKER value: ${BUILDER_IMG_CHUNKER}" >&2


### PR DESCRIPTION
The recent removal of the `bash` prefix from the heredoc (commit 6e2c0881) caused PROW to incorrectly parse labels containing spaces in ${DESCRIPTION} (e.g. "Red Hat Enterprise Linux CoreOS 9.8").

Without bash, buildah splits the value at spaces, resulting in:
  --label 'io...=machine-os="Red' Hat Enterprise Linux CoreOS '9.8"'

Wrapping the entire label argument in single quotes prevents this incorrect word splitting while preserving the inner double quotes for the label value.

Assisted-by: OpenCode (Claude Opus 4.5)"