### PR TITLE
manifest/fcos: add workaround back

### DIFF
--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -35,6 +35,24 @@ conditional-include:
     include:
       ostree-layers:
         - overlay.d/10aarch64
+  # Temporary workaround. containers-common moved policy.json from
+  # /etc/containers to /usr/share/containers. The rpm-ostreed bind mount
+  # could use CONTAINERS_POLICY_JSON env var instead, but bootc has a
+  # hardcoded path that prevents this approach.
+  # Copy the file until bootc supports the new config location.
+  #
+  # See:
+  # https://github.com/bootc-dev/bootc/issues/2258
+  # https://github.com/coreos/fedora-coreos-config/issues/4215
+  - if: releasever >= 45
+    include:
+      postprocess:
+        - |
+          #!/usr/bin/bash
+          set -eux -o pipefail
+          src=/usr/share/containers/policy.json
+          dest=/etc/containers/policy.json
+          cp "${src}" "${dest}"
 
   # WARN: Temporary workaround
   #


### PR DESCRIPTION
When reverting to bind mounting [1], we also need to add the workaround that ensures that the path we mount to exists.

This brings back the workaround [2] that I removed too early. It also extends it to f46 as well as f46. We should be able to delete this relatively soon, when this lands: coreos/rpm-ostree#5630 (without any errors this time :D).

[1] cff712a2aad99511a6c2ca01adfeb48c9892a5ff
[2] 9736538a8f7f6fe305accbd2269c65d2a37385ed