### PR TITLE
kola: pass --assumeyes to rpm-ostree install

### DIFF
--- a/tests/kola/extensions/package
+++ b/tests/kola/extensions/package
@@ -36,7 +36,7 @@ case "$(get_fcos_stream)" in
     *) ;;
 esac
 
-rpm-ostree install --apply-live "${commands[@]}"
+rpm-ostree install -y --apply-live "${commands[@]}"
 
 failed=""
 

--- a/tests/kola/systemd/sysexts
+++ b/tests/kola/systemd/sysexts
@@ -17,7 +17,7 @@ set -xeuo pipefail
 . "$KOLA_EXT_DATA/commonlib.sh"
 
 # Install tools that we need to build the sysexts
-rpm-ostree install --apply-live erofs-utils lz4
+rpm-ostree install -y --apply-live erofs-utils lz4
 
 build_sysext(){
   local -r rpm="${1}"


### PR DESCRIPTION
Explicitly pass `-y` to the non-interactive `rpm-ostree install --apply-live` calls in the package-extension and sysext Kola tests. This keeps the tests working after rpm-ostree stops auto-inferring `--assumeyes` in non-interactive contexts.

Fixes #2764.

Validation: `bash -n tests/kola/extensions/package tests/kola/systemd/sysexts`.