### PR TITLE
tests(fwupd-refresh-units): skip timer check for EL9

### DIFF
--- a/tests/kola/fwupd/fwupd-refresh-units
+++ b/tests/kola/fwupd/fwupd-refresh-units
@@ -26,7 +26,7 @@ ok "Ran ${unit} successfully"
 
 # TIMER
 unit="fwupd-refresh.timer"
-if is_rhcos && match_maj_ver "9"; then
+if match_maj_ver "9"; then
     ok "${unit} not enabled on EL9, skipping check."
     exit 0
 fi


### PR DESCRIPTION
The timer is not enabled on EL9 but the current condition does not skip SCOS9, but only RHCOS9. With this change, we skip the check for all EL9 distros.

The failure was caught with https://github.com/coreos/rhel-coreos-config/pull/292 