### PR TITLE
[next-devel] overrides: pin selinux-policy-44.6-1.fc44 and container-selinux-2.250.0-1.fc44

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -53,6 +53,11 @@ packages:
     metadata:
       reason: https://github.com/fedora-selinux/selinux-policy/pull/3169
       type: pin
+  container-selinux:
+    evra: 4:2.250.0-1.fc44.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2217
+      type: pin
   dnf5:
     evr: 5.4.4.0-1.fc45
     metadata:
@@ -198,3 +203,13 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2026-a5a7d496f8
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/2127#issuecomment-5624897433
       type: fast-track
+  selinux-policy:
+    evra: 44.6-1.fc44.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2217
+      type: pin
+  selinux-policy-targeted:
+    evra: 44.6-1.fc44.noarch
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/2217
+      type: pin


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/add-override.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/add-override.yml)).