### PR TITLE
revert container policy change; loosen aleph version check on upgrade test

### DIFF
--- a/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
+++ b/overlay.d/17fcos-container-signing/usr/lib/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
@@ -4,4 +4,4 @@
 #   mkdir /etc/systemd/system/rpm-ostreed.service.d
 #   ln -s /dev/null /etc/systemd/system/rpm-ostreed.service.d/coreos-containers-policy.conf
 [Service]
-Environment=CONTAINERS_POLICY_JSON=/usr/lib/coreos/coreos-containers-policy.json
+BindReadOnlyPaths=/usr/lib/coreos/coreos-containers-policy.json:/etc/containers/policy.json

--- a/tests/kola/upgrade/extended/test.sh
+++ b/tests/kola/upgrade/extended/test.sh
@@ -306,7 +306,7 @@ if vereq $version $target_version; then
     # log bootupctl information for inspection and check the status output
     state=$(/usr/bin/bootupctl status 2>&1)
     echo "$state"
-    if ! echo "$state" | grep -q "CoreOS aleph version"; then
+    if ! echo "$state" | grep -q -i "aleph version"; then
         fatal "check bootupctl status output"
     fi
     # One last check!


### PR DESCRIPTION
commit e4eca21b1dfaba0cc4450ed247a2630430e0b947
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Sep 7 13:35:18 2026 -0400

    Revert "rpm-ostreed: use env var rather than bind mounting"

    This reverts commit 7f6256c5553b02cc7bf4c53238c2dcaf4b9876cf.

    This broke updating from signed content in a registry on our F44
    builds for now. See [1].

    [1] https://github.com/coreos/fedora-coreos-tracker/issues/2218

commit 91b306b0c8858a7c0fe05b3486159dc7fc6e1215
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 10 15:27:15 2026 -0400

    tests/upgrade: loosen aleph version check

    Exactly like 15e178e, but now for the upgrade test.