### PR TITLE
[next-devel] fast-track downgraded packages 2026-09-11

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -9,6 +9,30 @@
 # for FCOS-specific packages (ignition, afterburn, etc.).
 
 packages:
+  bootc:
+    evr: 1.16.12-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-076c278f50
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  ca-certificates:
+    evra: 2026.2.90_v9.0.317-1.fc45.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-5847f6e29b
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  chrony:
+    evr: 4.9-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e08c7f3722
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  cifs-utils:
+    evr: 7.7-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-46b58299e7
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
   console-login-helper-messages:
     evra: 0.21.3-13.fc44.noarch
     metadata:
@@ -29,6 +53,12 @@ packages:
     metadata:
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
       type: pin
+  dnf5:
+    evr: 5.4.4.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-6099c3534e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
   dracut:
     evr: 109-7.fc45
     metadata:
@@ -56,6 +86,12 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-aad3eba395
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
       type: fast-track
+  hwdata:
+    evra: 0.411-1.fc45.noarch
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-372f0c1692
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
   ignition:
     evr: 2.27.0-1.fc45
     metadata:
@@ -65,4 +101,100 @@ packages:
     evr: 2.27.0-1.fc45
     metadata:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-e9b6491300
+      type: fast-track
+  kernel:
+    evr: 7.2.4-300.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a0019f8ab9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  kernel-core:
+    evr: 7.2.4-300.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a0019f8ab9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  kernel-modules:
+    evr: 7.2.4-300.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a0019f8ab9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  kernel-modules-core:
+    evr: 7.2.4-300.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a0019f8ab9
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  libdnf5:
+    evr: 5.4.4.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-6099c3534e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  libdnf5-cli:
+    evr: 5.4.4.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-6099c3534e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  librepo:
+    evr: 1.21.0-2.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-04f4e78da2
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nspr:
+    evr: 4.39.0-6.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nss:
+    evr: 3.127.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nss-softokn:
+    evr: 3.127.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nss-softokn-freebl:
+    evr: 3.127.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nss-sysinit:
+    evr: 3.127.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  nss-util:
+    evr: 3.127.0-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-823e097aaa
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  openldap:
+    evr: 2.6.14-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-3b3a65eff1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  rpm-sequoia:
+    evr: 1.10.3-1.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-be7110a01e
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
+      type: fast-track
+  rsync:
+    evr: 3.5.0-2.fc45
+    metadata:
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a7d496f8
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
       type: fast-track


### PR DESCRIPTION
F45 is now in beta freeze, which means that packages in F44 can sort as newer than those in F45. We prevent downgrades by fast-tracking these packages. Today they are:
```
bootc
ca-certificates
chrony
cifs-utils
dnf5
hwdata
kernel
librepo
nss
openldap
rust-rpm-sequoia
rsync
```